### PR TITLE
tests: multi-file Express, Next.js, and Gin realistic fixtures (refs #48)

### DIFF
--- a/tests/fixtures/realistic/express_api/routes.js
+++ b/tests/fixtures/realistic/express_api/routes.js
@@ -1,0 +1,52 @@
+// Multi-file Express fixture (issue #48). Companion to django_shop/.
+//
+// routes.js holds request sources; services.js holds dangerous sinks.
+// The current taint engine is intraprocedural + same-file interprocedural,
+// so cross-file flows from routes → services do NOT fire yet. This
+// fixture pins that limit so the day issue #46 (cross-file summaries)
+// lands, the expected counts in tests/realistic_fixtures.rs for this
+// fixture need to be updated to include the new cross-file findings.
+//
+// Hand-counted expected findings under the current engine:
+//   js/taint-xss-innerhtml : 1  (in-file, /render)
+
+const express = require("express");
+const services = require("./services");
+
+const app = express();
+
+// ─── In-file flow — should fire today ────────────────────────────────
+app.get("/render", (req, res) => {
+    // js/taint-xss-innerhtml — source and sink in the same function
+    const html = req.query.html;
+    res.send(`<div>${html}</div>`);
+});
+
+// ─── Cross-file flows — should fire after #46 lands ──────────────────
+app.get("/search", (req, res) => {
+    // Cross-file: source in routes.js, sink in services.js.
+    const name = req.query.name;
+    const rows = services.runQuery(name);
+    res.json({ rows });
+});
+
+app.post("/import", (req, res) => {
+    // Cross-file: tainted body into services.evalExpression.
+    const expr = req.body.expr;
+    res.send(String(services.evalExpression(expr)));
+});
+
+// ─── NEAR-MISS — must not fire ───────────────────────────────────────
+app.get("/healthz", (_req, res) => {
+    // literal, no source
+    res.send("<div>ok</div>");
+});
+
+app.get("/static-render", (req, res) => {
+    // tainted read and discarded; sink receives a literal
+    const _ignored = req.query.html;
+    void _ignored;
+    res.send("<div>static</div>");
+});
+
+module.exports = app;

--- a/tests/fixtures/realistic/express_api/services.js
+++ b/tests/fixtures/realistic/express_api/services.js
@@ -1,0 +1,27 @@
+// Query/eval helpers for the express_api fixture.
+//
+// These helpers each take a parameter that is tainted when called
+// from routes.js. Once the cross-file taint engine from issue #46
+// lands, callers in routes.js should produce taint findings that
+// propagate through these functions.
+
+const db = {
+    exec(_q) {
+        return [];
+    },
+};
+
+function runQuery(name) {
+    // Would become a taint SQL injection finding after #46 when
+    // called from routes.search with a tainted name.
+    return db.exec("SELECT * FROM users WHERE name = '" + name + "'");
+}
+
+function evalExpression(expr) {
+    // Would become a taint eval finding after #46 when called from
+    // routes.import with a tainted expression.
+    // eslint-disable-next-line no-eval
+    return eval(expr);
+}
+
+module.exports = { runQuery, evalExpression };

--- a/tests/fixtures/realistic/gin_service/handlers.go
+++ b/tests/fixtures/realistic/gin_service/handlers.go
@@ -1,0 +1,55 @@
+// Multi-file Gin fixture (issue #48). Companion to django_shop/ and
+// express_api/. handlers.go holds request sources; store.go holds the
+// dangerous sinks. The current Go taint engine is intraprocedural +
+// same-file interprocedural, so cross-file flows from handlers → store
+// do not fire yet. Issue #46 will fix that and this fixture's expected
+// counts will need to be updated.
+//
+// Hand-counted expected findings under the current engine:
+//   go/taint-command-injection : 1   (in-file runCmd)
+//   go/taint-ssrf              : 1   (in-file proxyFetch)
+
+package gin_service
+
+import (
+	"net/http"
+	"os/exec"
+
+	"github.com/gin-gonic/gin"
+)
+
+// In-file flow — should fire today.
+func runCmd(c *gin.Context) {
+	// go/taint-command-injection — source and sink in the same function
+	cmd := c.Query("cmd")
+	_, _ = exec.Command(cmd).Output()
+	c.String(http.StatusOK, "ok")
+}
+
+// In-file SSRF — should fire today.
+func proxyFetch(c *gin.Context) {
+	// go/taint-ssrf
+	url := c.Query("url")
+	_, _ = http.Get(url)
+	c.String(http.StatusOK, "ok")
+}
+
+// Cross-file flow — should fire after #46 lands.
+func search(c *gin.Context) {
+	name := c.Query("name")
+	rows := runQuery(name)
+	c.JSON(http.StatusOK, rows)
+}
+
+// NEAR-MISS — literal, no source
+func healthz(c *gin.Context) {
+	_, _ = exec.Command("uptime").Output()
+	c.String(http.StatusOK, "ok")
+}
+
+func Register(r *gin.Engine) {
+	r.GET("/run", runCmd)
+	r.GET("/fetch", proxyFetch)
+	r.GET("/search", search)
+	r.GET("/healthz", healthz)
+}

--- a/tests/fixtures/realistic/gin_service/store.go
+++ b/tests/fixtures/realistic/gin_service/store.go
@@ -1,0 +1,16 @@
+// Query helpers for the gin_service fixture. Takes a tainted argument
+// and passes it into a SQL execute sink via string concatenation. Will
+// become a cross-file taint finding after issue #46.
+
+package gin_service
+
+import "database/sql"
+
+var db *sql.DB
+
+func runQuery(name string) []any {
+	// Would become a go/taint-sql-injection finding after #46 when
+	// called from handlers.go with a tainted query string.
+	_, _ = db.Query("SELECT * FROM users WHERE name = '" + name + "'")
+	return nil
+}

--- a/tests/fixtures/realistic/next_app/actions.ts
+++ b/tests/fixtures/realistic/next_app/actions.ts
@@ -1,0 +1,22 @@
+// Query/eval helpers for the next_app fixture.
+//
+// These helpers each take a parameter that is tainted when called
+// from route.ts. Cross-file taint flow does not fire under the
+// current engine; issue #46 will fix that.
+
+const db = {
+    exec(_q: string): unknown[] {
+        return [];
+    },
+};
+
+export function runQuery(name: string): unknown[] {
+    // Would become a taint SQL injection finding after #46.
+    return db.exec("SELECT * FROM users WHERE name = '" + name + "'");
+}
+
+export function evalExpression(expr: string): unknown {
+    // Would become a taint eval finding after #46.
+    // eslint-disable-next-line no-eval
+    return eval(expr);
+}

--- a/tests/fixtures/realistic/next_app/route.ts
+++ b/tests/fixtures/realistic/next_app/route.ts
@@ -1,0 +1,37 @@
+// Multi-file Next.js App Router fixture (issue #48).
+//
+// route.ts holds request sources (Next.js App Router Request/searchParams);
+// actions.ts holds the dangerous sinks. Same deal as django_shop/ and
+// express_api/: cross-file flows do not fire under the current engine
+// and will fire after issue #46 (cross-file summaries) lands.
+//
+// Hand-counted expected findings under the current engine:
+//   js/taint-xss-innerhtml : 1  (in-file render handler)
+
+import { NextRequest, NextResponse } from "next/server";
+import { runQuery, evalExpression } from "./actions";
+
+// ─── In-file flow — should fire today ────────────────────────────────
+export async function GET(request: NextRequest) {
+    // js/taint-xss-innerhtml — source and sink in the same function
+    const { searchParams } = new URL(request.url);
+    const html = searchParams.get("html") ?? "";
+    return new NextResponse(`<div>${html}</div>`, {
+        headers: { "content-type": "text/html" },
+    });
+}
+
+// ─── Cross-file flow — should fire after #46 ─────────────────────────
+export async function POST(request: NextRequest) {
+    const body = await request.json();
+    // Cross-file: source in route.ts, sink in actions.ts.
+    const rows = runQuery(body.name);
+    const result = evalExpression(body.expr);
+    return NextResponse.json({ rows, result });
+}
+
+// ─── NEAR-MISS — must not fire ───────────────────────────────────────
+export async function HEAD(_request: NextRequest) {
+    // no source, no sink
+    return new NextResponse(null, { status: 200 });
+}

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -172,6 +172,42 @@ fn realistic_django_shop_multifile() {
     );
 }
 
