### PR TITLE
[codex] reposition foxguard and fix packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "foxguard"
 version = "0.1.0"
 edition = "2021"
-description = "The security linter fast enough to sit between your AI and your codebase."
+description = "Fast security linting for modern codebases."
 license = "MIT"
 repository = "https://github.com/peaktwilight/foxguard"
 homepage = "https://foxguard.dev"

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -4,611 +4,288 @@ Best posting time: **Tuesday 9:00 AM ET** (15:00 CET)
 
 ---
 
-## 1. Show HN Post
+## Positioning
+
+Use this framing consistently:
+
+- foxguard is a **Rust security linter**
+- it is built for **fast local feedback**
+- it supports a **Semgrep-compatible YAML subset**
+- it is best positioned as a **fast local complement** to Semgrep or OpenGrep
+- AI-generated code is a **use case**, not the whole product category
+
+Avoid these claims:
+
+- "AI-only security scanner"
+- "drop-in Semgrep replacement"
+- "same syntax, full compatibility"
+- benchmark numbers that are not in `benchmarks/results.md`
+
+Current checked-in benchmark snapshot:
+
+| Repository | Files | foxguard | Semgrep | Speedup |
+|------------|-------|----------|---------|---------|
+| express | 141 | 0.077s | 4.902s | 64x |
+| flask | 83 | 0.049s | 4.805s | 98x |
+| gin | 99 | 0.062s | 4.302s | 69x |
+
+---
+
+## 1. Show HN
 
 ### Title Options
 
-- **Option A:** `Show HN: Foxguard – security linter that runs between your AI and your codebase (Rust)`
-- **Option B:** `Show HN: Foxguard – Semgrep-compatible security linter in Rust, built for AI-generated code`
+- `Show HN: Foxguard – fast security linting in Rust with Semgrep-compatible rules`
+- `Show HN: Foxguard – local-first security scanner for JS, Python, and Go`
+- `Show HN: Foxguard – Rust security linter with Semgrep-compatible YAML support`
 
-### First Comment (Maker's Story)
+### First Comment
 
-> Hey HN, I'm Doruk (Peak Twilight). I built Foxguard because I kept hitting the same wall: AI-generated code that compiles, passes tests, and ships with security bugs.
+> Hey HN, I'm Doruk. I built Foxguard because I wanted security checks that are fast enough to run locally without getting skipped.
 >
-> **The problem:** 80% of AI-generated code that passes functional tests still contains security vulnerabilities — hardcoded secrets, missing auth checks, SQL injection via string interpolation, framework misconfigurations. The code works. It's just not safe.
+> Most security tooling is comfortable in CI, but a lot less comfortable in the edit-save-commit loop. Foxguard is a Rust security linter for JS/TS, Python, and Go that aims to close that gap.
 >
-> Every SAST tool that catches these issues — Semgrep, Bandit, ESLint security plugins — is designed for CI. They take 30+ seconds on a medium repo. That's fine for a pipeline, but useless when your AI agent is generating 50 files in a session and you need to catch problems before they compound.
+> What it does today:
 >
-> **The insight:** Security linting needs to move from CI into the generation loop. If you can lint in under 100ms, you can run it on every save, in your editor, as a pre-commit hook, or as a gate between your AI and your codebase. That changes the entire dynamic — you catch bugs at write-time instead of review-time.
+> - 36 built-in rules across JavaScript/TypeScript, Python, and Go
+> - JSON and SARIF output
+> - framework-aware checks for Express, Flask, Django, Gin, and `net/http`
+> - Semgrep-compatible YAML rule loading with `--rules`
+> - single binary, no JVM, no Python runtime, no network calls
 >
-> **What Foxguard does:**
-> - 36 built-in rules focused on what AI gets wrong: scaffold secrets, missing auth, framework misconfiguration
-> - Semgrep YAML rule compatibility — bring your existing rules, run them on the Rust engine
-> - Tree-sitter AST parsing (no regex — we understand code structure)
-> - <100ms on typical projects. Fast enough for the edit-save-lint loop.
-> - SARIF output for CI/CD integration (GitHub Advanced Security, GitLab SAST)
-> - Single binary, zero config, zero dependencies
+> The important positioning point is that this is not meant to be "security tooling only for AI code", and it's not a claim of full Semgrep replacement either.
 >
-> **Speed:**
+> The better way to think about it is:
 >
-> | Tool | 10K LOC repo | 50K LOC repo |
-> |---|---|---|
-> | Semgrep (25 rules) | 8.2s | 34.1s |
-> | Foxguard (36 rules) | 0.04s | 0.18s |
+> - Semgrep / OpenGrep: broad rule ecosystem and strong CI fit
+> - Foxguard: fast local feedback on a Rust engine
 >
-> Semgrep is great for CI. Foxguard is fast enough for your editor.
+> Checked-in benchmark numbers from the repo right now:
 >
-> **Why Semgrep compatibility?** Teams have invested years building custom Semgrep YAML rules. We don't want you to throw those away. Foxguard reads the same YAML rule format and runs it on a Rust engine with tree-sitter parsing. Same rules, 100x faster.
+> | Repo | Files | Foxguard | Semgrep |
+> |---|---:|---:|---:|
+> | express | 141 | 0.077s | 4.902s |
+> | flask | 83 | 0.049s | 4.805s |
+> | gin | 99 | 0.062s | 4.302s |
 >
-> **Architecture:** Rust + tree-sitter + rayon. Same playbook as Ruff. Tree-sitter gives us real AST analysis (not regex), rayon gives us parallelism, Rust gives us predictable sub-100ms latency and single-binary distribution.
+> Install is:
 >
-> **What's next:**
-> - Taint tracking for data-flow analysis
-> - VS Code / Cursor extension (lint-on-save)
-> - More framework-specific rules (Express, Flask, Django, Gin)
-> - Plugin system for custom rules
+> ```sh
+> cargo install foxguard
+> # or
+> npx foxguard .
+> ```
 >
-> MIT licensed. Install with `cargo install foxguard` or `npx foxguard`.
+> Scan is:
 >
-> GitHub: https://github.com/peaktwilight/foxguard
+> ```sh
+> foxguard .
+> foxguard --format sarif .
+> foxguard --rules ./semgrep-rules .
+> ```
+>
+> Repo: https://github.com/peaktwilight/foxguard
 > Site: https://foxguard.dev
 >
-> What rules would you want for AI-generated code? I'm prioritizing based on what developers actually hit.
+> If you're already using Semgrep or OpenGrep, the question I'd love feedback on is: what subset of rule compatibility matters most for local workflows?
 
 ---
 
-## 2. Reddit Posts
+## 2. Reddit
 
 ### r/rust
 
-**Title:** `Foxguard: Semgrep-compatible security linter in Rust — built for AI-generated code, <100ms scans`
+**Title:** `Foxguard: fast security linting in Rust with Semgrep-compatible YAML support`
 
 **Body:**
 
-I just released Foxguard, a security linter written in Rust that's designed to sit between AI code generation and your codebase. Wanted to share the architecture with this community since Rust made the core insight possible: security linting fast enough to run in the editor, not just CI.
+I just released Foxguard, a Rust security linter for JS/TS, Python, and Go.
 
-**Why this matters now:**
+The pitch is simple: security checks that are fast enough to run locally, not just in CI.
 
