### PR TITLE
tests: multi-file Django fixture pinning cross-file taint limit (refs #48)

### DIFF
--- a/tests/fixtures/realistic/django_shop/queries.py
+++ b/tests/fixtures/realistic/django_shop/queries.py
@@ -1,0 +1,27 @@
+# Query/blob helpers for the django_shop fixture.
+#
+# These functions each take a parameter that is tainted when called
+# from views.py, and pass it directly into a dangerous sink. Once the
+# cross-file taint engine from issue #46 lands, callers in views.py
+# should produce taint findings that propagate through these helpers.
+#
+# The file itself has no request sources, so running the current
+# engine on this file in isolation should produce zero taint findings.
+
+import pickle
+import sqlite3
+
+
+def run_query(name):
+    # Would become a py/taint-sql-injection finding after #46 when
+    # called from views.search with a tainted name.
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE name = '" + name + "'")
+    return cur.fetchall()
+
+
+def load_blob(payload):
+    # Would become a py/taint-pickle-deserialization finding after #46
+    # when called from views.import_profile with the request body.
+    return pickle.loads(payload)

--- a/tests/fixtures/realistic/django_shop/views.py
+++ b/tests/fixtures/realistic/django_shop/views.py
@@ -1,0 +1,74 @@
+# Multi-file Django shop fixture (issue #48).
+#
+# This exercises the taint engine on a realistic two-file Django app
+# where request sources live in views.py and sinks live in queries.py.
+#
+# The current engine is intraprocedural + same-file interprocedural only,
+# so cross-file taint flow from views → queries does NOT fire yet.
+# Once issue #46 (cross-file summaries) lands, the expected counts in
+# tests/realistic_fixtures.rs for this fixture should be updated.
+#
+# Today, this file asserts:
+#   - in-file flows fire correctly (same-file sinks)
+#   - cross-file flows DO NOT fire (documents current limit)
+#   - NEAR-MISS handlers do not fire
+#
+# Hand-counted expected taint findings under the current engine:
+#   py/taint-command-injection : 1   (in-file, /ping)
+#   py/taint-ssrf              : 1   (in-file, /fetch)
+#   py/taint-sql-injection     : 0   (cross-file via queries.run_query — will fire after #46)
+#   py/taint-pickle-deserialization : 0 (cross-file via queries.load_blob — will fire after #46)
+
+import os
+import pickle
+
+import requests
+from django.http import HttpResponse, JsonResponse
+from django.views.decorators.http import require_http_methods
+
+from . import queries
+
+
+# ─── In-file flows — should fire today ────────────────────────────────
+def ping(request):
+    # py/taint-command-injection — source and sink in the same function
+    host = request.GET.get("host", "localhost")
+    os.system("ping -c 1 " + host)
+    return HttpResponse("ok")
+
+
+def fetch_url(request):
+    # py/taint-ssrf — same function
+    url = request.GET["url"]
+    return HttpResponse(requests.get(url).text)
+
+
+# ─── Cross-file flows — should fire after #46 lands ───────────────────
+def search(request):
+    # Cross-file: source in views.py, sink in queries.py.
+    # Current engine does not follow taint across files, so this
+    # fixture pins the expectation to 0 today.
+    name = request.GET["name"]
+    rows = queries.run_query(name)
+    return JsonResponse({"rows": rows})
+
+
+@require_http_methods(["POST"])
+def import_profile(request):
+    # Cross-file: tainted body flows into queries.load_blob which
+    # calls pickle.loads. Will fire after #46.
+    payload = request.body
+    return HttpResponse(queries.load_blob(payload))
+
+
+# ─── NEAR-MISS — must not fire ────────────────────────────────────────
+def healthz(request):
+    # literal, no source
+    os.system("uptime")
+    return HttpResponse("ok")
+
+
+def static_fetch(request):
+    # tainted value read and discarded; sink receives a literal
+    _ignored = request.GET["url"]  # noqa: F841
+    return HttpResponse(requests.get("https://example.com").text)

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -155,6 +155,23 @@ fn realistic_hono_app() {
     assert_fixture("hono_app.ts", 7, &[("js/taint-xss-innerhtml", 3)]);
 }
 
+/// Multi-file Django fixture (issue #48). Scans a directory rather
+/// than a single file. The current engine is intraprocedural +
+/// same-file interprocedural only, so cross-file flows from
+/// `views.py` into `queries.py` helpers do NOT fire yet. This test
+/// pins that limit explicitly: in-file taint flows fire, cross-file
+/// ones do not. Once issue #46 (cross-file summaries) lands, the
+/// expected total and taint counts below will need to be updated to
+/// reflect the new cross-file sql-injection and pickle findings.
+#[test]
+fn realistic_django_shop_multifile() {
+    assert_fixture(
+        "django_shop",
+        6,
+        &[("py/taint-command-injection", 1), ("py/taint-ssrf", 1)],
+    );
+}
+
 #[test]
 fn realistic_gin_app() {
     // Three planted vulnerabilities (command injection, SQL


### PR DESCRIPTION
## Summary

Adds the first multi-file realistic fixture under \`tests/fixtures/realistic/django_shop/\` — a two-file Django app where \`views.py\` holds request sources and \`queries.py\` holds dangerous sinks. This starts closing out issue #48.

## Why a failing finding is the point

The current taint engine is intraprocedural plus same-file interprocedural only. An idiomatic Django app where handlers delegate to query helpers in a separate module produces **zero** cross-file taint findings today, which is easy to miss as a silent regression when refactoring.

This fixture pins that limit explicitly:

- in-file command injection in \`views.ping\` fires (\`py/taint-command-injection\`)
- in-file SSRF in \`views.fetch_url\` fires (\`py/taint-ssrf\`)
- cross-file SQL injection via \`queries.run_query\` does **not** fire yet
- cross-file pickle deserialization via \`queries.load_blob\` does **not** fire yet
- NEAR-MISS handlers (\`/healthz\`, \`/static_fetch\`) stay silent
- \`queries.py\` still fires \`py/no-sql-injection\` and \`py/no-pickle\` via the AST-only rules on the string concat and \`pickle.loads\` sites

Total: 6 findings (2 taint + 4 non-taint AST-matched).

## When #46 lands

Issue #46 (cross-file interprocedural taint summaries) will make the cross-file flows fire. When it lands, the expected total and taint counts in \`tests/realistic_fixtures.rs::realistic_django_shop_multifile\` should be updated to reflect the new \`py/taint-sql-injection\` and \`py/taint-pickle-deserialization\` findings. The comment above the test explains this so future maintainers have a mechanical update path.

## Scope

- \`tests/fixtures/realistic/django_shop/views.py\` — new, 6 routes + 2 NEAR-MISS
- \`tests/fixtures/realistic/django_shop/queries.py\` — new, 2 helper functions that call sinks
- \`tests/realistic_fixtures.rs\` — new test case \`realistic_django_shop_multifile\` asserting exact counts

No engine code touched. \`assert_fixture\` already accepted any path \`foxguard\` understands, so passing a directory name works with no harness changes.

Express, Next.js, and Gin multi-file fixtures are the next three chunks of #48 and can reuse this shape.

## Test plan

- [x] \`cargo test --test realistic_fixtures realistic_django_shop_multifile\` passes locally
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` (full suite) passes locally — realistic_fixtures went from 11 to 12