### PR TITLE
Add inline ignore comments for code findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,30 @@ secrets:
     - secret/github-token
 ```
 
+## Suppressing Deliberate Findings
+
+For one-off, deliberate code patterns, you can suppress code-scan findings inline instead of
+adding them to a baseline.
+
+```js
+// Ignore the next code line for one rule
+// foxguard: ignore[js/no-ssrf]
+fileContent = fetch(userControlledUrl);
+
+// Ignore the current line for one rule
+fileContent = fetch(userControlledUrl); // foxguard: ignore[js/no-ssrf]
+
+// Ignore the current line for all foxguard code findings
+eval(userInput); // foxguard: ignore
+```
+
+Notes:
+
+- Inline ignores currently apply to code scanning findings, not `foxguard secrets`.
+- Rule IDs must match exactly, for example `js/no-ssrf`.
+- Comment-only directives apply to the next non-empty, non-comment code line.
+- Supported comment styles are `//` and `#`, depending on the language.
+
 ## Contributing
 
 Adding a rule is one struct implementing a trait. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -2,9 +2,12 @@ use crate::rules::RuleRegistry;
 use crate::{Finding, Language};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::time::Instant;
 
 /// Result of a scan with metadata.
@@ -12,6 +15,23 @@ pub struct ScanResult {
     pub findings: Vec<Finding>,
     pub files_scanned: usize,
     pub duration: std::time::Duration,
+}
+
+#[derive(Default)]
+struct InlineIgnoreSpec {
+    all_rules: bool,
+    rule_ids: HashSet<String>,
+}
+
+impl InlineIgnoreSpec {
+    fn matches(&self, rule_id: &str) -> bool {
+        self.all_rules || self.rule_ids.contains(rule_id)
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.all_rules |= other.all_rules;
+        self.rule_ids.extend(other.rule_ids);
+    }
 }
 
 /// Detect language from file extension.
@@ -123,6 +143,133 @@ fn is_minified(source: &str) -> bool {
     avg_line_len > 300
 }
 
