### PR TITLE
Taint: add Next.js, Hono, Fastify, SvelteKit, Deno sources to JS taint (refs #32)

### DIFF
--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -178,6 +178,33 @@ rules:
 
 Load it with `foxguard --no-builtins --rules path/to/rule.yml target/` and each compiled rule becomes a regular foxguard `Rule` backed by the same intraprocedural engine described above.
 
+## Supported JavaScript / TypeScript frameworks
+
+Issue #32 extended `javascript_taint_sources()` with framework-specific
+sources beyond the original Express surface. The helper is organized
+top-to-bottom by framework; add new entries to the matching section.
+
+| Framework    | Sources that work today                                                                 | Requires #27 (method-call receiver propagation)                                                          |
+| ------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Express      | `req.body`, `req.query`, `req.params`, `req.headers`, `req.cookies` (same for `request`), `ParamName: req`/`request` | —                                                                                                        |
+| Next.js      | `request.nextUrl.*` (via `Attribute` + `ParamName: request`)                            | `request.headers.get(...)`, `request.cookies.get(...)`, `request.json()`, `request.formData()`          |
+| Hono         | `c.req.query()`, `c.req.param()`, `c.req.header()`, `c.req.json()`, `c.req.formData()`, `c.req.parseBody()`, `c.req` attribute access | —                                                                                                        |
+| Fastify      | Shares the Express attribute surface (`request.body` / `.query` / `.params` / `.headers` / `.cookies`) | Method-based Fastify helpers (none commonly used) would need #27                                         |
+| SvelteKit    | `event.request`, `event.params`, `event.url` attribute chains                            | `event.request.json()`, `event.request.formData()`                                                      |
+| Deno         | `Deno.args[...]`, `Deno.env.get(...)`                                                   | —                                                                                                        |
+
+Two deliberate non-additions:
+
+- **Hono's `c`** is not a `ParamName` source. `c` is too common a local
+  identifier in generic JS to be treated as an untrusted receiver
+  without type information.
+- **SvelteKit's `event`** is not a `ParamName` source either. DOM event
+  handlers (`onClick(event)`, `addEventListener("click", (event) => ...)`)
+  use the same name and would flood false positives.
+
+Because the engine only walks function bodies, Deno top-level scripts
+that want taint coverage should wrap their logic in a named function.
+
 ## Open questions for the full #10
 
 - **Cross-function propagation.** The first step — "trust the return of helpers whose body we can see in the same file" — landed in issue #19 as a single-hop, name-keyed summary pass. Next steps: multi-hop propagation via fixed-point iteration over the summary map, scope-aware keys that distinguish nested definitions, argument-based taint threading so callers' tainted arguments influence helper summaries, then cross-file via module symbol tables. Each is its own issue.

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1092,10 +1092,42 @@ fn match_source(
 }
 
 /// Canonical set of untrusted-input sources for JavaScript/TypeScript web
-/// handlers. Currently covers Express-style `req.*` access plus parameters
-/// named `req` / `request`.
+/// handlers. Organized by framework; add new sources to the matching
+/// section and keep the layout stable so future contributors know where
+/// their entries belong.
+///
+/// Frameworks covered today:
+/// 1. Generic handler parameters (`req`, `request`) — Express / Fastify /
+///    Next.js App Router share this convention.
+/// 2. Express-style `req.*` / `request.*` attribute access.
+/// 3. Next.js App Router (`request.nextUrl.*`, `request.cookies.*`).
+/// 4. Hono (`c.req.*` call / attribute patterns — `c` is intentionally
+///    NOT added as a `ParamName` matcher because single-letter locals
+///    named `c` are extremely common in generic JS and would explode
+///    false positives).
+/// 5. Fastify — largely overlaps with Express sources above; no new
+///    matchers needed today, but future Fastify-only fields go here.
+/// 6. SvelteKit (`event.request`, `event.params`, `event.url`). `event`
+///    is intentionally NOT a `ParamName` matcher — browser DOM event
+///    handlers use the same name and would flood false positives.
+/// 7. Deno (`Deno.args`, `Deno.env.get`).
+///
+/// Several method-call sources (`request.headers.get(...)`,
+/// `request.cookies.get(...)`, `request.formData()`, `request.json()`)
+/// require the engine to propagate taint from a method-call *receiver*
+/// into the call expression's result. That is tracked as issue #27 and
+/// is not expressible with the `NodeMatcher` variants today. Once #27
+/// lands, those patterns will fire automatically for any handler whose
+/// parameter is already seeded as `request` / `req` — no new matchers
+/// required here.
 pub fn javascript_taint_sources() -> Vec<NodeMatcher> {
     vec![
+        // ─── 1. Generic handler parameters ────────────────────────────
+        NodeMatcher::ParamName {
+            names: vec!["req".into(), "request".into()],
+            description: "untrusted request parameter".into(),
+        },
+        // ─── 2. Express / general `req.*` and `request.*` ────────────
         NodeMatcher::Attribute {
             root: "req".into(),
             field: "body".into(),
@@ -1146,9 +1178,87 @@ pub fn javascript_taint_sources() -> Vec<NodeMatcher> {
             field: "cookies".into(),
             description: "request.cookies".into(),
         },
-        NodeMatcher::ParamName {
-            names: vec!["req".into(), "request".into()],
-            description: "untrusted request parameter".into(),
+        // ─── 3. Next.js App Router ───────────────────────────────────
+        // `request.nextUrl` exposes a parsed URL — `.searchParams`,
+        // `.pathname`, `.href` are all untrusted when `request` is the
+        // handler input. `request.cookies` overlaps with Express above.
+        // Method-call variants (`request.headers.get`, `request.json`,
+        // `request.formData`, `request.cookies.get`) depend on issue
+        // #27 — see the header comment above.
+        NodeMatcher::Attribute {
+            root: "request".into(),
+            field: "nextUrl".into(),
+            description: "Next.js request.nextUrl".into(),
+        },
+        // ─── 4. Hono ─────────────────────────────────────────────────
+        // Hono handlers receive a context `c` whose `c.req` is the
+        // untrusted request. Direct `c.req` attribute access is covered
+        // by the `Attribute` matcher below; the most common call forms
+        // are enumerated explicitly so the engine picks them up even
+        // though `c` is never seeded via `ParamName` (see header
+        // comment for the rationale).
+        NodeMatcher::Attribute {
+            root: "c".into(),
+            field: "req".into(),
+            description: "Hono c.req".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.query".into(),
+            description: "Hono c.req.query()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.param".into(),
+            description: "Hono c.req.param()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.header".into(),
+            description: "Hono c.req.header()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.json".into(),
+            description: "Hono c.req.json()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.formData".into(),
+            description: "Hono c.req.formData()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "c.req.parseBody".into(),
+            description: "Hono c.req.parseBody()".into(),
+        },
+        // ─── 5. Fastify ──────────────────────────────────────────────
+        // Fastify uses the same `request.body` / `.query` / `.params` /
+        // `.headers` / `.cookies` surface as Express, so the section 2
+        // matchers already cover it. Add Fastify-specific fields here
+        // if any ever diverge.
+        // ─── 6. SvelteKit ────────────────────────────────────────────
+        // `event` is intentionally NOT a `ParamName` matcher — DOM
+        // event handlers use the same name. Rely on explicit
+        // attribute paths from the request event object.
+        NodeMatcher::Attribute {
+            root: "event".into(),
+            field: "request".into(),
+            description: "SvelteKit event.request".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "event".into(),
+            field: "params".into(),
+            description: "SvelteKit event.params".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "event".into(),
+            field: "url".into(),
+            description: "SvelteKit event.url".into(),
+        },
+        // ─── 7. Deno ─────────────────────────────────────────────────
+        NodeMatcher::Attribute {
+            root: "Deno".into(),
+            field: "args".into(),
+            description: "Deno.args".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Deno.env.get".into(),
+            description: "Deno.env.get()".into(),
         },
     ]
 }

--- a/tests/fixtures/safe_deno_taint.ts
+++ b/tests/fixtures/safe_deno_taint.ts
@@ -1,0 +1,30 @@
+// Safe Deno counterpart — no tainted flows should reach any sink.
+
+function literalOnly() {
+    // Literal, no taint.
+    const el = document.getElementById("msg");
+    if (el) el.innerHTML = "<h1>Hello</h1>";
+}
+
+function reassigned() {
+    // Reassignment kills taint before the sink.
+    let arg = Deno.args[0];
+    arg = "static";
+    const el = document.getElementById("arg");
+    if (el) el.innerHTML = arg;
+}
+
+// Cross-function: intraprocedural engine does not thread taint across
+// this call boundary.
+function render(value) {
+    const el = document.getElementById("x");
+    if (el) el.innerHTML = value;
+}
+
+function caller() {
+    render("static literal");
+}
+
+literalOnly();
+reassigned();
+caller();

--- a/tests/fixtures/safe_hono_taint.ts
+++ b/tests/fixtures/safe_hono_taint.ts
@@ -1,0 +1,31 @@
+// Safe Hono counterpart — no tainted flows should reach any sink.
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+    // Literal, no taint.
+    document.write("<h1>Hello</h1>");
+    return c.text("ok");
+});
+
+app.get("/reassign", (c) => {
+    // Reassignment kills taint before the sink.
+    let name = c.req.query("name");
+    name = "static";
+    const el = document.getElementById("out");
+    if (el) el.innerHTML = name;
+    return c.text("ok");
+});
+
+// Cross-function: intraprocedural engine does not thread taint across
+// this call boundary.
+function render(value) {
+    const el = document.getElementById("x");
+    if (el) el.innerHTML = value;
+}
+
+app.get("/iso", (c) => {
+    render("static literal");
+    return c.text("ok");
+});

--- a/tests/fixtures/safe_nextjs_taint.ts
+++ b/tests/fixtures/safe_nextjs_taint.ts
@@ -1,0 +1,27 @@
+// Safe Next.js counterpart — no tainted flows should reach any sink.
+import { NextRequest } from "next/server";
+
+export async function GET(_request: NextRequest) {
+    // Literal, no taint.
+    const el = document.getElementById("greeting");
+    if (el) el.innerHTML = "<h1>Hello</h1>";
+}
+
+export async function POST(request: NextRequest) {
+    // Reassignment kills taint: `target` is tainted on the first line,
+    // then replaced with a static literal before reaching the sink.
+    let target = request.nextUrl;
+    target = "/static";
+    document.write(`<h1>${target}</h1>`);
+}
+
+// Cross-function isolation: `helper` has no tainted input in its own
+// scope (intraprocedural engine), so the sink call here must not fire.
+function helper(name) {
+    const el = document.getElementById("out");
+    if (el) el.innerHTML = name;
+}
+
+export async function PUT(_request: NextRequest) {
+    helper("static literal");
+}

--- a/tests/fixtures/vulnerable_deno_taint.ts
+++ b/tests/fixtures/vulnerable_deno_taint.ts
@@ -1,0 +1,20 @@
+// Deno CLI script. `Deno.args` matches the Deno `Attribute` source,
+// and `Deno.env.get(...)` matches the `Call` source. The intraprocedural
+// taint engine only analyzes function bodies, so the sinks below live
+// inside explicit functions — top-level Deno scripts should wrap their
+// logic the same way to benefit from taint tracking.
+
+function renderArg() {
+    const userArg = Deno.args[0];
+    const el = document.getElementById("msg");
+    if (el) el.innerHTML = userArg; // js/taint-xss-innerhtml
+}
+
+function renderHost() {
+    const host = Deno.env.get("REMOTE_HOST");
+    const el = document.getElementById("host");
+    if (el) el.innerHTML = host; // js/taint-xss-innerhtml
+}
+
+renderArg();
+renderHost();

--- a/tests/fixtures/vulnerable_hono_taint.ts
+++ b/tests/fixtures/vulnerable_hono_taint.ts
@@ -1,0 +1,20 @@
+// Hono handler. `c` is intentionally not a `ParamName` source (it
+// collides with generic one-letter locals), so taint is picked up
+// through explicit `Call` matchers on `c.req.*` method sources and
+// the `Attribute` matcher on `c.req`.
+import { Hono } from "hono";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+    const name = c.req.query("name");
+    document.write(`<h1>${name}</h1>`); // js/taint-xss-innerhtml
+    return c.text("ok");
+});
+
+app.get("/param", (c) => {
+    const id = c.req.param("id");
+    const el = document.getElementById("out");
+    if (el) el.innerHTML = id; // js/taint-xss-innerhtml
+    return c.text("ok");
+});

