### PR TITLE
Taint engine: propagate taint through binary + on strings (refs #42)

### DIFF
--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -658,6 +658,33 @@ fn expression_taint(
         }
     }
 
+    // Binary `+` propagation: `"prefix " + tainted` or `tainted + "suffix"`
+    // is tainted. This mirrors the JS engine's string-concat rule and
+    // covers the most common SQL/command injection pattern in Python.
+    // Conservative: if EITHER operand is tainted, the result is tainted.
+    // Integer arithmetic on clean values short-circuits naturally because
+    // both recursive calls return None.
+    if expr.kind() == "binary_operator" {
+        if let Some(op) = expr.child_by_field_name("operator") {
+            if node_text(op, source) == "+" {
+                if let Some(left) = expr.child_by_field_name("left") {
+                    if let Some(desc) =
+                        expression_taint(left, source, spec, aliases, state, summaries)
+                    {
+                        return Some(desc);
+                    }
+                }
+                if let Some(right) = expr.child_by_field_name("right") {
+                    if let Some(desc) =
+                        expression_taint(right, source, spec, aliases, state, summaries)
+                    {
+                        return Some(desc);
+                    }
+                }
+            }
+        }
+    }
+
     // Recurse one level for wrapping expressions (e.g. `bytes(request.data)`),
     // so the taint survives trivial type conversions without requiring
     // full interprocedural tracking.
@@ -1676,5 +1703,77 @@ def handler():
     return p.loads(request.data)
 "#;
         assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn string_concat_with_tainted_right_operand_is_tainted() {
+        // "prefix " + request.data → tainted. The most common SQL/command
+        // injection pattern in Python.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = "prefix " + request.data
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn string_concat_with_tainted_left_operand_is_tainted() {
+        // request.data + " suffix" → tainted (symmetric to the above).
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = request.data + " suffix"
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn chained_string_concat_with_tainted_operand_is_tainted() {
+        // ("a" + "b") + request.data → tainted. Left-associative, so the
+        // engine sees `binary_operator("+", binary_operator("+", "a", "b"), request.data)`.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = "a" + "b" + request.data
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn string_concat_with_both_literal_is_clean() {
+        // "a" + "b" → no taint.
+        let src = r#"
+import pickle
+
+def handler():
+    data = "a" + "b"
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn integer_arithmetic_is_clean() {
+        // 1 + 2 → no taint. The engine's `+` handler must not over-fire
+        // on integer arithmetic. Clean operands short-circuit naturally.
+        let src = r#"
+import pickle
+
+def handler():
+    x = 1 + 2
+    data = b"trusted" + bytes([x])
+    return pickle.loads(data)
+"#;
+        assert_eq!(run(src).len(), 0);
     }
 }

--- a/tests/fixtures/realistic/flask_app.py
+++ b/tests/fixtures/realistic/flask_app.py
@@ -50,9 +50,10 @@ def calc():
 
 @app.route("/ping")
 def ping():
-    # py/taint-command-injection — tainted value flows directly into sink
-    host = request.args["host"]
-    os.system(host)
+    # py/taint-command-injection — string concat with tainted operand
+    # (exercises the binary `+` propagation path)
+    host = request.args.get("host", "localhost")
+    os.system("ping -c 1 " + host)
     return "ok"
 
 


### PR DESCRIPTION
## Problem

Discovered while building the realistic test corpus (#35 / PR #41). The realistic Flask app had a \`/ping\` handler:

\`\`\`python
host = request.args.get(\"host\", \"localhost\")
os.system(\"ping -c 1 \" + host)
\`\`\`

\`py/taint-command-injection\` did **not** fire because the engine's \`expression_taint\` had no case for \`binary_operator\` nodes. The JS engine has had binary \`+\` propagation since PR #24; Python was missing it. The realistic fixture originally worked around this by passing \`host\` directly into \`os.system\`.

## Fix

New case in \`expression_taint\` for \`binary_operator\` nodes. When the operator is \`+\`, recurse into both \`left\` and \`right\` operands. If either is tainted, return that taint source.

**Conservative and symmetric**: \`\"prefix \" + tainted\`, \`tainted + \" suffix\"\`, \`tainted + tainted\` all fire. \`\"a\" + \"b\"\` and \`1 + 2\` stay clean because the recursive calls return None on literal-only operands.

Integer arithmetic short-circuits for free — the engine never matches a literal integer or a clean identifier as a source, so clean \`+\` expressions stay silent.

## Tests

5 new unit tests in \`python_taint::tests\`:
- \`string_concat_with_tainted_right_operand_is_tainted\`
- \`string_concat_with_tainted_left_operand_is_tainted\`
- \`chained_string_concat_with_tainted_operand_is_tainted\`
- \`string_concat_with_both_literal_is_clean\`
- \`integer_arithmetic_is_clean\`

Full suite: **187+ tests pass**, zero regressions.

## Fixture change

\`tests/fixtures/realistic/flask_app.py\` — the \`/ping\` handler now uses string concat (\`\"ping -c 1 \" + host\`) to exercise the new path end-to-end. Total finding count unchanged because the rewritten form fires the same single \`py/taint-command-injection\` finding as the old form.

## Gates

\`cargo build --release\`, \`cargo test\`, \`cargo clippy --all-targets -- -D warnings\`, \`cargo fmt --check\` — all clean.

Closes #42.