### PR TITLE
ci: deploy foxguard.dev from GitHub Actions

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -1,0 +1,48 @@
+name: Deploy www
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "www/**"
+      - "src/rules/**"
+      - "src/bin/gen_rules_ts.rs"
+      - ".github/workflows/deploy-www.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: deploy-www-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy foxguard.dev
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.12.0"
+          cache: npm
+          cache-dependency-path: www/package-lock.json
+
+      - name: Install dependencies
+        working-directory: www
+        run: npm ci
+
+      - name: Build site
+        working-directory: www
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy www/dist --project-name=foxguard --branch=main


### PR DESCRIPTION
## Problem

The Cloudflare Pages project for foxguard.dev is connected via the Cloudflare dashboard's Git integration to \`peaktwilight/foxguard\` — the repo name before the move to the \`PwnKit-Labs\` org. Pushes to this repo (\`PwnKit-Labs/foxguard\`) do not trigger builds, so the live site has been drifting behind main.

At time of writing, foxguard.dev shows \`120 built-in rules\` while the current \`rules.ts\` has 130, and the 0.4.0 headline blog post has not appeared.

## Fix

Add \`.github/workflows/deploy-www.yml\`. It:

- runs on pushes to \`main\` touching \`www/**\`, \`src/rules/**\`, \`src/bin/gen_rules_ts.rs\`, or the workflow file itself (the Rust paths matter because \`gen_rules_ts\` regenerates \`www/src/data/rules.ts\` from the Rust registry)
- runs on manual \`workflow_dispatch\` so we can force a redeploy without pushing
- builds under \`www/\` with \`npm ci && npm run build\`
- deploys \`www/dist\` to the existing \`foxguard\` Cloudflare Pages project via \`cloudflare/wrangler-action@v3\`
- uses a concurrency group so stacked pushes cancel in-flight deploys

## Required before merging

Add two repository secrets under Settings → Secrets and variables → Actions:

- \`CLOUDFLARE_API_TOKEN\` — generate from Cloudflare dashboard → My Profile → API Tokens → Create Token → "Edit Cloudflare Workers" template (includes Pages permissions)
- \`CLOUDFLARE_ACCOUNT_ID\` — visible in the Cloudflare dashboard URL or in the top-right account switcher

## After merging

The existing dashboard Git integration pointing at \`peaktwilight/foxguard\` is now redundant and will keep producing stale "No build needed" logs on the wrong repo. Disconnect it in Cloudflare Pages → Settings → Builds & deployments → disconnect Git so the only deploy path is this workflow.

## Verification

After merging and adding the secrets, trigger a manual deploy via \`gh workflow run deploy-www.yml\` and check:

- foxguard.dev header says \`130 built-in rules\`
- /blog/ lists \`Taint tracking, without the YAML\` as the most recent post
- /blog/taint-tracking-without-the-yaml/ renders the full post