--- a/tests/fixtures/vulnerable_nextjs_taint.ts
+++ b/tests/fixtures/vulnerable_nextjs_taint.ts
@@ -1,0 +1,20 @@
+// Next.js App Router handler. `request` is seeded as a source by the
+// `ParamName` matcher, and its `nextUrl` / `cookies` attribute chains
+// propagate taint through to DOM sinks. Method-call sources like
+// `request.headers.get(...)` depend on issue #27 and are intentionally
+// not exercised here.
+import { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+    // Pure attribute chain — propagates taint via member-expression
+    // propagation because `request` is ParamName-seeded.
+    const params = request.nextUrl.searchParams;
+    const el = document.getElementById("greeting");
+    if (el) el.innerHTML = params; // js/taint-xss-innerhtml
+}
+
+export async function POST(request: NextRequest) {
+    // `request.nextUrl` matches the Next.js Attribute matcher directly.
+    const target = request.nextUrl;
+    document.write(`<h1>${target}</h1>`); // js/taint-xss-innerhtml
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -442,6 +442,147 @@ fn test_safe_js_taint_has_no_taint_findings() {
     );
 }
 
+/// Issue #32 — Next.js App Router taint sources. `request` is the
+/// ParamName-seeded handler input and `request.nextUrl` is a Next.js
+/// specific Attribute source. Both handlers must fire exactly once.
+#[test]
+fn test_vulnerable_nextjs_taint_catches_flow() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_nextjs_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 2,
+        "js/taint-xss-innerhtml should fire exactly twice on vulnerable_nextjs_taint.ts, got {} findings: {:?}",
+        n, findings
+    );
+}
+
+#[test]
+fn test_safe_nextjs_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_nextjs_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 0,
+        "js/taint-xss-innerhtml should not fire on safe_nextjs_taint.ts, got {} findings",
+        n
+    );
+}
+
+/// Issue #32 — Hono taint sources. `c` is intentionally NOT a ParamName
+/// matcher; the engine must pick up `c.req.query(...)` / `c.req.param(...)`
+/// through the explicit `Call` matchers.
+#[test]
+fn test_vulnerable_hono_taint_catches_flow() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_hono_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 2,
+        "js/taint-xss-innerhtml should fire exactly twice on vulnerable_hono_taint.ts, got {} findings: {:?}",
+        n, findings
+    );
+}
+
+#[test]
+fn test_safe_hono_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_hono_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 0,
+        "js/taint-xss-innerhtml should not fire on safe_hono_taint.ts, got {} findings",
+        n
+    );
+}
+
+/// Issue #32 — Deno taint sources. `Deno.args` is an Attribute source,
+/// `Deno.env.get(...)` is a Call source. The engine only analyzes
+/// function bodies, so the fixture wraps its sinks accordingly.
+#[test]
+fn test_vulnerable_deno_taint_catches_flow() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_deno_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success());
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 2,
+        "js/taint-xss-innerhtml should fire exactly twice on vulnerable_deno_taint.ts, got {} findings: {:?}",
+        n, findings
+    );
+}
+
+#[test]
+fn test_safe_deno_taint_has_no_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe_deno_taint.ts", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let n = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
+        .count();
+    assert_eq!(
+        n, 0,
+        "js/taint-xss-innerhtml should not fire on safe_deno_taint.ts, got {} findings",
+        n
+    );
+}
+
 /// Negative regression for issue #7: aliased imports of the *same* sensitive
 /// modules, but called in safe shapes (static literals, SafeLoader, sha256,
 /// write-only pickle methods). Alias resolution must not silently widen the


