### PR TITLE
Taint: add Django, FastAPI/Starlette, and CLI sources for Python (refs #29, #30)

### DIFF
--- a/docs/precision.md
+++ b/docs/precision.md
@@ -235,6 +235,12 @@ within their scope** but higher false negatives than their conservative
 counterparts — anything interprocedural, cross-file, or involving a flow
 shape the engine does not model will be missed.
 
+Python source coverage spans Flask, Django, and FastAPI/Starlette request
+attributes, plus common CLI-tool inputs (`sys.argv`, `sys.stdin`, `input()`,
+`os.environ`, `os.getenv`). Handler parameters named `request` or `req` are
+treated as implicit sources. See `python_taint_sources()` in
+`src/rules/python_taint.rs` for the canonical list.
+
 - `py/taint-pickle-deserialization`
 - `py/taint-eval`
 - `py/taint-command-injection`

--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -22,6 +22,7 @@ In scope:
 - **Alias-aware sinks and sources**: the engine resolves callees and source roots through the per-file import alias table already introduced for issue #7.
 - **Sanitizer support (collapsed to "clean")**: calls whose callee matches a `TaintSpec.sanitizers` entry produce a clean value even when their arguments were tainted. See the section below for the exact semantics.
 - **Same-file interprocedural return propagation (v1)**: a helper whose body returns a tainted expression marks its return as tainted, and bare calls to that helper elsewhere in the same file propagate the taint into the caller. See the dedicated section below for the exact scope.
+- **Supported Python source frameworks**: Flask (`request.data|form|args|values|json|files|cookies`, `request.get_data|get_json`), Django (`request.POST|GET|COOKIES|FILES|META|headers|body`), FastAPI/Starlette (`request.query_params|path_params|headers|cookies`, `await request.body|json|form|stream`), plus CLI-tool sources (`sys.argv`, `sys.stdin.read|readline`, `input()`, `os.environ`, `os.getenv`). Handler parameters named `request` or `req` are treated as implicit sources. Method calls on tainted receivers (e.g. `request.GET.get("x")`, `os.environ.get("X")`) are tracked via subscript access today; the method-call path is handled once issue #27 lands.
 
 Out of scope for this PR, tracked under #10 as follow-ups:
 

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -780,15 +780,28 @@ fn match_source(
     None
 }
 
-/// Canonical set of untrusted-input sources for Python web handlers.
+/// Canonical set of untrusted-input sources for Python web handlers
+/// and CLI entry points.
 ///
 /// Shared across every `py/taint-*` rule so that "what counts as
-/// untrusted" is defined once and stays consistent. Currently covers
-/// Flask-style `request.*` access plus handler parameters named
-/// `request`. Django is intentionally out of scope for the first batch
-/// of taint rules.
+/// untrusted" is defined once and stays consistent. Covers Flask,
+/// Django, FastAPI/Starlette request attributes, plus common CLI
+/// sources (`sys.argv`, `sys.stdin`, `input()`, `os.environ`,
+/// `os.getenv`).
+///
+/// Note on method calls: entries like `request.GET.get("x")` or
+/// `os.environ.get("X")` are method calls on a tainted attribute.
+/// The v1 engine only taints the *subject* of such a call when the
+/// subject itself is an attribute source (one-level attribute
+/// propagation); a method call *on top of* that attribute is not
+/// recognized as a source today. Subscript access
+/// (`request.GET["x"]`, `os.environ["X"]`) works correctly via the
+/// subscript-on-tainted-root propagation rule. The method-call path
+/// will be picked up once issue #27 (taint through method calls on
+/// tainted receivers) lands.
 pub fn python_taint_sources() -> Vec<NodeMatcher> {
     vec![
+        // ─── Flask ────────────────────────────────────────────────
         NodeMatcher::Attribute {
             root: "request".into(),
             field: "data".into(),
@@ -832,8 +845,114 @@ pub fn python_taint_sources() -> Vec<NodeMatcher> {
             canonical: "request.get_json".into(),
             description: "flask.request.get_json()".into(),
         },
+        // ─── Django ───────────────────────────────────────────────
+        // `request.GET`, `request.POST`, etc. are QueryDict attributes
+        // on Django's HttpRequest. Subscript access taints; method
+        // calls like `.get("key")` need issue #27.
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "POST".into(),
+            description: "django.request.POST".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "GET".into(),
+            description: "django.request.GET".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "COOKIES".into(),
+            description: "django.request.COOKIES".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "FILES".into(),
+            description: "django.request.FILES".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "META".into(),
+            description: "django.request.META".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "headers".into(),
+            description: "django/fastapi.request.headers".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "body".into(),
+            description: "django/fastapi.request.body".into(),
+        },
+        // ─── FastAPI / Starlette ──────────────────────────────────
+        // Starlette's Request exposes `query_params`, `path_params`,
+        // `cookies`, `headers`; body access goes through awaitable
+        // method calls (`await request.json()`, etc.). The Call
+        // entries below match the bare callee shape; `await` is a
+        // wrapper the engine sees through.
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "query_params".into(),
+            description: "fastapi/starlette.request.query_params".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "path_params".into(),
+            description: "fastapi/starlette.request.path_params".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.body".into(),
+            description: "fastapi/starlette.request.body()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.json".into(),
+            description: "fastapi/starlette.request.json()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.form".into(),
+            description: "fastapi/starlette.request.form()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "request.stream".into(),
+            description: "fastapi/starlette.request.stream()".into(),
+        },
+        // ─── CLI: sys.argv / sys.stdin / input() ──────────────────
+        NodeMatcher::Attribute {
+            root: "sys".into(),
+            field: "argv".into(),
+            description: "sys.argv".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "sys.stdin.read".into(),
+            description: "sys.stdin.read()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "sys.stdin.readline".into(),
+            description: "sys.stdin.readline()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "input".into(),
+            description: "input()".into(),
+        },
+        // ─── CLI: os.environ / os.getenv ──────────────────────────
+        // `os.environ["X"]` works via subscript; `os.environ.get("X")`
+        // depends on issue #27 (method calls on tainted receivers).
+        NodeMatcher::Attribute {
+            root: "os".into(),
+            field: "environ".into(),
+            description: "os.environ".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "os.getenv".into(),
+            description: "os.getenv(...)".into(),
+        },
+        // ─── Handler-parameter sources ────────────────────────────
+        // Covers `def view(request): ...` across Flask/Django and
+        // `async def handler(request: Request): ...` in
+        // FastAPI/Starlette. `req` is the idiomatic short alias in
+        // FastAPI and express-style examples.
         NodeMatcher::ParamName {
-            names: vec!["request".into()],
+            names: vec!["request".into(), "req".into()],
             description: "untrusted request parameter".into(),
         },
     ]

--- a/tests/fixtures/safe_cli_taint.py
+++ b/tests/fixtures/safe_cli_taint.py
@@ -1,0 +1,25 @@
+# Negative CLI fixture (issue #30). Every sink gets a trusted
+# argument; `py/taint-*` rules must stay silent.
+
+import os
+import subprocess
+import sys  # noqa: F401
+
+
+def static_cmd():
+    subprocess.run(["ls", "/tmp"])
+
+
+def reassignment_kills_taint():
+    cmd = os.getenv("USER_CMD")
+    cmd = "ls /tmp"
+    os.system(cmd)
+
+
+def clean_eval():
+    return eval("1 + 1")
+
+
+def static_input_unused():
+    _ = input("enter: ")  # noqa: F841 no sink reached
+    os.system("ls")

--- a/tests/fixtures/safe_django_taint.py
+++ b/tests/fixtures/safe_django_taint.py
@@ -1,0 +1,30 @@
+# Negative Django fixture (issue #29). Every handler calls a taint
+# sink with a non-tainted argument, so `py/taint-*` rules must stay
+# silent. Conservative `py/no-*` rules may still fire — that's the
+# intended division of labor.
+
+import os
+import pickle
+import yaml
+
+
+def clean_literal_pickle():
+    return pickle.loads(b"static-bytes")
+
+
+def reassignment_kills_taint(request):
+    data = request.POST["data"]
+    data = b"overwritten"
+    return pickle.loads(data)
+
+
+def clean_command():
+    os.system("ls /tmp")
+
+
+def clean_eval():
+    return eval("2 + 2")
+
+
+def clean_yaml():
+    return yaml.load("key: value")

--- a/tests/fixtures/safe_fastapi_taint.py
+++ b/tests/fixtures/safe_fastapi_taint.py
@@ -1,0 +1,26 @@
+# Negative FastAPI fixture (issue #29). All sinks get non-tainted
+# arguments; `py/taint-*` must stay silent.
+
+import os
+import pickle
+
+from fastapi import FastAPI, Request  # noqa: F401
+
+app = FastAPI()
+
+
+@app.post("/clean-pickle")
+async def clean_pickle():
+    return pickle.loads(b"static-bytes")
+
+
+@app.get("/kills-taint")
+async def kills_taint(request: Request):
+    value = request.query_params["x"]
+    value = "trusted-literal"
+    os.system(value)
+
+
+@app.get("/static")
+async def static_cmd():
+    os.system("ls /tmp")

--- a/tests/fixtures/vulnerable_cli_taint.py
+++ b/tests/fixtures/vulnerable_cli_taint.py
@@ -1,0 +1,37 @@
+# Taint fixture for CLI-tool sources (issue #30). Each handler shows
+# a different untrusted CLI input reaching a taint sink. These paths
+# all work today without issue #27: `sys.argv[1]` is subscript on a
+# tainted attribute, `input()` and `os.getenv(...)` are bare calls.
+
+import os
+import subprocess
+import sys
+
+
+# ─── py/taint-command-injection via sys.argv ───────────────────────
+def cli_argv():
+    subprocess.run(sys.argv[1], shell=True)
+
+
+# ─── py/taint-command-injection via os.getenv ──────────────────────
+def cli_env():
+    cmd = os.getenv("USER_CMD")
+    os.system(cmd)
+
+
+# ─── py/taint-eval via input() ─────────────────────────────────────
+def cli_input():
+    user_input = input("enter: ")
+    return eval(user_input)
+
+
+# ─── py/taint-eval via sys.stdin.read() ────────────────────────────
+def cli_stdin():
+    data = sys.stdin.read()
+    return eval(data)
+
+
+# ─── py/taint-command-injection via os.environ subscript ───────────
+def cli_environ_subscript():
+    cmd = os.environ["USER_CMD"]
+    os.system(cmd)

--- a/tests/fixtures/vulnerable_django_taint.py
+++ b/tests/fixtures/vulnerable_django_taint.py
@@ -1,0 +1,43 @@
+# Taint fixture for Django request sources (issue #29). Every handler
+# below takes a Django `HttpRequest` and flows an untrusted attribute
+# into a taint sink via subscript access. The engine's v1 scope taints
+# subscript access on a tainted attribute, so `request.POST["data"]`
+# works; `request.POST.get("data")` is method-call-on-tainted-receiver
+# and is covered once issue #27 lands.
+
+import os
+import pickle
+import subprocess  # noqa: F401
+import yaml
+
+from django.http import HttpRequest  # noqa: F401
+
+
+# ─── py/taint-pickle-deserialization via request.POST ──────────────
+def view_post(request):
+    return pickle.loads(request.POST["data"])
+
+
+# ─── py/taint-command-injection via request.GET ────────────────────
+def view_get(request):
+    cmd = request.GET["cmd"]
+    os.system(cmd)
+
+
+# ─── py/taint-eval via request.COOKIES ─────────────────────────────
+def view_cookies(request):
+    expr = request.COOKIES["expr"]
+    return eval(expr)
+
+
+# ─── py/taint-yaml-load via request.body ───────────────────────────
+def view_body(request):
+    return yaml.load(request.body)
+
+
+# ─── py/taint-ssrf via request.META ────────────────────────────────
+def view_meta(request):
+    import requests
+
+    url = request.META["HTTP_X_TARGET"]
+    return requests.get(url)

--- a/tests/fixtures/vulnerable_fastapi_taint.py
+++ b/tests/fixtures/vulnerable_fastapi_taint.py
@@ -1,0 +1,35 @@
+# Taint fixture for FastAPI/Starlette request sources (issue #29).
+# Uses attribute sources (`query_params`, `path_params`) that work
+# today via subscript propagation. The method-call sources
+# (`await request.json()`, etc.) also work when the call result is
+# assigned and used directly, because the engine matches the `Call`
+# shape regardless of `await` wrapping.
+
+import pickle
+
+from fastapi import FastAPI, Request  # noqa: F401
+
+app = FastAPI()
+
+
+# ─── py/taint-pickle-deserialization via query_params ──────────────
+@app.post("/deserialize")
+async def deserialize(request: Request):
+    raw = request.query_params["data"]
+    return pickle.loads(raw)
+
+
+# ─── py/taint-command-injection via path_params ────────────────────
+@app.get("/exec/{name}")
+async def run_path(request: Request):
+    import os
+
+    cmd = request.path_params["name"]
+    os.system(cmd)
+
+
+# ─── py/taint-eval via handler-param name `req` ────────────────────
+@app.get("/eval")
+async def evaluator(req: Request):
+    expr = req.query_params["expr"]
+    return eval(expr)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -163,10 +163,14 @@ fn test_vulnerable_py_finds_all_rules() {
     let findings: Vec<serde_json::Value> =
         serde_json::from_slice(&output.stdout).expect("invalid JSON output");
 
+    // Count grew to 31 when `input()` became a taint source (issues
+    // #29/#30): `dangerous()` now additionally fires py/taint-eval on
+    // `eval(input("Enter code: "))` alongside the conservative
+    // py/no-eval finding.
     assert_eq!(
         findings.len(),
-        30,
-        "vulnerable.py should have 30 findings, got {}",
+        31,
+        "vulnerable.py should have 31 findings, got {}",
         findings.len()
     );
 
@@ -362,6 +366,214 @@ fn test_safe_py_taint_has_no_taint_findings() {
         assert_eq!(
             n, 0,
             "{} should not fire on safe_py_taint.py, got {} findings",
+            taint_rule, n
+        );
+    }
+}
+
+/// Positive Django fixture for issues #29/#30: every handler flows an
+/// untrusted `HttpRequest` attribute into a taint sink via subscript
+/// access. Each taint rule must fire exactly once.
+#[test]
+fn test_vulnerable_django_taint_catches_flows() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_django_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    for rule in [
+        "py/taint-pickle-deserialization",
+        "py/taint-command-injection",
+        "py/taint-eval",
+        "py/taint-yaml-load",
+        "py/taint-ssrf",
+    ] {
+        assert_eq!(
+            counts.get(rule).copied(),
+            Some(1),
+            "{} should fire exactly once on vulnerable_django_taint.py. counts={:?}",
+            rule,
+            counts
+        );
+    }
+}
+
+/// Negative Django fixture for issue #29: every sink gets a trusted
+/// argument, so no `py/taint-*` rule may fire.
+#[test]
+fn test_safe_django_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_django_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    for taint_rule in [
+        "py/taint-pickle-deserialization",
+        "py/taint-eval",
+        "py/taint-command-injection",
+        "py/taint-ssrf",
+        "py/taint-yaml-load",
+        "py/taint-sql-injection",
+    ] {
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some(taint_rule))
+            .count();
+        assert_eq!(
+            n, 0,
+            "{} should not fire on safe_django_taint.py, got {} findings",
+            taint_rule, n
+        );
+    }
+}
+
+/// Positive FastAPI/Starlette fixture for issue #29. Covers attribute
+/// sources (`query_params`, `path_params`) and the handler-parameter
+/// name widening that recognizes `req: Request`.
+#[test]
+fn test_vulnerable_fastapi_taint_catches_flows() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_fastapi_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    for rule in [
+        "py/taint-pickle-deserialization",
+        "py/taint-command-injection",
+        "py/taint-eval",
+    ] {
+        assert_eq!(
+            counts.get(rule).copied(),
+            Some(1),
+            "{} should fire exactly once on vulnerable_fastapi_taint.py. counts={:?}",
+            rule,
+            counts
+        );
+    }
+}
+
+/// Negative FastAPI/Starlette fixture for issue #29.
+#[test]
+fn test_safe_fastapi_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_fastapi_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    for taint_rule in [
+        "py/taint-pickle-deserialization",
+        "py/taint-eval",
+        "py/taint-command-injection",
+        "py/taint-ssrf",
+        "py/taint-yaml-load",
+        "py/taint-sql-injection",
+    ] {
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some(taint_rule))
+            .count();
+        assert_eq!(
+            n, 0,
+            "{} should not fire on safe_fastapi_taint.py, got {} findings",
+            taint_rule, n
+        );
+    }
+}
+
+/// Positive CLI fixture for issue #30: `sys.argv`, `os.getenv`,
+/// `os.environ[...]`, `input()`, and `sys.stdin.read()` flowing into
+/// command-injection and eval sinks. Expects three
+/// command-injection findings (argv, getenv, environ subscript) and
+/// two eval findings (input, stdin.read).
+#[test]
+fn test_vulnerable_cli_taint_catches_flows() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_cli_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    assert_eq!(
+        counts.get("py/taint-command-injection").copied(),
+        Some(3),
+        "py/taint-command-injection should fire three times on vulnerable_cli_taint.py. counts={:?}",
+        counts
+    );
+    assert_eq!(
+        counts.get("py/taint-eval").copied(),
+        Some(2),
+        "py/taint-eval should fire twice on vulnerable_cli_taint.py. counts={:?}",
+        counts
+    );
+}
+
+/// Negative CLI fixture for issue #30.
+#[test]
+fn test_safe_cli_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_cli_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    for taint_rule in [
+        "py/taint-pickle-deserialization",
+        "py/taint-eval",
+        "py/taint-command-injection",
+        "py/taint-ssrf",
+        "py/taint-yaml-load",
+        "py/taint-sql-injection",
+    ] {
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some(taint_rule))
+            .count();
+        assert_eq!(
+            n, 0,
+            "{} should not fire on safe_cli_taint.py, got {} findings",
             taint_rule, n
         );
     }


