### PR TITLE
Taint engine: wire up sanitizer support (refs #16)

### DIFF
--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -18,12 +18,13 @@ In scope:
 - **One level of attribute and subscript propagation**: `x.y` and `x[k]` are tainted when `x` is tainted.
 - **One level of wrapping-call propagation**: `bytes(x)` is tainted when `x` is tainted. This covers the common "sanitize by retype" anti-pattern.
 - **Alias-aware sinks and sources**: the engine resolves callees and source roots through the per-file import alias table already introduced for issue #7.
+- **Sanitizer support (collapsed to "clean")**: calls whose callee matches a `TaintSpec.sanitizers` entry produce a clean value even when their arguments were tainted. See the section below for the exact semantics.
 
 Out of scope for this PR, tracked under #10 as follow-ups:
 
 - **Interprocedural**: no cross-function analysis. A helper `def get_data(): return request.data` will not taint callers.
 - **Cross-file**: no module boundary crossing.
-- **Sanitizer support**: `TaintSpec.sanitizers` exists on the struct so the YAML bridge in the next PR has a slot to fill, but the engine does not consult it yet. Every flow is reported.
+- **Per-finding sanitization**: Semgrep's `mode: taint` distinguishes "this specific flow was sanitized" from "the value is now clean"; it can still fire on secondary flows that bypassed the sanitizer along a different path. foxguard's v1 collapses both cases into "clean" and does not track per-finding sanitization state.
 - **Field sensitivity**: `d["key"]` is tainted because `d` is. Different keys are not distinguished.
 - **Object attribute propagation beyond one level**: `x.y.z` is tainted when `x` is tainted, but the engine does not persist taint on `x.y` as a distinct name.
 - **Dynamic import forms**: `importlib.import_module(...)` does not interact with the alias table, so sinks reached through it are not recognized.
@@ -43,7 +44,7 @@ pub enum NodeMatcher {
 pub struct TaintSpec {
     pub sources: Vec<NodeMatcher>,
     pub sinks: Vec<NodeMatcher>,
-    pub sanitizers: Vec<NodeMatcher>, // reserved — see "Scope"
+    pub sanitizers: Vec<NodeMatcher>, // see "Sanitizers" below
 }
 
 pub struct TaintFinding { /* sink location + source/sink descriptions */ }
@@ -63,6 +64,39 @@ Nothing about Flask, pickle, or any other library is baked into the engine. A ru
 - **`Attribute { root, field, description }`** — matches `root.field` and `root.intermediate.field` chains where the leftmost identifier equals `root`. The engine also tries the alias-resolved form of the leftmost, so one spec entry with `root: "request"` covers both `from flask import request` and `def handler(request)`.
 - **`Call { canonical, description }`** — matches a call whose callee resolves (raw *or* alias-resolved) to `canonical`. Use for method-call sources like `request.get_json()` and for sinks like `pickle.loads`.
 - **`ParamName { names, description }`** — matches function parameters whose name is in `names`. Used to mark implicit sources (e.g. a Flask handler signature `def handler(request):` should treat `request` as untrusted without any assignment).
+
+## Sanitizers
+
+A sanitizer is a call that turns a tainted value into a clean one. Populate `TaintSpec.sanitizers` with `NodeMatcher::Call` entries whose `canonical` is the dotted callee path you want the engine to recognize:
+
+```rust
+TaintSpec {
+    sources: vec![/* ... */],
+    sinks:   vec![/* ... */],
+    sanitizers: vec![NodeMatcher::Call {
+        canonical: "html.escape".into(),
+        description: "html.escape".into(),
+    }],
+}
+```
+
+With that spec:
+
+```python
+raw = request.data            # tainted
+clean = html.escape(raw)      # sanitized → clean
+document.write(clean)         # NOT reported
+document.write(raw)           # still reported — `raw` was never rewritten
+```
+
+Semantics:
+
+- **Collapse to clean.** When a call's callee resolves (raw *or* alias-resolved) to a sanitizer's `canonical`, the engine treats the whole call expression as producing a clean value, regardless of whether any argument was tainted.
+- **The input variable is unaffected.** `clean = sanitize(raw)` does not clear `raw`; only the RHS expression is "clean", so subsequent uses of `raw` still flow.
+- **Only `NodeMatcher::Call` is meaningful as a sanitizer.** `Attribute` and `ParamName` matchers in the `sanitizers` list are ignored — sanitizers are always calls.
+- **Wrapping-call propagation is bypassed for sanitizers.** `bytes(tainted)` preserves taint (by the wrapping-call rule) *unless* `bytes` is in the sanitizer list, in which case it is treated as clean.
+
+Per-finding sanitization (Semgrep's `mode: taint` style, where a sanitizer cleans one flow but secondary flows bypassing it still fire) is still out of scope. If that matters for a rule, open an issue describing the concrete case.
 
 ## Adding a new taint rule
 
@@ -85,7 +119,6 @@ The taint engine runs once per file, only on Python, and only when the file cont
 
 ## Open questions for the full #10
 
-- **Sanitizer semantics.** Semgrep's `mode: taint` distinguishes "sanitized value" from "killed taint". Do we track the difference, or collapse them into "clean" for v1?
 - **Cross-function propagation.** The first step beyond intraprocedural is probably "trust the return type of helpers whose body we can see in the same file", then cross-file via module symbol tables. Each step adds real complexity and should be its own issue.
 - **YAML bridge.** The next PR will map Semgrep-style `pattern-sources` / `pattern-sinks` YAML into `TaintSpec`. The main open question is how much of Semgrep's pattern language we need to support for real-world taint rules to work — probably just `pattern:` and `pattern-either:` to start.
 

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -19,9 +19,10 @@
 //!   Individual keys are not tracked.
 //! - **No attribute propagation beyond one level.** `x.y` is tainted if `x`
 //!   is tainted, but taint does not persist on `x.y` as a distinct name.
-//! - **No sanitizers yet.** The [`TaintSpec`] has a field for sanitizers so
-//!   the API is forward-compatible, but the engine does not consult it in
-//!   this POC.
+//! - **Sanitizers collapse to "clean".** When a call whose callee matches a
+//!   [`TaintSpec::sanitizers`] entry is applied to a tainted value, the
+//!   result is treated as clean — the engine does not track a separate
+//!   "sanitized" state the way Semgrep's `mode: taint` does.
 //!
 //! Everything the engine knows about *which* patterns are sources, sinks, or
 //! sanitizers is expressed declaratively via [`TaintSpec`] — nothing is
@@ -96,8 +97,9 @@ impl NodeMatcher {
 pub struct TaintSpec {
     pub sources: Vec<NodeMatcher>,
     pub sinks: Vec<NodeMatcher>,
-    /// Reserved for the next PR — sanitizers are not consulted yet, but the
-    /// field exists so the YAML bridge has a slot to fill.
+    /// Calls whose callee matches one of these matchers are treated as
+    /// producing a clean value, even if their arguments were tainted. See
+    /// the module-level docs for the collapsed-to-clean semantics.
     pub sanitizers: Vec<NodeMatcher>,
 }
 
@@ -399,7 +401,14 @@ fn expression_taint(
     // Recurse one level for wrapping expressions (e.g. `bytes(request.data)`),
     // so the taint survives trivial type conversions without requiring
     // full interprocedural tracking.
+    //
+    // BUT: if the callee matches a configured sanitizer, the result is
+    // clean regardless of whether any argument was tainted. This is the
+    // "collapse to clean" semantics documented at the top of the module.
     if expr.kind() == "call" {
+        if is_sanitizer_call(expr, source, spec, aliases) {
+            return None;
+        }
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
@@ -411,6 +420,36 @@ fn expression_taint(
     }
 
     None
+}
+
+/// Returns `true` if `call_node` is a call whose callee matches any of the
+/// configured sanitizer matchers in `spec`. Only `NodeMatcher::Call` entries
+/// are meaningful as sanitizers today; other kinds are ignored.
+fn is_sanitizer_call(
+    call_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+) -> bool {
+    if call_node.kind() != "call" {
+        return false;
+    }
+    let Some(func) = call_node.child_by_field_name("function") else {
+        return false;
+    };
+    let callee_text = node_text(func, source);
+    let resolved: std::borrow::Cow<'_, str> = match aliases {
+        Some(a) => a.resolve(callee_text),
+        None => std::borrow::Cow::Borrowed(callee_text),
+    };
+    for matcher in &spec.sanitizers {
+        if let NodeMatcher::Call { canonical, .. } = matcher {
+            if callee_text == canonical.as_str() || resolved.as_ref() == canonical.as_str() {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn match_source(
@@ -723,6 +762,138 @@ def handler():
     return pickle.loads(bytes(request.data))
 "#;
         assert_eq!(run(src).len(), 1);
+    }
+
+    fn spec_pickle_with_html_escape_sanitizer() -> TaintSpec {
+        let mut spec = spec_pickle_from_request();
+        spec.sanitizers = vec![NodeMatcher::Call {
+            canonical: "html.escape".into(),
+            description: "html.escape".into(),
+        }];
+        spec
+    }
+
+    fn run_with(source: &str, spec: &TaintSpec) -> Vec<TaintFinding> {
+        let tree = parse_file(source, Language::Python).expect("parse");
+        let aliases = ImportAliases::from_tree(source, &tree);
+        analyze_tree(tree.root_node(), source, spec, Some(&aliases))
+    }
+
+    #[test]
+    fn sanitizer_call_kills_taint() {
+        let src = r#"
+import pickle
+import html
+from flask import request
+
+def handler():
+    raw = request.data
+    clean = html.escape(raw)
+    return pickle.loads(clean)
+"#;
+        assert_eq!(
+            run_with(src, &spec_pickle_with_html_escape_sanitizer()).len(),
+            0
+        );
+    }
+
+    #[test]
+    fn sanitizer_bypassed_still_flows() {
+        // html.escape is applied to `raw` and stored in `escaped`, but the
+        // sink reads the still-tainted `raw`. Must still fire.
+        let src = r#"
+import pickle
+import html
+from flask import request
+
+def handler():
+    raw = request.data
+    escaped = html.escape(raw)
+    return pickle.loads(raw)
+"#;
+        assert_eq!(
+            run_with(src, &spec_pickle_with_html_escape_sanitizer()).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn non_sanitizer_wrapping_call_preserves_taint() {
+        // bytes() is not listed as a sanitizer, so the wrapping-call rule
+        // still applies and taint survives.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = bytes(request.data)
+    return pickle.loads(data)
+"#;
+        assert_eq!(
+            run_with(src, &spec_pickle_with_html_escape_sanitizer()).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn sanitizer_result_assigned_to_new_variable() {
+        // The assignment `data = html.escape(request.args["q"])` must not
+        // add `data` to the taint set.
+        let src = r#"
+import pickle
+import html
+from flask import request
+
+def handler():
+    data = html.escape(request.args["q"])
+    return pickle.loads(data)
+"#;
+        assert_eq!(
+            run_with(src, &spec_pickle_with_html_escape_sanitizer()).len(),
+            0
+        );
+    }
+
+    #[test]
+    fn multiple_sanitizers_in_spec() {
+        let mut spec = spec_pickle_from_request();
+        spec.sanitizers = vec![
+            NodeMatcher::Call {
+                canonical: "html.escape".into(),
+                description: "html.escape".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "shlex.quote".into(),
+                description: "shlex.quote".into(),
+            },
+        ];
+
+        let src_escape = r#"
+import pickle
+import html
+from flask import request
+
+def handler():
+    return pickle.loads(html.escape(request.data))
+"#;
+        let src_quote = r#"
+import pickle
+import shlex
+from flask import request
+
+def handler():
+    return pickle.loads(shlex.quote(request.data))
+"#;
+        let src_neither = r#"
+import pickle
+from flask import request
+
+def handler():
+    return pickle.loads(urllib.parse.quote(request.data))
+"#;
+        assert_eq!(run_with(src_escape, &spec).len(), 0);
+        assert_eq!(run_with(src_quote, &spec).len(), 0);
+        assert_eq!(run_with(src_neither, &spec).len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Wires up `TaintSpec.sanitizers` in the intraprocedural Python taint engine. Previously the field existed on the struct but `expression_taint` ignored it, so every flow was reported.
- When a call's callee (raw or alias-resolved) matches a `NodeMatcher::Call` sanitizer entry, the call expression now evaluates to clean regardless of whether any argument was tainted. Collapses Semgrep's "sanitized value" vs "killed taint" distinction into a single "clean" state for v1.
- Only `NodeMatcher::Call` is meaningful as a sanitizer; `Attribute` / `ParamName` entries in the list are ignored.

## Design decisions

- **Collapse to clean for v1.** Per the issue discussion, we do not track Semgrep-style per-finding sanitization. Bypass flows (same tainted variable reaching the sink along a different path that did not go through the sanitizer) still fire correctly because the input variable is not cleared — only the sanitizer-call expression is clean.
- **Wrapping-call rule still applies to non-sanitizers.** `bytes(tainted)` preserves taint as before, unless `bytes` is explicitly listed as a sanitizer.
- **No rule changes.** Kept infra-only as the issue suggested — rule authors can opt in per-rule when they want. The existing `py/taint-pickle-deserialization` rule is unchanged.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` — 17 `python_taint` unit tests pass (5 new), all integration tests green, no regressions
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo fmt`
- [x] New unit tests cover: sanitizer kills taint, sanitizer bypassed still flows, non-sanitizer wrapping call preserves taint, sanitizer result assigned to new variable, multiple sanitizers in spec

Refs #16.