+/// Multi-file Express fixture (issue #48). Server-side Express has no
+/// in-file JS taint rule coverage today (the engine targets client-side
+/// innerHTML sinks), so this fixture only fires the non-taint AST
+/// rules on `services.js`. When issue #46 (cross-file summaries) lands
+/// and JS taint sinks cover server-side SQL/eval, new cross-file
+/// taint findings will light up and the expected counts need updating.
+#[test]
+fn realistic_express_api_multifile() {
+    assert_fixture("express_api", 3, &[]);
+}
+
+/// Multi-file Next.js App Router fixture (issue #48). Same shape as
+/// the Express fixture: cross-file flows from `route.ts` into
+/// `actions.ts` do not fire today and will light up after #46 + JS
+/// server-side taint sink coverage.
+#[test]
+fn realistic_next_app_multifile() {
+    assert_fixture("next_app", 3, &[]);
+}
+
+/// Multi-file Gin fixture (issue #48). `handlers.go` holds request
+/// sources, `store.go` holds a SQL execute helper tainted across the
+/// file boundary. In-file taint flows fire today (command injection
+/// in `runCmd`, SSRF in `proxyFetch`). Cross-file flow via
+/// `store.runQuery` does NOT fire yet — the non-taint
+/// `go/no-sql-injection` pins that behavior. After #46 lands, a new
+/// `go/taint-sql-injection` finding appears and the counts update.
+#[test]
+fn realistic_gin_service_multifile() {
+    assert_fixture(
+        "gin_service",
+        5,
+        &[("go/taint-command-injection", 1), ("go/taint-ssrf", 1)],
+    );
+}
+
 #[test]
 fn realistic_gin_app() {
     // Three planted vulnerabilities (command injection, SQL


### PR DESCRIPTION
## Summary

Closes out the scaffolding for issue #48 by adding the three remaining multi-file realistic fixtures: \`express_api/\`, \`next_app/\`, and \`gin_service/\`. Follows the same shape as \`django_shop/\` from #50 — one file holds request sources, a sibling file holds dangerous sinks.

## Why

Every fixture in \`tests/fixtures/realistic/\` before today was a single file. Cross-file flow was structurally untestable. Single-file tests silently pass even if the engine grows a regression that breaks cross-file flow in the real world.

These fixtures pin the current engine's limit (intraprocedural + same-file interprocedural only) explicitly. The day issue #46 (cross-file summaries) lands, new taint findings will appear on the cross-file paths and the expected counts in \`tests/realistic_fixtures.rs\` need to be updated mechanically. Each test's docstring points to the specific update that will be required.

## Per-fixture behavior

**\`express_api/\`** — \`routes.js\` reads \`req.query.*\` and \`req.body.*\`; \`services.js\` runs the tainted args through \`db.exec\` and \`eval\`. Server-side Express has no in-file taint rule coverage today because the JS taint engine targets client-side \`innerHTML\` sinks. The fixture only fires \`js/no-command-injection\`, \`js/no-eval\`, and \`js/no-sql-injection\` on \`services.js\` today. Total = 3.

**\`next_app/\`** — identical structure for Next.js App Router. \`route.ts\` reads \`searchParams\` and JSON body; \`actions.ts\` holds the helpers. Total = 3.

**\`gin_service/\`** — \`handlers.go\` reads \`c.Query(...)\` and \`store.go\` holds a \`db.Query\` helper with string concat. Named top-level handler functions (not closures) so the Go taint engine can analyze them. Total = 5: \`go/taint-command-injection\` (runCmd, in-file), \`go/taint-ssrf\` (proxyFetch, in-file), \`go/no-command-injection\`, \`go/no-sql-injection\` on store.go, \`go/no-ssrf\`.

All three fixtures have NEAR-MISS handlers that must not fire (\`/healthz\` for gin, \`/static-render\` for Express, \`HEAD\` for Next.js).

## Follow-ups surfaced by writing these fixtures

- JS taint engine has no server-side sink coverage. It only tracks \`innerHTML =\` mutations. Express / Next / Hono / Fastify routes that pass tainted data into SQL execute, \`eval\`, \`exec\`, or template literals emit nothing. This should be its own issue on top of the existing taint engine.
- Go taint engine does not analyze closures passed as handler arguments to Gin's router methods. It works fine on named top-level functions. Documented by the switch from closure-based to named-function \`Register\` in \`gin_service/handlers.go\`.

## Test plan

- [x] \`cargo test --test realistic_fixtures\` — 12 passed (was 9 before this PR)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Each fixture exact-counts validated locally against the release binary

## Refs

- Closes out the \`express_api\`, \`next_app\`, \`gin_service\` bullets in #48
- Django counterpart merged in #50