### PR TITLE
Resolve Python import aliases in sink-matching rules (#7)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1,4 +1,5 @@
-use crate::rules::RuleRegistry;
+use crate::rules::python_aliases::ImportAliases;
+use crate::rules::{FileContext, RuleRegistry};
 use crate::{Finding, Language};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
@@ -155,11 +156,23 @@ fn scan_files(
         let relative_path = relative_scan_path(scan_root, path);
         let rules = registry.rules_for_language(*language);
 
+        // Per-file analysis context. Python builds an import alias table so
+        // rules can resolve aliased callees (`import pickle as p; p.loads(x)`)
+        // back to their canonical dotted paths before sink matching.
+        let python_aliases = if matches!(language, Language::Python) {
+            Some(ImportAliases::from_tree(&source, &tree))
+        } else {
+            None
+        };
+        let ctx = FileContext {
+            python_aliases: python_aliases.as_ref(),
+        };
+
         for rule in rules {
             if !rule.applies_to_path(&relative_path) {
                 continue;
             }
-            let mut rule_findings = rule.check(&source, &tree);
+            let mut rule_findings = rule.check_with_context(&source, &tree, &ctx);
             for f in &mut rule_findings {
                 f.file = file_str.clone();
             }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,6 +4,7 @@ pub mod java;
 pub mod javascript;
 pub mod php;
 pub mod python;
+pub mod python_aliases;
 pub mod ruby;
 pub mod rust_lang;
 pub mod semgrep_compat;
@@ -11,6 +12,17 @@ pub mod swift;
 
 use crate::{Finding, Language, Severity};
 use std::path::Path;
+
+/// Per-file analysis context shared across all rules running on a single file.
+///
+/// Computed once after parsing in the scanner and handed to each rule via
+/// `check_with_context`. Rules that need nothing from it can continue to
+/// implement `check` directly and rely on the default trait method.
+#[derive(Default)]
+pub struct FileContext<'a> {
+    /// Python import alias table. `None` for non-Python files.
+    pub python_aliases: Option<&'a python_aliases::ImportAliases>,
+}
 
 /// A security rule that checks parsed source code for vulnerabilities.
 pub trait Rule: Send + Sync {
@@ -23,6 +35,18 @@ pub trait Rule: Send + Sync {
         true
     }
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding>;
+
+    /// Context-aware variant. Defaults to calling `check` so every existing
+    /// rule works unchanged. Rules that need the per-file context (e.g.
+    /// Python import aliases) override this instead of `check`.
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        _ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        self.check(source, tree)
+    }
 }
 
 /// Registry holding all available rules.

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1,8 +1,21 @@
-use crate::rules::Rule;
+use crate::rules::{FileContext, Rule};
 use crate::{Finding, Language, Severity};
 use regex::Regex;
+use std::borrow::Cow;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve a raw callee text through the per-file Python import alias table.
+/// Returns the canonical dotted path when an alias matches, otherwise the
+/// input unchanged. Falls back to the raw text when no alias table is
+/// available (e.g. under the legacy `check` entry point used by some unit
+/// tests).
+fn resolve_callee<'a>(func_text: &'a str, ctx: &'a FileContext<'_>) -> Cow<'a, str> {
+    match ctx.python_aliases {
+        Some(aliases) => aliases.resolve(func_text),
+        None => Cow::Borrowed(func_text),
+    }
+}
 
 fn get_source_line(source: &str, byte_offset: usize) -> String {
     let start = source[..byte_offset].rfind('\n').map_or(0, |p| p + 1);
@@ -70,20 +83,30 @@ impl Rule for NoEval {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
-                    if func_text == "eval" || func_text == "exec" {
+                    let resolved = resolve_callee(func_text, ctx);
+                    if resolved.as_ref() == "eval" || resolved.as_ref() == "exec" {
                         findings.push(make_finding(
                             self.id(),
                             self.severity(),
                             self.cwe(),
                             &format!(
                                 "{}() allows arbitrary code execution — avoid using it with untrusted input",
-                                func_text
+                                resolved
                             ),
                             node,
                             src,
@@ -304,6 +327,15 @@ impl Rule for NoCommandInjection {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let dangerous_fns = [
             "os.system",
@@ -319,7 +351,8 @@ impl Rule for NoCommandInjection {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
-                    if dangerous_fns.contains(&func_text) {
+                    let resolved = resolve_callee(func_text, ctx);
+                    if dangerous_fns.contains(&resolved.as_ref()) {
                         if let Some(args) = node.child_by_field_name("arguments") {
                             if let Some(first_arg) = args.named_child(0) {
                                 // Flag if argument is not a plain string literal
@@ -341,7 +374,7 @@ impl Rule for NoCommandInjection {
                                         self.cwe(),
                                         &format!(
                                             "{}() called with dynamic argument — risk of command injection",
-                                            func_text
+                                            resolved
                                         ),
                                         node,
                                         src,
@@ -379,14 +412,24 @@ impl Rule for NoPathTraversal {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
+                    let resolved = resolve_callee(func_text, ctx);
                     let sink_fns = ["open", "os.remove", "os.unlink", "os.listdir", "os.scandir"];
-                    if sink_fns.contains(&func_text) {
+                    if sink_fns.contains(&resolved.as_ref()) {
                         if let Some(args) = node.child_by_field_name("arguments") {
                             if let Some(first_arg) = args.named_child(0) {
                                 // Flag if path uses concatenation or f-string
@@ -407,7 +450,7 @@ impl Rule for NoPathTraversal {
                                         self.cwe(),
                                         &format!(
                                             "{}() called with dynamic path — validate and sanitize to prevent path traversal",
-                                            func_text
+                                            resolved
                                         ),
                                         node,
                                         src,
@@ -445,6 +488,15 @@ impl Rule for NoSsrf {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let request_fns = [
             "requests.get",
@@ -471,7 +523,8 @@ impl Rule for NoSsrf {
                 return;
             };
             let func_text = &src[func.byte_range()];
-            if !request_fns.contains(&func_text) {
+            let resolved = resolve_callee(func_text, ctx);
+            if !request_fns.contains(&resolved.as_ref()) {
                 return;
             }
 
@@ -479,7 +532,9 @@ impl Rule for NoSsrf {
                 return;
             };
 
-            let url_arg = if func_text == "requests.request" || func_text == "httpx.request" {
+            let url_arg = if resolved.as_ref() == "requests.request"
+                || resolved.as_ref() == "httpx.request"
+            {
                 args.named_child(1)
             } else {
                 args.named_child(0)
@@ -504,7 +559,7 @@ impl Rule for NoSsrf {
                     self.cwe(),
                     &format!(
                         "{} called with dynamic URL — validate and allowlist outbound destinations to prevent SSRF",
-                        func_text
+                        resolved
                     ),
                     node,
                     src,
@@ -538,14 +593,24 @@ impl Rule for NoWeakCrypto {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
-                    if func_text == "hashlib.md5" || func_text == "hashlib.sha1" {
-                        let algo = if func_text.contains("md5") {
+                    let resolved = resolve_callee(func_text, ctx);
+                    if resolved.as_ref() == "hashlib.md5" || resolved.as_ref() == "hashlib.sha1" {
+                        let algo = if resolved.as_ref().contains("md5") {
                             "MD5"
                         } else {
                             "SHA1"
@@ -564,7 +629,7 @@ impl Rule for NoWeakCrypto {
                     }
 
                     // hashlib.new('md5') / hashlib.new('sha1')
-                    if func_text == "hashlib.new" {
+                    if resolved.as_ref() == "hashlib.new" {
                         if let Some(args) = node.child_by_field_name("arguments") {
                             if let Some(first_arg) = args.named_child(0) {
                                 if first_arg.kind() == "string" {
@@ -616,6 +681,15 @@ impl Rule for NoPickle {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let dangerous_fns = [
             "pickle.loads",
@@ -628,14 +702,15 @@ impl Rule for NoPickle {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
-                    if dangerous_fns.contains(&func_text) {
+                    let resolved = resolve_callee(func_text, ctx);
+                    if dangerous_fns.contains(&resolved.as_ref()) {
                         findings.push(make_finding(
                             self.id(),
                             self.severity(),
                             self.cwe(),
                             &format!(
                                 "{}() deserializes untrusted data — can execute arbitrary code",
-                                func_text
+                                resolved
                             ),
                             node,
                             src,
@@ -670,13 +745,23 @@ impl Rule for NoYamlLoad {
     }
 
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call" {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
-                    if func_text == "yaml.load" {
+                    let resolved = resolve_callee(func_text, ctx);
+                    if resolved.as_ref() == "yaml.load" {
                         // Check if SafeLoader or safe_load is used
                         if let Some(args) = node.child_by_field_name("arguments") {
                             let args_text = &src[args.byte_range()];

--- a/src/rules/python_aliases.rs
+++ b/src/rules/python_aliases.rs
@@ -1,0 +1,257 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use tree_sitter::{Node, Tree};
+
+/// Per-file Python import alias table.
+///
+/// Maps a local identifier (as it appears in the source) to its canonical
+/// dotted path. For example `import pickle as p` produces `p -> pickle`,
+/// and `from pickle import loads as d` produces `d -> pickle.loads`.
+///
+/// Used by Python rules so that call sites like `p.loads(x)` or
+/// `d(x)` resolve back to `pickle.loads` before comparison against sink lists,
+/// closing the obvious aliasing bypasses.
+///
+/// Scope is intentionally file-level only: function-local rebindings like
+/// `pickle = something_else` inside one function are not tracked. Dynamic
+/// forms such as `importlib.import_module(...)` are also out of scope and
+/// tracked separately under the dataflow roadmap.
+#[derive(Debug, Default, Clone)]
+pub struct ImportAliases {
+    map: HashMap<String, String>,
+}
+
+impl ImportAliases {
+    pub fn from_tree(source: &str, tree: &Tree) -> Self {
+        let mut aliases = Self::default();
+        aliases.walk_for_imports(tree.root_node(), source);
+        aliases
+    }
+
+    fn walk_for_imports(&mut self, node: Node, source: &str) {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "import_statement" => self.collect_import(child, source),
+                "import_from_statement" => self.collect_import_from(child, source),
+                // Recurse into top-level blocks so `if sys.version_info: import foo`
+                // at the module level still contributes. Stop at function and class
+                // bodies — alias resolution there is explicitly out of scope.
+                "if_statement" | "try_statement" | "with_statement" | "block" | "module" => {
+                    self.walk_for_imports(child, source);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_import(&mut self, node: Node, source: &str) {
+        // `import X`, `import X as Y`, `import X.Y`, `import X.Y as Z`
+        let mut cursor = node.walk();
+        for name in node.children_by_field_name("name", &mut cursor) {
+            match name.kind() {
+                "dotted_name" => {
+                    // `import urllib.request` makes the *first* identifier
+                    // (`urllib`) the accessible local name, and the full dotted
+                    // path (`urllib.request`) is what the source will write for
+                    // callees. Record both so either form resolves correctly.
+                    let full = node_text(name, source).to_string();
+                    if let Some(first) = name.child(0) {
+                        let root = node_text(first, source).to_string();
+                        self.map.entry(root.clone()).or_insert(root);
+                    }
+                    self.map.entry(full.clone()).or_insert(full);
+                }
+                "aliased_import" => {
+                    // `import X.Y as Z`  →  local `Z` → canonical `X.Y`
+                    let canonical = name
+                        .child_by_field_name("name")
+                        .map(|n| node_text(n, source).to_string());
+                    let alias = name
+                        .child_by_field_name("alias")
+                        .map(|n| node_text(n, source).to_string());
+                    if let (Some(canonical), Some(alias)) = (canonical, alias) {
+                        self.map.insert(alias, canonical);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_import_from(&mut self, node: Node, source: &str) {
+        // `from MODULE import NAME [as ALIAS], ...`
+        let Some(module_node) = node.child_by_field_name("module_name") else {
+            return;
+        };
+        let module = node_text(module_node, source).to_string();
+        if module.is_empty() {
+            return;
+        }
+
+        let mut cursor = node.walk();
+        for name in node.children_by_field_name("name", &mut cursor) {
+            match name.kind() {
+                "dotted_name" | "identifier" => {
+                    // `from pickle import loads`  →  `loads` → `pickle.loads`
+                    let local = node_text(name, source).to_string();
+                    if local.is_empty() {
+                        continue;
+                    }
+                    let canonical = format!("{}.{}", module, local);
+                    self.map.insert(local, canonical);
+                }
+                "aliased_import" => {
+                    // `from pickle import loads as d`  →  `d` → `pickle.loads`
+                    let real = name
+                        .child_by_field_name("name")
+                        .map(|n| node_text(n, source).to_string());
+                    let alias = name
+                        .child_by_field_name("alias")
+                        .map(|n| node_text(n, source).to_string());
+                    if let (Some(real), Some(alias)) = (real, alias) {
+                        let canonical = format!("{}.{}", module, real);
+                        self.map.insert(alias, canonical);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Resolve a call-site callee text (as it appears in the source) back to
+    /// its canonical dotted path. Returns the input unchanged when no alias
+    /// matches. For example, with `import pickle as p`:
+    ///   `p.loads`        → `pickle.loads`
+    ///   `pickle.loads`   → `pickle.loads`
+    ///   `eval`           → `eval`
+    pub fn resolve<'a>(&'a self, callee: &'a str) -> Cow<'a, str> {
+        if let Some((head, tail)) = callee.split_once('.') {
+            if let Some(canonical_root) = self.map.get(head) {
+                if canonical_root == head {
+                    return Cow::Borrowed(callee);
+                }
+                return Cow::Owned(format!("{}.{}", canonical_root, tail));
+            }
+            return Cow::Borrowed(callee);
+        }
+        if let Some(canonical) = self.map.get(callee) {
+            return Cow::Borrowed(canonical.as_str());
+        }
+        Cow::Borrowed(callee)
+    }
+
+    #[cfg(test)]
+    pub fn get(&self, local: &str) -> Option<&str> {
+        self.map.get(local).map(String::as_str)
+    }
+}
+
+fn node_text<'a>(node: Node, source: &'a str) -> &'a str {
+    &source[node.byte_range()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parser::parse_file;
+    use crate::Language;
+
+    fn build(source: &str) -> ImportAliases {
+        let tree = parse_file(source, Language::Python).expect("parse");
+        ImportAliases::from_tree(source, &tree)
+    }
+
+    #[test]
+    fn plain_import_maps_root_to_itself() {
+        let a = build("import pickle\n");
+        assert_eq!(a.resolve("pickle.loads"), "pickle.loads");
+        assert_eq!(a.resolve("pickle"), "pickle");
+    }
+
+    #[test]
+    fn aliased_import_resolves_alias_to_module() {
+        let a = build("import pickle as p\n");
+        assert_eq!(a.resolve("p.loads"), "pickle.loads");
+        assert_eq!(a.resolve("p.load"), "pickle.load");
+    }
+
+    #[test]
+    fn from_import_resolves_bare_name_to_dotted_path() {
+        let a = build("from pickle import loads\n");
+        assert_eq!(a.resolve("loads"), "pickle.loads");
+    }
+
+    #[test]
+    fn from_import_with_alias_resolves_alias() {
+        let a = build("from pickle import loads as deserialize\n");
+        assert_eq!(a.resolve("deserialize"), "pickle.loads");
+    }
+
+    #[test]
+    fn from_import_multiple_names() {
+        let a = build("from pickle import loads, load, dumps\n");
+        assert_eq!(a.resolve("loads"), "pickle.loads");
+        assert_eq!(a.resolve("load"), "pickle.load");
+        assert_eq!(a.resolve("dumps"), "pickle.dumps");
+    }
+
+    #[test]
+    fn cpickle_shadowing_pickle_resolves_to_cpickle() {
+        // `import cPickle as pickle` is the classic shadowing form.
+        let a = build("import cPickle as pickle\n");
+        assert_eq!(a.resolve("pickle.loads"), "cPickle.loads");
+    }
+
+    #[test]
+    fn dotted_module_import() {
+        let a = build("import urllib.request\n");
+        // `urllib.request.urlopen` should resolve untouched (not an alias).
+        assert_eq!(
+            a.resolve("urllib.request.urlopen"),
+            "urllib.request.urlopen"
+        );
+    }
+
+    #[test]
+    fn dotted_module_import_with_alias() {
+        let a = build("import urllib.request as ur\n");
+        assert_eq!(a.resolve("ur.urlopen"), "urllib.request.urlopen");
+    }
+
+    #[test]
+    fn unknown_identifier_passes_through_unchanged() {
+        let a = build("import pickle\n");
+        assert_eq!(a.resolve("json.loads"), "json.loads");
+        assert_eq!(a.resolve("some_random_fn"), "some_random_fn");
+    }
+
+    #[test]
+    fn multiple_imports_combine() {
+        let a = build(
+            r#"
+import pickle as p
+import yaml
+from subprocess import Popen as SpawnProc
+from hashlib import md5
+"#,
+        );
+        assert_eq!(a.resolve("p.loads"), "pickle.loads");
+        assert_eq!(a.resolve("yaml.load"), "yaml.load");
+        assert_eq!(a.resolve("SpawnProc"), "subprocess.Popen");
+        assert_eq!(a.resolve("md5"), "hashlib.md5");
+    }
+
+    #[test]
+    fn from_import_with_alias_raw_map_stores_canonical() {
+        let a = build("from pickle import loads as d\n");
+        assert_eq!(a.get("d"), Some("pickle.loads"));
+        assert_eq!(a.get("loads"), None);
+    }
+
+    #[test]
+    fn empty_source_produces_empty_table() {
+        let a = build("");
+        assert_eq!(a.resolve("pickle.loads"), "pickle.loads");
+    }
+}

--- a/tests/fixtures/safe_py_aliases.py
+++ b/tests/fixtures/safe_py_aliases.py
@@ -1,0 +1,58 @@
+# Negative fixture for issue #7: aliased imports of the *same* sensitive
+# modules used above, but called in ways that should NOT trigger any rule.
+# This proves alias resolution doesn't silently widen the match surface.
+
+import pickle as p
+import yaml as y
+import hashlib as hl
+import requests as rq
+import urllib.request as ur
+import os as osmod
+from hashlib import sha256 as strong_hash
+from yaml import safe_load as y_safe
+
+
+# ─── py/no-pickle: serializing (dump/dumps) is not the sink ───────────────
+def dump_via_alias(obj):
+    return p.dumps(obj)
+
+def dump_via_alias_write(obj, fh):
+    return p.dump(obj, fh)
+
+
+# ─── py/no-yaml-load: SafeLoader explicitly passed ────────────────────────
+def yaml_load_safe(data):
+    return y.load(data, Loader=y.SafeLoader)
+
+def yaml_load_base(data):
+    return y.load(data, Loader=y.BaseLoader)
+
+def yaml_safe_load_from_import(data):
+    return y_safe(data)
+
+
+# ─── py/no-weak-crypto: sha256 through alias is fine ──────────────────────
+def strong_hash_alias(data):
+    return hl.sha256(data)
+
+def strong_hash_from_import(data):
+    return strong_hash(data)
+
+
+# ─── py/no-ssrf: static URL literal is not flagged ────────────────────────
+def health_check_literal():
+    return rq.get("https://example.com/health")
+
+def urllib_static():
+    return ur.urlopen("https://example.com/robots.txt")
+
+
+# ─── py/no-command-injection: static string arg is fine ──────────────────
+def list_hostname():
+    return osmod.system("hostname")
+
+
+# ─── py/no-path-traversal: static path literal is fine ────────────────────
+def read_hostname():
+    with open("/etc/hostname") as f:
+        return f.read()

--- a/tests/fixtures/vulnerable_py_aliases.py
+++ b/tests/fixtures/vulnerable_py_aliases.py
@@ -1,0 +1,93 @@
+# Regression fixture for issue #7: Python import alias resolution.
+#
+# Every call site below used to slip past the Python rules because the rules
+# string-matched the callee text against a fixed sink list. With the
+# per-file ImportAliases table, each call should now be resolved back to its
+# canonical dotted path and flagged.
+#
+# One finding per call site. Rules covered:
+#   py/no-eval, py/no-command-injection, py/no-path-traversal,
+#   py/no-ssrf, py/no-weak-crypto, py/no-pickle, py/no-yaml-load.
+
+import pickle as p
+import cPickle as pick2
+import yaml as y
+import hashlib as hl
+import requests as rq
+import urllib.request as ur
+import os as osmod
+import subprocess as sp
+from pickle import loads as p_loads
+from pickle import load
+from yaml import load as y_load
+from hashlib import md5, sha1
+from subprocess import Popen as SpawnProc
+from os import system as run_shell
+
+
+# ─── py/no-pickle ──────────────────────────────────────────────────────────
+def bypass_pickle_aliased(data):
+    return p.loads(data)                 # import pickle as p
+
+def bypass_pickle_shadowed(data):
+    return pick2.loads(data)             # import cPickle as pick2
+
+def bypass_pickle_from_import_alias(data):
+    return p_loads(data)                 # from pickle import loads as p_loads
+
+def bypass_pickle_from_import_bare(data):
+    return load(data)                    # from pickle import load
+
+
+# ─── py/no-yaml-load ───────────────────────────────────────────────────────
+def bypass_yaml_aliased(data):
+    return y.load(data)                  # import yaml as y
+
+def bypass_yaml_from_import_alias(data):
+    return y_load(data)                  # from yaml import load as y_load
+
+
+# ─── py/no-weak-crypto ─────────────────────────────────────────────────────
+def bypass_md5_aliased(data):
+    return hl.md5(data)                  # import hashlib as hl
+
+def bypass_sha1_aliased(data):
+    return hl.sha1(data)                 # import hashlib as hl
+
+def bypass_md5_from_import(data):
+    return md5(data)                     # from hashlib import md5
+
+def bypass_sha1_from_import(data):
+    return sha1(data)                    # from hashlib import sha1
+
+
+# ─── py/no-ssrf ────────────────────────────────────────────────────────────
+def bypass_ssrf_aliased(user_url):
+    return rq.get(user_url)              # import requests as rq
+
+def bypass_ssrf_dotted_alias(user_url):
+    return ur.urlopen(user_url)          # import urllib.request as ur
+
+
+# ─── py/no-command-injection ───────────────────────────────────────────────
+def bypass_cmdinj_aliased_module(user_input):
+    return osmod.system(user_input)      # import os as osmod
+
+def bypass_cmdinj_from_import_alias(user_input):
+    return run_shell(user_input)         # from os import system as run_shell
+
+def bypass_cmdinj_subprocess_aliased(user_input):
+    return sp.Popen(user_input)          # import subprocess as sp
+
+def bypass_cmdinj_from_import_popen_alias(user_input):
+    return SpawnProc(user_input)         # from subprocess import Popen as SpawnProc
+
+
+# ─── py/no-path-traversal ──────────────────────────────────────────────────
+def bypass_path_traversal_aliased(user_path):
+    return osmod.remove(user_path)       # import os as osmod
+
+# Note: `open` is a builtin, so no alias form is interesting for py/no-path-traversal.
+# One direct hit just to keep the rule represented.
+def direct_open_dynamic(user_path):
+    return open(user_path)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -209,6 +209,85 @@ fn test_vulnerable_py_finds_all_rules() {
     }
 }
 
+/// Regression test for issue #7: Python rules used to string-match callee
+/// text against a fixed sink list, so `import pickle as p; p.loads(x)` and
+/// every other aliased form slipped past. With the per-file import alias
+/// table, each call site should resolve back to its canonical dotted path
+/// and fire.
+#[test]
+fn test_vulnerable_py_aliases_catches_all_bypass_forms() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_py_aliases.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    assert_eq!(
+        findings.len(),
+        18,
+        "vulnerable_py_aliases.py should have 18 findings, got {}",
+        findings.len()
+    );
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    // One row per rule that should be exercised by the aliased fixture,
+    // with the exact number of bypass forms we expect it to catch.
+    let expected: &[(&str, usize)] = &[
+        ("py/no-pickle", 4),
+        ("py/no-yaml-load", 2),
+        ("py/no-weak-crypto", 4),
+        ("py/no-ssrf", 2),
+        ("py/no-command-injection", 4),
+        ("py/no-path-traversal", 2),
+    ];
+
+    for (rule, want) in expected {
+        let got = counts.get(rule).copied().unwrap_or(0);
+        assert_eq!(
+            got, *want,
+            "rule {} caught {} bypass forms, expected {}",
+            rule, got, want
+        );
+    }
+}
+
+/// Negative regression for issue #7: aliased imports of the *same* sensitive
+/// modules, but called in safe shapes (static literals, SafeLoader, sha256,
+/// write-only pickle methods). Alias resolution must not silently widen the
+/// match surface — this file should still produce zero findings.
+#[test]
+fn test_safe_py_aliases_no_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_py_aliases.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "safe_py_aliases.py should exit zero"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    assert_eq!(
+        findings.len(),
+        0,
+        "safe_py_aliases.py should have 0 findings, got {:?}",
+        findings
+    );
+}
+
 #[test]
 fn test_vulnerable_go_finds_all_rules() {
     let output = foxguard_cmd()


### PR DESCRIPTION
## Summary

Python rules used to string-match callee text against a fixed sink list, so every aliased import form slipped past them:
- \`import pickle as p; p.loads(x)\`
- \`from pickle import loads; loads(x)\`
- \`from pickle import loads as deserialize; deserialize(x)\`
- \`import cPickle as pickle; pickle.loads(x)\`
- \`import urllib.request as ur; ur.urlopen(x)\`

This PR builds a per-file \`ImportAliases\` table from \`import\` / \`from ... import\` statements at scan time, plumbs it through a new \`FileContext\` handed to each rule via \`check_with_context\`, and resolves the raw callee back to its canonical dotted path before comparing against the sink list.

Seven Python rules are migrated: \`py/no-eval\`, \`py/no-command-injection\`, \`py/no-path-traversal\`, \`py/no-ssrf\`, \`py/no-weak-crypto\`, \`py/no-pickle\`, \`py/no-yaml-load\`.

## Design

- **New module** \`src/rules/python_aliases.rs\` — walks top-level \`import_statement\` / \`import_from_statement\` nodes and builds a \`HashMap<local_name, canonical_dotted_path>\`. \`resolve(callee)\` splits on the first dot, looks up the head, and rewrites the path. Falls through unchanged when no alias matches.
- **New \`FileContext\` struct** in \`src/rules/mod.rs\` — per-file analysis context shared across rules. Currently only holds \`python_aliases\`, but it's the obvious place to hang future per-file state on.
- **New \`Rule::check_with_context\` trait method** with a default implementation that calls \`check\`. All non-migrated rules work unchanged.
- **Scanner plumbing** — \`scan_files\` in \`src/engine/scanner.rs\` computes the alias table once per Python file after parsing, then passes \`FileContext\` into each rule invocation.

## Scope

**In scope:** file-level alias resolution for the top-level \`import\` / \`from ... import\` forms (including multi-name, aliased, and dotted-module variants).

**Out of scope** — tracked separately under the dataflow roadmap (#10):
- \`importlib.import_module(...)\` with constant or dynamic arguments.
- Function-local rebindings (\`pickle = something_else\` inside a function body).
- Cross-file resolution.
- Field-sensitive tracking on objects.

## Testing

**Unit tests** (\`src/rules/python_aliases.rs\`, 12 tests):
- Plain import, aliased import, \`from X import Y\`, \`from X import Y as Z\`, multi-name \`from\` imports, \`cPickle as pickle\` shadowing, dotted-module import, dotted-module with alias, unknown identifier passthrough, empty source, multi-import combined.

**Integration fixtures:**
- \`tests/fixtures/vulnerable_py_aliases.py\` — 18 bypass forms across 6 sink rules. New test \`test_vulnerable_py_aliases_catches_all_bypass_forms\` asserts exact counts per rule.
- \`tests/fixtures/safe_py_aliases.py\` — aliased imports of the *same* sensitive modules used in benign shapes (SafeLoader, sha256, write-only pickle, static URL/path literals). New test \`test_safe_py_aliases_no_findings\` asserts zero findings, proving alias resolution doesn't widen the match surface.

**Regression safety:** existing \`test_vulnerable_py_finds_all_rules\` (30 findings on \`vulnerable.py\`) and \`test_safe_py_no_findings\` both still pass.

\`\`\`
cargo test           # 36 integration + 12 unit, all green
cargo clippy         # no new warnings
cargo build --release
\`\`\`

## Test plan

- [x] \`cargo test\` — 36 integration + 12 unit tests green
- [x] \`cargo clippy --all-targets\` — no new warnings (one pre-existing unrelated warning in \`tests/semgrep_integration.rs\`)
- [x] \`cargo build --release\` — clean
- [x] Manual scan: \`vulnerable_py_aliases.py\` → 18 findings, \`safe_py_aliases.py\` → 0 findings, \`vulnerable.py\` → 30 findings (unchanged)

Closes #7.