### PR TITLE
Semgrep-compatible YAML bridge for taint rules (refs #17)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -63,6 +63,17 @@ Metavariable filtering:
 
 - `metavariable-regex`
 
+Taint rules (`mode: taint`):
+
+- `mode: taint` on Python rules only; non-Python taint rules are skipped with a warning
+- `pattern-sources`, `pattern-sinks`, `pattern-sanitizers` — each entry must be a single `pattern:` string
+- Supported `pattern:` shapes:
+  - bare identifier (`request`) — a source-only shape compiled to a parameter-name match
+  - dotted attribute chain (`request.data`, `request.json`) — nested chains flatten to `leftmost root + outermost field` (matches the engine's one-level attribute propagation)
+  - call forms with any arguments (`pickle.loads($X)`, `pickle.loads(...)`, `pickle.loads()`, `eval($X)`) — arguments are stripped, the dotted callee path is what matches
+- Severity mapping matches the pattern-rule bridge (`ERROR` → Critical, `WARNING` → High, `INFO` → Medium) and `metadata.cwe` is propagated to findings
+- Rules that use anything outside this subset (`pattern-either` / `pattern-inside` / `metavariable-pattern` inside a source/sink/sanitizer block, unsupported pattern shapes, non-Python languages, missing sources or sinks) are skipped with a warning — other rules in the same file still load
+
 Language mapping:
 
 - JavaScript / TypeScript

--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -119,9 +119,36 @@ Taint rules do not replace direct-sink rules. In the POC, `py/no-pickle` fires o
 
 The taint engine runs once per file, only on Python, and only when the file contains function definitions. The walk is a single pass over the AST with a small `HashMap` as state. No additional parsing, no network, no disk. On the existing `vulnerable.py` fixture the taint rule adds microseconds to a run that was already sub-millisecond.
 
+## Semgrep-compatible YAML bridge
+
+Issue #17 added a narrow YAML bridge so existing Semgrep `mode: taint` rules can be loaded with `--rules` and compiled into the same `TaintSpec` that native rules build by hand. The bridge lives in [`src/rules/semgrep_taint.rs`](../src/rules/semgrep_taint.rs); see [COMPATIBILITY.md](../COMPATIBILITY.md) for the exact subset of Semgrep's taint schema that is supported and what falls back to "skip with warning".
+
+A minimum working YAML rule looks like this:
+
+```yaml
+rules:
+  - id: semgrep-pickle-taint
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: "Untrusted Flask input reaches pickle.loads"
+    metadata:
+      cwe: "CWE-502"
+    pattern-sources:
+      - pattern: request.data
+      - pattern: request.form
+      - pattern: request.get_json($X)
+      - pattern: request
+    pattern-sinks:
+      - pattern: pickle.loads($X)
+      - pattern: pickle.load($X)
+```
+
+Load it with `foxguard --no-builtins --rules path/to/rule.yml target/` and each compiled rule becomes a regular foxguard `Rule` backed by the same intraprocedural engine described above.
+
 ## Open questions for the full #10
 
 - **Cross-function propagation.** The first step beyond intraprocedural is probably "trust the return type of helpers whose body we can see in the same file", then cross-file via module symbol tables. Each step adds real complexity and should be its own issue.
-- **YAML bridge.** The next PR will map Semgrep-style `pattern-sources` / `pattern-sinks` YAML into `TaintSpec`. The main open question is how much of Semgrep's pattern language we need to support for real-world taint rules to work — probably just `pattern:` and `pattern-either:` to start.
+- **Broader pattern surface in the YAML bridge.** `pattern-either` inside source/sink blocks, `pattern-inside` / `metavariable-pattern` constraints, and per-finding sanitization semantics are still unsupported. The bridge skips such rules with a warning rather than partially loading them.
 
 Contributions and concrete counter-examples welcome on #10.

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,6 +9,7 @@ pub mod python_taint;
 pub mod ruby;
 pub mod rust_lang;
 pub mod semgrep_compat;
+pub mod semgrep_taint;
 pub mod swift;
 
 use crate::{Finding, Language, Severity};

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -953,13 +953,44 @@ fn extract_cwe(yaml: &SemgrepRuleYaml) -> Option<String> {
 
 /// Parse a single Semgrep YAML file into foxguard rules.
 pub fn parse_semgrep_file(path: &Path) -> Result<Vec<Box<dyn Rule>>, String> {
+    use crate::rules::semgrep_taint::{self, TaintRuleParse};
+    use serde_yaml::Value as YamlValue;
+
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
 
-    let semgrep_file: SemgrepFile = serde_yaml::from_str(&content)
+    // First pass: parse as an untyped Value so we can detect `mode: taint`
+    // rules and route them to the taint bridge without breaking the strict
+    // `SemgrepRuleYaml` schema used for pattern rules.
+    let raw_doc: YamlValue = serde_yaml::from_str(&content)
         .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
 
     let mut rules: Vec<Box<dyn Rule>> = Vec::new();
+    let mut pattern_rule_nodes: Vec<YamlValue> = Vec::new();
+
+    if let Some(raw_rules) = raw_doc.get("rules").and_then(YamlValue::as_sequence) {
+        for raw_rule in raw_rules {
+            match semgrep_taint::parse_taint_rule(raw_rule) {
+                TaintRuleParse::Compiled(r) => rules.push(Box::new(r)),
+                TaintRuleParse::Skip(msg) => eprintln!("Warning: {}", msg),
+                TaintRuleParse::NotTaint => pattern_rule_nodes.push(raw_rule.clone()),
+            }
+        }
+    }
+
+    // Second pass: the non-taint rules go through the existing strict
+    // deserialization path. Re-serialize them into a minimal `SemgrepFile`
+    // so we reuse `build_matcher`, path filters, language mapping, etc.
+    let pattern_file = YamlValue::Mapping({
+        let mut m = serde_yaml::Mapping::new();
+        m.insert(
+            YamlValue::String("rules".into()),
+            YamlValue::Sequence(pattern_rule_nodes),
+        );
+        m
+    });
+    let semgrep_file: SemgrepFile = serde_yaml::from_value(pattern_file)
+        .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
 
     for yaml_rule in semgrep_file.rules {
         let cwe = extract_cwe(&yaml_rule);

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -1,0 +1,547 @@
+//! Semgrep-compatible YAML bridge for `mode: taint` rules.
+//!
+//! This module parses a *narrow* subset of Semgrep's taint-mode schema into
+//! foxguard's [`TaintSpec`] so that users can load existing Semgrep taint
+//! rules via `--rules` without rewriting them.
+//!
+//! # Supported today
+//!
+//! - `mode: taint` with `languages: [python]` (other languages are rejected
+//!   with a warning and the rule is skipped; non-taint rules fall through to
+//!   the regular Semgrep bridge).
+//! - `pattern-sources`, `pattern-sinks`, `pattern-sanitizers` as lists of
+//!   single-`pattern:` entries.
+//! - Severity mapping via the same `map_severity` used by the pattern-rule
+//!   bridge (`ERROR` → Critical, `WARNING` → High, `INFO` → Medium).
+//! - `metadata.cwe` propagated to findings.
+//!
+//! # Unsupported (rule is skipped with a warning)
+//!
+//! - `pattern-either:` lists inside source/sink/sanitizer entries.
+//! - `pattern-inside:`, `metavariable-pattern:` inside source/sink blocks.
+//! - Any `mode: taint` rule that does not target Python.
+//! - Any `pattern:` string whose shape is not one of:
+//!   - bare identifier (`request`) — compiled to `ParamName`
+//!   - dotted attribute chain (`request.data`, `request.json`) — compiled
+//!     to `Attribute { root, field }` using the *leftmost* identifier and
+//!     the *outermost* attribute (nested chains like `request.session.id`
+//!     are flattened to `root="request", field="id"`; documented as a known
+//!     gap that matches the engine's own one-level attribute propagation).
+//!   - call form (`pickle.loads($X)`, `pickle.loads(...)`, `func($X)`,
+//!     `func()`) — compiled to `Call { canonical }`, stripping arguments.
+//!
+//! Unsupported patterns inside an otherwise-loadable rule cause the *whole
+//! rule* to be skipped (with an explanatory warning) so the user sees a
+//! clear signal rather than a silently-degraded match surface.
+
+use crate::rules::python_taint::{self, NodeMatcher, TaintSpec};
+use crate::rules::{FileContext, Rule};
+use crate::{Finding, Language, Severity};
+use serde_yaml::Value as YamlValue;
+
+/// A compiled Semgrep `mode: taint` rule.
+pub struct SemgrepTaintRule {
+    pub id: String,
+    pub message: String,
+    pub severity: Severity,
+    pub cwe: Option<String>,
+    pub lang: Language,
+    pub spec: TaintSpec,
+}
+
+impl Rule for SemgrepTaintRule {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+    fn cwe(&self) -> Option<&str> {
+        self.cwe.as_deref()
+    }
+    fn description(&self) -> &str {
+        &self.message
+    }
+    fn language(&self) -> Language {
+        self.lang
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let raw =
+            python_taint::analyze_tree(tree.root_node(), source, &self.spec, ctx.python_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id.clone(),
+                severity: self.severity,
+                cwe: self.cwe.clone(),
+                description: format!(
+                    "{} — {} reaches {}",
+                    self.message, t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}
+
+fn get_source_line(source: &str, byte_offset: usize) -> String {
+    let start = source[..byte_offset].rfind('\n').map_or(0, |p| p + 1);
+    let end = source[byte_offset..]
+        .find('\n')
+        .map_or(source.len(), |p| byte_offset + p);
+    source[start..end].to_string()
+}
+
+// ─── YAML → TaintSpec compilation ─────────────────────────────────────────
+
+/// Outcome of trying to parse a single YAML rule as a taint rule.
+pub enum TaintRuleParse {
+    /// The rule is `mode: taint` and was compiled successfully.
+    Compiled(SemgrepTaintRule),
+    /// The rule is `mode: taint` but we could not compile it (bad language,
+    /// unsupported pattern syntax, missing required sections, …). The caller
+    /// should surface the warning and skip the rule.
+    Skip(String),
+    /// The rule is *not* `mode: taint`. The caller should fall through to
+    /// its existing pattern-rule handling path.
+    NotTaint,
+}
+
+/// Attempt to parse a single Semgrep YAML rule as a `mode: taint` rule.
+///
+/// Returns [`TaintRuleParse::NotTaint`] when the rule does not declare
+/// `mode: taint`, so the caller can keep running its normal pattern-rule
+/// compilation without an early exit.
+pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
+    // Only engage for rules that explicitly declare `mode: taint`.
+    let mode = yaml.get("mode").and_then(YamlValue::as_str);
+    if mode != Some("taint") {
+        return TaintRuleParse::NotTaint;
+    }
+
+    let id = match yaml.get("id").and_then(YamlValue::as_str) {
+        Some(s) => s.to_string(),
+        None => return TaintRuleParse::Skip("taint rule missing `id`".into()),
+    };
+
+    // Language: Python only for now.
+    let lang = match yaml.get("languages").and_then(YamlValue::as_sequence) {
+        Some(langs) => {
+            let has_python = langs
+                .iter()
+                .filter_map(YamlValue::as_str)
+                .any(|s| matches!(s.to_lowercase().as_str(), "python" | "py"));
+            if !has_python {
+                return TaintRuleParse::Skip(format!(
+                    "taint rule `{}` targets non-Python languages; only Python is supported",
+                    id
+                ));
+            }
+            Language::Python
+        }
+        None => return TaintRuleParse::Skip(format!("taint rule `{}` missing `languages`", id)),
+    };
+
+    let message = yaml
+        .get("message")
+        .and_then(YamlValue::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let severity_str = yaml
+        .get("severity")
+        .and_then(YamlValue::as_str)
+        .unwrap_or("WARNING");
+    let severity = map_severity(severity_str);
+
+    let cwe = extract_cwe(yaml);
+
+    // ── Compile sources ────────────────────────────────────────────────
+    let sources = match compile_matcher_list(yaml.get("pattern-sources"), MatcherRole::Source) {
+        Ok(v) => v,
+        Err(e) => return TaintRuleParse::Skip(format!("taint rule `{}` skipped: {}", id, e)),
+    };
+    if sources.is_empty() {
+        return TaintRuleParse::Skip(format!("taint rule `{}` has no `pattern-sources`", id));
+    }
+
+    let sinks = match compile_matcher_list(yaml.get("pattern-sinks"), MatcherRole::Sink) {
+        Ok(v) => v,
+        Err(e) => return TaintRuleParse::Skip(format!("taint rule `{}` skipped: {}", id, e)),
+    };
+    if sinks.is_empty() {
+        return TaintRuleParse::Skip(format!("taint rule `{}` has no `pattern-sinks`", id));
+    }
+
+    let sanitizers =
+        match compile_matcher_list(yaml.get("pattern-sanitizers"), MatcherRole::Sanitizer) {
+            Ok(v) => v,
+            Err(e) => return TaintRuleParse::Skip(format!("taint rule `{}` skipped: {}", id, e)),
+        };
+
+    TaintRuleParse::Compiled(SemgrepTaintRule {
+        id: format!("semgrep/{}", id),
+        message,
+        severity,
+        cwe,
+        lang,
+        spec: TaintSpec {
+            sources,
+            sinks,
+            sanitizers,
+        },
+    })
+}
+
+#[derive(Copy, Clone)]
+enum MatcherRole {
+    Source,
+    Sink,
+    Sanitizer,
+}
+
+impl MatcherRole {
+    fn label(self) -> &'static str {
+        match self {
+            MatcherRole::Source => "pattern-sources",
+            MatcherRole::Sink => "pattern-sinks",
+            MatcherRole::Sanitizer => "pattern-sanitizers",
+        }
+    }
+}
+
+fn compile_matcher_list(
+    node: Option<&YamlValue>,
+    role: MatcherRole,
+) -> Result<Vec<NodeMatcher>, String> {
+    let Some(node) = node else {
+        return Ok(Vec::new());
+    };
+    let Some(entries) = node.as_sequence() else {
+        return Err(format!("{} must be a list", role.label()));
+    };
+
+    let mut out = Vec::new();
+    for entry in entries {
+        // Each entry is expected to be a mapping with a `pattern:` key.
+        // Reject `pattern-either`, `pattern-inside`, `metavariable-pattern`
+        // etc. explicitly so users get a clear error instead of a silent
+        // no-op match.
+        let Some(map) = entry.as_mapping() else {
+            return Err(format!(
+                "{} entries must be mappings with a `pattern:` key",
+                role.label()
+            ));
+        };
+
+        for (k, _) in map {
+            match k.as_str() {
+                Some("pattern") => {}
+                Some(other) => {
+                    return Err(format!(
+                        "{} uses unsupported key `{}` (only `pattern:` is supported today)",
+                        role.label(),
+                        other
+                    ));
+                }
+                None => {
+                    return Err(format!("{} has a non-string key", role.label()));
+                }
+            }
+        }
+
+        let pattern = map
+            .get(YamlValue::String("pattern".into()))
+            .and_then(YamlValue::as_str)
+            .ok_or_else(|| format!("{} entry missing `pattern:`", role.label()))?;
+
+        let matcher = compile_pattern(pattern, role)
+            .ok_or_else(|| format!("{}: unsupported pattern shape `{}`", role.label(), pattern))?;
+        out.push(matcher);
+    }
+    Ok(out)
+}
+
+/// Compile a single Semgrep pattern string into a [`NodeMatcher`].
+///
+/// Returns `None` if the pattern shape is not one of the supported forms
+/// (see module docs). Callers surface that as a skip-with-warning at the
+/// rule level.
+fn compile_pattern(pattern: &str, role: MatcherRole) -> Option<NodeMatcher> {
+    let pat = pattern.trim();
+    if pat.is_empty() {
+        return None;
+    }
+
+    // ── Call form: `root.method(...)` or `func($X)` ─────────────────────
+    if let Some(open_paren) = pat.find('(') {
+        if !pat.ends_with(')') {
+            return None;
+        }
+        let callee = pat[..open_paren].trim();
+        if callee.is_empty() {
+            return None;
+        }
+        // Callee must be a plain identifier or dotted identifier chain.
+        if !is_dotted_identifier(callee) {
+            return None;
+        }
+        let canonical = callee.to_string();
+        return Some(NodeMatcher::Call {
+            canonical: canonical.clone(),
+            description: describe(&canonical, role),
+        });
+    }
+
+    // ── No parens: identifier or attribute chain ────────────────────────
+    if !is_dotted_identifier(pat) {
+        return None;
+    }
+
+    if let Some(dot) = pat.rfind('.') {
+        // `root.field` or `root.intermediate.field`. The engine only
+        // supports one-level roots, so we take the leftmost segment as
+        // the root and the outermost (last) segment as the field.
+        let root = pat[..pat.find('.').unwrap()].to_string();
+        let field = pat[dot + 1..].to_string();
+        if root.is_empty() || field.is_empty() {
+            return None;
+        }
+        let desc = describe(pat, role);
+        return Some(NodeMatcher::Attribute {
+            root,
+            field,
+            description: desc,
+        });
+    }
+
+    // Bare identifier → treat as a ParamName source / sink would not make
+    // sense, so for non-source roles we refuse this shape.
+    match role {
+        MatcherRole::Source => Some(NodeMatcher::ParamName {
+            names: vec![pat.to_string()],
+            description: format!("untrusted `{}` parameter", pat),
+        }),
+        MatcherRole::Sink | MatcherRole::Sanitizer => None,
+    }
+}
+
+fn describe(canonical: &str, role: MatcherRole) -> String {
+    match role {
+        MatcherRole::Source => format!("semgrep source `{}`", canonical),
+        MatcherRole::Sink => format!("semgrep sink `{}`", canonical),
+        MatcherRole::Sanitizer => format!("semgrep sanitizer `{}`", canonical),
+    }
+}
+
+/// True when `s` is a `.`-separated chain of identifier segments, each of
+/// which is an ASCII identifier (`[A-Za-z_][A-Za-z0-9_]*`). Used to reject
+/// pattern strings that contain metavariables, operators, or whitespace
+/// outside of a call form.
+fn is_dotted_identifier(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    s.split('.').all(is_identifier)
+}
+
+fn is_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn map_severity(s: &str) -> Severity {
+    match s.to_ascii_uppercase().as_str() {
+        "ERROR" => Severity::Critical,
+        "WARNING" => Severity::High,
+        "INFO" => Severity::Medium,
+        _ => Severity::Medium,
+    }
+}
+
+fn extract_cwe(yaml: &YamlValue) -> Option<String> {
+    let meta = yaml.get("metadata")?;
+    let cwe = meta.get("cwe")?;
+    match cwe {
+        YamlValue::String(s) => Some(s.clone()),
+        YamlValue::Sequence(v) => v.first().and_then(|x| x.as_str()).map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn compile(pattern: &str, role: MatcherRole) -> Option<NodeMatcher> {
+        compile_pattern(pattern, role)
+    }
+
+    #[test]
+    fn compile_attribute_source() {
+        let m = compile("request.data", MatcherRole::Source).expect("attribute");
+        match m {
+            NodeMatcher::Attribute { root, field, .. } => {
+                assert_eq!(root, "request");
+                assert_eq!(field, "data");
+            }
+            _ => panic!("expected Attribute"),
+        }
+    }
+
+    #[test]
+    fn compile_nested_attribute_takes_leftmost_root_and_outermost_field() {
+        let m = compile("request.session.user_id", MatcherRole::Source).expect("attribute");
+        match m {
+            NodeMatcher::Attribute { root, field, .. } => {
+                assert_eq!(root, "request");
+                assert_eq!(field, "user_id");
+            }
+            _ => panic!("expected Attribute"),
+        }
+    }
+
+    #[test]
+    fn compile_call_with_metavar() {
+        let m = compile("pickle.loads($X)", MatcherRole::Sink).expect("call");
+        match m {
+            NodeMatcher::Call { canonical, .. } => assert_eq!(canonical, "pickle.loads"),
+            _ => panic!("expected Call"),
+        }
+    }
+
+    #[test]
+    fn compile_call_with_ellipsis() {
+        let m = compile("pickle.loads(...)", MatcherRole::Sink).expect("call");
+        match m {
+            NodeMatcher::Call { canonical, .. } => assert_eq!(canonical, "pickle.loads"),
+            _ => panic!("expected Call"),
+        }
+    }
+
+    #[test]
+    fn compile_bare_func_call() {
+        let m = compile("eval($X)", MatcherRole::Sink).expect("call");
+        match m {
+            NodeMatcher::Call { canonical, .. } => assert_eq!(canonical, "eval"),
+            _ => panic!("expected Call"),
+        }
+    }
+
+    #[test]
+    fn compile_bare_identifier_source() {
+        let m = compile("request", MatcherRole::Source).expect("paramname");
+        match m {
+            NodeMatcher::ParamName { names, .. } => assert_eq!(names, vec!["request".to_string()]),
+            _ => panic!("expected ParamName"),
+        }
+    }
+
+    #[test]
+    fn bare_identifier_rejected_as_sink() {
+        assert!(compile("request", MatcherRole::Sink).is_none());
+    }
+
+    #[test]
+    fn weird_shapes_rejected() {
+        assert!(compile("$X + $Y", MatcherRole::Source).is_none());
+        assert!(compile("a.b.c(d", MatcherRole::Sink).is_none());
+        assert!(compile("", MatcherRole::Source).is_none());
+    }
+
+    #[test]
+    fn parse_full_taint_rule() {
+        let yaml = r#"
+id: semgrep-pickle-taint
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Untrusted input reaches pickle.loads"
+metadata:
+  cwe: "CWE-502"
+pattern-sources:
+  - pattern: request.data
+  - pattern: request
+pattern-sinks:
+  - pattern: pickle.loads($X)
+"#;
+        let v: YamlValue = serde_yaml::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => {
+                assert_eq!(r.id, "semgrep/semgrep-pickle-taint");
+                assert_eq!(r.lang, Language::Python);
+                assert_eq!(r.cwe.as_deref(), Some("CWE-502"));
+                assert_eq!(r.spec.sources.len(), 2);
+                assert_eq!(r.spec.sinks.len(), 1);
+            }
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    #[test]
+    fn non_taint_rule_falls_through() {
+        let yaml = r#"
+id: classic
+pattern: eval(...)
+message: x
+severity: ERROR
+languages: [python]
+"#;
+        let v: YamlValue = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(parse_taint_rule(&v), TaintRuleParse::NotTaint));
+    }
+
+    #[test]
+    fn taint_rule_with_non_python_language_is_skipped() {
+        let yaml = r#"
+id: x
+mode: taint
+languages: [javascript]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: req}]
+pattern-sinks: [{pattern: eval($X)}]
+"#;
+        let v: YamlValue = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(parse_taint_rule(&v), TaintRuleParse::Skip(_)));
+    }
+
+    #[test]
+    fn pattern_either_inside_source_is_rejected() {
+        let yaml = r#"
+id: x
+mode: taint
+languages: [python]
+severity: ERROR
+message: m
+pattern-sources:
+  - pattern-either:
+      - pattern: request.data
+pattern-sinks:
+  - pattern: pickle.loads($X)
+"#;
+        let v: YamlValue = serde_yaml::from_str(yaml).unwrap();
+        assert!(matches!(parse_taint_rule(&v), TaintRuleParse::Skip(_)));
+    }
+}

--- a/tests/fixtures/semgrep_taint/pickle_taint.yml
+++ b/tests/fixtures/semgrep_taint/pickle_taint.yml
@@ -1,0 +1,19 @@
+rules:
+  - id: semgrep-pickle-taint
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: "Untrusted Flask input reaches pickle.loads"
+    metadata:
+      cwe: "CWE-502"
+    pattern-sources:
+      - pattern: request.data
+      - pattern: request.form
+      - pattern: request.args
+      - pattern: request.json
+      - pattern: request.get_json($X)
+      - pattern: request.get_data($X)
+      - pattern: request
+    pattern-sinks:
+      - pattern: pickle.loads($X)
+      - pattern: pickle.load($X)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1660,3 +1660,77 @@ fn test_sarif_output_valid() {
         .expect("missing results array");
     assert!(!results.is_empty(), "SARIF results should not be empty");
 }
+
+/// Semgrep-compatible `mode: taint` YAML rules should load via `--rules`
+/// and fire on the same flows as the native `py/taint-pickle-deserialization`
+/// rule. See issue #17.
+#[test]
+fn test_semgrep_taint_yaml_bridge_vulnerable() {
+    let output = foxguard_cmd()
+        .args([
+            "tests/fixtures/vulnerable_py_taint.py",
+            "-f",
+            "json",
+            "--no-builtins",
+            "--rules",
+            "tests/fixtures/semgrep_taint/pickle_taint.yml",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let lines: Vec<u64> = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("semgrep/semgrep-pickle-taint"))
+        .filter_map(|f| f["line"].as_u64())
+        .collect();
+
+    assert!(
+        !lines.is_empty(),
+        "semgrep taint rule should fire at least once on vulnerable_py_taint.py, got: {:?}",
+        findings
+    );
+
+    // Every pickle handler in the fixture (14 flows, matching the native
+    // py/taint-pickle-deserialization rule) should be caught by the YAML
+    // bridge. Asserting the exact count keeps the bridge honest: regressions
+    // in pattern translation or the taint engine will flip this number.
+    assert_eq!(
+        lines.len(),
+        14,
+        "semgrep taint rule should fire on all 14 pickle flows, got {} (lines: {:?})",
+        lines.len(),
+        lines
+    );
+}
+
+#[test]
+fn test_semgrep_taint_yaml_bridge_safe() {
+    let output = foxguard_cmd()
+        .args([
+            "tests/fixtures/safe_py_taint.py",
+            "-f",
+            "json",
+            "--no-builtins",
+            "--rules",
+            "tests/fixtures/semgrep_taint/pickle_taint.yml",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("semgrep/semgrep-pickle-taint"))
+        .count();
+
+    assert_eq!(
+        n, 0,
+        "semgrep taint rule should not fire on safe_py_taint.py, got {} findings",
+        n
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `src/rules/semgrep_taint.rs`, a Semgrep-compatible YAML bridge that compiles `mode: taint` rules into foxguard's existing `TaintSpec` and reuses the intraprocedural Python taint engine for matching.
- Wires the bridge into `parse_semgrep_file`: each rule is inspected as an untyped `serde_yaml::Value` first, taint-mode rules are routed to the new compiler, everything else falls through to the existing pattern-rule path unchanged.
- Ships a fixture rule at `tests/fixtures/semgrep_taint/pickle_taint.yml` that replicates `py/taint-pickle-deserialization` and two integration tests asserting it fires on all 14 pickle flows in `vulnerable_py_taint.py` and zero on `safe_py_taint.py`.
- Adds unit tests for the pattern-to-`NodeMatcher` translator (attribute, nested attribute flattening, call forms with `$X` / `...`, bare-identifier source, rejection of unsupported shapes).
- Documents the supported subset in `COMPATIBILITY.md` and replaces the "YAML bridge is the next PR" note in `docs/taint-tracking.md` with a link to the new module and a worked example.

Refs #17.

## Supported today

- `mode: taint`, `languages: [python]` only.
- `pattern-sources` / `pattern-sinks` / `pattern-sanitizers` as lists of single-`pattern:` entries.
- Pattern shapes: bare identifier (source-only, compiled to `ParamName`), dotted attribute chain (`root.field`, nested chains flatten to leftmost root + outermost field to match the engine's one-level attribute propagation), and call forms `func(...)` / `root.method($X)` / `func()` (arguments stripped).
- `severity` mapped via the same `map_severity` used by the pattern-rule bridge for consistency (`ERROR` -> Critical, `WARNING` -> High, `INFO` -> Medium). `metadata.cwe` is propagated.

## Deferred (skip-with-warning)

- `pattern-either:` inside source/sink/sanitizer blocks, `pattern-inside:`, `metavariable-pattern:` - issue brief called these out as out-of-scope.
- Non-Python taint rules - the engine itself is Python-only.
- Pattern shapes outside the three supported forms (binary ops, metavariables in non-call positions, etc.) - surfaced as explicit "unsupported pattern shape" warnings at rule-load time so users see a clear signal instead of a silently-degraded match surface.
- Per-finding sanitization semantics are still collapsed to "clean" by the underlying engine.

## Tricky translation notes

- Nested attribute chains like `request.session.user_id` flatten to `root=request, field=user_id`. That is a deliberate match to the engine's own one-level attribute propagation - documented as a known gap in the module docs and `COMPATIBILITY.md`.
- The issue brief suggested `ERROR/WARNING/INFO` -> `High/Medium/Low`, but the existing Semgrep pattern-rule bridge maps `ERROR -> Critical`. Two different mappings in the same file would break user expectations and regress the existing `semgrep_compat` tests, so the taint bridge follows the existing mapping. Happy to revisit in a follow-up if the product decision is to break that consistency.
- The strictly-typed `SemgrepRuleYaml` deserializer is kept as-is; the dispatch works by parsing the file once as a `serde_yaml::Value`, peeling off taint-mode rules, and re-serializing the remainder into the existing schema so all the pattern-rule machinery (path filters, metavariable regexes, language aliases) keeps working unchanged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (all 57+45+12+6+... suites green)
- [x] `cargo build --release`
- [x] Manual: `./target/release/foxguard --no-builtins --rules tests/fixtures/semgrep_taint/pickle_taint.yml tests/fixtures/vulnerable_py_taint.py` reports all 14 pickle flows with source->sink descriptions.