+fn inline_ignore_regex() -> &'static Regex {
+    static INLINE_IGNORE_REGEX: OnceLock<Regex> = OnceLock::new();
+    INLINE_IGNORE_REGEX.get_or_init(|| {
+        Regex::new(r"^foxguard\s*:\s*ignore(?:\[(?P<rules>[^\]]*)\])?\s*$")
+            .expect("invalid inline ignore regex")
+    })
+}
+
+fn inline_ignore_directives(source: &str, language: Language) -> HashMap<usize, InlineIgnoreSpec> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut directives = HashMap::new();
+
+    for (index, line) in lines.iter().enumerate() {
+        let line_number = index + 1;
+        let Some((comment_only, spec)) = parse_inline_ignore(line, language) else {
+            continue;
+        };
+
+        let target_line = if comment_only {
+            next_code_line(&lines, line_number, language)
+        } else {
+            Some(line_number)
+        };
+
+        if let Some(target_line) = target_line {
+            directives
+                .entry(target_line)
+                .or_insert_with(InlineIgnoreSpec::default)
+                .merge(spec);
+        }
+    }
+
+    directives
+}
+
+fn parse_inline_ignore(line: &str, language: Language) -> Option<(bool, InlineIgnoreSpec)> {
+    let mut markers = comment_markers(language)
+        .iter()
+        .copied()
+        .flat_map(|marker| {
+            let mut positions = Vec::new();
+            let mut start = 0;
+            while let Some(offset) = line[start..].find(marker) {
+                let index = start + offset;
+                positions.push((index, marker));
+                start = index + marker.len();
+            }
+            positions
+        })
+        .collect::<Vec<_>>();
+
+    markers.sort_by_key(|(index, _)| *index);
+
+    for (index, marker) in markers {
+        let comment_text = line[index + marker.len()..].trim();
+        let Some(captures) = inline_ignore_regex().captures(comment_text) else {
+            continue;
+        };
+
+        let mut spec = InlineIgnoreSpec::default();
+        match captures.name("rules").map(|rules| rules.as_str().trim()) {
+            None | Some("") => spec.all_rules = true,
+            Some(rules) => {
+                for rule_id in rules
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|rule| !rule.is_empty())
+                {
+                    spec.rule_ids.insert(rule_id.to_string());
+                }
+                if spec.rule_ids.is_empty() {
+                    spec.all_rules = true;
+                }
+            }
+        }
+
+        let comment_only = line[..index].trim().is_empty();
+        return Some((comment_only, spec));
+    }
+
+    None
+}
+
+fn next_code_line(lines: &[&str], line_number: usize, language: Language) -> Option<usize> {
+    for (index, line) in lines.iter().enumerate().skip(line_number) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || is_comment_only_line(trimmed, language) {
+            continue;
+        }
+        return Some(index + 1);
+    }
+    None
+}
+
+fn is_comment_only_line(trimmed_line: &str, language: Language) -> bool {
+    comment_markers(language)
+        .iter()
+        .any(|marker| trimmed_line.starts_with(marker))
+}
+
+fn comment_markers(language: Language) -> &'static [&'static str] {
+    match language {
+        Language::Python | Language::Ruby => &["#"],
+        Language::Php => &["//", "#"],
+        Language::JavaScript
+        | Language::Go
+        | Language::Java
+        | Language::Rust
+        | Language::CSharp
+        | Language::Swift => &["//"],
+    }
+}
+
+fn apply_inline_ignores(
+    findings: Vec<Finding>,
+    directives: &HashMap<usize, InlineIgnoreSpec>,
+) -> Vec<Finding> {
+    findings
+        .into_iter()
+        .filter(|finding| {
+            directives
+                .get(&finding.line)
+                .is_none_or(|spec| !spec.matches(&finding.rule_id))
+        })
+        .collect()
+}
+
 fn scan_files(
     scan_root: &Path,
     files: Vec<(PathBuf, Language)>,
@@ -147,6 +294,8 @@ fn scan_files(
             return;
         }
 
+        let inline_ignores = inline_ignore_directives(&source, *language);
+
         let Some(tree) = super::parser::parse_file(&source, *language) else {
             return;
         };
@@ -163,6 +312,7 @@ fn scan_files(
             for f in &mut rule_findings {
                 f.file = file_str.clone();
             }
+            let rule_findings = apply_inline_ignores(rule_findings, &inline_ignores);
             if !rule_findings.is_empty() {
                 findings.lock().unwrap().extend(rule_findings);
             }

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -263,9 +263,11 @@ fn apply_inline_ignores(
     findings
         .into_iter()
         .filter(|finding| {
-            directives
-                .get(&finding.line)
-                .is_none_or(|spec| !spec.matches(&finding.rule_id))
+            !(finding.line..=finding.end_line).any(|line| {
+                directives
+                    .get(&line)
+                    .is_some_and(|spec| spec.matches(&finding.rule_id))
+            })
         })
         .collect()
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -847,6 +847,59 @@ fn test_inline_ignore_remains_rule_specific() {
 }
 
 #[test]
+fn test_inline_ignore_without_rule_list_suppresses_all_findings_on_line() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let target = repo.path().join("ignored-all.js");
+    fs::write(
+        &target,
+        "const user_input = process.argv[2];\neval(user_input); // foxguard: ignore\n",
+    )
+    .expect("failed to write fixture");
+
+    let output = foxguard_cmd()
+        .args([target.to_str().expect("non-utf8 path"), "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "ignore without rule list should suppress all findings on the line"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert!(findings.is_empty(), "expected no findings after ignore-all");
+}
+
+#[test]
+fn test_inline_ignore_suppresses_multiline_finding_when_directive_is_on_end_line() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let target = repo.path().join("multiline-ignored.js");
+    fs::write(
+        &target,
+        "const user_input = process.argv[2];\neval(\n  user_input // foxguard: ignore[js/no-eval]\n);\n",
+    )
+    .expect("failed to write fixture");
+
+    let output = foxguard_cmd()
+        .args([target.to_str().expect("non-utf8 path"), "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "directive on the end line of a multiline finding should still suppress it"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert!(
+        findings.is_empty(),
+        "expected no findings after multiline inline ignore"
+    );
+}
+
+#[test]
 fn test_changed_mode_scans_only_staged_files() {
     let repo = setup_git_repo(&["vulnerable.js", "safe.py"]);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -768,6 +768,85 @@ fn test_scan_uses_discovered_config_baseline() {
 }
 
 #[test]
+fn test_inline_ignore_suppresses_same_line_js_finding() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let target = repo.path().join("ignored.js");
+    fs::write(
+        &target,
+        "const user_input = process.argv[2];\neval(user_input); // foxguard: ignore[js/no-eval]\n",
+    )
+    .expect("failed to write fixture");
+
+    let output = foxguard_cmd()
+        .args([target.to_str().expect("non-utf8 path"), "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "same-line ignore should suppress the matching finding"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert!(
+        findings.is_empty(),
+        "expected no findings after same-line ignore"
+    );
+}
+
+#[test]
+fn test_inline_ignore_suppresses_next_python_line_after_blank_lines() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let target = repo.path().join("ignored.py");
+    fs::write(&target, "# foxguard: ignore[py/no-eval]\n\neval(input())\n")
+        .expect("failed to write fixture");
+
+    let output = foxguard_cmd()
+        .args([target.to_str().expect("non-utf8 path"), "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "comment-only ignore should suppress the next code-line finding"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert!(
+        findings.is_empty(),
+        "expected no findings after next-line ignore"
+    );
+}
+
+#[test]
+fn test_inline_ignore_remains_rule_specific() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let target = repo.path().join("not-ignored.js");
+    fs::write(
+        &target,
+        "const user_input = process.argv[2];\neval(user_input); // foxguard: ignore[js/no-sql-injection]\n",
+    )
+    .expect("failed to write fixture");
+
+    let output = foxguard_cmd()
+        .args([target.to_str().expect("non-utf8 path"), "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        !output.status.success(),
+        "mismatched rule ID should not suppress the finding"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert_eq!(findings.len(), 1, "expected the finding to remain");
+    assert_eq!(findings[0]["rule_id"], "js/no-eval");
+}
+
+#[test]
 fn test_changed_mode_scans_only_staged_files() {
     let repo = setup_git_repo(&["vulnerable.js", "safe.py"]);
 

--- a/tests/semgrep_integration.rs
+++ b/tests/semgrep_integration.rs
@@ -58,7 +58,7 @@ fn test_sql_injection_rule() {
 
     let source = "query = \"SELECT * FROM users WHERE name = '\" + user_input\n";
     let tree = parse_file(source, Language::Python).unwrap();
-    let findings = rules[0].check(&source, &tree);
+    let findings = rules[0].check(source, &tree);
 
     assert_eq!(
         findings.len(),


### PR DESCRIPTION
## Summary

Adds inline suppression comments for code-scan findings so deliberate patterns can be ignored in-source without creating a baseline entry.

What changed:
- added `foxguard: ignore[...]` parsing in the Rust scan engine
- supports both same-line ignores and comment-only directives for the next code line
- applies suppressions across the full finding span so multiline matches can still be ignored
- documented the syntax in the README
- added regression tests for rule-specific ignores, ignore-all behavior, next-line directives, and multiline findings

Why:
- addresses the feature request in #3 for one-off, local suppressions when a reported issue is intentional
- keeps suppression logic centralized so built-in rules and Semgrep-compatible rules inherit the behavior automatically

Impact:
- no CLI or config changes
- affects code scanning only, not `foxguard secrets`
- supported inline comment styles are currently `//` and `#`, depending on language

Closes #3

## Checklist

- [x] Code compiles without warnings (`cargo clippy`)
- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [ ] Security rules have test coverage in `tests/fixtures/` (not applicable; no new security rule was added)
- [ ] Breaking changes are documented (not applicable; no breaking change)