-80% of AI-generated code that passes functional tests still has security bugs. The existing tools to catch them (Semgrep, Bandit) are designed for CI pipelines — 30+ seconds per scan. That's fine for a nightly build, but useless when Copilot or Cursor is generating code in real-time.
+What it has today:
 
-Foxguard runs in <100ms. That's fast enough for on-save linting, pre-commit hooks, or as a gate in the AI generation loop.
+- 36 built-in rules
+- JSON and SARIF output
+- framework-aware checks for Express, Flask, Django, Gin, and `net/http`
+- Semgrep-compatible YAML loading via `--rules`
+- single-binary distribution
 
-**Architecture:**
+I do not want to overstate it:
 
-- **tree-sitter** for parsing — each language gets a tree-sitter grammar, and rules are written as tree-sitter queries against the CST. No regex. This means we can distinguish `eval(userInput)` from `eval("literal")` at the AST level.
-- **rayon** for parallelism — files are scanned in parallel with zero coordination overhead. On an 8-core machine, scanning 50K LOC takes ~0.18s.
-- **Semgrep YAML compatibility** — the rule engine reads Semgrep's YAML format, so teams can bring their existing rules and run them on the Rust engine. Same syntax, 100x faster.
+- it is not "security tooling only for AI code"
+- it is not a full drop-in Semgrep replacement
 
-**Example rule definition (simplified):**
+The intended position is more like a local-first complement:
 
-```rust
-Rule {
-    id: "JS-SQLI-001",
-    severity: High,
-    cwe: "CWE-89",
-    query: r#"
-        (call_expression
-            function: (member_expression
-                property: (property_identifier) @method)
-            arguments: (arguments
-                (template_string) @query)
-            (#eq? @method "query"))
-    "#,
-}
-```
+- Semgrep / OpenGrep for broad ecosystem coverage
+- Foxguard for fast feedback in hooks, scripts, and the edit-save-commit loop
 
-**Benchmarks:**
+Current benchmark snapshot checked into the repo:
 
-```
-$ hyperfine 'foxguard scan ./project' 'semgrep --config auto ./project'
+| Repo | Files | Foxguard | Semgrep |
+|---|---:|---:|---:|
+| express | 141 | 0.077s | 4.902s |
+| flask | 83 | 0.049s | 4.805s |
+| gin | 99 | 0.062s | 4.302s |
 
-Foxguard:  0.04s ± 0.003s
-Semgrep:   8.2s  ± 0.41s
-```
+Would especially love feedback from Rust folks on the rule engine and packaging approach.
 
-**What's in it:**
-
-- 36 built-in rules focused on what AI gets wrong (scaffold secrets, missing auth, framework misconfig)
-- Semgrep YAML rule compatibility
-- CWE mappings for every rule
-- SARIF output for GitHub/GitLab integration
-- Framework-aware: Express, Flask, Django, Gin
-- Single binary, `cargo install foxguard`
-
-MIT licensed: https://github.com/peaktwilight/foxguard
-
-Feedback on the Rust architecture is very welcome — particularly around the Semgrep compatibility layer and rule engine design.
-
----
+Repo: https://github.com/peaktwilight/foxguard
 
 ### r/netsec
 
-**Title:** `Foxguard: Semgrep-compatible SAST tool in Rust — 36 rules targeting AI-generated code vulnerabilities`
+**Title:** `Foxguard: open-source Rust security linter with SARIF output and Semgrep-compatible rules`
 
 **Body:**
 
-Releasing Foxguard, an open-source SAST tool built specifically for the AI code generation era. The core idea: security linting needs to move from CI into the generation loop.
+Released a small open-source security linter called Foxguard.
 
-**The problem:** 80% of AI-generated code that passes functional tests still contains security vulnerabilities. Not exotic bugs — the same CWEs we've been fighting for a decade: hardcoded secrets, missing auth, SQL injection, framework misconfigurations. AI is great at producing code that works. It's terrible at producing code that's secure.
+Current scope:
 
-**What it catches (sample):**
+- JS/TS, Python, Go
+- 36 built-in rules
+- JSON and SARIF output
+- Semgrep-compatible YAML subset loading
+- local CLI usage first
 
-| Rule ID | CWE | Description |
-|---|---|---|
-| JS-SQLI-001 | CWE-89 | SQL injection via string concatenation/template literals |
-| PY-CMDI-001 | CWE-78 | OS command injection via subprocess with shell=True |
-| GO-PATH-001 | CWE-22 | Path traversal via unsanitized user input in file operations |
-| JS-XSS-001 | CWE-79 | DOM XSS via innerHTML/document.write with dynamic data |
-| PY-DESER-001 | CWE-502 | Unsafe deserialization via pickle.loads |
-| GO-SQLI-001 | CWE-89 | SQL injection via fmt.Sprintf in query construction |
-| JS-CRYPTO-001 | CWE-327 | Use of weak cryptographic algorithms (MD5, SHA1 for security) |
-| PY-SSRF-001 | CWE-918 | Server-side request forgery via unvalidated URL in requests |
+Examples of built-in checks include hardcoded secrets, SQL injection via interpolation, command injection, XSS sinks, weak crypto, unsafe deserialization, and framework misconfiguration.
 
-36 rules total across JavaScript/TypeScript, Python, and Go. Every rule maps to a CWE. Framework-aware for Express, Flask, Django, and Gin.
+The main product idea is not "new rule universe". It is "fast engine that fits existing workflows better".
 
-**Key differentiator:** Foxguard reads Semgrep YAML rules. If your team has invested in custom Semgrep rules, you can run them on Foxguard's Rust engine — same syntax, 100x faster. Fast enough (<100ms) to run in-editor, on save, or as a gate between your AI agent and your codebase.
+So the intended comparison is:
 
-**CI/CD integration:**
+- Semgrep / OpenGrep: larger ecosystem, deeper coverage
+- Foxguard: faster local feedback, smaller current scope
 
-```yaml
-# GitHub Actions
-- name: Security scan
-  run: |
-    cargo install foxguard
-    foxguard scan ./src --format sarif --output results.sarif
+If you're already maintaining Semgrep rules, I'd be interested in which compatibility features matter most in practice.
 
-- name: Upload SARIF
-  uses: github/codeql-action/upload-sarif@v3
-  with:
-    sarif_file: results.sarif
-```
-
-The scan runs in 0.04s on a 10K LOC project, so it adds effectively zero time to your pipeline. But the real value is running it before CI — in the editor, on save, in the AI generation loop.
-
-MIT licensed. Single binary. No cloud dependency. No telemetry.
-
-https://github.com/peaktwilight/foxguard
-https://foxguard.dev
-
-What rules would you want for AI-generated code? I'm prioritizing based on what's actually shipping in production.
-
----
+Repo: https://github.com/peaktwilight/foxguard
 
 ### r/programming
 
-**Title:** `Foxguard: a Semgrep-compatible security linter in Rust — fast enough to run between your AI and your codebase`
+**Title:** `Foxguard: Rust security linting with Semgrep-compatible YAML support`
 
 **Body:**
 
-Here's a stat that should worry everyone using Copilot or Cursor: 80% of AI-generated code that passes functional tests still has security bugs. Not edge cases — hardcoded secrets, missing auth checks, SQL injection via string interpolation.
+Built a small security scanner in Rust called Foxguard.
 
