### PR TITLE
feat(js): js/taint-sql-injection server-side taint rule

### DIFF
--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1870,3 +1870,88 @@ impl Rule for TaintXssInnerHtml {
             .collect()
     }
 }
+
+// ─── js/taint-sql-injection ───────────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted Express/Next/etc input
+// (`req.body`, `req.query`, `searchParams.get(...)`, ...) reaches a SQL
+// execute sink. Sinks are identified by method name on any receiver,
+// matching the common JS SQL client conventions (`db.query`, `pool.query`,
+// `connection.execute`, `sequelize.query`, `knex.raw`). This is noisier
+// than the canonical-callee approach but catches the realistic shape of
+// server-side JS apps where database handles are ad-hoc variables.
+
+pub struct TaintSqlInjection;
+
+impl TaintSqlInjection {
+    fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::MethodName {
+                    method: "query".into(),
+                    description: "SQL .query() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "execute".into(),
+                    description: "SQL .execute() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "raw".into(),
+                    description: "SQL .raw() call (knex-style)".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintSqlInjection {
+    fn id(&self) -> &str {
+        "js/taint-sql-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-89")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches a SQL execute sink — possible SQL injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can inject SQL",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -105,6 +105,7 @@ impl RuleRegistry {
         registry.register(Box::new(javascript::JwtVerifyMissingAlgorithms));
         registry.register(Box::new(javascript::NoUnsafeFormatString));
         registry.register(Box::new(javascript::TaintXssInnerHtml));
+        registry.register(Box::new(javascript::TaintSqlInjection));
 
         // Register Python rules
         registry.register(Box::new(python::NoEval));

--- a/tests/fixtures/realistic/express_api/routes.js
+++ b/tests/fixtures/realistic/express_api/routes.js
@@ -8,18 +8,20 @@
 // fixture need to be updated to include the new cross-file findings.
 //
 // Hand-counted expected findings under the current engine:
-//   js/taint-xss-innerhtml : 1  (in-file, /render)
+//   js/taint-sql-injection : 1  (in-file /user handler)
 
 const express = require("express");
 const services = require("./services");
 
 const app = express();
+const db = { query(_q) { return []; } };
 
 // ─── In-file flow — should fire today ────────────────────────────────
-app.get("/render", (req, res) => {
-    // js/taint-xss-innerhtml — source and sink in the same function
-    const html = req.query.html;
-    res.send(`<div>${html}</div>`);
+app.get("/user", (req, res) => {
+    // js/taint-sql-injection — source and sink in the same function
+    const name = req.query.name;
+    db.query("SELECT * FROM users WHERE name = '" + name + "'");
+    res.send("ok");
 });
 
 // ─── Cross-file flows — should fire after #46 lands ──────────────────
@@ -42,11 +44,12 @@ app.get("/healthz", (_req, res) => {
     res.send("<div>ok</div>");
 });
 
-app.get("/static-render", (req, res) => {
+app.get("/static-query", (req, res) => {
     // tainted read and discarded; sink receives a literal
-    const _ignored = req.query.html;
+    const _ignored = req.query.name;
     void _ignored;
-    res.send("<div>static</div>");
+    db.query("SELECT * FROM users WHERE name = 'admin'");
+    res.send("ok");
 });
 
 module.exports = app;

--- a/tests/fixtures/realistic/next_app/route.ts
+++ b/tests/fixtures/realistic/next_app/route.ts
@@ -6,19 +6,20 @@
 // and will fire after issue #46 (cross-file summaries) lands.
 //
 // Hand-counted expected findings under the current engine:
-//   js/taint-xss-innerhtml : 1  (in-file render handler)
+//   js/taint-sql-injection : 1  (in-file GET handler)
 
 import { NextRequest, NextResponse } from "next/server";
 import { runQuery, evalExpression } from "./actions";
 
+const db = { query(_q: string): unknown[] { return []; } };
+
 // ─── In-file flow — should fire today ────────────────────────────────
 export async function GET(request: NextRequest) {
-    // js/taint-xss-innerhtml — source and sink in the same function
-    const { searchParams } = new URL(request.url);
-    const html = searchParams.get("html") ?? "";
-    return new NextResponse(`<div>${html}</div>`, {
-        headers: { "content-type": "text/html" },
-    });
+    // js/taint-sql-injection — source and sink in the same function.
+    // Uses the canonical Next.js App Router source: request.nextUrl.
+    const name = request.nextUrl.searchParams.get("name") ?? "";
+    db.query("SELECT * FROM users WHERE name = '" + name + "'");
+    return NextResponse.json({ ok: true });
 }
 
 // ─── Cross-file flow — should fire after #46 ─────────────────────────

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -172,24 +172,23 @@ fn realistic_django_shop_multifile() {
     );
 }
 
-/// Multi-file Express fixture (issue #48). Server-side Express has no
-/// in-file JS taint rule coverage today (the engine targets client-side
-/// innerHTML sinks), so this fixture only fires the non-taint AST
-/// rules on `services.js`. When issue #46 (cross-file summaries) lands
-/// and JS taint sinks cover server-side SQL/eval, new cross-file
-/// taint findings will light up and the expected counts need updating.
+/// Multi-file Express fixture (issue #48). In-file SQL injection in
+/// `routes.js::/user` fires under `js/taint-sql-injection`. The
+/// cross-file flows via `services.runQuery` and `services.evalExpression`
+/// do not fire today and will light up after issue #46 (cross-file
+/// summaries).
 #[test]
 fn realistic_express_api_multifile() {
-    assert_fixture("express_api", 3, &[]);
+    assert_fixture("express_api", 5, &[("js/taint-sql-injection", 1)]);
 }
 
 /// Multi-file Next.js App Router fixture (issue #48). Same shape as
-/// the Express fixture: cross-file flows from `route.ts` into
-/// `actions.ts` do not fire today and will light up after #46 + JS
-/// server-side taint sink coverage.
+/// the Express fixture: in-file SQL injection via `request.nextUrl`
+/// → `db.query` fires; cross-file flows into `actions.ts` do not
+/// fire yet and will light up after issue #46.
 #[test]
 fn realistic_next_app_multifile() {
-    assert_fixture("next_app", 3, &[]);
+    assert_fixture("next_app", 5, &[("js/taint-sql-injection", 1)]);
 }
 
 /// Multi-file Gin fixture (issue #48). `handlers.go` holds request

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -42,6 +42,7 @@ const jsRules: Rule[] = [
   { id: 'js/no-unsafe-regex', cwe: 'CWE-1333', desc: 'Potentially catastrophic backtracking regex pattern', severity: 'medium' },
   { id: 'js/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic hash (MD5/SHA1)', severity: 'medium' },
   { id: 'js/no-xss-innerhtml', cwe: 'CWE-79', desc: 'Assignment to innerHTML may lead to XSS', severity: 'high' },
+  { id: 'js/taint-sql-injection', cwe: 'CWE-89', desc: 'Untrusted input reaches a SQL execute sink — possible SQL injection', severity: 'critical' },
   { id: 'js/taint-xss-innerhtml', cwe: 'CWE-79', desc: 'Untrusted input reaches innerHTML or document.write sink', severity: 'high' },
 ];
 


### PR DESCRIPTION
## Summary

Adds \`js/taint-sql-injection\` — the first server-side JavaScript taint rule. Modeled on the Python \`py/taint-sql-injection\` shape. Fires when untrusted Express / Next.js / Hono / Fastify / SvelteKit / Deno request input reaches a \`.query()\`, \`.execute()\`, or \`.raw()\` call in the same function.

## Why

Before this PR, the JS taint engine only tracked client-side \`innerHTML\` sinks. PR #51 (multi-file Express and Next.js fixtures) exposed this gap: realistic server-side handlers that pass \`req.query.x\` into \`db.query(...)\` produced zero taint findings. The non-taint AST rules caught some of it but gave no dataflow context.

## What fires now

Added \`/user\` / \`GET\` handlers to the existing \`express_api/\` and \`next_app/\` multi-file fixtures that exercise the new rule in-file. Both now fire exactly 1 \`js/taint-sql-injection\` each. Cross-file flows through \`services.runQuery\` / \`actions.runQuery\` still do not fire and are still waiting on issue #46.

Non-taint \`js/no-sql-injection\` coexists on the same lines as the taint rule (same as every other foxguard taint rule — the conservative AST match stays as a safety net for shapes the engine misses).

## Sink choice

Sinks are matched by method name on any receiver (\`MethodName\` matcher), not by canonical callee:

- \`.query\` — \`db.query\`, \`pool.query\`, \`connection.query\`, \`sequelize.query\`
- \`.execute\` — \`connection.execute\`, \`mysql2.execute\`
- \`.raw\` — \`knex.raw\`

This is noisier than the canonical-callee approach (e.g. it'll match \`url.query\` or \`element.query()\` if someone built an AST where those methods receive tainted data), but it matches the actual shape of real Node.js apps where database handles are ad-hoc variables. The same tradeoff Python makes for \`cur.execute()\` and Go makes for \`.Query()\`.

## Follow-ups (tracked separately)

Two gaps surfaced while writing this PR are filed as follow-up issues, not stacked here:

- Remaining JS server-side sinks: \`eval\`, \`Function\` constructor, \`child_process.exec\`, \`child_process.execSync\`, \`child_process.spawn\`
- Go taint engine does not analyze closures passed to Gin router methods — only named top-level functions

## Test plan

- [x] New \`js/taint-sql-injection\` rule registered in \`src/rules/mod.rs\`
- [x] \`www/src/data/rules.ts\` regenerated via \`cargo run --bin gen_rules_ts\`
- [x] \`cargo test\` full suite passes (129 unit tests, 12 realistic fixtures, 12 integration, all green)
- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] Dogfood count unchanged (108 findings in 32 files)
- [x] Existing \`express_app.js\` / \`nextjs_handlers.ts\` / \`hono_app.ts\` single-file fixture counts unchanged
- [x] \`express_api\` and \`next_app\` multi-file fixtures now assert the new rule fires exactly 1× each

## Refs

- Built on top of #51 (multi-file fixtures)
- Closes partial scope of #48 follow-ups (JS server-side taint coverage)