### PR TITLE
Add LoC metric and larger-corpus target to benchmarks (#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,17 +96,18 @@ cargo install foxguard                 # crates.io
 
 ## Benchmarks
 
-Real-world benchmarks on local codebases:
+Reproducible benchmarks via `./benchmarks/run.sh`. Numbers below are from a local run on an Apple Silicon laptop with `foxguard 0.3.3`, `semgrep 1.156.0`, `tokei 14.0.0`. LoC is counted by tokei, scoped to the target language only (no vendored HTML/JSON).
 
-| Repo | Files | foxguard | Semgrep (cached) | Speedup |
-|------|-------|----------|-------------------|---------|
-| youtube-reader (Next.js) | 41 | **0.03s** | 4.6s | **153x** |
-| doruk.ch (Astro) | 28 | **0.04s** | 5.4s | **134x** |
-| SwissPriceScraper (Python) | 17 | **0.01s** | 4.8s | **482x** |
-| express (framework) | 141 | **0.28s** | 17.4s | **61x** |
-| flask (framework) | 83 | **0.08s** | 7.3s | **87x** |
+| Repo | Files | LoC | foxguard | Semgrep | Speedup |
+|------|-------|-----|----------|---------|---------|
+| express (framework) | 141 | 15,804 JS | **0.11s** | 4.80s | **45x** |
+| flask (framework) | 83 | 14,029 Py | **0.08s** | 5.70s | **73x** |
+| gin (framework) | 99 | 17,669 Go | **0.07s** | 4.61s | **63x** |
+| **sentry (production)** | **8,539** | **1,291,606 Py** | **12.19s** | 164.53s | **13x** |
 
-Semgrep times measured with cached rules (second run). foxguard has no cache — it's just fast.
+Sentry is the larger-corpus stress target added under issue #8: a real production monitoring platform at ~1.3M Python LoC. foxguard scans the whole tree in ~12 seconds (~106k LoC/sec); Semgrep with `--config auto` takes ~2m45s on the same tree. Run on one machine — your numbers will vary; reproduce locally with `./benchmarks/run.sh`.
+
+To reproduce: `./benchmarks/run.sh` (add `BENCH_SKIP_LARGE=1` for the quick matrix only). See `benchmarks/README.md` for the reproduction recipe.
 
 ## Built-in coverage
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,31 +8,64 @@ Comparative benchmarks for foxguard against other security linters.
 # Build foxguard first
 cargo build --release
 
-# Product comparison: foxguard built-ins vs Semgrep/OpenGrep auto rules
+# Product comparison: foxguard built-ins vs Semgrep/OpenGrep auto rules.
+# Includes the large-corpus target (sentry) — expect tens of minutes
+# on the semgrep leg if semgrep is installed.
 ./benchmarks/run.sh
 
-# Same-rules engine comparison
+# Quick matrix: skip the large-corpus target (sentry).
+BENCH_SKIP_LARGE=1 ./benchmarks/run.sh
+
+# Same-rules engine comparison.
 BENCH_MODE=compat ./benchmarks/run.sh
 
-# Pin tool paths explicitly if needed
+# Pin tool paths explicitly if needed.
 SEMGREP=/opt/homebrew/bin/semgrep OPENGREP=/path/to/opengrep ./benchmarks/run.sh
 ```
 
+### Required and optional tools
+
+| Tool | Purpose | If missing |
+|------|---------|------------|
+| `cargo` | Build foxguard | Required |
+| `python3` | Parse JSON findings output from each tool | Required |
+| `tokei` | Compute LoC column | Install via `brew install tokei` (or `cargo install tokei`). LoC column shows `N/A` if absent. |
+| `semgrep` | Comparison leg | Corresponding columns show `N/A`. |
+| `opengrep` | Comparison leg | Corresponding columns show `N/A`. |
+
 ## Methodology
 
-The benchmark suite measures foxguard, Semgrep, and OpenGrep against three popular open-source repositories covering different languages:
+The benchmark suite measures foxguard, Semgrep, and OpenGrep against small and large open-source repositories covering different languages:
 
-| Repository | Language | Description |
-|------------|----------|-------------|
-| [express](https://github.com/expressjs/express) | JavaScript | Fast, unopinionated web framework for Node.js |
-| [flask](https://github.com/pallets/flask) | Python | Lightweight WSGI web application framework |
-| [gin](https://github.com/gin-gonic/gin) | Go | HTTP web framework written in Go |
+| Repository | Language | Scale | Description |
+|------------|----------|-------|-------------|
+| [express](https://github.com/expressjs/express) | JavaScript | small | Fast, unopinionated web framework for Node.js |
+| [flask](https://github.com/pallets/flask) | Python | small | Lightweight WSGI web application framework |
+| [gin](https://github.com/gin-gonic/gin) | Go | small | HTTP web framework written in Go |
+| [sentry](https://github.com/getsentry/sentry) | Python | large (~500k LoC) | Production application monitoring platform — larger-corpus stress target |
+
+The small targets stay in the matrix for a fast local loop; `sentry` is the larger-corpus target added under #8 to stress the benchmark beyond framework-sized repos. Skip it with `BENCH_SKIP_LARGE=1` when you want a fast run.
 
 ### What is measured
 
 - **Wall time** — Total elapsed time for the scan
 - **Files scanned** — Count of source files in the repository (`.js`, `.ts`, `.py`, `.go`)
+- **LoC** — Lines of code (comments and blanks excluded) as reported by `tokei`, scoped to the language foxguard scans on that repo. `express` counts `JavaScript,TypeScript,Jsx,Tsx` only; `flask`/`sentry` count `Python`; `gin` counts `Go`. Vendored HTML/CSS/JSON is not counted. See `tokei_types_for_lang` in `run.sh`.
 - **Findings count** — Number of findings reported by each tool
+
+### Reproduction recipe
+
+When publishing numbers from `results-default.md` or `results-compat.md`, include the following so the run is reproducible:
+
+- **Machine**: model, CPU, RAM (e.g. `Apple M2 Pro, 32GB`)
+- **OS**: `uname -sr`
+- **foxguard**: `foxguard --version`
+- **semgrep**: `semgrep --version`
+- **opengrep**: `opengrep --version | tail -1`
+- **tokei**: `tokei --version`
+- **Run command**: the exact `BENCH_MODE=... ./benchmarks/run.sh` invocation
+- **Repo SHAs**: `git -C benchmarks/repos/<name> rev-parse HEAD` for each target (the benchmark uses `--depth 1` clones, so these change over time)
+- **Cache state**: note whether semgrep rules were already cached locally (first run vs. second run of `--config auto` has materially different timings)
 
 ### Modes
 

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -30,11 +30,17 @@ cleanup() {
 trap cleanup EXIT
 
 # Repos to benchmark: name, url, language
+# `sentry` is included as a larger-corpus target (~500k Python LoC) to stress
+# the benchmark beyond small framework repos. Disable it with BENCH_SKIP_LARGE=1
+# when running the quick matrix locally.
 REPOS=(
   "express|https://github.com/expressjs/express.git|javascript"
   "flask|https://github.com/pallets/flask.git|python"
   "gin|https://github.com/gin-gonic/gin.git|go"
 )
+if [ -z "${BENCH_SKIP_LARGE:-}" ]; then
+  REPOS+=("sentry|https://github.com/getsentry/sentry.git|python")
+fi
 
 echo -e "${CYAN}=== foxguard benchmark suite ===${NC}"
 echo ""
@@ -98,6 +104,17 @@ if [ "$HAS_OPENGREP" = true ]; then
 else
   echo -e "${YELLOW}opengrep not installed — skipping opengrep benchmarks${NC}"
 fi
+
+# Check tokei for LoC counting. Benchmarks fall back to "N/A" if missing,
+# but the LoC column is the whole point of the upgrade so we complain loudly.
+HAS_TOKEI=false
+if command -v tokei &>/dev/null; then
+  HAS_TOKEI=true
+  echo -e "tokei: $(command -v tokei)"
+  echo -e "tokei version: $(tokei --version 2>/dev/null || echo 'unknown')"
+else
+  echo -e "${YELLOW}tokei not installed — LoC column will show N/A. Install with: brew install tokei${NC}"
+fi
 echo ""
 
 # Clone repos
@@ -116,6 +133,41 @@ echo ""
 count_files() {
   local dir="$1"
   find "$dir" -type f \( -name "*.js" -o -name "*.ts" -o -name "*.py" -o -name "*.go" \) | wc -l | tr -d ' '
+}
+
+# Map benchmark `lang` field to the tokei --type argument set. Keeps the
+# LoC count scoped to languages foxguard actually scans on each repo, so
+# `express` doesn't balloon its LoC by counting vendored HTML/JSON fixtures.
+tokei_types_for_lang() {
+  case "$1" in
+    javascript) echo "JavaScript,TypeScript,Jsx,Tsx" ;;
+    python)     echo "Python" ;;
+    go)         echo "Go" ;;
+    *)          echo "" ;;
+  esac
+}
+
+count_loc() {
+  local dir="$1"
+  local lang="$2"
+  if [ "$HAS_TOKEI" != true ]; then
+    echo "N/A"
+    return
+  fi
+  local types
+  types="$(tokei_types_for_lang "$lang")"
+  if [ -z "$types" ]; then
+    echo "N/A"
+    return
+  fi
+  tokei -t "$types" "$dir" --output json 2>/dev/null \
+    | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("Total", {}).get("code", "N/A"))
+except Exception:
+    print("N/A")' \
+    || echo "N/A"
 }
 
 TMP_RESULTS="$(mktemp "$SCRIPT_DIR/results.tmp.XXXXXX")"
@@ -143,15 +195,16 @@ echo "" >> "$TMP_RESULTS"
 
 echo "## Results" >> "$TMP_RESULTS"
 echo "" >> "$TMP_RESULTS"
-echo "| Repository | Language | Files | foxguard Time | foxguard Findings | semgrep Time | semgrep Findings | opengrep Time | opengrep Findings |" >> "$TMP_RESULTS"
-echo "|------------|----------|-------|---------------|-------------------|--------------|------------------|---------------|-------------------|" >> "$TMP_RESULTS"
+echo "| Repository | Language | Files | LoC | foxguard Time | foxguard Findings | semgrep Time | semgrep Findings | opengrep Time | opengrep Findings |" >> "$TMP_RESULTS"
+echo "|------------|----------|-------|-----|---------------|-------------------|--------------|------------------|---------------|-------------------|" >> "$TMP_RESULTS"
 
 for entry in "${REPOS[@]}"; do
   IFS='|' read -r name url lang <<< "$entry"
   repo_path="$REPOS_DIR/$name"
   file_count=$(count_files "$repo_path")
+  loc_count=$(count_loc "$repo_path" "$lang")
 
-  echo -e "${CYAN}--- Benchmarking: $name ($lang, $file_count files) ---${NC}"
+  echo -e "${CYAN}--- Benchmarking: $name ($lang, $file_count files, $loc_count LoC) ---${NC}"
 
   echo -n "  foxguard... "
   fox_start=$(perl -MTime::HiRes=time -e 'printf "%.3f\n", time')
@@ -201,7 +254,7 @@ for entry in "${REPOS[@]}"; do
     echo "  opengrep: skipped"
   fi
 
-  echo "| $name | $lang | $file_count | ${fox_time}s | $fox_findings | $sem_time | $sem_findings | $open_time | $open_findings |" >> "$TMP_RESULTS"
+  echo "| $name | $lang | $file_count | $loc_count | ${fox_time}s | $fox_findings | $sem_time | $sem_findings | $open_time | $open_findings |" >> "$TMP_RESULTS"
 done
 
 echo "" >> "$TMP_RESULTS"


### PR DESCRIPTION
## Summary

The benchmark tables reported file counts only, on small framework repos. File count is a weak proxy for work, and the corpora were all smallish, so the speed claim didn't transfer to users with real production codebases. This PR fixes both gaps.

- **LoC column** driven by [tokei](https://github.com/XAMPPRocky/tokei), scoped per-repo to the language foxguard actually scans on that target (no vendored HTML/JSON in the denominator). Falls back to \`N/A\` when tokei is absent.
- **Larger-corpus stress target**: \`sentry\` (getsentry/sentry, ~1.3M Python LoC) added to \`benchmarks/run.sh\`. Opt out with \`BENCH_SKIP_LARGE=1\` for a fast local loop.
- **Fresh numbers** in the root README table from a local run against \`foxguard 0.3.3 / semgrep 1.156.0 / tokei 14.0.0\`, including the sentry row.
- **Reproduction recipe** in \`benchmarks/README.md\`: required/optional tools, machine-spec fields, and how to capture SHA + cache state when publishing numbers.

## New benchmark numbers

| Repo | Files | LoC | foxguard | Semgrep | Speedup |
|------|-------|-----|----------|---------|---------|
| express | 141 | 15,804 JS | 0.11s | 4.80s | 45x |
| flask | 83 | 14,029 Py | 0.08s | 5.70s | 73x |
| gin | 99 | 17,669 Go | 0.07s | 4.61s | 63x |
| **sentry** | **8,539** | **1,291,606 Py** | **12.19s** | **164.53s** | **13x** |

Sentry is the headline addition — a real production monitoring platform at 1.3M Python LoC. foxguard scans the whole tree in ~12 seconds (~106k LoC/sec), Semgrep in ~2m45s. The speedup narrows at scale vs. the small-framework ratios, which is both expected and honest — and still a big enough delta to matter for CI and local loops.

## Design notes

- **LoC scoping.** \`tokei -t <Language>\` is invoked once per repo via a new \`count_loc\` helper. The \`tokei_types_for_lang\` mapping keeps the LoC count aligned with what foxguard actually scans on each target: \`JavaScript,TypeScript,Jsx,Tsx\` for express; \`Python\` for flask/sentry; \`Go\` for gin. This avoids the "repo has 200k LoC but 180k of it is vendored \`.json\`" problem.
- **Opt-out.** \`sentry\` is cloned and scanned by default, but \`BENCH_SKIP_LARGE=1\` drops it from the matrix for anyone running the quick loop.
- **Results are still gitignored.** \`benchmarks/results-default.md\` is regenerated on every run and is not committed; the root README table is the snapshot published with the repo.

## Test plan

- [x] \`BENCH_SKIP_LARGE=1 BENCH_MODE=default ./benchmarks/run.sh\` — quick matrix, real LoC numbers in output
- [x] \`BENCH_MODE=default ./benchmarks/run.sh\` — full matrix including sentry, end-to-end
- [x] Script still handles missing tokei gracefully (\`N/A\` in the LoC column)
- [x] Script still handles missing semgrep/opengrep gracefully (\`N/A\` in those columns)

Closes #8.