-The tools to catch these exist (Semgrep is excellent). But they're designed for CI — 30+ seconds on a medium project. That's fine for a pipeline. It's useless when your AI is generating code in real-time and you need feedback before the next prompt.
+The goal was not "replace all existing SAST". The goal was to make local security feedback fast enough that people actually run it before CI.
 
-So I built Foxguard. It's a Rust-powered security linter that runs in <100ms. Fast enough for on-save linting, pre-commit hooks, or as a gate in the AI generation loop.
+Current feature set:
 
-**The workflow:**
+- scans JS/TS, Python, and Go
+- 36 built-in rules
+- terminal, JSON, and SARIF output
+- Semgrep-compatible YAML loading with `--rules`
 
-```
-AI writes code → foxguard checks (60ms) → fix → commit
-```
-
-**The "just run it" experience:**
+Example usage:
 
 ```bash
-# Install
 cargo install foxguard
-
-# Scan
-foxguard scan .
-
-# Output
-src/api/users.js:42:5  HIGH  JS-SQLI-001
-  SQL injection: template literal used in database query
-  → const result = await db.query(`SELECT * FROM users WHERE id = ${userId}`)
-
-src/auth/login.py:18:1  HIGH  PY-CMDI-001
-  Command injection: subprocess call with shell=True and f-string argument
-  → subprocess.run(f"echo {user_input}", shell=True)
-
-src/server/handler.go:67:3  MEDIUM  GO-PATH-001
-  Path traversal: user-controlled input in filepath.Join
-  → path := filepath.Join(baseDir, r.URL.Query().Get("file"))
-
-Found 3 issues (2 high, 1 medium) in 0.04s
+foxguard .
+foxguard --severity high .
+foxguard --format sarif .
+foxguard --rules ./semgrep-rules .
 ```
 
-**Key features:**
+The useful framing is probably:
 
-- 36 built-in rules focused on what AI gets wrong
-- **Semgrep YAML compatibility** — bring your existing rules, run them on the Rust engine
-- Framework-aware: Express, Flask, Django, Gin
-- tree-sitter AST parsing (not regex)
-- SARIF output for GitHub/GitLab integration
+- if you want a broad mature rule ecosystem, Semgrep / OpenGrep is the reference point
+- if you want a fast local Rust scanner that can also load a useful Semgrep-style subset, that's where Foxguard fits
 
-**Comparison:**
-
-| | Foxguard | Semgrep | Bandit |
-|---|---|---|---|
-| 10K LOC | 0.04s | 8.2s | 4.1s |
-| Language | Rust | Python/OCaml | Python |
-| Semgrep rules | Compatible | Native | No |
-| Best for | Editor + CI | CI | CI |
-| Rules | 36 built-in | 2000+ (community) | 70+ |
-
-Semgrep has way more rules and deeper analysis — no question. Foxguard is complementary: same rule format, fast enough for the places Semgrep can't go (your editor, your pre-commit hook, your AI generation loop).
-
-MIT licensed: https://github.com/peaktwilight/foxguard
+Repo: https://github.com/peaktwilight/foxguard
 
 ---
 
-### r/cybersecurity
+## 3. X / Twitter
 
-**Title:** `Open-source SAST tool for AI-generated code: 36 rules, Semgrep-compatible, <100ms scans (Rust)`
+### Tweet 1
 
-**Body:**
+Built `foxguard`, a Rust security linter for JS/TS, Python, and Go.
 
-For those of you dealing with the security implications of AI-generated code — I built an open-source SAST tool called Foxguard that's designed to catch what AI gets wrong, fast enough to run in the development loop instead of just CI.
+- 36 built-in rules
+- JSON + SARIF
+- Semgrep-compatible YAML loading
+- fast enough for local workflows
 
-**The problem:** I come from a SOC background (Migros Security Operations Center). The same CWEs kept coming through — SQL injection, hardcoded secrets, missing auth, framework misconfigs. Now with AI code generation, the volume of these bugs is accelerating. 80% of AI-generated code that passes tests still has security vulnerabilities. AI writes code that works but isn't safe.
+Repo: https://github.com/peaktwilight/foxguard
 
-**What Foxguard does:**
+### Tweet 2
 
-- 36 security rules focused on what AI gets wrong: scaffold boilerplate, hardcoded secrets, missing auth, framework misconfiguration
-- Semgrep YAML rule compatibility — bring your existing rules, run them 100x faster
-- Framework-aware: Express, Flask, Django, Gin
-- Every rule maps to a CWE and OWASP Top 10 category
-- SARIF output for direct integration with GitHub Advanced Security or GitLab SAST
-- <100ms on typical projects
+The pitch for Foxguard is not "AI-only security tooling" and not "full Semgrep replacement".
 
-**The key insight:** Shift-left only works if the tooling is fast enough. Foxguard is fast enough to run in-editor, on save, as a pre-commit hook, or as a gate between your AI agent and your codebase. Not just CI.
+It's:
 
-**CI/CD integration examples:**
+- local-first security feedback
+- Rust engine
+- useful built-in rules
+- Semgrep/OpenGrep-style workflow fit
 
-GitHub Actions:
-```yaml
-jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Foxguard
-        run: cargo install foxguard
-      - name: Run security scan
-        run: foxguard scan ./src --format sarif --output foxguard.sarif
-      - name: Upload results
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: foxguard.sarif
-```
+### Tweet 3
 
-Pre-commit hook:
-```bash
-#!/bin/sh
-foxguard scan --staged-only
-```
+Current checked-in benchmark snapshot for Foxguard vs Semgrep:
 
-MIT licensed, single binary, no telemetry, no cloud dependency.
+- express: `0.077s` vs `4.902s`
+- flask: `0.049s` vs `4.805s`
+- gin: `0.062s` vs `4.302s`
 
-GitHub: https://github.com/peaktwilight/foxguard
-Docs: https://foxguard.dev
+Fast enough to be reasonable in hooks and local scripts.
 
-What rules would you want for AI-generated code? What CWEs are you seeing most from Copilot/Cursor output?
+### Tweet 4
+
+If your team already has Semgrep rules, the interesting part of Foxguard is `--rules`.
+
+It supports a useful Semgrep-compatible subset today.
+
+That means the story can be "bring part of your existing workflow", not "start over with a new tool."
 
 ---
 
-## 3. Twitter/X Thread (@Peak_Twilight)
+## 4. Short Boilerplate
 
-**Tweet 1 (Hook):**
+### One-liner
 
-Your AI writes code that compiles, passes tests, and ships with security bugs.
+Foxguard is a Rust security linter for modern codebases with built-in rules, SARIF output, and Semgrep-compatible YAML rule loading.
 
-I built a security linter in Rust that catches them in 60ms — fast enough to run between your AI and your codebase.
+### Two-liner
 
-It's called Foxguard. Here's why it exists:
+Foxguard is a fast local security scanner for JS/TS, Python, and Go. It ships with built-in checks and can load a useful Semgrep-compatible YAML subset, which makes it a good complement to Semgrep or OpenGrep in local workflows.
 
-[thread]
+### Comparison Line
 
----
-
-**Tweet 2 (Problem):**
-
-80% of AI-generated code that passes functional tests still has security vulnerabilities.
-
-Hardcoded secrets. Missing auth. SQL injection. Framework misconfigs.
-
-The code works. It's just not safe. And existing SAST tools are too slow to catch it before it compounds.
+Semgrep and OpenGrep are the broader ecosystem reference points; Foxguard is the smaller Rust-native tool optimized for fast local feedback.
 
 ---
 