### PR DESCRIPTION
## Summary

Extends `javascript_taint_sources()` in `src/rules/javascript_taint.rs` beyond the original Express surface with Next.js, Hono, SvelteKit, and Deno matchers. Fastify reuses the existing Express `request.*` attribute set — no new matchers needed today.

- **Next.js App Router**: `Attribute { root: "request", field: "nextUrl" }` for `request.nextUrl.*` chains. `ParamName: request` already seeded Express/Next handlers; this adds a framework-named source on top.
- **Hono**: explicit `Call` matchers for `c.req.query`, `c.req.param`, `c.req.header`, `c.req.json`, `c.req.formData`, `c.req.parseBody`, plus an `Attribute { root: "c", field: "req" }` matcher. `c` is intentionally NOT a `ParamName` matcher — it collides with generic one-letter locals.
- **SvelteKit**: `Attribute` matchers on `event.request`, `event.params`, `event.url`. `event` is intentionally NOT a `ParamName` matcher — DOM event handlers use the same name.
- **Deno**: `Attribute { root: "Deno", field: "args" }` and `Call { canonical: "Deno.env.get" }`.
- **Fastify**: covered by existing `request.*` attribute matchers.

The helper is reorganized into labeled sections so future contributors know where to add new sources.

### Fixtures and tests