### PR DESCRIPTION
## Summary

Combined implementation of issues #29 (Django, FastAPI/Starlette request sources) and #30 (CLI sources). Both extend the single shared `python_taint_sources()` helper in `src/rules/python_taint.rs`, so they land together as one clean commit.

### New sources

- **Django** — `request.POST`, `request.GET`, `request.COOKIES`, `request.FILES`, `request.META`, `request.headers`, `request.body`.
- **FastAPI / Starlette** — `request.query_params`, `request.path_params`; `request.body()`, `request.json()`, `request.form()`, `request.stream()` Call shapes (the `await` wrapper is transparent to the engine).
- **CLI** — `sys.argv`, `sys.stdin.read()`, `sys.stdin.readline()`, `input()`, `os.environ`, `os.getenv(...)`.
- **ParamName** widened so handler parameters named `req` are recognized in addition to `request`, matching idiomatic FastAPI/Starlette examples.

### What works today vs gated on #27

Works now via existing subscript/attribute/Call propagation:
- `request.POST["data"]`, `request.GET["cmd"]`, `request.query_params["x"]`, etc. (subscript-on-tainted-root)
- `sys.argv[1]`, `os.environ["X"]` (subscript-on-tainted-root)
- `input()`, `os.getenv("X")`, `sys.stdin.read()` (bare `Call` shapes)
- Handler params typed as `Request`/`HttpRequest` via `ParamName`
- `await request.json()` etc. — the Call matcher sees through `await`