-**Tweet 3 (Insight):**
+## 5. FAQ Angles
 
-The insight: security linting needs to move from CI into the generation loop.
+### Is this just for AI-generated code?
 
-Semgrep takes 30+ seconds. That's fine for a pipeline.
+No. AI-generated code is one workflow where fast security feedback helps, but Foxguard is a general-purpose local security scanner.
 
-But when your AI agent is generating 50 files in a session, you need feedback in milliseconds, not minutes.
+### Is this a Semgrep replacement?
 
----
+Not fully. Foxguard currently supports a useful Semgrep-compatible subset for local rule loading, but it should be presented as complementary rather than drop-in equivalent.
 
-**Tweet 4 (What it does):**
+### Why not just use Semgrep or OpenGrep?
 
-What Foxguard does:
-
-- 36 built-in rules focused on what AI gets wrong
-- Semgrep YAML compatibility (bring your existing rules)
-- <100ms on typical projects
-- Framework-aware: Express, Flask, Django, Gin
-- Tree-sitter AST parsing, not regex
-
-The workflow: AI writes code → foxguard checks (60ms) → fix → commit
-
----
-
-**Tweet 5 (Speed benchmark):**
-
-Speed comparison on a 10K LOC project:
-
-Semgrep: 8.2 seconds
-Foxguard: 0.04 seconds
-
-Semgrep is great for CI. Foxguard is fast enough for your editor.
-
-Same rule format. Rust engine. 100x faster.
-
----
-
-**Tweet 6 (Semgrep compat):**
-
-The Semgrep compatibility matters.
-
-Teams have invested years building custom YAML rules. Foxguard reads the same format and runs it on a Rust engine.
-
-Don't throw away your rules. Just run them faster — fast enough for places Semgrep can't go (editor, pre-commit, AI loop).
-
----
-
-**Tweet 7 (Install):**
-
-Try it in 10 seconds:
-
-```
-cargo install foxguard
-foxguard scan .
-```
-
-Or: `npx foxguard`
-
-No config. No Docker. No cloud account. One binary, one command. SARIF output for GitHub/GitLab.
-
----
-
-**Tweet 8 (GitHub link):**
-
-Foxguard is MIT licensed and 100% open source.
-
-GitHub: github.com/peaktwilight/foxguard
-Docs: foxguard.dev
-
-Star it if this is useful. I'm building this in public.
-
----
-
-**Tweet 9 (Background):**
-
-Background: I come from a SOC at Migros. Same CWEs hit production over and over — SQLi, hardcoded secrets, missing auth.
-
-Now AI is generating these bugs at scale. The tooling to catch them needs to be in the generation loop, not just the CI pipeline.
-
----
-
-**Tweet 10 (CTA):**
-
-What rules would you want for AI-generated code?
-
-I'm working on:
-- VS Code / Cursor extension (lint-on-save)
-- Taint tracking (data-flow analysis)
-- More framework-specific rules
-- Plugin system for custom rules
-
-Drop a reply or open an issue.
-
----
-
-## 4. Dev.to Blog Post
-
-**Title:** I built a security linter in Rust that's 100x faster than Semgrep
-
-**Tags:** rust, security, opensource, programming
-
-**Cover image alt text:** Foxguard logo — a Rust-powered security linter
-
----
-
-Every security linter I've used has the same fatal flaw: developers disable it because it's too slow.
-
-I built Foxguard to fix that. It's a Rust-powered static analysis tool that scans your codebase for security vulnerabilities in 0.04 seconds. 28 rules across JavaScript/TypeScript, Python, and Go. MIT licensed. Single binary.
-
-Here's the full story.
-
-### The Problem: AI Code Ships With Security Flaws
-
-GitHub's own data shows that 41% of code on the platform is now AI-generated. Research from Snyk found that roughly 25% of AI-generated code contains security vulnerabilities. Not obscure edge cases — the bread-and-butter CWEs that have been on the OWASP Top 10 for a decade: SQL injection, command injection, cross-site scripting, path traversal.
-
-The tools to catch these exist. Semgrep is excellent. Bandit works. ESLint has security plugins. But they all share the same problem: they're slow. On a medium-sized project (50K lines), a Semgrep scan takes 30-40 seconds. That's long enough for developers to skip it in local development, and long enough to be annoying in CI.
-
-I come from a Security Operations Center background at Migros, one of Switzerland's largest retailers. I watched the same vulnerability classes hit production month after month. SQL injection in an API handler. Hardcoded AWS keys in a config file. `eval()` called on user input. These are all detectable at write-time — if the tooling is fast enough that people keep it enabled.
-
-### The Solution: Ruff, but for Security
-
-If you've used [Ruff](https://github.com/astral-sh/ruff), you know what happens when you rewrite a Python linter in Rust: it goes from "annoying background process" to "instant feedback." I applied the same idea to security analysis.
-
-Foxguard is a Rust-powered security linter that uses tree-sitter for AST parsing and rayon for parallelism. It scans a 10K LOC project in 0.04 seconds. A 50K LOC project takes about 0.18 seconds.
-
-Here's what a scan looks like:
-
-```bash
-$ foxguard scan ./src
-
-src/api/users.js:42:5  HIGH  JS-SQLI-001
-  SQL injection: template literal used in database query
-  → const result = await db.query(`SELECT * FROM users WHERE id = ${userId}`)
-
-src/auth/login.py:18:1  HIGH  PY-CMDI-001
-  Command injection: subprocess call with shell=True and f-string argument
-  → subprocess.run(f"echo {user_input}", shell=True)
-
-src/server/handler.go:67:3  MEDIUM  GO-PATH-001
-  Path traversal: user-controlled input in filepath.Join
-  → path := filepath.Join(baseDir, r.URL.Query().Get("file"))
-
-Found 3 issues (2 high, 1 medium) in 0.04s
-```
-
-No config files. No rule downloads. No Docker. No cloud account. Install and scan.
+You probably should for broad ecosystem coverage. Foxguard is for cases where a smaller Rust-native scanner with faster local feedback is useful.
 
 ### Why Rust?
 
-The same reason Ruff exists. Python-based tools hit a performance ceiling that no amount of optimization can break through. The GIL limits parallelism. Startup time alone eats hundreds of milliseconds. Every file operation involves Python's IO stack.
+Predictable local performance, single-binary distribution, and straightforward parallel scanning.
 
-Rust gives you:
+---
 
-- **Predictable latency** — no garbage collector pauses, no JIT warmup
-- **Trivial parallelism** — rayon lets you parallelize file scanning with a one-line change
-- **Single-binary distribution** — `cargo install foxguard` and you're done, no runtime dependencies
-- **Zero-copy operations** — parse the file once, match rules against the tree without allocating intermediate strings
+## 6. Canonical Commands
 
