### PR TITLE
Taint engine: same-file interprocedural return propagation (refs #19)

### DIFF
--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -21,11 +21,14 @@ In scope:
 - **Tuple/list destructuring with flow-insensitive conservative semantics**: `a, b = expr1, expr2` and `[a, b] = [expr1, expr2]` pair targets with RHS elements when the arities match, so only the matching slot carries taint. When the RHS is a single opaque expression (e.g. `a, b = helper()`), the engine conservatively taints *every* LHS target — we lack the type info to pick the right slot.
 - **Alias-aware sinks and sources**: the engine resolves callees and source roots through the per-file import alias table already introduced for issue #7.
 - **Sanitizer support (collapsed to "clean")**: calls whose callee matches a `TaintSpec.sanitizers` entry produce a clean value even when their arguments were tainted. See the section below for the exact semantics.
+- **Same-file interprocedural return propagation (v1)**: a helper whose body returns a tainted expression marks its return as tainted, and bare calls to that helper elsewhere in the same file propagate the taint into the caller. See the dedicated section below for the exact scope.
 
 Out of scope for this PR, tracked under #10 as follow-ups:
 
-- **Interprocedural**: no cross-function analysis. A helper `def get_data(): return request.data` will not taint callers.
+- **Multi-hop interprocedural chains**: only one level of helper-call propagation is supported. A helper that itself calls another helper is not tracked through the deeper hop.
 - **Cross-file**: no module boundary crossing.
+- **Instance and class methods in interprocedural summaries**: only top-level `function_declaration`s and `const/let/var foo = ...` arrow/function-expression helpers are summarized. `obj.method()` and `self.helper()` calls are not looked up in the summary map.
+- **Argument taint propagation**: helper summaries are computed with only their parameters' taint sources seeded (via `ParamName`). Passing an already-tainted local into a helper does not influence the helper's return summary — pass 1 analyzes helpers with a conservative view of their parameters.
 - **Per-finding sanitization**: Semgrep's `mode: taint` distinguishes "this specific flow was sanitized" from "the value is now clean"; it can still fire on secondary flows that bypassed the sanitizer along a different path. foxguard's v1 collapses both cases into "clean" and does not track per-finding sanitization state.
 - **Field sensitivity**: `d["key"]` is tainted because `d` is. Different keys are not distinguished.
 - **Object attribute propagation beyond one level**: `x.y.z` is tainted when `x` is tainted, but the engine does not persist taint on `x.y` as a distinct name.
@@ -66,6 +69,35 @@ Nothing about Flask, pickle, or any other library is baked into the engine. A ru
 - **`Attribute { root, field, description }`** — matches `root.field` and `root.intermediate.field` chains where the leftmost identifier equals `root`. The engine also tries the alias-resolved form of the leftmost, so one spec entry with `root: "request"` covers both `from flask import request` and `def handler(request)`.
 - **`Call { canonical, description }`** — matches a call whose callee resolves (raw *or* alias-resolved) to `canonical`. Use for method-call sources like `request.get_json()` and for sinks like `pickle.loads`.
 - **`ParamName { names, description }`** — matches function parameters whose name is in `names`. Used to mark implicit sources (e.g. a Flask handler signature `def handler(request):` should treat `request` as untrusted without any assignment).
+
+## Interprocedural (v1)
+
+Issue #19 extends the engine with one level of same-file interprocedural return propagation. The implementation runs two passes over each file:
+
+1. **Pass 1 — return summaries.** Every eligible function in the file is walked with the same expression-taint machinery used in pass 2, but with an empty summary map. For each function, the first tainted `return` expression discovered becomes the function's summary value (`Some(description)`); otherwise the summary is `None`.
+
+2. **Pass 2 — analysis with summaries.** The usual per-function walk runs again, but now `expression_taint` resolves a bare-identifier call whose name is in the summary map by returning the summarized description, decorated with ` (via <callee>)` so findings show the helper chain.
+
+The worked example:
+
+```python
+def get_user_input():
+    return request.data          # summary: Some("flask.request.data")
+
+def handler():
+    data = get_user_input()      # pass 2: data ← "flask.request.data (via get_user_input)"
+    return pickle.loads(data)    # fires with that description
+```
+
+produces a finding whose message reads `flask.request.data (via get_user_input) reaches pickle.loads`.
+
+Scope and limitations:
+
+- **Eligible helpers.** Python: all `function_definition`s are summarized by their simple name. JavaScript/TypeScript: top-level `function_declaration`s and `const/let/var name = arrow_function | function_expression` declarators. Methods on classes/objects (`class Foo { bar() {} }`, `{ helper: function() {} }`) are not summarized.
+- **Single hop only.** Pass 1 runs each helper with an empty summary map, so a helper that itself calls another helper sees the inner call as untyped and cannot recognize its return. A two-hop chain like `handler → middle → source` is *not* caught. This limitation is pinned by a `multi_hop_chain_is_out_of_scope_v1` unit test in each engine.
+- **Bare identifier callees.** `handler()` looks up `handler` in the summary map. `obj.handler()`, `self.helper()`, and aliased forms of method calls do not. Rationale: method calls need receiver/type information the engine does not model.
+- **Name collisions are last-write-wins.** If two functions in the same file share a simple name (e.g. an outer `def helper` and a nested `def helper` inside another function), one summary will overwrite the other during pass 1. This is a known v1 limitation — fix by making summaries scope-aware when it stops being hypothetical.
+- **Argument-based taint is not threaded through helpers.** A helper's summary is computed using only its own parameter sources (`ParamName` matchers); passing an already-tainted local in as an argument does not retroactively taint the helper's return.
 
 ## Sanitizers
 
@@ -148,7 +180,7 @@ Load it with `foxguard --no-builtins --rules path/to/rule.yml target/` and each 
 
 ## Open questions for the full #10
 
-- **Cross-function propagation.** The first step beyond intraprocedural is probably "trust the return type of helpers whose body we can see in the same file", then cross-file via module symbol tables. Each step adds real complexity and should be its own issue.
+- **Cross-function propagation.** The first step — "trust the return of helpers whose body we can see in the same file" — landed in issue #19 as a single-hop, name-keyed summary pass. Next steps: multi-hop propagation via fixed-point iteration over the summary map, scope-aware keys that distinguish nested definitions, argument-based taint threading so callers' tainted arguments influence helper summaries, then cross-file via module symbol tables. Each is its own issue.
 - **Broader pattern surface in the YAML bridge.** `pattern-either` inside source/sink blocks, `pattern-inside` / `metavariable-pattern` constraints, and per-finding sanitization semantics are still unsupported. The bridge skips such rules with a warning rather than partially loading them.
 
 Contributions and concrete counter-examples welcome on #10.

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -105,19 +105,196 @@ pub struct TaintFinding {
     pub sink_description: String,
 }
 
+/// Return-taint summary map keyed by a function's simple name. Mirrors
+/// `python_taint::ReturnSummary`. Only top-level `function_declaration`s
+/// and arrow/function-expression helpers assigned to a `const`/`let`/
+/// `var` identifier are collected — instance methods and object-literal
+/// methods are out of scope for v1 because they live on objects with
+/// different call semantics. Function-name collisions are resolved
+/// last-write-wins (known v1 limitation).
+pub type ReturnSummary = HashMap<String, Option<String>>;
+
 /// Run the taint engine over every function/method body inside `root` and
 /// return one `TaintFinding` per source→sink flow.
+///
+/// Runs two passes per file. Pass 1 builds the return-taint summary for
+/// every eligible function in the file. Pass 2 re-analyzes each scope
+/// with that summary available so bare helper calls propagate their
+/// return taint into the caller. See `python_taint::analyze_tree` for
+/// the full design; the JS engine mirrors it.
 pub fn analyze_tree(
     root: Node<'_>,
     source: &str,
     spec: &TaintSpec,
     aliases: Option<&JsImportAliases>,
 ) -> Vec<TaintFinding> {
+    let empty_summary = ReturnSummary::new();
+    let mut summaries = ReturnSummary::new();
+    collect_summary_targets(root, source, &mut |name, func_node| {
+        let ret = summarize_function(func_node, source, spec, aliases, &empty_summary);
+        summaries.insert(name, ret);
+    });
+
     let mut findings = Vec::new();
     collect_function_scopes(root, &mut |func_node| {
-        analyze_function(func_node, source, spec, aliases, &mut findings);
+        analyze_function(func_node, source, spec, aliases, &summaries, &mut findings);
     });
     findings
+}
+
+/// Walk `root` and invoke `visit(name, body_node)` for every function
+/// whose simple name we can recover: top-level `function_declaration`s
+/// and `const foo = (...) => {...}` / `const foo = function(...) {...}`
+/// variable declarators with an arrow-function or function-expression
+/// initializer. Nested definitions inside other function scopes are NOT
+/// descended into for v1 — their summaries would rarely be useful and
+/// instance-method / class-method handling is explicitly out of scope.
+fn collect_summary_targets<'tree, F>(node: Node<'tree>, source: &str, visit: &mut F)
+where
+    F: FnMut(String, Node<'tree>),
+{
+    // Function declarations: record by name, don't descend into their
+    // body (nested helpers are out of scope for v1 summaries).
+    if matches!(
+        node.kind(),
+        "function_declaration" | "generator_function_declaration"
+    ) {
+        if let Some(name) = node.child_by_field_name("name") {
+            visit(node_text(name, source).to_string(), node);
+        }
+        return;
+    }
+    // `const foo = (...) => ...` / `const foo = function(...) {...}`
+    if node.kind() == "variable_declarator" {
+        if let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        ) {
+            if name.kind() == "identifier"
+                && matches!(value.kind(), "arrow_function" | "function_expression")
+            {
+                visit(node_text(name, source).to_string(), value);
+                return;
+            }
+        }
+    }
+    // Otherwise recurse, but don't descend into *other* function scopes:
+    // nested-scope helpers are out of scope for v1.
+    if is_function_scope(node.kind()) {
+        return;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_summary_targets(child, source, visit);
+    }
+}
+
+/// Pass-1 walker: compute the return-taint summary for a single function
+/// scope. Walks the body with the normal state machinery but throws away
+/// sink findings and records the first tainted return expression it sees.
+fn summarize_function(
+    func_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&JsImportAliases>,
+    summaries: &ReturnSummary,
+) -> Option<String> {
+    let mut state = TaintState::default();
+    if let Some(params) = func_node.child_by_field_name("parameters") {
+        seed_param_sources(params, source, spec, &mut state);
+    }
+    if let Some(single) = func_node.child_by_field_name("parameter") {
+        if single.kind() == "identifier" {
+            let name = node_text(single, source);
+            for matcher in &spec.sources {
+                if let NodeMatcher::ParamName { names, description } = matcher {
+                    if names.iter().any(|n| n == name) {
+                        state.taint(name.to_string(), description.clone());
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    let body = func_node.child_by_field_name("body")?;
+
+    // Arrow-function concise body (`() => expr`): the body field holds
+    // the expression directly rather than a `statement_block`, and there
+    // is no `return_statement` node to visit. Evaluate taint on it up
+    // front so the summary still reflects the implicit return.
+    if func_node.kind() == "arrow_function" && body.kind() != "statement_block" {
+        return expression_taint(body, source, spec, aliases, &state, summaries);
+    }
+
+    let mut scratch: Vec<TaintFinding> = Vec::new();
+    let mut return_taint: Option<String> = None;
+    walk_body_for_summary(
+        body,
+        source,
+        spec,
+        aliases,
+        &mut state,
+        &mut scratch,
+        summaries,
+        &mut return_taint,
+    );
+    return_taint
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_body_for_summary(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&JsImportAliases>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
+    return_taint: &mut Option<String>,
+) {
+    if is_function_scope(node.kind()) {
+        return;
+    }
+
+    match node.kind() {
+        "variable_declarator" => {
+            handle_variable_declarator(node, source, spec, aliases, state, summaries);
+        }
+        "assignment_expression" => {
+            handle_assignment(node, source, spec, aliases, state, findings, summaries);
+        }
+        "call_expression" => {
+            handle_call(node, source, spec, aliases, state, findings, summaries);
+        }
+        "return_statement" => {
+            if return_taint.is_none() {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    if let Some(desc) =
+                        expression_taint(child, source, spec, aliases, state, summaries)
+                    {
+                        *return_taint = Some(desc);
+                        break;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_body_for_summary(
+            child,
+            source,
+            spec,
+            aliases,
+            state,
+            findings,
+            summaries,
+            return_taint,
+        );
+    }
 }
 
 // ─── Per-file import alias table ──────────────────────────────────────────
@@ -393,6 +570,7 @@ fn analyze_function(
     source: &str,
     spec: &TaintSpec,
     aliases: Option<&JsImportAliases>,
+    summaries: &ReturnSummary,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
@@ -421,7 +599,7 @@ fn analyze_function(
     let Some(body) = func_node.child_by_field_name("body") else {
         return;
     };
-    walk_body(body, source, spec, aliases, &mut state, findings);
+    walk_body(body, source, spec, aliases, &mut state, findings, summaries);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -476,6 +654,7 @@ fn walk_body(
     aliases: Option<&JsImportAliases>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
 ) {
     // Nested function scopes have their own taint state — skip them; they'll
     // be picked up independently by analyze_tree.
@@ -484,15 +663,19 @@ fn walk_body(
     }
 
     match node.kind() {
-        "variable_declarator" => handle_variable_declarator(node, source, spec, aliases, state),
-        "assignment_expression" => handle_assignment(node, source, spec, aliases, state, findings),
-        "call_expression" => handle_call(node, source, spec, aliases, state, findings),
+        "variable_declarator" => {
+            handle_variable_declarator(node, source, spec, aliases, state, summaries)
+        }
+        "assignment_expression" => {
+            handle_assignment(node, source, spec, aliases, state, findings, summaries)
+        }
+        "call_expression" => handle_call(node, source, spec, aliases, state, findings, summaries),
         _ => {}
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body(child, source, spec, aliases, state, findings);
+        walk_body(child, source, spec, aliases, state, findings, summaries);
     }
 }
 
@@ -502,6 +685,7 @@ fn handle_variable_declarator(
     spec: &TaintSpec,
     aliases: Option<&JsImportAliases>,
     state: &mut TaintState,
+    summaries: &ReturnSummary,
 ) {
     let Some(name) = node.child_by_field_name("name") else {
         return;
@@ -513,7 +697,7 @@ fn handle_variable_declarator(
 
     if name.kind() == "identifier" {
         let lhs = node_text(name, source).to_string();
-        if let Some(desc) = expression_taint(value, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
             state.taint(lhs, desc);
         } else {
             state.clear(&lhs);
@@ -527,7 +711,7 @@ fn handle_variable_declarator(
     // destructuring shapes are more varied than Python's tuple unpack.
     if matches!(name.kind(), "object_pattern" | "array_pattern") {
         let targets = collect_destructuring_targets(name, source);
-        if let Some(desc) = expression_taint(value, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
             for t in &targets {
                 state.taint(t.clone(), desc.clone());
             }
@@ -580,6 +764,7 @@ fn handle_assignment(
     aliases: Option<&JsImportAliases>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
 ) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
@@ -598,7 +783,9 @@ fn handle_assignment(
                 }
                 _ => None,
             }) {
-                if let Some(src_desc) = expression_taint(right, source, spec, aliases, state) {
+                if let Some(src_desc) =
+                    expression_taint(right, source, spec, aliases, state, summaries)
+                {
                     let start = node.start_position();
                     let end = node.end_position();
                     findings.push(TaintFinding {
@@ -620,7 +807,7 @@ fn handle_assignment(
 
     if left.kind() == "identifier" {
         let lhs = node_text(left, source).to_string();
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
             state.taint(lhs, desc);
         } else {
             state.clear(&lhs);
@@ -631,7 +818,7 @@ fn handle_assignment(
     // Destructuring LHS: `({ a } = req.body)` or `[a, b] = arr`.
     if matches!(left.kind(), "object_pattern" | "array_pattern") {
         let targets = collect_destructuring_targets(left, source);
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
             for t in &targets {
                 state.taint(t.clone(), desc.clone());
             }
@@ -650,6 +837,7 @@ fn handle_call(
     aliases: Option<&JsImportAliases>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
 ) {
     let Some(func) = node.child_by_field_name("function") else {
         return;
@@ -681,7 +869,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state) {
+        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -705,6 +893,7 @@ fn expression_taint(
     spec: &TaintSpec,
     aliases: Option<&JsImportAliases>,
     state: &TaintState,
+    summaries: &ReturnSummary,
 ) -> Option<String> {
     // Direct source match on this expression.
     if let Some(desc) = match_source(expr, source, spec, aliases) {
@@ -722,7 +911,7 @@ fn expression_taint(
     // Tainted member-expression root: `x.y` where `x` is tainted.
     if expr.kind() == "member_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, source, spec, aliases, state) {
+            if let Some(desc) = expression_taint(object, source, spec, aliases, state, summaries) {
                 return Some(desc);
             }
         }
@@ -731,7 +920,7 @@ fn expression_taint(
     // Tainted subscript: `x[k]` where `x` is tainted (no key sensitivity).
     if expr.kind() == "subscript_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, source, spec, aliases, state) {
+            if let Some(desc) = expression_taint(object, source, spec, aliases, state, summaries) {
                 return Some(desc);
             }
         }
@@ -745,7 +934,8 @@ fn expression_taint(
             if child.kind() == "template_substitution" {
                 let mut inner = child.walk();
                 for inner_child in child.named_children(&mut inner) {
-                    if let Some(desc) = expression_taint(inner_child, source, spec, aliases, state)
+                    if let Some(desc) =
+                        expression_taint(inner_child, source, spec, aliases, state, summaries)
                     {
                         return Some(desc);
                     }
@@ -758,7 +948,7 @@ fn expression_taint(
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state) {
+            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
                 return Some(desc);
             }
         }
@@ -771,7 +961,7 @@ fn expression_taint(
     ) {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state) {
+            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
                 return Some(desc);
             }
         }
@@ -786,8 +976,21 @@ fn expression_taint(
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, source, spec, aliases, state) {
+                if let Some(desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
                     return Some(desc);
+                }
+            }
+        }
+
+        // Same-file interprocedural v1: a bare identifier callee whose
+        // name is in the return-summary map propagates the summary's
+        // taint description through the call result. Method calls
+        // (`obj.helper()`) are out of scope for v1.
+        if let Some(func) = expr.child_by_field_name("function") {
+            if func.kind() == "identifier" {
+                let callee = node_text(func, source);
+                if let Some(Some(desc)) = summaries.get(callee) {
+                    return Some(format!("{desc} (via {callee})"));
                 }
             }
         }
@@ -1224,6 +1427,110 @@ function handler(req) {
 }
 "#;
         assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn interprocedural_tainted_return_propagates_to_caller() {
+        // Use a module-scoped `req` so the caller's argument list is clean
+        // and the only path to taint in the caller is via the helper's
+        // return summary.
+        let src = r#"
+function getUserInput() {
+    return req.body;
+}
+
+function handler() {
+    const data = getUserInput();
+    document.write(data);
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("getUserInput"));
+    }
+
+    #[test]
+    fn interprocedural_clean_return_does_not_fire() {
+        let src = r#"
+function cleanHelper() {
+    return "static";
+}
+
+function handler() {
+    document.write(cleanHelper());
+}
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_late_definition_still_found() {
+        let src = r#"
+function handler() {
+    const data = helper();
+    document.write(data);
+}
+
+function helper() {
+    return req.body;
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("helper"));
+    }
+
+    #[test]
+    fn multi_hop_chain_is_out_of_scope_v1() {
+        // Two-hop chain: `middle` calls `sourceFn`. Pass 1 uses an empty
+        // summary, so `middle`'s return is seen as clean. Documented
+        // v1 limitation — the test pins the behavior. The handler has
+        // no tainted argument (no `req` param or access), so the only
+        // path to taint would be a working multi-hop summary.
+        let src = r#"
+function sourceFn() {
+    return req.body;
+}
+
+function middle() {
+    return sourceFn();
+}
+
+function handler() {
+    document.write(middle());
+}
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_arrow_function_helper_propagates() {
+        // Arrow-function helper with concise body assigned to a const.
+        let src = r#"
+const getInput = () => req.body;
+
+function handler() {
+    document.write(getInput());
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("getInput"));
+    }
+
+    #[test]
+    fn interprocedural_arrow_function_block_body_propagates() {
+        let src = r#"
+const getInput = () => { return req.body; };
+
+function handler() {
+    const data = getInput();
+    document.write(data);
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("getInput"));
     }
 
     #[test]

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -130,23 +130,154 @@ pub struct TaintFinding {
     pub sink_description: String,
 }
 
+/// Return-taint summary for a single function. Keyed by the function's
+/// simple name (class/nesting are ignored for v1). The value is `Some`
+/// description if any `return` statement in the function returns a
+/// tainted expression, `None` otherwise.
+///
+/// Function-name collisions (e.g. a nested `def helper` inside an outer
+/// function when another top-level `def helper` exists) are resolved
+/// last-write-wins, which is a known v1 limitation.
+pub type ReturnSummary = HashMap<String, Option<String>>;
+
 /// Run the taint engine over every function definition inside `root` and
 /// return one [`TaintFinding`] per source→sink flow discovered.
 ///
 /// The root can be a whole file tree. The engine finds every
 /// `function_definition` inside it (including nested ones) and analyzes
 /// each independently.
+///
+/// Internally this runs in two passes:
+///
+/// 1. **Pass 1 — return summaries.** Every function in the file is walked
+///    and its `return` expressions are classified as tainted / clean
+///    using the same `expression_taint` logic that pass 2 uses. The
+///    difference is that pass 1 has an *empty* return summary, so calls
+///    to local helpers fall through to default behavior. This gives one
+///    level of interprocedural propagation: a direct helper whose body
+///    reads a source will be summarized as tainted, but a helper that
+///    itself calls another helper will not (the deeper chain is missed).
+///    Documented limitation for v1.
+///
+/// 2. **Pass 2 — analysis with summaries.** Re-analyze each function with
+///    the pass-1 summary available. A call to a bare local helper whose
+///    summary says "tainted" now makes the call result tainted, so the
+///    caller's local bindings and sink arguments propagate correctly.
 pub fn analyze_tree(
     root: Node<'_>,
     source: &str,
     spec: &TaintSpec,
     aliases: Option<&ImportAliases>,
 ) -> Vec<TaintFinding> {
+    // Pass 1: build return summaries using an empty summary map so that
+    // calls to local helpers inside helper bodies fall through to the
+    // default behavior. This is the one-level interprocedural limit.
+    let empty_summary = ReturnSummary::new();
+    let mut summaries = ReturnSummary::new();
+    collect_function_defs(root, &mut |func_node| {
+        let (name, ret_taint) =
+            summarize_function(func_node, source, spec, aliases, &empty_summary);
+        if let Some(name) = name {
+            // Last-write-wins on name collisions (v1 limitation).
+            summaries.insert(name, ret_taint);
+        }
+    });
+
+    // Pass 2: full analysis with the summary map available.
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
-        analyze_function(func_node, source, spec, aliases, &mut findings);
+        analyze_function(func_node, source, spec, aliases, &summaries, &mut findings);
     });
     findings
+}
+
+/// Pass-1 walker: compute a function's return-taint summary by scanning
+/// its body with the same state machinery used in pass 2, then inspecting
+/// every `return_statement` that appears inside it (excluding nested
+/// function bodies, which have their own summary).
+fn summarize_function(
+    func_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    summaries: &ReturnSummary,
+) -> (Option<String>, Option<String>) {
+    let name = func_node
+        .child_by_field_name("name")
+        .map(|n| node_text(n, source).to_string());
+
+    let mut state = TaintState::default();
+    if let Some(params) = func_node.child_by_field_name("parameters") {
+        seed_param_sources(params, source, spec, &mut state);
+    }
+    let Some(body) = func_node.child_by_field_name("body") else {
+        return (name, None);
+    };
+
+    let mut return_taint: Option<String> = None;
+    // Reuse the normal walker but throw away sink findings — we only want
+    // to update the taint state and inspect return statements.
+    let mut scratch: Vec<TaintFinding> = Vec::new();
+    walk_body_for_summary(
+        body,
+        source,
+        spec,
+        aliases,
+        &mut state,
+        &mut scratch,
+        summaries,
+        &mut return_taint,
+    );
+    (name, return_taint)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn walk_body_for_summary(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    aliases: Option<&ImportAliases>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
+    return_taint: &mut Option<String>,
+) {
+    // Don't descend into nested function definitions — their own returns
+    // belong to their own summary.
+    if node.kind() == "function_definition" {
+        return;
+    }
+
+    if node.kind() == "assignment" {
+        handle_assignment(node, source, spec, aliases, state, summaries);
+    }
+    if node.kind() == "call" {
+        handle_call(node, source, spec, aliases, state, findings, summaries);
+    }
+    if node.kind() == "return_statement" && return_taint.is_none() {
+        // The return's argument is the first named child, if any.
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+                *return_taint = Some(desc);
+                break;
+            }
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_body_for_summary(
+            child,
+            source,
+            spec,
+            aliases,
+            state,
+            findings,
+            summaries,
+            return_taint,
+        );
+    }
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────
@@ -190,6 +321,7 @@ fn analyze_function(
     source: &str,
     spec: &TaintSpec,
     aliases: Option<&ImportAliases>,
+    summaries: &ReturnSummary,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
@@ -204,7 +336,7 @@ fn analyze_function(
     let Some(body) = func_node.child_by_field_name("body") else {
         return;
     };
-    walk_body(body, source, spec, aliases, &mut state, findings);
+    walk_body(body, source, spec, aliases, &mut state, findings, summaries);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -248,6 +380,7 @@ fn walk_body(
     aliases: Option<&ImportAliases>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
 ) {
     // Nested function definitions have their own scope. Skip them — they'll
     // be picked up independently by analyze_tree.
@@ -256,11 +389,11 @@ fn walk_body(
     }
 
     if node.kind() == "assignment" {
-        handle_assignment(node, source, spec, aliases, state);
+        handle_assignment(node, source, spec, aliases, state, summaries);
     }
 
     if node.kind() == "call" {
-        handle_call(node, source, spec, aliases, state, findings);
+        handle_call(node, source, spec, aliases, state, findings, summaries);
     }
 
     // Tree-sitter's cursor walks in document order, which is exactly the
@@ -268,7 +401,7 @@ fn walk_body(
     // semantics the POC wants.
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body(child, source, spec, aliases, state, findings);
+        walk_body(child, source, spec, aliases, state, findings, summaries);
     }
 }
 
@@ -278,6 +411,7 @@ fn handle_assignment(
     spec: &TaintSpec,
     aliases: Option<&ImportAliases>,
     state: &mut TaintState,
+    summaries: &ReturnSummary,
 ) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
@@ -289,7 +423,7 @@ fn handle_assignment(
     // Simple identifier LHS: the common case.
     if left.kind() == "identifier" {
         let lhs_name = node_text(left, source).to_string();
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
             state.taint(lhs_name, desc);
         } else {
             // Reassignment with a clean RHS kills any previous taint on LHS.
@@ -314,7 +448,9 @@ fn handle_assignment(
         if let Some(rhs_elems) = tuple_like_elements(right) {
             if rhs_elems.len() == lhs_targets.len() {
                 for (target, rhs) in lhs_targets.iter().zip(rhs_elems.iter()) {
-                    if let Some(desc) = expression_taint(*rhs, source, spec, aliases, state) {
+                    if let Some(desc) =
+                        expression_taint(*rhs, source, spec, aliases, state, summaries)
+                    {
                         state.taint(target.clone(), desc);
                     } else {
                         state.clear(target);
@@ -325,7 +461,7 @@ fn handle_assignment(
         }
 
         // Arity mismatch or opaque RHS: apply conservative semantics.
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state) {
+        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
             for target in &lhs_targets {
                 state.taint(target.clone(), desc.clone());
             }
@@ -393,6 +529,7 @@ fn handle_call(
     aliases: Option<&ImportAliases>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
+    summaries: &ReturnSummary,
 ) {
     let Some(func) = node.child_by_field_name("function") else {
         return;
@@ -430,7 +567,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state) {
+        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -458,6 +595,7 @@ fn expression_taint(
     spec: &TaintSpec,
     aliases: Option<&ImportAliases>,
     state: &TaintState,
+    summaries: &ReturnSummary,
 ) -> Option<String> {
     // Direct source match on this expression.
     if let Some(desc) = match_source(expr, source, spec, aliases) {
@@ -492,7 +630,7 @@ fn expression_taint(
     // identifier roots via the recursive call.
     if expr.kind() == "subscript" {
         if let Some(value) = expr.child_by_field_name("value") {
-            if let Some(desc) = expression_taint(value, source, spec, aliases, state) {
+            if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
                 return Some(desc);
             }
         }
@@ -512,8 +650,24 @@ fn expression_taint(
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, source, spec, aliases, state) {
+                if let Some(desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
                     return Some(desc);
+                }
+            }
+        }
+
+        // Same-file interprocedural v1: a bare identifier callee whose
+        // name matches a function in the return-summary map propagates
+        // the summary's taint description as the call's result. The
+        // description is decorated with "(via <callee>)" so findings
+        // show the helper chain. Only bare identifiers are considered —
+        // attribute calls like `self.helper()` or `obj.method()` need
+        // different semantics and are out of scope for v1.
+        if let Some(func) = expr.child_by_field_name("function") {
+            if func.kind() == "identifier" {
+                let callee = node_text(func, source);
+                if let Some(Some(desc)) = summaries.get(callee) {
+                    return Some(format!("{desc} (via {callee})"));
                 }
             }
         }
@@ -1133,6 +1287,96 @@ from flask import request
 def handler():
     [a, b] = [request.args["a"], b"static"]
     return pickle.loads(a)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn interprocedural_tainted_return_propagates_to_caller() {
+        let src = r#"
+import pickle
+from flask import request
+
+def get_user_input():
+    return request.data
+
+def handler():
+    data = get_user_input()
+    return pickle.loads(data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("get_user_input"));
+        assert!(f[0].source_description.contains("request.data"));
+    }
+
+    #[test]
+    fn interprocedural_clean_return_does_not_fire() {
+        let src = r#"
+import pickle
+
+def literal_helper():
+    return b"static"
+
+def handler():
+    return pickle.loads(literal_helper())
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_late_definition_still_found() {
+        // Helper defined *below* the caller: pass 1 collects summaries
+        // for every function in the file before pass 2 runs, so the
+        // order of definitions does not matter.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = helper()
+    return pickle.loads(data)
+
+def helper():
+    return request.data
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn multi_hop_chain_is_out_of_scope_v1() {
+        // Two-hop chain: `middle()` calls `source()`. Pass 1 evaluates
+        // each helper with an empty summary, so `middle`'s return (which
+        // calls `source`) is seen as clean. Documented v1 limitation —
+        // the test pins the behavior so a future upgrade breaking it is
+        // a deliberate decision.
+        let src = r#"
+import pickle
+from flask import request
+
+def source():
+    return request.data
+
+def middle():
+    return source()
+
+def handler():
+    return pickle.loads(middle())
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_direct_call_as_sink_argument() {
+        let src = r#"
+import pickle
+from flask import request
+
+def get_user_input():
+    return request.data
+
+def handler():
+    return pickle.loads(get_user_input())
 "#;
         assert_eq!(run(src).len(), 1);
     }

--- a/tests/fixtures/safe_js_taint.js
+++ b/tests/fixtures/safe_js_taint.js
@@ -31,3 +31,13 @@ function consumer() {
     const x = "trusted";
     document.write(x);
 }
+
+// Same-file interprocedural v1: helper returns a literal, caller passes
+// its result to a sink. Summary is clean, taint rule must not fire.
+function cleanLiteralHelper() {
+    return "static-helper";
+}
+
+function interproceduralCleanHelper() {
+    document.write(cleanLiteralHelper());
+}

--- a/tests/fixtures/safe_py_taint.py
+++ b/tests/fixtures/safe_py_taint.py
@@ -42,6 +42,16 @@ def consumer_of_different_function():
     return pickle.loads(data)
 
 
+# Same-file interprocedural v1: the helper returns a constant literal,
+# so its return summary is clean and the caller must not fire.
+def clean_literal_helper():
+    return b"static-helper-payload"
+
+
+def interprocedural_clean_helper():
+    return pickle.loads(clean_literal_helper())
+
+
 # A call that happens to be named `loads` but isn't the pickle sink.
 class NotPickle:
     def loads(self, x):

--- a/tests/fixtures/vulnerable_js_taint.js
+++ b/tests/fixtures/vulnerable_js_taint.js
@@ -38,3 +38,22 @@ function aliased(req) {
 function subscripted(req) {
     document.write(req.body["payload"]);
 }
+
+// ─── Same-file helper return propagation (issue #19, v1) ─────────────
+// Function-declaration helper: pass 1 summarizes its return as tainted,
+// pass 2 lets the caller's local pick up that taint.
+function getUserInputFromGlobal() {
+    return req.body.payload;
+}
+
+function interproceduralDirect() {
+    const data = getUserInputFromGlobal();
+    document.write(data);
+}
+
+// ─── Arrow-function helper assigned to a const ───────────────────────
+const getInputArrow = () => req.body.arrow;
+
+function interproceduralArrow() {
+    document.write(getInputArrow());
+}

--- a/tests/fixtures/vulnerable_py_taint.py
+++ b/tests/fixtures/vulnerable_py_taint.py
@@ -92,6 +92,32 @@ def tuple_unpack_conservative():
 def list_unpack_elementwise():
     [x, y] = [b"static", request.form["payload"]]
     return pickle.loads(y)
+
+
+# ─── Same-file helper return propagation (issue #19, v1) ───────────────
+# The helper reads an untrusted source and returns it; the caller
+# assigns the result to a local and passes it to pickle.loads. Pass 1
+# summarizes `get_user_input` as tainted; pass 2 taints `data` in the
+# caller via the summary.
+def get_user_input():
+    return request.data
+
+
+def interprocedural_direct_return():
+    data = get_user_input()
+    return pickle.loads(data)
+
+
+# Caller defined *above* its helper — the two-pass design visits every
+# function before analyzing any of them, so definition order does not
+# matter within the file.
+def interprocedural_late_definition():
+    data = late_helper()
+    return pickle.loads(data)
+
+
+def late_helper():
+    return request.form["payload"]
 # ═══ py/taint-eval ══════════════════════════════════════════════════════
 import os  # noqa: E402
 import subprocess  # noqa: E402

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -285,20 +285,21 @@ fn test_vulnerable_py_taint_catches_every_flow() {
         }
     }
 
-    // Fourteen pickle handlers (10 original + 4 added by #15 for nested
-    // subscripts and tuple/list destructuring). Each has one flow: one
-    // py/taint-pickle-deserialization finding per handler. The conservative
-    // py/no-pickle rule coexists on the same fourteen calls.
+    // Sixteen pickle handlers (10 original + 4 added by #15 for nested
+    // subscripts and tuple/list destructuring + 2 added by #19 for
+    // same-file interprocedural return propagation). Each has one flow:
+    // one py/taint-pickle-deserialization finding per handler. The
+    // conservative py/no-pickle rule coexists on the same sixteen calls.
     assert_eq!(
         counts.get("py/taint-pickle-deserialization").copied(),
-        Some(14),
-        "pickle taint rule should fire fourteen times. counts={:?}",
+        Some(16),
+        "pickle taint rule should fire sixteen times. counts={:?}",
         counts
     );
     assert_eq!(
         counts.get("py/no-pickle").copied(),
-        Some(14),
-        "NoPickle should still fire fourteen times alongside the taint rule. counts={:?}",
+        Some(16),
+        "NoPickle should still fire sixteen times alongside the taint rule. counts={:?}",
         counts
     );
 
@@ -391,11 +392,15 @@ fn test_vulnerable_js_taint_catches_every_flow() {
         }
     }
 
-    // Six handlers, each with exactly one source→sink flow.
+    // Eight handlers, each with exactly one source→sink flow (six
+    // original + two added by #19 for same-file interprocedural return
+    // propagation: `interproceduralDirect` via a function_declaration
+    // helper and `interproceduralArrow` via an arrow-function helper
+    // assigned to a const).
     assert_eq!(
         counts.get("js/taint-xss-innerhtml").copied(),
-        Some(6),
-        "js/taint-xss-innerhtml should fire exactly six times. counts={:?}",
+        Some(8),
+        "js/taint-xss-innerhtml should fire exactly eight times. counts={:?}",
         counts
     );
     // The conservative rules must still coexist on the same fixture.
@@ -1764,14 +1769,14 @@ fn test_semgrep_taint_yaml_bridge_vulnerable() {
         findings
     );
 
-    // Every pickle handler in the fixture (14 flows, matching the native
+    // Every pickle handler in the fixture (16 flows, matching the native
     // py/taint-pickle-deserialization rule) should be caught by the YAML
     // bridge. Asserting the exact count keeps the bridge honest: regressions
     // in pattern translation or the taint engine will flip this number.
     assert_eq!(
         lines.len(),
-        14,
-        "semgrep taint rule should fire on all 14 pickle flows, got {} (lines: {:?})",
+        16,
+        "semgrep taint rule should fire on all 16 pickle flows, got {} (lines: {:?})",
         lines.len(),
         lines
     );


### PR DESCRIPTION
## Summary

Extend the Python and JS/TS taint engines with one level of same-file interprocedural return propagation. When helper `A` returns a tainted value and caller `B` calls `A` by bare name, `B`'s binding for the result is now tainted and downstream sinks fire with a `flask.request.data (via A) reaches pickle.loads` style chain in the finding message.

Implementation is a two-pass design per file:

1. **Pass 1 — return summaries.** Every eligible function in the file is walked with the normal `expression_taint` machinery but an *empty* summary map. The first tainted `return` expression becomes the function's summary value, keyed by simple name. JS also summarizes arrow/function-expression helpers assigned to `const/let/var`.
2. **Pass 2 — analysis with summaries.** The normal per-function walk re-runs, now resolving bare-identifier call expressions against the summary map. A hit decorates the existing source description with `(via <callee>)` so the chain shows up in the finding.

## Scope (v1)

- Single hop only. Two-hop chains (`handler → middle → source`) are pinned out of scope by a `multi_hop_chain_is_out_of_scope_v1` test in each engine.
- Bare identifier callees only. Methods like `obj.helper()` / `self.helper()` are not looked up in the summary map.
- JS: `function_declaration` plus `const/let/var name = arrow_function | function_expression`. Instance/class/object methods are not summarized.
- Function-name collisions are last-write-wins.
- A helper's summary is computed using only its own `ParamName` sources — argument-based taint threading (callers passing tainted locals to helpers) is still out of scope.

All limitations are documented in the new "Interprocedural (v1)" section of `docs/taint-tracking.md`.

## Changes

- `src/rules/python_taint.rs`: new `ReturnSummary` type, `summarize_function` / `walk_body_for_summary` helpers, two-pass `analyze_tree`, summaries threaded through `expression_taint` and friends.
- `src/rules/javascript_taint.rs`: mirrors the Python changes, plus a `collect_summary_targets` walker for JS's wider range of function shapes and special handling for arrow-function concise bodies.
- Fixtures: new interprocedural handlers in `vulnerable_py_taint.py`, `safe_py_taint.py`, `vulnerable_js_taint.js`, `safe_js_taint.js`.
- Unit tests: `interprocedural_tainted_return_propagates_to_caller`, `interprocedural_clean_return_does_not_fire`, `interprocedural_late_definition_still_found`, `multi_hop_chain_is_out_of_scope_v1` in both engines, plus arrow-function variants on the JS side.
- Integration: Python pickle handler count 14 → 16, JS XSS handler count 6 → 8, semgrep YAML bridge count 14 → 16 (same engine).
- `docs/taint-tracking.md`: new "Interprocedural (v1)" section with worked example; scope / out-of-scope bullets updated.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` — 85 lib + 47 integration + 12 semgrep_integration + 6 parity + 1 rule inventory, all green
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] `./target/release/foxguard tests/fixtures/vulnerable_py_taint.py` — new interprocedural handlers fire with `(via get_user_input)` / `(via late_helper)` chain descriptions
- [x] `./target/release/foxguard tests/fixtures/safe_py_taint.py` — clean helper handler does NOT fire the taint rule
- [x] Same for JS fixtures: `interproceduralDirect` and `interproceduralArrow` both fire on the vuln file, `interproceduralCleanHelper` stays silent on the safe file

Refs #19.