### PR TITLE
docs: adopt PwnKit Labs umbrella tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ Adding a rule is one struct implementing a trait. See [`CONTRIBUTING.md`](./CONT
 
 *Built by [PwnKit Labs](https://github.com/PwnKit-Labs) and [Doruk Tan Ozturk](https://doruk.ch)*
 
-## Part of the open-source modern SOC
+## Part of PwnKit Labs
 
-foxguard is one piece of a three-part open-source security stack:
+**Adversarial reliability infrastructure for humans and AI agents.** foxguard is one piece of a three-part open-source stack:
 - **[pwnkit](https://github.com/PwnKit-Labs/pwnkit)** — AI agent pentester (detect)
 - **[foxguard](https://github.com/PwnKit-Labs/foxguard)** — Rust security scanner (prevent)
 - **[opensoar](https://github.com/opensoar-hq/opensoar-core)** — Python-native SOAR platform (respond)

--- a/www/src/components/sections/Footer.astro
+++ b/www/src/components/sections/Footer.astro
@@ -4,6 +4,9 @@
 <footer class="py-20 text-center">
   <div class="section-divider mb-16"></div>
   <div class="max-w-3xl mx-auto px-6">
+    <p class="font-mono text-[10px] uppercase tracking-[0.12em] text-noir-600 mb-5">
+      A PwnKit Labs product · Adversarial reliability infrastructure for humans and AI agents
+    </p>
     <h2 class="font-heading text-2xl text-noir-50 mb-3">Open source. MIT licensed.</h2>
     <p class="text-noir-500 text-sm mb-8">Star on GitHub and help make codebases safer.</p>
     <a


### PR DESCRIPTION
## Summary

Replaces the \"open-source modern SOC\" framing in the README with the PwnKit Labs umbrella tagline:

> **Adversarial reliability infrastructure for humans and AI agents.**

Echoes the same kicker in the foxguard.dev footer so every page carries the umbrella positioning without touching the Hero.

## Why

The \"modern SOC\" framing was accurate but dated — enterprise security vendor-speak that doesn't capture what PwnKit Labs actually is in 2026. The three products are unified by one thesis: adversarial tooling (red team + defensive scanning + response automation) built for a world where both humans and AI agents write the code that ships to production.

- **pwnkit** — AI pentesting agent (adversarial testing)
- **foxguard** — security scanner for pre-commit / local loop (reliability hardening)
- **opensoar** — SOAR for incident response (reliability recovery)

Having one umbrella tagline that covers all three makes each product's marketing reinforce the others instead of competing. It also names the audience explicitly — humans *and* AI agents — because in 2026 both are writing code, both are making security decisions, and both need tooling built with that reality in mind.

## What changed

- **\`README.md\`** — \"## Part of the open-source modern SOC\" → \"## Part of PwnKit Labs\" with the umbrella tagline as the lead sentence. Detect / prevent / respond bullets unchanged.
- **\`www/src/components/sections/Footer.astro\`** — added one short monospace kicker above \"Open source. MIT licensed.\" on foxguard.dev that reads *A PwnKit Labs product · Adversarial reliability infrastructure for humans and AI agents*. Matches the Hero kicker typography.

No code, no tests, no rules, no dependencies touched.

## Followups (separate repos, not in this PR)

These need to be updated manually in their respective repos to carry the same tagline:

- \`pwnkit.com\` hero
- PwnKit Labs org README
- \`opensoar.app\` footer

## Test plan

- [x] \`npm run build\` (www/) clean — 7 pages built, 736ms
- [x] Hero unchanged (umbrella belongs in footer, not next to product tagline)
- [x] Existing blog post footer boilerplates unchanged (product-level, not umbrella-level)
- [x] No Rust code or test changes; \`cargo test\` / \`cargo clippy\` / \`cargo fmt\` untouched