-### Why Tree-sitter?
-
-Most security scanners use regex pattern matching. That works until it doesn't. A regex for "detect eval with a variable argument" will flag:
-
-```javascript
-// Don't use eval(userInput) here
-const comment = "eval(safe)";
-```
-
-Neither of those is an actual `eval()` call. Tree-sitter gives us a full concrete syntax tree, so we can write queries that understand code structure:
-
-```
-(call_expression
-    function: (identifier) @func
-    arguments: (arguments
-        (identifier) @arg)
-    (#eq? @func "eval"))
-```
-
-This matches `eval(userInput)` but not `eval` inside a comment or string. Fewer false positives means developers trust the tool and keep it enabled.
-
-### Why Not an LLM?
-
-Large language models are excellent at many things. Deterministic security scanning is not one of them.
-
-A security linter needs to be:
-
-1. **Fast** — sub-second for the edit-save-lint loop
-2. **Deterministic** — the same code must produce the same results every time
-3. **Auditable** — when something is flagged, you need to know exactly why, mapped to a specific CWE
-4. **Offline** — no API calls, no cloud dependency, works in air-gapped environments
-
-LLMs fail on all four. They're slow (seconds per request), nondeterministic (different results on the same input), opaque (no CWE mapping), and require network access.
-
-Use LLMs for code review and threat modeling. Use deterministic tooling for CI gates.
-
-### Benchmarks
-
-Measured with `hyperfine` on a real-world Node.js project:
-
-| Tool | 10K LOC | 50K LOC | 100K LOC |
-|---|---|---|---|
-| Foxguard (28 rules) | 0.04s | 0.18s | 0.91s |
-| Semgrep (25 rules) | 8.2s | 34.1s | 72.3s |
-| Bandit (Python only) | 4.1s | — | — |
-
-Foxguard is roughly 200x faster on the 10K LOC benchmark. The gap widens with project size because Rust's parallelism scales linearly with cores while Python-based tools hit the GIL.
-
-### What It Catches
-
-28 rules across three languages, covering the vulnerabilities that actually show up in production:
-
-**JavaScript/TypeScript:**
-- SQL injection via string concatenation and template literals
-- XSS via innerHTML, document.write, and dangerouslySetInnerHTML
-- Command injection via child_process with unsanitized input
-- Prototype pollution
-- Hardcoded secrets and API keys
-- Use of eval() with dynamic arguments
-- Weak cryptographic algorithms
-
-**Python:**
-- SQL injection via f-strings and format() in queries
-- Command injection via subprocess with shell=True
-- Unsafe deserialization (pickle, yaml.load)
-- SSRF via unvalidated URLs in requests
-- Path traversal in file operations
-- Hardcoded secrets
-
-**Go:**
-- SQL injection via fmt.Sprintf in queries
-- Path traversal via unsanitized input in filepath operations
-- Command injection via os/exec with user input
-- Use of weak cryptographic primitives
-- Unvalidated redirects
-
-Every rule maps to a CWE identifier and includes an OWASP Top 10 category reference.
-
-### CI/CD Integration
-
-Foxguard outputs SARIF, which means it integrates directly with GitHub Advanced Security and GitLab SAST:
-
-```yaml
-# GitHub Actions
-jobs:
-  security:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Foxguard
-        run: cargo install foxguard
-      - name: Scan
-        run: foxguard scan ./src --format sarif --output results.sarif
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-```
-
-Because it runs in under a second, you can also use it as a pre-commit hook:
-
-```bash
-#!/bin/sh
-foxguard scan --staged-only
-```
-
-Shift-left only works if the tooling doesn't slow people down.
-
-### What's Next
-
-Foxguard is at v0.2 with 28 rules. Here's the roadmap:
-
-- **50+ rules by v0.3** — expanding coverage for all three languages
-- **Taint tracking** — data-flow analysis to trace user input through the program to dangerous sinks (this is where the real power of AST-based analysis shows up)
-- **TypeScript-specific rules** — using type information for more precise analysis
-- **Plugin system** — WASM-based custom rules so teams can add their own patterns
-- **More languages** — Java and C# are the most requested
-
-### Try It
-
-```bash
+```sh
 cargo install foxguard
-foxguard scan .
+npx foxguard .
+foxguard .
+foxguard --severity high .
+foxguard --format json .
+foxguard --format sarif .
+foxguard --rules ./semgrep-rules .
 ```
-
-Or grab a prebuilt binary from the [releases page](https://github.com/peaktwilight/foxguard/releases).
-
-- **GitHub:** [github.com/peaktwilight/foxguard](https://github.com/peaktwilight/foxguard)
-- **Docs:** [foxguard.dev](https://foxguard.dev)
-- **License:** MIT
-
-I'm building this in public and prioritizing rules based on community feedback. If there's a vulnerability class you keep seeing in production, open an issue or drop a comment below.
-
-What security rules would you want to see?

--- a/README.md
+++ b/README.md
@@ -5,18 +5,25 @@
 <h1 align="center">foxguard</h1>
 
 <p align="center">
-  The security linter fast enough to sit between your AI and your codebase.
+  Fast security linting for modern codebases.
   <br/>
   <a href="https://foxguard.dev">foxguard.dev</a> | <a href="https://crates.io/crates/foxguard">crates.io</a> | <a href="https://www.npmjs.com/package/foxguard">npm</a>
 </p>
 
-> Your AI writes code. foxguard catches what it gets wrong.
+> Fast local security scanning for JS/TS, Python, and Go.
 
-## The Problem
+## What foxguard is
 
-80% of AI-generated code that passes functional tests still has security bugs ([SusVibes, 2025](https://arxiv.org/abs/2512.03559)). Existing SAST tools were built for human-written code -- they miss the patterns AI gets wrong: scaffold boilerplate with hardcoded secrets, over-permissive defaults, missing auth middleware, BaaS misconfigurations.
+foxguard is a Rust security linter built for the edit-save-commit loop. It runs locally, scans quickly, emits terminal/JSON/SARIF output, and can load Semgrep-compatible YAML rules with `--rules`.
 
-foxguard is purpose-built for the vibe coding era.
+The point of the product is not "our opinionated rules vs everyone else's". The point is fast security feedback in a form teams can actually drop into existing workflows.
+
+Use it:
+
+- on a repo before commit
+- in scripts and CI
+- with the built-in rules
+- with your own Semgrep-style or OpenGrep-style rules
 
 ## Install
 
@@ -25,7 +32,7 @@ cargo install foxguard
 ```
 
 ```sh
-npx foxguard
+npx foxguard .
 ```
 
 ## Usage
@@ -34,7 +41,14 @@ npx foxguard
 foxguard .
 ```
 
+```sh
+foxguard --severity high .
+foxguard --format json .
+foxguard --format sarif .
+foxguard --rules ./rules .
 ```
+
+```text
 src/app.js
   12:5  CRITICAL  js/express-no-hardcoded-session-secret (CWE-798)
         Hardcoded session secret -- use environment variables