Gated on #27 (method calls on tainted receivers):
- `request.GET.get("key")`, `request.POST.get("key")`
- `os.environ.get("X")`

A block comment on `python_taint_sources()` documents this explicitly.

### Fixtures and tests

New positive/negative pairs with exact-count assertions:
- `vulnerable_django_taint.py` / `safe_django_taint.py` — 5 taint findings / 0
- `vulnerable_fastapi_taint.py` / `safe_fastapi_taint.py` — 3 / 0
- `vulnerable_cli_taint.py` / `safe_cli_taint.py` — 5 / 0 (3 command-injection + 2 eval)

Integration tests added: `test_vulnerable_django_taint_catches_flows`, `test_safe_django_taint_has_no_taint_findings`, `test_vulnerable_fastapi_taint_catches_flows`, `test_safe_fastapi_taint_has_no_taint_findings`, `test_vulnerable_cli_taint_catches_flows`, `test_safe_cli_taint_has_no_taint_findings`.

`tests/fixtures/vulnerable.py`'s expected finding count bumped from 30 to 31 because `eval(input(...))` now additionally fires `py/taint-eval` alongside the conservative `py/no-eval`. Commented inline.

### Docs

- `docs/taint-tracking.md` Scope section lists supported frameworks.
- `docs/precision.md` Tier-4 section mentions Django, FastAPI/Starlette, and CLI coverage.

### Gates

- `cargo build --release` — clean
- `cargo test` — 85 + 53 + 12 + 6 + 1 tests passing
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

No website `rules.ts` change — this PR only widens sources for existing `py/taint-*` rule IDs.

## Test plan

- [x] Manual scan of each new fixture produces expected finding counts
- [x] Existing `vulnerable_py_taint.py` / `safe_py_taint.py` unchanged (16 pickle findings, all Flask flows preserved)
- [x] `cargo test` fully green
- [x] Clippy + fmt gates pass

none