### PR TITLE
Add intraprocedural taint engine and first Python taint rule (refs #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To reproduce: `./benchmarks/run.sh` (add `BENCH_SKIP_LARGE=1` for the quick matr
 | Language | Rules | Frameworks |
 |----------|-------|------------|
 | JavaScript/TypeScript | 25 | Express, JWT, cookies, XSS, log injection |
-| Python | 26 | Flask, Django, CSRF, session |
+| Python | 27 | Flask, Django, CSRF, session, intraprocedural taint |
 | Go | 8 | Gin, net/http, TLS |
 | Ruby | 10 | Rails, mass assignment, CSRF |
 | Java | 10 | Spring, XXE, deserialization |

--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -1,0 +1,92 @@
+# Taint tracking in foxguard
+
+This document describes the intraprocedural taint engine added as a proof of concept for issue #10. It is intended for rule authors and contributors, not end users.
+
+## Why taint at all
+
+Pure AST pattern matching can answer "is this dangerous sink used anywhere?" It cannot answer "is untrusted data reaching this sink?" Those are different questions. The conservative rules (`py/no-pickle`, `py/no-command-injection`, etc.) answer the first and are the right default for a local-first scanner: fast, zero false negatives on the sink itself, high recall at the cost of precision.
+
+The taint engine answers the second, on a narrower footprint. It lets us ship rules that fire only when there is a provable flow from a known source into a known sink within a single function. Higher precision, lower recall. The two rule classes coexist.
+
+## Scope of the POC
+
+In scope:
+
+- **One language**: Python.
+- **Intraprocedural**: each function body is analyzed independently.
+- **Flow-insensitive**: statements are processed in source order. Reassigning a tainted variable to a clean value drops the taint. Branches are not modeled — taint observed in one branch of an `if` persists through the fall-through.
+- **One level of attribute and subscript propagation**: `x.y` and `x[k]` are tainted when `x` is tainted.
+- **One level of wrapping-call propagation**: `bytes(x)` is tainted when `x` is tainted. This covers the common "sanitize by retype" anti-pattern.
+- **Alias-aware sinks and sources**: the engine resolves callees and source roots through the per-file import alias table already introduced for issue #7.
+
+Out of scope for this PR, tracked under #10 as follow-ups:
+
+- **Interprocedural**: no cross-function analysis. A helper `def get_data(): return request.data` will not taint callers.
+- **Cross-file**: no module boundary crossing.
+- **Sanitizer support**: `TaintSpec.sanitizers` exists on the struct so the YAML bridge in the next PR has a slot to fill, but the engine does not consult it yet. Every flow is reported.
+- **Field sensitivity**: `d["key"]` is tainted because `d` is. Different keys are not distinguished.
+- **Object attribute propagation beyond one level**: `x.y.z` is tainted when `x` is tainted, but the engine does not persist taint on `x.y` as a distinct name.
+- **Dynamic import forms**: `importlib.import_module(...)` does not interact with the alias table, so sinks reached through it are not recognized.
+- **Other languages**: JS/TS, Go, Java, etc. have no taint engine yet. Adding one per language is expected — the shape of the current Python engine is intended to serve as a template.
+
+## API
+
+The engine lives in `src/rules/python_taint.rs`. The public surface is four items:
+
+```rust
+pub enum NodeMatcher {
+    Attribute { root: String, field: String, description: String },
+    Call      { canonical: String,           description: String },
+    ParamName { names: Vec<String>,          description: String },
+}
+
+pub struct TaintSpec {
+    pub sources: Vec<NodeMatcher>,
+    pub sinks: Vec<NodeMatcher>,
+    pub sanitizers: Vec<NodeMatcher>, // reserved — see "Scope"
+}
+
+pub struct TaintFinding { /* sink location + source/sink descriptions */ }
+
+pub fn analyze_tree(
+    root: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+) -> Vec<TaintFinding>;
+```
+
+Nothing about Flask, pickle, or any other library is baked into the engine. A rule that wants to use taint tracking builds its own `TaintSpec`, hands it to `analyze_tree`, and maps the returned `TaintFinding`s to `Finding`s. The first consumer is `py/taint-pickle-deserialization` in `src/rules/python.rs` and is a good worked example.
+
+### `NodeMatcher` kinds
+
+- **`Attribute { root, field, description }`** — matches `root.field` and `root.intermediate.field` chains where the leftmost identifier equals `root`. The engine also tries the alias-resolved form of the leftmost, so one spec entry with `root: "request"` covers both `from flask import request` and `def handler(request)`.
+- **`Call { canonical, description }`** — matches a call whose callee resolves (raw *or* alias-resolved) to `canonical`. Use for method-call sources like `request.get_json()` and for sinks like `pickle.loads`.
+- **`ParamName { names, description }`** — matches function parameters whose name is in `names`. Used to mark implicit sources (e.g. a Flask handler signature `def handler(request):` should treat `request` as untrusted without any assignment).
+
+## Adding a new taint rule
+
+1. Define a struct in the appropriate rules module (e.g. `python.rs`).
+2. Build a `TaintSpec` with your sources, sinks, and (once supported) sanitizers.
+3. Implement `Rule::check_with_context` to call `python_taint::analyze_tree` with the spec and the context's alias table.
+4. Map each `TaintFinding` to a `Finding` with a description that mentions both the source and the sink — users want to know *why* a flow was flagged.
+5. Register the rule in `src/rules/mod.rs`.
+6. Add positive + negative fixtures in `tests/fixtures/` and an integration test asserting exact finding counts.
+
+The `py/taint-pickle-deserialization` rule is ~120 lines and is the canonical example.
+
+## Coexistence with conservative rules
+
+Taint rules do not replace direct-sink rules. In the POC, `py/no-pickle` fires on every `pickle.loads` call; `py/taint-pickle-deserialization` fires only on the subset where a flow is provable. A user may see both findings on the same line, with different messages. That is intended — the two rules encode different questions and should be silenced independently if the user wants to suppress one but not the other.
+
+## Performance
+
+The taint engine runs once per file, only on Python, and only when the file contains function definitions. The walk is a single pass over the AST with a small `HashMap` as state. No additional parsing, no network, no disk. On the existing `vulnerable.py` fixture the taint rule adds microseconds to a run that was already sub-millisecond.
+
+## Open questions for the full #10
+
+- **Sanitizer semantics.** Semgrep's `mode: taint` distinguishes "sanitized value" from "killed taint". Do we track the difference, or collapse them into "clean" for v1?
+- **Cross-function propagation.** The first step beyond intraprocedural is probably "trust the return type of helpers whose body we can see in the same file", then cross-file via module symbol tables. Each step adds real complexity and should be its own issue.
+- **YAML bridge.** The next PR will map Semgrep-style `pattern-sources` / `pattern-sinks` YAML into `TaintSpec`. The main open question is how much of Semgrep's pattern language we need to support for real-world taint rules to work — probably just `pattern:` and `pattern-either:` to start.
+
+Contributions and concrete counter-examples welcome on #10.

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -5,6 +5,7 @@ pub mod javascript;
 pub mod php;
 pub mod python;
 pub mod python_aliases;
+pub mod python_taint;
 pub mod ruby;
 pub mod rust_lang;
 pub mod semgrep_compat;
@@ -123,6 +124,7 @@ impl RuleRegistry {
         registry.register(Box::new(python::WtfCsrfCheckDefaultDisabled));
         registry.register(Box::new(python::DjangoAllowedHostsWildcard));
         registry.register(Box::new(python::SecureSslRedirectDisabled));
+        registry.register(Box::new(python::TaintPickleDeserialization));
 
         // Register Go rules
         registry.register(Box::new(go::NoSqlInjection));

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1803,3 +1803,144 @@ impl Rule for SecureSslRedirectDisabled {
         findings
     }
 }
+
+// ─── Rule: taint-pickle-deserialization ────────────────────────────────────
+//
+// Proof-of-concept rule exercising the new per-function taint engine.
+// Fires when Flask-style untrusted input reaches a pickle deserialization
+// sink within a single function body. Coexists with `py/no-pickle`:
+//
+//   - `py/no-pickle` is the conservative direct-sink rule. It fires on any
+//     call to `pickle.loads(...)` regardless of what the argument is.
+//   - `py/taint-pickle-deserialization` fires only when the argument is
+//     provably reachable from a known untrusted source within the same
+//     function. Higher precision, lower recall.
+//
+// Scope and limitations are documented in `docs/taint-tracking.md` and in
+// the doc comment on `python_taint`. Intraprocedural only, flow-insensitive,
+// no sanitizers yet.
+
+use crate::rules::python_taint::{self, NodeMatcher, TaintSpec};
+
+pub struct TaintPickleDeserialization;
+
+impl TaintPickleDeserialization {
+    fn spec() -> TaintSpec {
+        TaintSpec {
+            sources: vec![
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "data".into(),
+                    description: "flask.request.data".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "form".into(),
+                    description: "flask.request.form".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "args".into(),
+                    description: "flask.request.args".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "values".into(),
+                    description: "flask.request.values".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "json".into(),
+                    description: "flask.request.json".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "request.get_data".into(),
+                    description: "flask.request.get_data()".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "request.get_json".into(),
+                    description: "flask.request.get_json()".into(),
+                },
+                NodeMatcher::ParamName {
+                    names: vec!["request".into()],
+                    description: "untrusted request parameter".into(),
+                },
+            ],
+            sinks: vec![
+                NodeMatcher::Call {
+                    canonical: "pickle.loads".into(),
+                    description: "pickle.loads".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "pickle.load".into(),
+                    description: "pickle.load".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "cPickle.loads".into(),
+                    description: "cPickle.loads".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "cPickle.load".into(),
+                    description: "cPickle.load".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintPickleDeserialization {
+    fn id(&self) -> &str {
+        "py/taint-pickle-deserialization"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-502")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches pickle deserialization sink"
+    }
+    fn language(&self) -> Language {
+        Language::Python
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let taint_findings = python_taint::analyze_tree(
+            tree.root_node(),
+            source,
+            &spec,
+            ctx.python_aliases,
+        );
+
+        taint_findings
+            .into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can execute arbitrary code via pickle",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1917,12 +1917,8 @@ impl Rule for TaintPickleDeserialization {
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
         let spec = Self::spec();
-        let taint_findings = python_taint::analyze_tree(
-            tree.root_node(),
-            source,
-            &spec,
-            ctx.python_aliases,
-        );
+        let taint_findings =
+            python_taint::analyze_tree(tree.root_node(), source, &spec, ctx.python_aliases);
 
         taint_findings
             .into_iter()

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -196,12 +196,7 @@ fn analyze_function(
     walk_body(body, source, spec, aliases, &mut state, findings);
 }
 
-fn seed_param_sources(
-    params: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    state: &mut TaintState,
-) {
+fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
     let mut cursor = params.walk();
     for child in params.children(&mut cursor) {
         let param_name = match child.kind() {
@@ -569,7 +564,12 @@ mod tests {
     fn run(source: &str) -> Vec<TaintFinding> {
         let tree = parse_file(source, Language::Python).expect("parse");
         let aliases = ImportAliases::from_tree(source, &tree);
-        analyze_tree(tree.root_node(), source, &spec_pickle_from_request(), Some(&aliases))
+        analyze_tree(
+            tree.root_node(),
+            source,
+            &spec_pickle_from_request(),
+            Some(&aliases),
+        )
     }
 
     #[test]

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -1,0 +1,741 @@
+//! Intraprocedural, flow-insensitive taint analysis for Python.
+//!
+//! # Scope
+//!
+//! The engine walks a single function body in source order and reports
+//! every sink call whose arguments are reachable from a configured source.
+//! It is deliberately small:
+//!
+//! - **Per function.** No cross-function analysis. Each function is analyzed
+//!   independently; taint does not cross call boundaries.
+//! - **Per file.** No cross-file analysis. Callers of helper functions in
+//!   other modules are on their own.
+//! - **Flow-insensitive.** Statements are processed in source order. When a
+//!   variable is reassigned to a non-tainted expression the old taint is
+//!   dropped, but control flow is not modeled — taint observed in one branch
+//!   of an `if` is treated as taint in the fall-through. Over-approximation
+//!   is the whole point.
+//! - **No container sensitivity.** `d["key"]` is tainted if `d` is tainted.
+//!   Individual keys are not tracked.
+//! - **No attribute propagation beyond one level.** `x.y` is tainted if `x`
+//!   is tainted, but taint does not persist on `x.y` as a distinct name.
+//! - **No sanitizers yet.** The [`TaintSpec`] has a field for sanitizers so
+//!   the API is forward-compatible, but the engine does not consult it in
+//!   this POC.
+//!
+//! Everything the engine knows about *which* patterns are sources, sinks, or
+//! sanitizers is expressed declaratively via [`TaintSpec`] — nothing is
+//! hardcoded about Flask, pickle, or any other library. The POC ships one
+//! built-in rule as the first consumer; future rules (including
+//! Semgrep-compatible `mode: taint` YAML) will plug into the same API.
+
+use crate::rules::python_aliases::ImportAliases;
+use std::collections::HashMap;
+use tree_sitter::{Node, TreeCursor};
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+/// A pattern that matches an AST node for the purposes of taint analysis.
+///
+/// Kept intentionally narrow so that the YAML bridge in the follow-up PR
+/// has a finite target to compile into. Every match returns a short human
+/// description that is propagated to findings so the report can say
+/// *why* something was tainted.
+#[derive(Debug, Clone)]
+pub enum NodeMatcher {
+    /// Match an attribute access like `request.data` or `request.form`.
+    ///
+    /// The match is conservative: it triggers whenever the *leftmost*
+    /// identifier in a dotted chain equals `root` and the *final* attribute
+    /// segment equals `field`. This catches both `request.data` and
+    /// `flask.request.data`-style forms after alias resolution, without
+    /// over-fitting to a specific depth.
+    Attribute {
+        root: String,
+        field: String,
+        description: String,
+    },
+
+    /// Match a function or method call by its canonical dotted callee
+    /// path, after resolution through the per-file import alias table.
+    ///
+    /// Example: `canonical: "request.get_json"` matches `request.get_json()`,
+    /// `req.get_json()` where `req` is an alias for `request`, and
+    /// `from flask import request; request.get_json()`.
+    Call {
+        canonical: String,
+        description: String,
+    },
+
+    /// Match any use of a function parameter whose name is in this list.
+    ///
+    /// Useful for marking `request`-typed parameters as implicit sources:
+    /// `def handler(request): pickle.loads(request.data)` flags without
+    /// requiring an explicit assignment from a known source.
+    ParamName {
+        names: Vec<String>,
+        description: String,
+    },
+}
+
+impl NodeMatcher {
+    /// Short human description used in findings.
+    pub fn description(&self) -> &str {
+        match self {
+            NodeMatcher::Attribute { description, .. } => description,
+            NodeMatcher::Call { description, .. } => description,
+            NodeMatcher::ParamName { description, .. } => description,
+        }
+    }
+}
+
+/// Declarative taint specification consumed by the engine. Each rule that
+/// wants to use taint analysis builds one of these and passes it to
+/// [`analyze_function`].
+#[derive(Debug, Clone, Default)]
+pub struct TaintSpec {
+    pub sources: Vec<NodeMatcher>,
+    pub sinks: Vec<NodeMatcher>,
+    /// Reserved for the next PR — sanitizers are not consulted yet, but the
+    /// field exists so the YAML bridge has a slot to fill.
+    pub sanitizers: Vec<NodeMatcher>,
+}
+
+/// A single source→sink flow reported by the engine.
+#[derive(Debug, Clone)]
+pub struct TaintFinding {
+    /// Byte range of the sink node within the source string.
+    pub sink_start_byte: usize,
+    pub sink_end_byte: usize,
+    /// 1-indexed line of the sink.
+    pub sink_line: usize,
+    /// 1-indexed column of the sink.
+    pub sink_column: usize,
+    pub sink_end_line: usize,
+    pub sink_end_column: usize,
+    /// Description of the source matcher that tainted this flow.
+    pub source_description: String,
+    /// Description of the sink matcher that flagged this flow.
+    pub sink_description: String,
+}
+
+/// Run the taint engine over every function definition inside `root` and
+/// return one [`TaintFinding`] per source→sink flow discovered.
+///
+/// The root can be a whole file tree. The engine finds every
+/// `function_definition` inside it (including nested ones) and analyzes
+/// each independently.
+pub fn analyze_tree(
+    root: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+) -> Vec<TaintFinding> {
+    let mut findings = Vec::new();
+    collect_function_defs(root, &mut |func_node| {
+        analyze_function(func_node, source, spec, aliases, &mut findings);
+    });
+    findings
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+fn collect_function_defs<'tree, F>(node: Node<'tree>, visit: &mut F)
+where
+    F: FnMut(Node<'tree>),
+{
+    if node.kind() == "function_definition" {
+        visit(node);
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_function_defs(child, visit);
+    }
+}
+
+/// State maintained while walking a single function body. Maps local
+/// identifier names to a description of the source that tainted them.
+#[derive(Default)]
+struct TaintState {
+    tainted: HashMap<String, String>,
+}
+
+impl TaintState {
+    fn taint(&mut self, name: String, description: String) {
+        self.tainted.insert(name, description);
+    }
+
+    fn clear(&mut self, name: &str) {
+        self.tainted.remove(name);
+    }
+
+    fn describe(&self, name: &str) -> Option<&str> {
+        self.tainted.get(name).map(String::as_str)
+    }
+}
+
+fn analyze_function(
+    func_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    findings: &mut Vec<TaintFinding>,
+) {
+    let mut state = TaintState::default();
+
+    // Seed the state with any parameters marked as implicit sources.
+    if let Some(params) = func_node.child_by_field_name("parameters") {
+        seed_param_sources(params, source, spec, &mut state);
+    }
+
+    // Walk the body in source order, updating taint state at assignments
+    // and reporting flows at sink calls.
+    let Some(body) = func_node.child_by_field_name("body") else {
+        return;
+    };
+    walk_body(body, source, spec, aliases, &mut state, findings);
+}
+
+fn seed_param_sources(
+    params: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    state: &mut TaintState,
+) {
+    let mut cursor = params.walk();
+    for child in params.children(&mut cursor) {
+        let param_name = match child.kind() {
+            "identifier" => node_text(child, source),
+            "typed_parameter" | "default_parameter" | "typed_default_parameter" => {
+                // Drill to the first identifier inside.
+                let mut inner_cursor = child.walk();
+                let mut found: Option<&str> = None;
+                for inner in child.children(&mut inner_cursor) {
+                    if inner.kind() == "identifier" {
+                        found = Some(node_text(inner, source));
+                        break;
+                    }
+                }
+                match found {
+                    Some(n) => n,
+                    None => continue,
+                }
+            }
+            _ => continue,
+        };
+
+        for matcher in &spec.sources {
+            if let NodeMatcher::ParamName { names, description } = matcher {
+                if names.iter().any(|n| n == param_name) {
+                    state.taint(param_name.to_string(), description.clone());
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn walk_body(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+) {
+    // Nested function definitions have their own scope. Skip them — they'll
+    // be picked up independently by analyze_tree.
+    if node.kind() == "function_definition" {
+        return;
+    }
+
+    if node.kind() == "assignment" {
+        handle_assignment(node, source, spec, aliases, state);
+    }
+
+    if node.kind() == "call" {
+        handle_call(node, source, spec, aliases, state, findings);
+    }
+
+    // Tree-sitter's cursor walks in document order, which is exactly the
+    // "process statements in source order, unioning taint across branches"
+    // semantics the POC wants.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_body(child, source, spec, aliases, state, findings);
+    }
+}
+
+fn handle_assignment(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    state: &mut TaintState,
+) {
+    let (Some(left), Some(right)) = (
+        node.child_by_field_name("left"),
+        node.child_by_field_name("right"),
+    ) else {
+        return;
+    };
+
+    // Only track simple identifier LHS. Tuple/subscript LHS are out of
+    // scope for the POC.
+    if left.kind() != "identifier" {
+        return;
+    }
+    let lhs_name = node_text(left, source).to_string();
+
+    if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+        state.taint(lhs_name, desc);
+    } else {
+        // Reassignment with a clean RHS kills any previous taint on LHS.
+        state.clear(&lhs_name);
+    }
+}
+
+fn handle_call(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+) {
+    let Some(func) = node.child_by_field_name("function") else {
+        return;
+    };
+    let callee_text = node_text(func, source);
+    let resolved = match aliases {
+        Some(a) => a.resolve(callee_text).into_owned(),
+        None => callee_text.to_string(),
+    };
+
+    // Is this a sink?
+    let sink_desc = spec.sinks.iter().find_map(|m| match m {
+        NodeMatcher::Call {
+            canonical,
+            description,
+        } if *canonical == resolved => Some(description.clone()),
+        _ => None,
+    });
+    let Some(sink_desc) = sink_desc else {
+        return;
+    };
+
+    // Check each argument for taint.
+    let Some(args) = node.child_by_field_name("arguments") else {
+        return;
+    };
+    let mut cursor = args.walk();
+    for arg in args.named_children(&mut cursor) {
+        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state) {
+            let start = node.start_position();
+            let end = node.end_position();
+            findings.push(TaintFinding {
+                sink_start_byte: node.start_byte(),
+                sink_end_byte: node.end_byte(),
+                sink_line: start.row + 1,
+                sink_column: start.column + 1,
+                sink_end_line: end.row + 1,
+                sink_end_column: end.column + 1,
+                source_description: source_desc,
+                sink_description: sink_desc.clone(),
+            });
+            // One finding per sink call is enough — don't double-report
+            // when multiple args are tainted.
+            break;
+        }
+    }
+}
+
+/// Returns the source description if `expr` evaluates to (or references) a
+/// tainted value, otherwise `None`.
+fn expression_taint(
+    expr: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    state: &TaintState,
+) -> Option<String> {
+    // Direct source match on this expression.
+    if let Some(desc) = match_source(expr, source, spec, aliases) {
+        return Some(desc);
+    }
+
+    // Tainted identifier reference.
+    if expr.kind() == "identifier" {
+        let name = node_text(expr, source);
+        if let Some(desc) = state.describe(name) {
+            return Some(desc.to_string());
+        }
+    }
+
+    // Tainted attribute access on a tainted root (x.y where x is tainted).
+    if expr.kind() == "attribute" {
+        if let Some(object) = expr.child_by_field_name("object") {
+            if object.kind() == "identifier" {
+                let name = node_text(object, source);
+                if let Some(desc) = state.describe(name) {
+                    return Some(desc.to_string());
+                }
+            }
+        }
+    }
+
+    // Tainted subscript (d[k] where d is tainted — no key sensitivity).
+    if expr.kind() == "subscript" {
+        if let Some(value) = expr.child_by_field_name("value") {
+            if value.kind() == "identifier" {
+                let name = node_text(value, source);
+                if let Some(desc) = state.describe(name) {
+                    return Some(desc.to_string());
+                }
+            }
+            // Also: subscript whose value is itself a source attribute
+            // like `request.form["x"]`.
+            if let Some(desc) = match_source(value, source, spec, aliases) {
+                return Some(desc);
+            }
+        }
+    }
+
+    // Recurse one level for wrapping expressions (e.g. `bytes(request.data)`),
+    // so the taint survives trivial type conversions without requiring
+    // full interprocedural tracking.
+    if expr.kind() == "call" {
+        if let Some(args) = expr.child_by_field_name("arguments") {
+            let mut cursor = args.walk();
+            for arg in args.named_children(&mut cursor) {
+                if let Some(desc) = expression_taint(arg, source, spec, aliases, state) {
+                    return Some(desc);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn match_source(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+) -> Option<String> {
+    for matcher in &spec.sources {
+        match matcher {
+            NodeMatcher::Attribute {
+                root,
+                field,
+                description,
+            } => {
+                if node.kind() != "attribute" {
+                    continue;
+                }
+                let Some(final_attr) = node.child_by_field_name("attribute") else {
+                    continue;
+                };
+                if node_text(final_attr, source) != field.as_str() {
+                    continue;
+                }
+                let Some(raw_root) = leftmost_identifier(node, source) else {
+                    continue;
+                };
+                // Match against both the raw leftmost identifier (e.g.
+                // `request` from `from flask import request`) and its
+                // alias-resolved canonical (e.g. `flask.request`). This lets
+                // one spec cover both imported and parameter-introduced
+                // `request` names without requiring callers to duplicate
+                // their source list.
+                if raw_root == root.as_str() {
+                    return Some(description.clone());
+                }
+                if let Some(a) = aliases {
+                    if a.resolve(raw_root).as_ref() == root.as_str() {
+                        return Some(description.clone());
+                    }
+                }
+            }
+            NodeMatcher::Call {
+                canonical,
+                description,
+            } => {
+                if node.kind() != "call" {
+                    continue;
+                }
+                let Some(func) = node.child_by_field_name("function") else {
+                    continue;
+                };
+                let callee_text = node_text(func, source);
+                if callee_text == canonical.as_str() {
+                    return Some(description.clone());
+                }
+                if let Some(a) = aliases {
+                    if a.resolve(callee_text).as_ref() == canonical.as_str() {
+                        return Some(description.clone());
+                    }
+                }
+            }
+            NodeMatcher::ParamName { .. } => {
+                // ParamName matchers are applied when seeding the state
+                // from the function's parameter list, not when walking
+                // expressions.
+            }
+        }
+    }
+    None
+}
+
+/// Walk an attribute chain leftward and return the leftmost identifier text.
+/// For `request.form.get`, returns `"request"`. For `x.y`, returns `"x"`.
+/// Returns `None` if the leftmost node is not a simple identifier.
+fn leftmost_identifier<'a>(mut node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    loop {
+        match node.kind() {
+            "identifier" => return Some(node_text(node, source)),
+            "attribute" => {
+                node = node.child_by_field_name("object")?;
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    &source[node.byte_range()]
+}
+
+#[allow(dead_code)]
+fn debug_tree(node: Node<'_>, depth: usize) {
+    let mut cursor: TreeCursor = node.walk();
+    for _ in 0..depth {
+        eprint!("  ");
+    }
+    eprintln!("{}", node.kind());
+    for child in node.children(&mut cursor) {
+        debug_tree(child, depth + 1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parser::parse_file;
+    use crate::Language;
+
+    fn spec_pickle_from_request() -> TaintSpec {
+        TaintSpec {
+            sources: vec![
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "data".into(),
+                    description: "flask.request.data".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "form".into(),
+                    description: "flask.request.form".into(),
+                },
+                NodeMatcher::Attribute {
+                    root: "request".into(),
+                    field: "args".into(),
+                    description: "flask.request.args".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "request.get_json".into(),
+                    description: "flask.request.get_json()".into(),
+                },
+                NodeMatcher::ParamName {
+                    names: vec!["request".into()],
+                    description: "function parameter named request".into(),
+                },
+            ],
+            sinks: vec![
+                NodeMatcher::Call {
+                    canonical: "pickle.loads".into(),
+                    description: "pickle.loads".into(),
+                },
+                NodeMatcher::Call {
+                    canonical: "pickle.load".into(),
+                    description: "pickle.load".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+
+    fn run(source: &str) -> Vec<TaintFinding> {
+        let tree = parse_file(source, Language::Python).expect("parse");
+        let aliases = ImportAliases::from_tree(source, &tree);
+        analyze_tree(tree.root_node(), source, &spec_pickle_from_request(), Some(&aliases))
+    }
+
+    #[test]
+    fn direct_flow_request_data_to_pickle_loads() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = request.data
+    return pickle.loads(data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("request.data"));
+        assert_eq!(f[0].sink_description, "pickle.loads");
+    }
+
+    #[test]
+    fn chained_assignment_propagates_taint() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    a = request.form
+    b = a
+    c = b
+    return pickle.loads(c)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn reassignment_to_literal_kills_taint() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = request.data
+    data = b"static"
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn taint_survives_branch_over_approximation() {
+        // Flow-insensitive: taint observed in one branch persists into the
+        // fall-through. The POC deliberately over-approximates.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler(cond):
+    if cond:
+        data = request.data
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn function_parameter_named_request_is_tainted() {
+        let src = r#"
+import pickle
+
+def handler(request):
+    return pickle.loads(request.data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn nested_function_has_independent_taint() {
+        // The outer function taints `data`, but the inner function never
+        // sees it — each function body is analyzed independently.
+        let src = r#"
+import pickle
+from flask import request
+
+def outer():
+    data = request.data
+    def inner():
+        return pickle.loads(data)
+    return inner
+"#;
+        // outer() has no sink call; inner() has a sink call on `data`
+        // which is not in its own scope, so zero findings.
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn no_source_no_finding() {
+        let src = r#"
+import pickle
+
+def handler():
+    data = b"trusted"
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn source_call_get_json_flows_to_sink() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    payload = request.get_json()
+    return pickle.loads(payload)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn direct_source_as_sink_argument_without_intermediate() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    return pickle.loads(request.data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn subscript_on_tainted_root_is_tainted() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    form = request.form
+    return pickle.loads(form["payload"])
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn wrapping_call_preserves_taint() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    return pickle.loads(bytes(request.data))
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn alias_resolution_through_import_table() {
+        // import pickle as p; p.loads(...) must still be recognized as the
+        // pickle.loads sink when the alias table is supplied.
+        let src = r#"
+import pickle as p
+from flask import request
+
+def handler():
+    return p.loads(request.data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+}

--- a/tests/fixtures/safe_py_taint.py
+++ b/tests/fixtures/safe_py_taint.py
@@ -1,0 +1,53 @@
+# Negative fixture for the taint POC. Every function here calls
+# `pickle.loads` on something, but none of the arguments are reachable
+# from an untrusted source within the same function — so
+# `py/taint-pickle-deserialization` must NOT fire on this file.
+#
+# The existing `py/no-pickle` rule WILL fire on every call here because
+# it's conservative by design. That's correct and expected. This fixture
+# proves the new taint rule doesn't over-fire relative to NoPickle.
+
+import pickle
+from flask import request
+
+
+# Static literal argument — never untrusted.
+def static_literal():
+    return pickle.loads(b"static-bytes-payload")
+
+
+# Reassignment with a clean literal kills earlier taint.
+def reassignment_kills_taint():
+    data = request.data
+    data = b"overwritten-with-trusted-bytes"
+    return pickle.loads(data)
+
+
+# `request` is a *local variable* here, not a parameter or import, so
+# it is not tainted. The taint rule must not assume any name equal to
+# `request` is a source.
+def local_named_request_is_not_a_source():
+    request = b"some-bytes"  # noqa: F811  local shadow
+    return pickle.loads(request)
+
+
+# Taint from a DIFFERENT function should not leak into this one — the
+# engine is intraprocedural and per-function.
+def producer():
+    return request.data
+
+
+def consumer_of_different_function():
+    data = b"trusted"
+    return pickle.loads(data)
+
+
+# A call that happens to be named `loads` but isn't the pickle sink.
+class NotPickle:
+    def loads(self, x):
+        return x
+
+
+def not_pickle_loads():
+    fake = NotPickle()
+    return fake.loads(request.data)

--- a/tests/fixtures/vulnerable_py_taint.py
+++ b/tests/fixtures/vulnerable_py_taint.py
@@ -1,0 +1,71 @@
+# Taint-tracking POC fixture: every handler here shows untrusted input
+# reaching `pickle.loads` via a different intraprocedural path. Each
+# function should produce exactly one `py/taint-pickle-deserialization`
+# finding. The file also produces `py/no-pickle` findings from the
+# existing conservative rule — that's expected: the two rules coexist
+# and the taint rule is the precision upgrade, not a replacement.
+
+import pickle
+import pickle as p_alias
+from flask import request
+
+
+# ─── Direct: source flows into sink as the raw argument ────────────────
+def direct():
+    return pickle.loads(request.data)
+
+
+# ─── One-hop: source assigned to a local, local flows into sink ────────
+def one_hop():
+    data = request.form
+    return pickle.loads(data)
+
+
+# ─── Chained: taint survives a chain of assignments ────────────────────
+def chained():
+    a = request.args
+    b = a
+    c = b
+    return pickle.loads(c)
+
+
+# ─── Source call: `request.get_json()` is a Call source ────────────────
+def get_json_source():
+    payload = request.get_json()
+    return pickle.loads(payload)
+
+
+# ─── get_data method call source ───────────────────────────────────────
+def get_data_source():
+    raw = request.get_data()
+    return pickle.loads(raw)
+
+
+# ─── Parameter source: handler(request) marks `request` as tainted ─────
+def param_source(request):
+    return pickle.loads(request.data)
+
+
+# ─── Branch: taint observed in one branch persists (over-approximation)
+def through_branch(cond):
+    data = b"default"
+    if cond:
+        data = request.data
+    return pickle.loads(data)
+
+
+# ─── Subscript: `form["key"]` is tainted because `form` is ─────────────
+def through_subscript():
+    form = request.form
+    return pickle.loads(form["payload"])
+
+
+# ─── Wrapping call: `bytes(x)` preserves taint ─────────────────────────
+def through_wrapping():
+    return pickle.loads(bytes(request.data))
+
+
+# ─── Alias: `import pickle as p_alias; p_alias.loads(...)` still sinks
+def through_sink_alias():
+    data = request.data
+    return p_alias.loads(data)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -261,6 +261,82 @@ fn test_vulnerable_py_aliases_catches_all_bypass_forms() {
     }
 }
 
+/// POC for issue #10 intraprocedural taint tracking. Every function in
+/// `vulnerable_py_taint.py` shows a different shape of untrusted Flask
+/// input reaching `pickle.loads`. The taint rule must catch each flow,
+/// and the existing conservative `py/no-pickle` rule must keep firing
+/// alongside it (the two rules coexist by design).
+#[test]
+fn test_vulnerable_py_taint_catches_every_flow() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_py_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    // Ten function bodies, each with one source→sink flow: one taint
+    // finding per function. The conservative NoPickle rule fires on the
+    // same ten calls because its scope is "any pickle.loads", so we
+    // should see exactly ten of each.
+    assert_eq!(
+        counts.get("py/taint-pickle-deserialization").copied(),
+        Some(10),
+        "taint rule should fire ten times, one per handler. counts={:?}",
+        counts
+    );
+    assert_eq!(
+        counts.get("py/no-pickle").copied(),
+        Some(10),
+        "NoPickle should still fire ten times alongside the taint rule. counts={:?}",
+        counts
+    );
+    assert_eq!(
+        findings.len(),
+        20,
+        "expected 20 total findings (10 taint + 10 NoPickle), got {}",
+        findings.len()
+    );
+}
+
+/// Negative counterpart for the taint POC. Every pickle.loads call in
+/// `safe_py_taint.py` receives a non-tainted argument (static literal,
+/// reassignment kills taint, local variable named `request`, cross-function
+/// taint that the engine intentionally does not track). The taint rule
+/// must not fire at all. NoPickle still fires on every call — that's the
+/// intended division of labor between the conservative and precision
+/// rules.
+#[test]
+fn test_safe_py_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_py_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let taint_findings = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("py/taint-pickle-deserialization"))
+        .count();
+    assert_eq!(
+        taint_findings, 0,
+        "taint rule should not fire on safe_py_taint.py, got {} findings: {:?}",
+        taint_findings, findings
+    );
+}
+
 /// Negative regression for issue #7: aliased imports of the *same* sensitive
 /// modules, but called in safe shapes (static literals, SafeLoader, sha256,
 /// write-only pickle methods). Alias resolution must not silently widen the

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -49,6 +49,7 @@ const pyRules: Rule[] = [
   { id: 'py/no-ssrf', cwe: 'CWE-918', desc: 'SSRF via dynamic outbound request URL', severity: 'high' },
   { id: 'py/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic hash (MD5/SHA1)', severity: 'medium' },
   { id: 'py/no-pickle', cwe: 'CWE-502', desc: 'Deserialization of untrusted data via pickle', severity: 'high' },
+  { id: 'py/taint-pickle-deserialization', cwe: 'CWE-502', desc: 'Untrusted input reaches pickle deserialization (intraprocedural taint)', severity: 'critical' },
   { id: 'py/no-yaml-load', cwe: 'CWE-502', desc: 'Unsafe yaml.load() without SafeLoader', severity: 'high' },
   { id: 'py/no-debug-true', cwe: 'CWE-489', desc: 'DEBUG=True left enabled in production config', severity: 'medium' },
   { id: 'py/no-open-redirect', cwe: 'CWE-601', desc: 'Open redirect via user-controlled URL', severity: 'medium' },


### PR DESCRIPTION
## Summary

Pure AST matching can answer *"is this sink used"*, not *"is untrusted data reaching this sink"*. This PR adds a per-function intraprocedural taint engine for Python that answers the second question, and ships the first rule that consumes it.

**The engine is declarative.** Rules build a \`TaintSpec { sources, sinks, sanitizers }\` and hand it to \`analyze_tree\`. Nothing about Flask, pickle, or any other library is baked in. Sources/sinks are expressed as \`NodeMatcher\` variants — \`Attribute\`, \`Call\`, or \`ParamName\` — and resolve through the per-file import alias table from #7 so aliased imports don't bypass detection.

**First consumer**: \`py/taint-pickle-deserialization\` fires when Flask request data reaches any pickle loads sink within a single function body. Coexists with the conservative \`py/no-pickle\` rule — they encode different questions and are silenced independently.

## What's caught (all from the new fixture)

\`\`\`python
def direct():                                def through_subscript():
    return pickle.loads(request.data)            form = request.form
                                                 return pickle.loads(form["payload"])
def one_hop():
    data = request.form                      def through_wrapping():
    return pickle.loads(data)                    return pickle.loads(bytes(request.data))

def chained():                               def through_sink_alias():
    a = request.args                             data = request.data
    b = a                                        return p_alias.loads(data)
    c = b
    return pickle.loads(c)                   def param_source(request):
                                                 return pickle.loads(request.data)
def get_json_source():
    payload = request.get_json()             def through_branch(cond):
    return pickle.loads(payload)                 data = b"default"
                                                 if cond:
def get_data_source():                           data = request.data
    raw = request.get_data()                 return pickle.loads(data)
    return pickle.loads(raw)
\`\`\`

Ten handlers, one flow each. Ten taint findings. NoPickle also fires ten times (same calls, different question).

## What's intentionally not caught (yet — tracked under #10)

- Interprocedural / cross-file
- Sanitizers (\`TaintSpec.sanitizers\` field reserved; YAML bridge lands next)
- Field sensitivity (\`d["key"]\` is tainted because \`d\` is; keys aren't distinguished)
- Object attribute propagation beyond one level
- Dynamic imports (\`importlib.import_module\`)
- Other languages (JS/TS, Go, Java — each gets its own engine module)

Full scope and API in \`docs/taint-tracking.md\`.

## API surface

\`\`\`rust
pub enum NodeMatcher {
    Attribute { root: String, field: String, description: String },
    Call      { canonical: String,           description: String },
    ParamName { names: Vec<String>,          description: String },
}

pub struct TaintSpec {
    pub sources: Vec<NodeMatcher>,
    pub sinks: Vec<NodeMatcher>,
    pub sanitizers: Vec<NodeMatcher>,  // reserved
}

pub fn analyze_tree(
    root: Node<'_>,
    source: &str,
    spec: &TaintSpec,
    aliases: Option<&ImportAliases>,
) -> Vec<TaintFinding>;
\`\`\`

One entry point, one state type. The wire-through in the rule is ~120 lines of pure spec-building plus a \`TaintFinding → Finding\` map. Adding a new taint rule for command injection, SSRF, or SQLi against a different set of sources and sinks is now a day's work instead of a week's.

## Tests

**12 engine unit tests** (\`src/rules/python_taint.rs\`): direct flow, chained assignment, reassignment kills taint, branch over-approximation, parameter sources, nested function isolation, subscript propagation, wrapping calls, alias-resolved sinks, no-source baseline, empty source.

**2 integration tests** (\`tests/integration.rs\`):
- \`test_vulnerable_py_taint_catches_every_flow\` — 10 taint + 10 NoPickle = 20 findings
- \`test_safe_py_taint_has_no_taint_findings\` — 0 taint findings on the negative fixture (NoPickle still fires, expected)

**Regression safety**: existing \`test_vulnerable_py_finds_all_rules\` stays at 30 findings — the taint rule correctly does not fire on \`vulnerable.py\`'s \`pickle.loads(data)\` inside \`def deserialize(data):\` because \`data\` is a plain parameter, not named \`request\`.

## E2E validation performed locally

- [x] \`cargo test\` — 97 tests green (35 unit + 43 integration + 12 semgrep + 6 parity + 1 inventory)
- [x] \`cargo clippy --all-targets\` — no warnings
- [x] \`cargo build --release\` — clean
- [x] Terminal, JSON, SARIF 2.1.0 output formats all produce expected results on the new fixtures
- [x] \`-s critical\` severity filter returns only the 10 taint findings (correctly rated Critical)
- [x] \`-s high\` returns both rules (20 findings)
- [x] Directory scan \`tests/fixtures/\` finds 218 total, taint fires only on the new fixture
- [x] Exit codes: vulnerable=1, safe=0
- [x] Dogfood: \`foxguard src/\` finds 83 total, 0 taint (no self-flag)
- [x] \`vulnerable.py\` unchanged at 30 findings (regression-safe)

## Why this is a POC, not the full #10

\`#10\` is a tracking issue for dataflow/taint work across languages and use cases. This PR lands **one step**: the engine, one Python rule, docs, and tests. It deliberately **does not close #10**. Follow-ups on the roadmap:

1. **YAML bridge** — Semgrep-compatible \`mode: taint\` rules that compile to a \`TaintSpec\` at load time. Makes the engine user-extensible without a recompile.
2. **Sanitizer support** — the field exists; the engine doesn't consult it yet.
3. **More Python rules** — SSRF from \`request.url\`, command injection from \`request.form\` to \`subprocess\`, SQLi from \`request.args\` into a \`cursor.execute\` string build.
4. **Other languages** — JS/TS is the natural next target.

Refs #10.