@@ -44,37 +58,29 @@ src/app.js
 WARNING 2 issues found: 1 critical, 1 high, 0 medium, 0 low
 ```
 
-## What It Catches
+## Why foxguard
 
-36 security rules across 3 languages, focused on what AI gets wrong:
+- Fast enough to run locally without becoming background noise
+- Single binary, no JVM, no Python runtime, no network calls
+- Semgrep-compatible rule loading via `--rules`
+- Built-in security coverage out of the box
+- SARIF output for code scanning and CI systems
 
-**AI scaffold patterns**
-- Hardcoded secrets and placeholder credentials (CWE-798)
-- Debug mode left enabled (CWE-489)
-- Missing cookie security flags (CWE-614, CWE-1004)
-- CORS allow-all origins (CWE-942)
+foxguard is best thought of as a fast security engine you can slot into your workflow, not as a closed rules product.
 
-**Injection**
-- SQL injection via string concatenation (CWE-89)
-- Command injection via exec/spawn (CWE-78)
-- XSS via innerHTML, document.write, res.send (CWE-79)
-- Path traversal (CWE-22)
+## Bring your own rules
 
-**Framework-specific (Express, Flask, Django, Gin)**
-- Express hardcoded session secrets
-- Express direct response write with user input
-- Flask debug mode enabled
-- Django SECRET_KEY hardcoded
-- Gin missing trusted proxies
-- net/http missing timeouts
+foxguard can load Semgrep-compatible YAML rules from a file or directory:
 
-**Crypto and data safety**
-- Weak crypto (MD5, SHA1) (CWE-327)
-- Unsafe deserialization: pickle, yaml.load (CWE-502)
-- Prototype pollution (CWE-1321)
-- SSRF via dynamic URLs (CWE-918)
+```sh
+foxguard --rules ./semgrep-rules .
+```
 
-## Languages
+foxguard currently supports a useful Semgrep-compatible subset for local rule loading. That makes it a good fit for teams already using Semgrep or OpenGrep-style rules, without claiming full drop-in compatibility.
+
+## Built-in coverage
+
+foxguard currently ships with 36 built-in rules across 3 languages:
 
 | Language | Rules | Frameworks |
 |----------|-------|------------|
@@ -82,19 +88,20 @@ WARNING 2 issues found: 1 critical, 1 high, 0 medium, 0 low
 | Python | 13 | Flask, Django |
 | Go | 7 | Gin, net/http |
 
-## Output Formats
+Examples of included checks:
 
-```sh
-foxguard .                    # Colored terminal output
-foxguard --format json .      # JSON
-foxguard --format sarif .     # SARIF (GitHub Code Scanning)
-foxguard --severity high .    # Filter by severity
-```
+- Hardcoded secrets and placeholder credentials
+- SQL injection via string interpolation
+- Command injection via exec/spawn
+- XSS via unsafe response or DOM writes
+- Weak crypto such as MD5 and SHA1
+- Unsafe deserialization
+- Framework misconfigurations
 
 ## GitHub Action
 
 ```yaml
-- uses: peaktwilight/foxguard-action@v1
+- uses: peaktwilight/foxguard/action@v1
   with:
     path: .
     severity: medium
@@ -104,12 +111,11 @@ foxguard --severity high .    # Filter by severity
 
 | Repository | Files | foxguard | Semgrep | Speedup |
 |------------|-------|----------|---------|---------|
-| express | 141 | 0.57s | 5.3s | 9x |
-| flask | 83 | 0.06s | 5.2s | 85x |
-| gin | 99 | 0.08s | 4.7s | 60x |
-| next.js | 14,777 | 4.5s | 229s | 51x |
+| express | 141 | 0.077s | 4.902s | 64x |
+| flask | 83 | 0.049s | 4.805s | 98x |
+| gin | 99 | 0.062s | 4.302s | 69x |
 
-Rust + tree-sitter + rayon. No JVM, no Python runtime, no network calls.
+Rust + tree-sitter + rayon.
 
 ## License
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,5 +1,5 @@
 name: "Foxguard Security Scan"
-description: "Blazing fast security linter for modern codebases"
+description: "Fast security linting for modern codebases"
 author: "peaktwilight"
 
 branding:

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -21,6 +21,7 @@ ARCH=$(uname -m)
 case "${OS}" in
     linux)  PLATFORM="linux" ;;
     darwin) PLATFORM="macos" ;;
+    mingw*|msys*|cygwin*) PLATFORM="windows" ;;
     *)      echo "::error::Unsupported OS: ${OS}"; exit 1 ;;
 esac
 
@@ -30,7 +31,13 @@ case "${ARCH}" in
     *)             echo "::error::Unsupported architecture: ${ARCH}"; exit 1 ;;
 esac
 
-BINARY_NAME="foxguard-${PLATFORM}-${ARCH_SUFFIX}"
+if [ "${PLATFORM}" = "windows" ]; then
+    BINARY_NAME="foxguard-${PLATFORM}-${ARCH_SUFFIX}.exe"
+    EXECUTABLE_NAME="foxguard.exe"
+else
+    BINARY_NAME="foxguard-${PLATFORM}-${ARCH_SUFFIX}"
+    EXECUTABLE_NAME="foxguard"
+fi
 
 # ─── Download binary ────────────────────────────────────────────────────────
 
@@ -41,8 +48,10 @@ echo "URL: ${DOWNLOAD_URL}"
 INSTALL_DIR="${RUNNER_TEMP:-/tmp}/foxguard"
 mkdir -p "${INSTALL_DIR}"
 
-curl -sL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/foxguard"
-chmod +x "${INSTALL_DIR}/foxguard"
+curl -sL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${EXECUTABLE_NAME}"
+if [ "${PLATFORM}" != "windows" ]; then
+    chmod +x "${INSTALL_DIR}/${EXECUTABLE_NAME}"
+fi
 echo "::endgroup::"
 
 # ─── Build arguments ────────────────────────────────────────────────────────
@@ -61,14 +70,15 @@ fi
 
 # ─── Run scan ────────────────────────────────────────────────────────────────
 
-echo "::group::Running foxguard scan"
+echo "::group::Running foxguard"
 echo "foxguard ${ARGS[*]}"
 
 SARIF_FILE="${RUNNER_TEMP:-/tmp}/foxguard-results.sarif"
 EXIT_CODE=0
+EXECUTABLE_PATH="${INSTALL_DIR}/${EXECUTABLE_NAME}"
 
 if [ "${FORMAT}" = "sarif" ]; then
-    "${INSTALL_DIR}/foxguard" "${ARGS[@]}" > "${SARIF_FILE}" || EXIT_CODE=$?
+    "${EXECUTABLE_PATH}" "${ARGS[@]}" > "${SARIF_FILE}" || EXIT_CODE=$?
     FINDINGS_COUNT=$(python3 -c "
 import json, sys
 try:
@@ -79,7 +89,7 @@ except:
     print(0)
 " 2>/dev/null || echo "0")
 else
-    OUTPUT=$("${INSTALL_DIR}/foxguard" "${ARGS[@]}" 2>&1) || EXIT_CODE=$?
+    OUTPUT=$("${EXECUTABLE_PATH}" "${ARGS[@]}" 2>&1) || EXIT_CODE=$?
     echo "${OUTPUT}"
     if [ "${FORMAT}" = "json" ]; then
         FINDINGS_COUNT=$(echo "${OUTPUT}" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -100,7 +100,7 @@ for entry in "${REPOS[@]}"; do
   fox_output=$($FOXGUARD "$repo_path" --format json 2>/dev/null || true)
   fox_end=$(perl -MTime::HiRes=time -e 'printf "%.3f\n", time')
   fox_time=$(perl -e "printf '%.3f', $fox_end - $fox_start")
-  fox_findings=$(echo "$fox_output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('total_findings', len(d.get('findings', []))))" 2>/dev/null || echo "0")
+  fox_findings=$(echo "$fox_output" | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d, list) else d.get('total_findings', len(d.get('findings', []))))" 2>/dev/null || echo "0")
   echo "${fox_time}s, ${fox_findings} findings"
 
   # semgrep

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,10 +1,10 @@
 # foxguard
 
-Blazing fast security linter for modern codebases. Written in Rust.
-
-> The Ruff of security.
+Fast security linting for modern codebases. Written in Rust.
 
 This is the npm wrapper for foxguard. It downloads the correct prebuilt binary for your platform from GitHub Releases.
+
+foxguard scans JS/TS, Python, and Go with built-in security rules and can load a useful Semgrep-compatible YAML subset with `--rules`.
 
 ## Usage
 

--- a/packages/npm/bin/foxguard
+++ b/packages/npm/bin/foxguard
@@ -110,26 +110,24 @@ async function downloadBinary() {
     }
   }
 