Six new fixtures under `tests/fixtures/`:

- `vulnerable_nextjs_taint.ts`, `safe_nextjs_taint.ts`
- `vulnerable_hono_taint.ts`, `safe_hono_taint.ts`
- `vulnerable_deno_taint.ts`, `safe_deno_taint.ts`

Each vulnerable fixture asserts exactly two `js/taint-xss-innerhtml` findings; each safe fixture asserts zero. Six new integration tests in `tests/integration.rs` wire them up.

### Dependency on #27

Method-call sources where the receiver is tainted but the call itself isn't directly matched — `request.headers.get(x)`, `request.cookies.get(x)`, `request.json()`, `request.formData()`, `event.request.json()`, `event.request.formData()` — still do not fire today. The engine's `expression_taint` for a `call_expression` only recurses into arguments and the bare-identifier callee summary, not the member-expression receiver. Once issue #27 lands (method call propagation on tainted roots), these patterns will light up automatically for any already-seeded handler parameter without any new matchers. `docs/taint-tracking.md` now contains a per-framework table enumerating exactly which patterns work today vs. which depend on #27, plus a note about why Deno scripts should wrap their logic in a named function (the engine only walks function bodies).

Refs #32.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` — 5 integration test suites, 85+53+6+12+1 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt`
- [x] Manual scan of each new fixture — vulnerable files each report 2 `js/taint-xss-innerhtml`, safe files report 0

none