### PR TITLE
Add realistic test corpus under tests/fixtures/realistic/ (refs #35)

### DIFF
--- a/docs/precision.md
+++ b/docs/precision.md
@@ -37,6 +37,20 @@ foxguard measures rule quality with three artifacts that all live in the repo:
    these produce **zero findings**. This is our **precision floor** for the
    patterns we already know about.
 
+   Sitting between the one-function-per-case positive fixtures and the real-
+   world corpus scans is a **realistic test corpus** under
+   `tests/fixtures/realistic/`. Each file there is a small-but-complete
+   vulnerable application for one supported framework (Flask, Django,
+   FastAPI, a CLI tool, Express, Next.js, Hono) with idiomatic routing,
+   helper functions that exercise interprocedural propagation, and 2–3
+   explicitly-labelled `NEAR MISS` functions per file whose patterns the
+   engine might be tempted to flag but should not. The integration test
+   `tests/realistic_fixtures.rs` pins the exact total finding count and the
+   exact count per taint rule for every file. Any rule addition or engine
+   change that shifts these counts forces explicit acknowledgement — which
+   is how we catch end-to-end precision regressions that neither the
+   single-function fixtures nor the public corpus scan would notice.
+
 3. **Real-world corpus scans.** We have run foxguard against the latest HEAD of
    Express, Flask, Gin, Laravel, Rails (actionpack), Spring Petclinic, and a
    Next.js starter — 799 files, 369 findings, 0.86 seconds total. Numbers and

--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -146,6 +146,21 @@ Per-finding sanitization (Semgrep's `mode: taint` style, where a sanitizer clean
 
 The `py/taint-pickle-deserialization` rule is ~120 lines and is the canonical example.
 
+## What real-world usage looks like
+
+For a hand-crafted but more realistic picture of what the engine fires on,
+see the fixtures under `tests/fixtures/realistic/`. Each file there is a
+small-but-complete vulnerable application for one supported framework —
+`flask_app.py`, `django_views.py`, `fastapi_app.py`, `cli_tool.py`,
+`express_app.js`, `nextjs_handlers.ts`, `hono_app.ts` — with idiomatic
+routing, helper functions that exercise interprocedural return
+propagation, and 2–3 `NEAR MISS` functions per file whose patterns the
+engine must not flag (literal arguments, reassignment to literals,
+tainted values that never reach a sink). The integration test
+`tests/realistic_fixtures.rs` pins the exact total finding count and the
+exact count per taint rule for every file, which is the bar we hold the
+engine to when adding new sources or sinks.
+
 ## Coexistence with conservative rules
 
 Taint rules do not replace direct-sink rules. In the POC, `py/no-pickle` fires on every `pickle.loads` call; `py/taint-pickle-deserialization` fires only on the subset where a flow is provable. A user may see both findings on the same line, with different messages. That is intended — the two rules encode different questions and should be silenced independently if the user wants to suppress one but not the other.

--- a/tests/fixtures/realistic/cli_tool.py
+++ b/tests/fixtures/realistic/cli_tool.py
@@ -1,0 +1,87 @@
+# Realistic CLI fixture (issue #35). Mixes sys.argv, os.getenv, and
+# input() flowing through helper functions into command-injection and
+# eval sinks. Exercises interprocedural propagation.
+#
+# Hand-counted expected taint findings:
+#   py/taint-command-injection : 2
+#   py/taint-eval              : 2
+
+import os
+import subprocess
+import sys
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+def read_argv():
+    """Return the first CLI argument — tainted source through helper."""
+    return sys.argv[1]
+
+
+def env_cmd():
+    """Environment variable helper — tainted source."""
+    return os.getenv("USER_CMD")
+
+
+def prompt():
+    """Interactive input — tainted source."""
+    return input("expr> ")
+
+
+# ─── CLI entry points ──────────────────────────────────────────────────
+def run_from_argv():
+    # py/taint-command-injection — helper returns tainted argv[1]
+    cmd = read_argv()
+    subprocess.run(cmd, shell=True)
+
+
+def run_from_env():
+    # py/taint-command-injection — helper returns tainted env var
+    cmd = env_cmd()
+    os.system(cmd)
+
+
+def calc_interactive():
+    # py/taint-eval — helper returns tainted input()
+    expr = prompt()
+    return eval(expr)
+
+
+def calc_from_stdin():
+    # py/taint-eval — direct sys.stdin source
+    data = sys.stdin.read()
+    return eval(data)
+
+
+def main():
+    if len(sys.argv) < 2:
+        return
+    action = sys.argv[1]
+    if action == "run":
+        run_from_argv()
+    elif action == "env":
+        run_from_env()
+    elif action == "calc":
+        calc_interactive()
+    else:
+        calc_from_stdin()
+
+
+# ─── NEAR MISS — must not fire ─────────────────────────────────────────
+def static_run():
+    # NEAR MISS — literal command
+    subprocess.run("ls -la", shell=True)
+
+
+def trusted_eval():
+    # NEAR MISS — literal expression
+    return eval("40 + 2")
+
+
+def ignore_argv():
+    # NEAR MISS — tainted value read but never flows to a sink
+    _unused = sys.argv[1]  # noqa: F841
+    os.system("whoami")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/realistic/django_views.py
+++ b/tests/fixtures/realistic/django_views.py
@@ -1,0 +1,82 @@
+# Realistic Django views fixture (issue #35). Uses idiomatic
+# `request.POST`, `request.GET`, `request.COOKIES`, and `request.META`
+# access through small helper functions so interprocedural propagation
+# is exercised end-to-end.
+#
+# Hand-counted expected taint findings:
+#   py/taint-command-injection : 2
+#   py/taint-sql-injection     : 1
+#   py/taint-ssrf              : 1
+#   py/taint-pickle-deserialization : 1
+
+import os
+import pickle
+import sqlite3
+
+import requests
+from django.http import HttpResponse
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+def extract_post(request, key):
+    return request.POST[key]
+
+
+def read_cookie(request):
+    return request.COOKIES["session_blob"]
+
+
+# ─── Views ─────────────────────────────────────────────────────────────
+def delete_file(request):
+    # py/taint-command-injection
+    name = request.GET["name"]
+    os.system(name)
+    return HttpResponse("ok")
+
+
+def run_admin_action(request):
+    # py/taint-command-injection — through helper
+    cmd = extract_post(request, "cmd")
+    os.system(cmd)
+    return HttpResponse("ok")
+
+
+def search_users(request):
+    # py/taint-sql-injection
+    q = request.GET["q"]
+    conn = sqlite3.connect(":memory:")
+    conn.cursor().execute(q)
+    return HttpResponse("ok")
+
+
+def proxy_fetch(request):
+    # py/taint-ssrf — untrusted target pulled from request META
+    url = request.META["HTTP_X_PROXY_TARGET"]
+    return HttpResponse(requests.get(url).content)
+
+
+def import_session(request):
+    # py/taint-pickle-deserialization — helper returns tainted cookie
+    blob = read_cookie(request)
+    return pickle.loads(blob)
+
+
+# ─── NEAR MISS — must not fire ─────────────────────────────────────────
+def healthcheck(request):
+    # NEAR MISS — literal sink argument
+    os.system("uptime")
+    return HttpResponse("ok")
+
+
+def static_query(request):
+    # NEAR MISS — tainted value reassigned to literal before sink
+    q = request.GET["q"]  # noqa: F841
+    q = "SELECT 1"
+    conn = sqlite3.connect(":memory:")
+    conn.cursor().execute(q)
+    return HttpResponse("ok")
+
+
+def trusted_fetch(request):
+    # NEAR MISS — literal URL
+    return HttpResponse(requests.get("https://example.com/status").content)

--- a/tests/fixtures/realistic/express_app.js
+++ b/tests/fixtures/realistic/express_app.js
@@ -1,0 +1,80 @@
+// Realistic Express app fixture (issue #35). Mixes req.body, req.query
+// and req.params flowing into XSS sinks (innerHTML, document.write),
+// exercises helper functions, and includes NEAR-MISS cases.
+//
+// Hand-counted expected taint findings:
+//   js/taint-xss-innerhtml : 5
+
+const express = require("express");
+const app = express();
+app.use(express.json());
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+function extractName(req) {
+    return req.body.name;
+}
+
+function getSearchTerm(req) {
+    return req.query.q;
+}
+
+// ─── Routes ────────────────────────────────────────────────────────────
+app.post("/profile", function (req, res) {
+    // js/taint-xss-innerhtml — helper returns tainted body field
+    const name = extractName(req);
+    document.getElementById("profile").innerHTML = name;
+    res.send("ok");
+});
+
+app.get("/search", function (req, res) {
+    // js/taint-xss-innerhtml — helper + template literal
+    const term = getSearchTerm(req);
+    document.getElementById("results").innerHTML = `<h2>Results for ${term}</h2>`;
+    res.send("ok");
+});
+
+app.get("/user/:id", function (req, res) {
+    // js/taint-xss-innerhtml — req.params
+    const id = req.params.id;
+    document.write(`<div>User ${id}</div>`);
+    res.send("ok");
+});
+
+app.post("/comment", function (req, res) {
+    // js/taint-xss-innerhtml — req.body subscript
+    const text = req.body["text"];
+    document.getElementById("comments").innerHTML = text;
+    res.send("ok");
+});
+
+app.get("/about", function (req, res) {
+    // js/taint-xss-innerhtml — req.query alias chain
+    const raw = req.query.bio;
+    const bio = raw;
+    document.write(bio);
+    res.send("ok");
+});
+
+// ─── NEAR MISS — must not fire ─────────────────────────────────────────
+app.get("/health", function (req, res) {
+    // NEAR MISS — literal argument
+    document.getElementById("h").innerHTML = "ok";
+    res.send("ok");
+});
+
+app.get("/static", function (req, res) {
+    // NEAR MISS — tainted read but discarded, sink gets a literal
+    const _ignored = req.query.q;
+    document.write("<h1>Hello</h1>");
+    res.send("ok");
+});
+
+app.get("/safe", function (req, res) {
+    // NEAR MISS — tainted value reassigned to a literal before sink
+    let msg = req.query.msg;
+    msg = "welcome";
+    document.getElementById("m").innerHTML = msg;
+    res.send("ok");
+});
+
+app.listen(3000);

--- a/tests/fixtures/realistic/fastapi_app.py
+++ b/tests/fixtures/realistic/fastapi_app.py
@@ -1,0 +1,69 @@
+# Realistic FastAPI app fixture (issue #35). Covers Request parameter
+# sources and Pydantic model use, with a couple of helpers for
+# interprocedural propagation and NEAR MISS cases.
+#
+# Hand-counted expected taint findings:
+#   py/taint-eval                    : 1
+#   py/taint-pickle-deserialization  : 1
+#   py/taint-ssrf                    : 1
+
+import pickle
+
+import requests
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class Job(BaseModel):
+    expr: str
+    target: str
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────
+def pick_query(req: Request, key: str):
+    return req.query_params[key]
+
+
+# ─── Endpoints ─────────────────────────────────────────────────────────
+@app.get("/eval")
+async def eval_endpoint(request: Request):
+    # py/taint-eval — helper returns tainted query param
+    expr = pick_query(request, "expr")
+    return {"result": eval(expr)}
+
+
+@app.post("/restore")
+async def restore(request: Request):
+    # py/taint-pickle-deserialization
+    blob = request.query_params["blob"]
+    return pickle.loads(blob)
+
+
+@app.get("/fetch")
+async def fetch(request: Request):
+    # py/taint-ssrf
+    target = request.query_params["target"]
+    return {"content": requests.get(target).text}
+
+
+# ─── NEAR MISS — must not fire ─────────────────────────────────────────
+@app.post("/run")
+async def run_job(job: Job):
+    # NEAR MISS — Pydantic-validated model field; the engine does not
+    # treat non-Request parameters as sources, so this must not fire.
+    return {"result": eval(job.expr)}
+
+
+@app.get("/static")
+async def static_eval_endpoint():
+    # NEAR MISS — literal argument
+    return {"result": eval("2 + 2")}
+
+
+@app.get("/ok")
+async def ok(request: Request):
+    # NEAR MISS — read a query param, then discard it and return a literal
+    _seen = request.query_params["seen"]  # noqa: F841
+    return {"status": "ok"}

--- a/tests/fixtures/realistic/flask_app.py
+++ b/tests/fixtures/realistic/flask_app.py
@@ -1,0 +1,109 @@
+# Realistic Flask app fixture (issue #35). Exercises the intraprocedural
+# Python taint engine on an idiomatic multi-route application that mixes
+# helpers, multiple sinks, and NEAR-MISS functions that must not fire.
+#
+# Hand-counted expected taint findings (see tests/realistic_fixtures.rs):
+#   py/taint-pickle-deserialization : 1
+#   py/taint-eval                   : 1
+#   py/taint-command-injection      : 2
+#   py/taint-ssrf                   : 1
+#   py/taint-yaml-load              : 1
+#   py/taint-sql-injection          : 1
+
+import os
+import pickle
+import sqlite3
+import subprocess  # noqa: F401
+import yaml
+
+import requests
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+# ─── Helpers (exercise interprocedural propagation) ────────────────────
+def fetch_body():
+    """Return the raw request body — a helper that returns tainted data."""
+    return request.data
+
+
+def fetch_arg(name):
+    """Typical 'just read a query parameter' helper."""
+    return request.args[name]
+
+
+# ─── Routes ─────────────────────────────────────────────────────────────
+@app.route("/import", methods=["POST"])
+def import_profile():
+    # py/taint-pickle-deserialization — helper returns tainted body
+    payload = fetch_body()
+    return pickle.loads(payload)
+
+
+@app.route("/calc")
+def calc():
+    # py/taint-eval
+    expr = request.args["expr"]
+    return str(eval(expr))
+
+
+@app.route("/ping")
+def ping():
+    # py/taint-command-injection — tainted value flows directly into sink
+    host = request.args["host"]
+    os.system(host)
+    return "ok"
+
+
+@app.route("/run")
+def run_cmd():
+    # py/taint-command-injection — tainted via helper return
+    cmd = fetch_arg("cmd")
+    os.system(cmd)
+    return "ok"
+
+
+@app.route("/fetch")
+def fetch_url():
+    # py/taint-ssrf
+    url = request.args["url"]
+    return requests.get(url).text
+
+
+@app.route("/config", methods=["POST"])
+def load_config():
+    # py/taint-yaml-load
+    doc = request.data
+    return yaml.load(doc)
+
+
+@app.route("/user")
+def lookup_user():
+    # py/taint-sql-injection — tainted name flows into .execute
+    name = request.args["name"]
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute(name)
+    return "ok"
+
+
+# ─── NEAR MISS — must not fire any py/taint-* rule ─────────────────────
+@app.route("/healthz")
+def healthz():
+    # NEAR MISS — literal argument, no source involvement
+    os.system("uptime")
+    return "ok"
+
+
+@app.route("/static-eval")
+def static_eval():
+    # NEAR MISS — tainted value is discarded; sink receives a literal
+    _ignored = request.args["expr"]  # noqa: F841
+    return str(eval("1 + 1"))
+
+
+def unused_tainted_helper():
+    # NEAR MISS — helper reads source but caller never passes it to a sink
+    data = request.data
+    return len(data)

--- a/tests/fixtures/realistic/hono_app.ts
+++ b/tests/fixtures/realistic/hono_app.ts
@@ -1,0 +1,56 @@
+// Realistic Hono app fixture (issue #35). Uses `c.req.query`,
+// `c.req.param` and friends through helpers into XSS sinks.
+//
+// Hand-counted expected taint findings:
+//   js/taint-xss-innerhtml : 3
+
+import { Hono } from "hono";
+
+const app = new Hono();
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+function readQuery(c: any, key: string) {
+    return c.req.query(key);
+}
+
+// ─── Routes ────────────────────────────────────────────────────────────
+app.get("/greet", (c) => {
+    // js/taint-xss-innerhtml — helper returns tainted query value
+    const name = readQuery(c, "name");
+    const el = document.getElementById("greet");
+    if (el) el.innerHTML = `<p>Hello ${name}</p>`;
+    return c.text("ok");
+});
+
+app.get("/user/:id", (c) => {
+    // js/taint-xss-innerhtml — c.req.param
+    const id = c.req.param("id");
+    document.write(`<div>User ${id}</div>`);
+    return c.text("ok");
+});
+
+app.get("/search", (c) => {
+    // js/taint-xss-innerhtml — alias chain from c.req.query
+    const raw = c.req.query("q");
+    const term = raw;
+    const el = document.getElementById("results");
+    if (el) el.innerHTML = term;
+    return c.text("ok");
+});
+
+// ─── NEAR MISS — must not fire ─────────────────────────────────────────
+app.get("/health", (c) => {
+    // NEAR MISS — literal argument
+    const el = document.getElementById("h");
+    if (el) el.innerHTML = "ok";
+    return c.text("ok");
+});
+
+app.get("/noop", (c) => {
+    // NEAR MISS — tainted value read but never reaches a sink
+    const _q = c.req.query("q");
+    document.write("<h1>noop</h1>");
+    return c.text("ok");
+});
+
+export default app;

--- a/tests/fixtures/realistic/nextjs_handlers.ts
+++ b/tests/fixtures/realistic/nextjs_handlers.ts
@@ -1,0 +1,53 @@
+// Realistic Next.js App Router fixture (issue #35). Uses
+// `NextRequest.nextUrl.searchParams` and related attribute chains
+// through helpers and into XSS sinks.
+//
+// Hand-counted expected taint findings:
+//   js/taint-xss-innerhtml : 3
+
+import { NextRequest, NextResponse } from "next/server";
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+function readName(request: NextRequest) {
+    return request.nextUrl.searchParams;
+}
+
+// ─── Route handlers ────────────────────────────────────────────────────
+export async function GET(request: NextRequest) {
+    // js/taint-xss-innerhtml — helper returns tainted searchParams
+    const params = readName(request);
+    const el = document.getElementById("greeting");
+    if (el) el.innerHTML = params;
+    return NextResponse.json({ ok: true });
+}
+
+export async function POST(request: NextRequest) {
+    // js/taint-xss-innerhtml — direct nextUrl attribute into document.write
+    const target = request.nextUrl;
+    document.write(`<h2>Redirecting to ${target}</h2>`);
+    return NextResponse.json({ ok: true });
+}
+
+export async function PUT(request: NextRequest) {
+    // js/taint-xss-innerhtml — searchParams alias chain
+    const q = request.nextUrl.searchParams;
+    const term = q;
+    const el = document.getElementById("out");
+    if (el) el.innerHTML = term;
+    return NextResponse.json({ ok: true });
+}
+
+// ─── NEAR MISS — must not fire ─────────────────────────────────────────
+export async function DELETE(request: NextRequest) {
+    // NEAR MISS — literal argument; tainted value read but never used
+    const _seen = request.nextUrl.searchParams;
+    const el = document.getElementById("gone");
+    if (el) el.innerHTML = "deleted";
+    return NextResponse.json({ ok: true });
+}
+
+export async function PATCH() {
+    // NEAR MISS — no source involvement at all
+    document.write("<h1>Patched</h1>");
+    return NextResponse.json({ ok: true });
+}

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -1,0 +1,156 @@
+// Integration test for the realistic test corpus (issue #35).
+//
+// Each fixture under `tests/fixtures/realistic/` is a small-but-complete
+// vulnerable application for one supported framework. We pin the exact
+// total finding count and the exact count per taint rule. Any rule
+// addition or engine change will break these counts, which is the whole
+// point: it forces explicit acknowledgment of precision shifts.
+//
+// The fixtures also contain NEAR-MISS functions whose line ranges must
+// not contain any `*/taint-*` findings. We check that indirectly by
+// pinning the total taint-finding count per file — if a NEAR-MISS
+// function started firing, the total would change.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn foxguard_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_foxguard"))
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("realistic")
+        .join(name)
+}
+
+/// Scan a realistic fixture and assert exact total finding count and
+/// exact per-taint-rule counts. `taint_counts` lists every taint rule
+/// that must fire, with the expected count. Any taint rule observed in
+/// the output that is not in `taint_counts` (or with a different count)
+/// fails the test — this catches accidental false positives on the
+/// NEAR-MISS sections.
+fn assert_fixture(file: &str, expected_total: usize, taint_counts: &[(&str, usize)]) {
+    let path = fixture_path(file);
+    let output = foxguard_cmd()
+        .args([path.to_str().unwrap(), "-f", "json"])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run foxguard on {}: {}", file, e));
+
+    let findings: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON output for {}: {}", file, e));
+
+    assert_eq!(
+        findings.len(),
+        expected_total,
+        "{}: expected {} total findings, got {}. findings={:?}",
+        file,
+        expected_total,
+        findings.len(),
+        findings
+            .iter()
+            .map(|f| f["rule_id"].as_str().unwrap_or(""))
+            .collect::<Vec<_>>()
+    );
+
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for f in &findings {
+        if let Some(rule) = f["rule_id"].as_str() {
+            *counts.entry(rule).or_insert(0) += 1;
+        }
+    }
+
+    // Every expected taint rule must fire exactly the expected number
+    // of times.
+    for (rule, want) in taint_counts {
+        let got = counts.get(rule).copied().unwrap_or(0);
+        assert_eq!(
+            got, *want,
+            "{}: taint rule {} expected {} times, got {}. counts={:?}",
+            file, rule, want, got, counts
+        );
+    }
+
+    // Any taint finding for a rule NOT in `taint_counts` is an
+    // unexpected false positive — likely on the NEAR-MISS section.
+    let expected_rules: std::collections::HashSet<&str> =
+        taint_counts.iter().map(|(r, _)| *r).collect();
+    for (rule, count) in &counts {
+        if rule.contains("/taint-") && !expected_rules.contains(rule) {
+            panic!(
+                "{}: unexpected taint rule {} fired {} times (likely NEAR-MISS false positive). counts={:?}",
+                file, rule, count, counts
+            );
+        }
+    }
+}
+
+#[test]
+fn realistic_flask_app() {
+    assert_fixture(
+        "flask_app.py",
+        14,
+        &[
+            ("py/taint-pickle-deserialization", 1),
+            ("py/taint-eval", 1),
+            ("py/taint-command-injection", 2),
+            ("py/taint-ssrf", 1),
+            ("py/taint-yaml-load", 1),
+            ("py/taint-sql-injection", 1),
+        ],
+    );
+}
+
+#[test]
+fn realistic_django_views() {
+    assert_fixture(
+        "django_views.py",
+        9,
+        &[
+            ("py/taint-command-injection", 2),
+            ("py/taint-sql-injection", 1),
+            ("py/taint-ssrf", 1),
+            ("py/taint-pickle-deserialization", 1),
+        ],
+    );
+}
+
+#[test]
+fn realistic_fastapi_app() {
+    assert_fixture(
+        "fastapi_app.py",
+        8,
+        &[
+            ("py/taint-eval", 1),
+            ("py/taint-pickle-deserialization", 1),
+            ("py/taint-ssrf", 1),
+        ],
+    );
+}
+
+#[test]
+fn realistic_cli_tool() {
+    assert_fixture(
+        "cli_tool.py",
+        9,
+        &[("py/taint-command-injection", 2), ("py/taint-eval", 2)],
+    );
+}
+
+#[test]
+fn realistic_express_app() {
+    assert_fixture("express_app.js", 12, &[("js/taint-xss-innerhtml", 5)]);
+}
+
+#[test]
+fn realistic_nextjs_handlers() {
+    assert_fixture("nextjs_handlers.ts", 7, &[("js/taint-xss-innerhtml", 3)]);
+}
+
+#[test]
+fn realistic_hono_app() {
+    assert_fixture("hono_app.ts", 7, &[("js/taint-xss-innerhtml", 3)]);
+}


### PR DESCRIPTION
## Summary

Adds a realistic test corpus under `tests/fixtures/realistic/` with seven small-but-complete vulnerable applications, one per supported framework. Each fixture uses idiomatic routing, helper functions that exercise interprocedural return propagation, and 2-3 NEAR-MISS functions that must not fire.

Files and taint findings per file:

- `flask_app.py` - 7 taint findings: pickle (1), eval (1), command-injection (2), ssrf (1), yaml-load (1), sql-injection (1)
- `django_views.py` - 5 taint findings: command-injection (2), sql-injection (1), ssrf (1), pickle (1)
- `fastapi_app.py` - 3 taint findings: eval (1), pickle (1), ssrf (1)
- `cli_tool.py` - 4 taint findings: command-injection (2), eval (2)
- `express_app.js` - 5 taint findings: xss-innerhtml (5)
- `nextjs_handlers.ts` - 3 taint findings: xss-innerhtml (3)
- `hono_app.ts` - 3 taint findings: xss-innerhtml (3)

A new integration test `tests/realistic_fixtures.rs` pins the exact total finding count and exact per-taint-rule count for each file. Any taint rule observed that was not in the expected set (likely a NEAR-MISS regression) fails the test. The docs `precision.md` and `taint-tracking.md` now reference the corpus as the end-to-end layer between single-function fixtures and real-world corpus scans.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test` (all suites green, 7 new tests pass)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Manual scan of each fixture confirms expected rules fire and NEAR-MISS functions produce zero `*/taint-*` findings

none