-  const ext = os.platform() === "win32" ? ".zip" : ".tar.gz";
-  const assetName = `foxguard-v${VERSION}-${target}${ext}`;
+  const [arch, vendor, osPart] = target.split("-");
+  let assetName;
+  if (osPart === "darwin") {
+    assetName = `foxguard-macos-${arch}`;
+  } else if (osPart === "linux") {
+    assetName = `foxguard-linux-${arch}`;
+  } else if (osPart === "windows") {
+    assetName = `foxguard-windows-${arch}.exe`;
+  } else {
+    throw new Error(`unsupported release target: ${target}`);
+  }
   const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${assetName}`;
 
   console.error(`foxguard: downloading v${VERSION} for ${target}...`);
 
   try {
     const data = await download(url);
-    const archivePath = path.join(cacheDir, assetName);
-    fs.writeFileSync(archivePath, data);
-
-    // Extract
-    if (ext === ".tar.gz") {
-      execSync(`tar -xzf "${archivePath}" -C "${cacheDir}"`, { stdio: "pipe" });
-    } else {
-      execSync(`unzip -o "${archivePath}" -d "${cacheDir}"`, { stdio: "pipe" });
-    }
-
-    // Clean up archive
-    fs.unlinkSync(archivePath);
+    fs.writeFileSync(cachedBin, data);
 
     // Make executable
     if (os.platform() !== "win32") {

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foxguard",
   "version": "0.1.0",
-  "description": "Security linter for AI-generated code for modern codebases. The Ruff of security.",
+  "description": "Fast security linting for modern codebases.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,7 @@ pub enum SeverityFilter {
 #[derive(Parser, Debug)]
 #[command(
     name = "foxguard",
-    about = "Blazing fast security linter for modern codebases",
+    about = "Fast security linting for modern codebases",
     version
 )]
 pub struct Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,12 @@ fn main() {
     let cli = Cli::parse();
     let mut registry = RuleRegistry::new();
 
+    let scan_path = Path::new(&cli.path);
+    if !scan_path.exists() {
+        eprintln!("Error: path '{}' does not exist", cli.path);
+        std::process::exit(2);
+    }
+
     // Load external Semgrep YAML rules if --rules is provided
     if let Some(ref rules_path) = cli.rules {
         let path = Path::new(rules_path);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -188,6 +188,26 @@ fn test_safe_go_no_findings() {
     assert_eq!(findings.len(), 0, "safe.go should have 0 findings");
 }
 
+#[test]
+fn test_invalid_path_exits_nonzero() {
+    let output = foxguard_cmd()
+        .args(["not_a_real_path_foxguard_test", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        !output.status.success(),
+        "invalid paths should exit non-zero"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "expected missing path error, got: {}",
+        stderr
+    );
+}
+
 // ─── Severity filtering ─────────────────────────────────────────────────────
 
 #[test]

--- a/www/src/layouts/Base.astro
+++ b/www/src/layouts/Base.astro
@@ -4,7 +4,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'Blazing fast security linter for modern codebases. Written in Rust.' } = Astro.props;
+const { title, description = 'Fast security linting for modern codebases. Written in Rust.' } = Astro.props;
 ---
 
 <!doctype html>

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -56,7 +56,7 @@ function severityColor(s: string) {
 }
 ---
 
-<Base title="foxguard - The security linter for AI-generated code">
+<Base title="foxguard - Fast security linting for modern codebases">
 
   <!-- Hero -->
   <section class="relative pt-24 pb-16 sm:pt-32 sm:pb-20">
@@ -86,10 +86,10 @@ function severityColor(s: string) {
 
       <!-- Tagline -->
       <p class="fade-up fade-up-delay-3 text-lg sm:text-xl text-smoke max-w-2xl mx-auto mb-4">
-        The security linter <span class="text-white font-semibold">fast enough to sit between your AI and your codebase.</span>
+        Fast security linting <span class="text-white font-semibold">for local workflows and modern codebases.</span>
       </p>
       <p class="fade-up fade-up-delay-3 text-sm sm:text-base text-ash max-w-xl mx-auto mb-10">
-        Your AI writes code. foxguard catches what it gets wrong. {totalRules} rules for JS/TS, Python, Go. Semgrep-compatible. Rust-fast.
+        Scan JS/TS, Python, and Go with built-in rules, JSON or SARIF output, and Semgrep-compatible rule loading on a Rust engine.
       </p>
 
       <!-- npx copy button -->
@@ -99,7 +99,7 @@ function severityColor(s: string) {
           class="group relative flex items-center gap-3 bg-night-light border border-night-lighter hover:border-fox/30 rounded-lg px-5 py-3 font-mono text-sm text-fox transition-all duration-200 cursor-pointer"
         >
           <span class="text-ash">$</span>
-          <span>npx foxguard</span>
+          <span>npx foxguard .</span>
           <svg class="w-4 h-4 text-ash group-hover:text-fox transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
         </button>
 
@@ -154,15 +154,15 @@ function severityColor(s: string) {
   <!-- Speed -->
   <section class="py-20 border-t border-night-lighter" id="speed">
     <div class="max-w-5xl mx-auto px-6 text-center">
-      <h2 class="font-heading text-3xl font-bold text-white mb-2">Fast enough for the generation loop</h2>
-      <p class="text-ash mb-10">Benchmark: next.js monorepo, 14,777 files</p>
+      <h2 class="font-heading text-3xl font-bold text-white mb-2">Fast enough for local workflows</h2>
+      <p class="text-ash mb-10">Checked-in benchmark suite: express repository, 141 files</p>
 
       <div class="max-w-xl mx-auto flex flex-col gap-4 mb-12">
         <div class="flex items-center gap-4">
           <span class="font-mono text-sm text-ash w-24 text-right shrink-0">foxguard</span>
           <div class="flex-1 bg-night-light rounded h-9 overflow-hidden">
             <div class="h-full rounded bg-fox flex items-center justify-end px-3 min-w-[60px]" style="width: 2%">
-              <span class="font-mono text-xs font-semibold text-night">4.5s</span>
+              <span class="font-mono text-xs font-semibold text-night">0.077s</span>
             </div>
           </div>
         </div>
@@ -170,18 +170,18 @@ function severityColor(s: string) {
           <span class="font-mono text-sm text-ash w-24 text-right shrink-0">Semgrep</span>
           <div class="flex-1 bg-night-light rounded h-9 overflow-hidden">
             <div class="h-full rounded bg-night-lighter flex items-center justify-end px-3 min-w-[60px]" style="width: 100%">
-              <span class="font-mono text-xs font-semibold text-white">229s</span>
+              <span class="font-mono text-xs font-semibold text-white">4.902s</span>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Generation loop diagram -->
+      <!-- Local workflow diagram -->
       <div class="max-w-2xl mx-auto mb-10">
         <div class="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-0 font-mono text-sm">
-          <div class="bg-night-light border border-night-lighter rounded-lg px-4 py-3 text-ash">AI writes code</div>
+          <div class="bg-night-light border border-night-lighter rounded-lg px-4 py-3 text-ash">edit</div>
           <svg class="w-6 h-6 text-fox shrink-0 rotate-90 sm:rotate-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14m-7-7 7 7-7 7"/></svg>
-          <div class="bg-fox/10 border border-fox/30 rounded-lg px-4 py-3 text-fox font-semibold">foxguard checks <span class="text-fox/70">(60ms)</span></div>
+          <div class="bg-fox/10 border border-fox/30 rounded-lg px-4 py-3 text-fox font-semibold">foxguard checks <span class="text-fox/70">(77ms)</span></div>
           <svg class="w-6 h-6 text-fox shrink-0 rotate-90 sm:rotate-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14m-7-7 7 7-7 7"/></svg>
           <div class="bg-night-light border border-night-lighter rounded-lg px-4 py-3 text-ash">fix</div>
           <svg class="w-6 h-6 text-fox shrink-0 rotate-90 sm:rotate-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14m-7-7 7 7-7 7"/></svg>
@@ -190,8 +190,8 @@ function severityColor(s: string) {
       </div>
 
       <p class="text-ash text-sm max-w-lg mx-auto text-center">
-        <span class="text-white font-semibold">Semgrep:</span> great for CI.
-        <span class="text-fox font-semibold">foxguard:</span> fast enough for your editor.
+        <span class="text-white font-semibold">Semgrep / OpenGrep:</span> broad rule ecosystems.
+        <span class="text-fox font-semibold">foxguard:</span> fast local feedback on a Rust engine.
       </p>
     </div>
   </section>
@@ -200,14 +200,14 @@ function severityColor(s: string) {
   <section class="py-20 border-t border-night-lighter" id="features">
     <div class="max-w-5xl mx-auto px-6 text-center">
       <h2 class="font-heading text-3xl font-bold text-white mb-2">Features</h2>
-      <p class="text-ash mb-10">Security linting that keeps up with AI-speed development.</p>
+      <p class="text-ash mb-10">Security linting built for local feedback and existing workflows.</p>
 
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
         {[
-          { icon: '< 60ms', title: 'In-editor speed', desc: 'Fast enough for VS Code, Cursor, pre-commit. Not just CI.' },
-          { icon: '80%', title: 'Built for AI code', desc: 'Rules targeting what AI gets wrong: scaffold boilerplate, hardcoded secrets, missing auth.' },
-          { icon: '.yaml', title: 'Semgrep compatible', desc: 'Bring your existing YAML rules. Same syntax, Rust engine.' },
-          { icon: '4+', title: 'Framework-aware', desc: 'Express, Flask, Django, Gin. Not just generic patterns.' },
+          { icon: '< 60ms', title: 'Local-first speed', desc: 'Fast enough for edit-save-commit loops, hooks, and scripts.' },
+          { icon: '.yaml', title: 'Custom rules', desc: 'Load a useful Semgrep-compatible YAML subset from a file or directory.' },
+          { icon: '36', title: 'Built-in coverage', desc: 'Security checks for JS/TS, Python, and Go, including framework-specific rules.' },
+          { icon: 'SARIF', title: 'CI-friendly output', desc: 'Use terminal output locally or JSON and SARIF in automation.' },
         ].map((f) => (
           <div class="group bg-night-light border border-night-lighter rounded-xl p-6 hover:border-fox/20 transition-colors">
             <div class="text-xs font-mono font-bold text-fox mb-3 tracking-wider">{f.icon}</div>
@@ -215,6 +215,37 @@ function severityColor(s: string) {
             <p class="text-sm text-ash leading-relaxed">{f.desc}</p>
           </div>
         ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Positioning -->
+  <section class="py-20 border-t border-night-lighter" id="positioning">
+    <div class="max-w-5xl mx-auto px-6">
+      <div class="text-center mb-10">
+        <h2 class="font-heading text-3xl font-bold text-white mb-2">Where It Fits</h2>
+        <p class="text-ash">foxguard is best positioned as a local-first complement, not a claim of full tool replacement.</p>
+      </div>
+
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div class="bg-night-light border border-night-lighter rounded-xl p-6">
+          <div class="text-xs font-mono font-bold text-ash mb-3 tracking-wider">SEMGREP / OPENGREP</div>
+          <h3 class="text-white font-semibold mb-3">Broad ecosystem coverage</h3>
+          <div class="flex flex-col gap-2 text-sm text-ash">
+            <div>Large existing rule ecosystems</div>
+            <div>Strong CI and platform fit</div>
+            <div>Broader language and analysis scope</div>
+          </div>
+        </div>
+        <div class="bg-night-light border border-fox/25 rounded-xl p-6 shadow-[0_0_0_1px_rgba(245,158,11,0.06)]">
+          <div class="text-xs font-mono font-bold text-fox mb-3 tracking-wider">FOXGUARD</div>
+          <h3 class="text-white font-semibold mb-3">Fast local feedback on a Rust engine</h3>
+          <div class="flex flex-col gap-2 text-sm text-ash">
+            <div>Useful built-in rules out of the box</div>
+            <div>Terminal, JSON, and SARIF output</div>
+            <div>Semgrep-compatible YAML subset loading with <code>--rules</code></div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -238,8 +269,8 @@ function severityColor(s: string) {
         <div class="bg-night-light border border-night-lighter rounded-xl p-5">
           <div class="text-xs font-semibold text-ash uppercase tracking-wider mb-3">npm / npx</div>
           <div class="flex items-center justify-between bg-night border border-night-lighter rounded-lg px-4 py-3 font-mono text-sm text-fox">
-            <code>npx foxguard</code>
-            <button class="copy-btn text-ash hover:text-white transition-colors cursor-pointer" data-copy="npx foxguard" aria-label="Copy">
+            <code>npx foxguard .</code>
+            <button class="copy-btn text-ash hover:text-white transition-colors cursor-pointer" data-copy="npx foxguard ." aria-label="Copy">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
             </button>
           </div>


### PR DESCRIPTION
## What changed

- repositioned foxguard across the repo as a Rust local-first security scanner rather than an AI-only tool
- aligned README, launch copy, website, npm metadata, Cargo metadata, and action metadata around Semgrep/OpenGrep-style compatibility as a subset rather than a full drop-in claim
- fixed runtime and distribution issues including missing-path handling, benchmark counting, npm binary asset resolution, and GitHub Action binary naming

## Why it changed

The repo messaging had drifted away from the actual product shape. The codebase is a fast local security scanner with built-in rules plus a useful Semgrep-compatible subset, so the public copy needed to reflect that more accurately.

This also fixes a few real product issues that would have caused confusing behavior or broken packaging flows.

## User impact

- clearer and more credible positioning for users evaluating foxguard against Semgrep or OpenGrep
- invalid scan paths now fail instead of silently reporting no findings
- npm wrapper downloads now match the release asset naming
- GitHub Action download/execution paths are aligned with published binaries
- benchmark artifacts and published benchmark numbers are now consistent

## Validation

- cargo test
- bash -n action/entrypoint.sh
- node --check packages/npm/bin/foxguard
- npm --prefix www run build
- reran benchmarks/run.sh and refreshed the checked-in benchmark snapshot
