### PR TITLE
Taint engine: nested subscripts and tuple destructuring (refs #15)

### DIFF
--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -15,8 +15,10 @@ In scope:
 - **One language**: Python.
 - **Intraprocedural**: each function body is analyzed independently.
 - **Flow-insensitive**: statements are processed in source order. Reassigning a tainted variable to a clean value drops the taint. Branches are not modeled — taint observed in one branch of an `if` persists through the fall-through.
-- **One level of attribute and subscript propagation**: `x.y` and `x[k]` are tainted when `x` is tainted.
+- **One level of attribute propagation**: `x.y` is tainted when `x` is tainted.
+- **Nested subscript chains**: `x[k1][k2]...[kn]` is tainted whenever any link in the chain (or its root) is tainted. Keys are not distinguished — taint is propagated regardless of which key is read.
 - **One level of wrapping-call propagation**: `bytes(x)` is tainted when `x` is tainted. This covers the common "sanitize by retype" anti-pattern.
+- **Tuple/list destructuring with flow-insensitive conservative semantics**: `a, b = expr1, expr2` and `[a, b] = [expr1, expr2]` pair targets with RHS elements when the arities match, so only the matching slot carries taint. When the RHS is a single opaque expression (e.g. `a, b = helper()`), the engine conservatively taints *every* LHS target — we lack the type info to pick the right slot.
 - **Alias-aware sinks and sources**: the engine resolves callees and source roots through the per-file import alias table already introduced for issue #7.
 
 Out of scope for this PR, tracked under #10 as follow-ups:

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -275,18 +275,103 @@ fn handle_assignment(
         return;
     };
 
-    // Only track simple identifier LHS. Tuple/subscript LHS are out of
-    // scope for the POC.
-    if left.kind() != "identifier" {
+    // Simple identifier LHS: the common case.
+    if left.kind() == "identifier" {
+        let lhs_name = node_text(left, source).to_string();
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+            state.taint(lhs_name, desc);
+        } else {
+            // Reassignment with a clean RHS kills any previous taint on LHS.
+            state.clear(&lhs_name);
+        }
         return;
     }
-    let lhs_name = node_text(left, source).to_string();
 
-    if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
-        state.taint(lhs_name, desc);
-    } else {
-        // Reassignment with a clean RHS kills any previous taint on LHS.
-        state.clear(&lhs_name);
+    // Tuple/list destructuring LHS: `a, b = ...` or `[a, b] = ...`.
+    // Tree-sitter-python uses `pattern_list` for bare `a, b`, and
+    // `tuple_pattern` / `list_pattern` for parenthesized/bracketed forms.
+    // We walk the LHS targets and pair them with RHS elements when the
+    // RHS is also a tuple/list literal of the same arity. Otherwise we
+    // fall back to conservative semantics: if the RHS is tainted at all,
+    // taint every LHS target (we lack type info to pick the slot).
+    if is_destructuring_pattern(left) {
+        let lhs_targets = collect_destructuring_targets(left, source);
+        if lhs_targets.is_empty() {
+            return;
+        }
+
+        if let Some(rhs_elems) = tuple_like_elements(right) {
+            if rhs_elems.len() == lhs_targets.len() {
+                for (target, rhs) in lhs_targets.iter().zip(rhs_elems.iter()) {
+                    if let Some(desc) = expression_taint(*rhs, source, spec, aliases, state) {
+                        state.taint(target.clone(), desc);
+                    } else {
+                        state.clear(target);
+                    }
+                }
+                return;
+            }
+        }
+
+        // Arity mismatch or opaque RHS: apply conservative semantics.
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+            for target in &lhs_targets {
+                state.taint(target.clone(), desc.clone());
+            }
+        } else {
+            for target in &lhs_targets {
+                state.clear(target);
+            }
+        }
+    }
+}
+
+fn is_destructuring_pattern(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "pattern_list" | "tuple_pattern" | "list_pattern"
+    )
+}
+
+/// Collect the identifier names that are direct targets of a destructuring
+/// LHS. Nested patterns (`(a, (b, c)) = ...`) recurse; non-identifier
+/// targets like `obj.attr` or `d[k]` are skipped because the engine only
+/// tracks plain names in its taint state.
+fn collect_destructuring_targets(node: Node<'_>, source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            "identifier" => out.push(node_text(child, source).to_string()),
+            "pattern_list" | "tuple_pattern" | "list_pattern" => {
+                out.extend(collect_destructuring_targets(child, source));
+            }
+            // `*rest` captures in unpacking: tree-sitter-python wraps the
+            // inner name in a list_splat_pattern.
+            "list_splat_pattern" => {
+                let mut inner = child.walk();
+                for c in child.named_children(&mut inner) {
+                    if c.kind() == "identifier" {
+                        out.push(node_text(c, source).to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// If `node` is a tuple/list literal or an `expression_list`, return its
+/// element nodes in order. Otherwise return `None`.
+fn tuple_like_elements<'tree>(node: Node<'tree>) -> Option<Vec<Node<'tree>>> {
+    match node.kind() {
+        "expression_list" | "tuple" | "list" => {
+            let mut cursor = node.walk();
+            let elems: Vec<Node<'tree>> = node.named_children(&mut cursor).collect();
+            Some(elems)
+        }
+        _ => None,
     }
 }
 
@@ -380,17 +465,14 @@ fn expression_taint(
     }
 
     // Tainted subscript (d[k] where d is tainted — no key sensitivity).
+    // Recurse into the subject so that nested subscript chains like
+    // `request.json["a"]["b"]` propagate taint: if any link in the chain
+    // (or its root) is tainted, the whole chain is. This also naturally
+    // handles attribute-then-subscript (`request.form["x"]`) and
+    // identifier roots via the recursive call.
     if expr.kind() == "subscript" {
         if let Some(value) = expr.child_by_field_name("value") {
-            if value.kind() == "identifier" {
-                let name = node_text(value, source);
-                if let Some(desc) = state.describe(name) {
-                    return Some(desc.to_string());
-                }
-            }
-            // Also: subscript whose value is itself a source attribute
-            // like `request.form["x"]`.
-            if let Some(desc) = match_source(value, source, spec, aliases) {
+            if let Some(desc) = expression_taint(value, source, spec, aliases, state) {
                 return Some(desc);
             }
         }
@@ -721,6 +803,84 @@ from flask import request
 
 def handler():
     return pickle.loads(bytes(request.data))
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn nested_subscript_propagates_through_chain() {
+        // `request.form["a"]["b"]["c"]` must be tainted: the innermost
+        // subject `request.form` is a source, and every outer subscript
+        // preserves taint regardless of the keys.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    return pickle.loads(request.form["a"]["b"]["c"])
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("request.form"));
+    }
+
+    #[test]
+    fn tuple_unpack_literal_rhs_taints_matching_element() {
+        // `a, b = request.args["a"], request.args["b"]`: both a and b are
+        // tainted because each RHS element is a subscript on a source.
+        // The sink reads `a`, so we should see exactly one finding.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    a, b = request.args["a"], request.args["b"]
+    return pickle.loads(a)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn tuple_unpack_literal_rhs_leaves_clean_element_clean() {
+        // Precise pairing: only the first element of the RHS is tainted,
+        // the sink reads `b` which pairs with the clean literal, so the
+        // taint rule must stay silent.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    a, b = request.args["a"], b"static"
+    return pickle.loads(b)
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn tuple_unpack_tainted_rhs_conservatively_taints_all_targets() {
+        // When the RHS is a single opaque expression we can't know which
+        // slot is tainted without type info, so both targets are tainted.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    a, b = request.get_json()
+    return pickle.loads(b)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn list_unpack_similar_to_tuple_unpack() {
+        // `[a, b] = ...` should behave the same as `a, b = ...`.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    [a, b] = [request.args["a"], b"static"]
+    return pickle.loads(a)
 "#;
         assert_eq!(run(src).len(), 1);
     }

--- a/tests/fixtures/safe_py_taint.py
+++ b/tests/fixtures/safe_py_taint.py
@@ -51,3 +51,17 @@ class NotPickle:
 def not_pickle_loads():
     fake = NotPickle()
     return fake.loads(request.data)
+
+
+# Tuple destructuring with two clean literal elements. Neither target
+# should be tainted — element-wise unpack kills any prior taint.
+def safe_tuple():
+    a, b = b"clean1", b"clean2"
+    return pickle.loads(a)
+
+
+# Element-wise unpack where only the OTHER slot is tainted. The sink
+# reads the clean slot, so the taint rule must stay silent.
+def safe_tuple_other_slot_tainted():
+    a, b = b"clean", request.args["x"]
+    return pickle.loads(a)

--- a/tests/fixtures/vulnerable_py_taint.py
+++ b/tests/fixtures/vulnerable_py_taint.py
@@ -69,3 +69,26 @@ def through_wrapping():
 def through_sink_alias():
     data = request.data
     return p_alias.loads(data)
+
+
+# ─── Nested subscript chain: taint must propagate through every level ──
+def nested_subscript_chain():
+    return pickle.loads(request.json["data"]["payload"])
+
+
+# ─── Tuple unpack with element-wise taint from a tuple RHS ─────────────
+def tuple_unpack_elementwise():
+    a, b = request.args["a"], request.args["b"]
+    return pickle.loads(a)
+
+
+# ─── Tuple unpack with opaque RHS: conservative taint of both targets ──
+def tuple_unpack_conservative():
+    a, b = request.get_json()
+    return pickle.loads(b)
+
+
+# ─── List unpack: same semantics as tuple unpack ───────────────────────
+def list_unpack_elementwise():
+    [x, y] = [b"static", request.form["payload"]]
+    return pickle.loads(y)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -285,26 +285,26 @@ fn test_vulnerable_py_taint_catches_every_flow() {
         }
     }
 
-    // Ten function bodies, each with one source→sink flow: one taint
-    // finding per function. The conservative NoPickle rule fires on the
-    // same ten calls because its scope is "any pickle.loads", so we
-    // should see exactly ten of each.
+    // Fourteen function bodies, each with one source→sink flow: one
+    // taint finding per function. The conservative NoPickle rule fires
+    // on the same fourteen calls because its scope is "any pickle.loads",
+    // so we should see exactly fourteen of each.
     assert_eq!(
         counts.get("py/taint-pickle-deserialization").copied(),
-        Some(10),
-        "taint rule should fire ten times, one per handler. counts={:?}",
+        Some(14),
+        "taint rule should fire fourteen times, one per handler. counts={:?}",
         counts
     );
     assert_eq!(
         counts.get("py/no-pickle").copied(),
-        Some(10),
-        "NoPickle should still fire ten times alongside the taint rule. counts={:?}",
+        Some(14),
+        "NoPickle should still fire fourteen times alongside the taint rule. counts={:?}",
         counts
     );
     assert_eq!(
         findings.len(),
-        20,
-        "expected 20 total findings (10 taint + 10 NoPickle), got {}",
+        28,
+        "expected 28 total findings (14 taint + 14 NoPickle), got {}",
         findings.len()
     );
 }


### PR DESCRIPTION
## Summary

Fixes two known limitations in the intraprocedural Python taint engine (refs #15).

- **Nested subscript chains.** `request.json["a"]["b"]` now propagates taint. The `subscript` branch of `expression_taint` recurses into the subject instead of only checking if the immediate value is an identifier or source, so any tainted link anywhere in the chain taints the whole expression.
- **Tuple/list destructuring.** `a, b = expr1, expr2` and `[a, b] = [expr1, expr2]` are now handled. When the LHS is a `pattern_list` / `tuple_pattern` / `list_pattern` and the RHS is a tuple/list literal of matching arity, targets are paired element-wise so only the matching slot carries taint. When the RHS is a single opaque expression (e.g. `a, b = helper()`), the engine conservatively taints every LHS target — we lack the type info to know which slot is tainted.

## Design notes

- Subscript generalization is a one-liner recursion, which also subsumes the previous special cases (tainted identifier subject, tainted source attribute subject).
- Destructuring uses element-wise pairing when possible because it gives cleaner precision on the common idiom (`a, b = request.args["a"], b"static"` should not taint `b`), with a conservative fallback for opaque RHSs so we don't miss flows through helper-call unpack.
- Nested LHS patterns recurse; `*rest` splat targets are flattened into the target list.

## Test plan

- [x] `cargo test` — 17 unit tests in `python_taint` (4 new) and the integration test asserting the new 14/14 counts on `vulnerable_py_taint.py` all pass.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt` clean.
- [x] `cargo build --release` clean.
- [x] Manual smoke on `tests/fixtures/vulnerable_py_taint.py`: 14 `py/taint-pickle-deserialization` + 14 `py/no-pickle`.
- [x] Manual smoke on `tests/fixtures/safe_py_taint.py`: 0 taint findings, 6 `py/no-pickle`.
- [x] `docs/taint-tracking.md` updated — nested subscripts and tuple/list destructuring moved from "out of scope" to the supported list with precise wording on the conservative semantics.