### PR TITLE
feat: add MCP server for AI coding agent integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,9 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 globset = "0.4"
 
+[[bin]]
+name = "foxguard-mcp"
+path = "src/bin/foxguard_mcp.rs"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -1,0 +1,197 @@
+use foxguard::engine::{scan_directory, ScanResult};
+use foxguard::rules::RuleRegistry;
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+use std::path::Path;
+
+fn main() {
+    let registry = RuleRegistry::new();
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let request: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                let error_response = json!({
+                    "jsonrpc": "2.0",
+                    "id": null,
+                    "error": {
+                        "code": -32700,
+                        "message": format!("Parse error: {}", e)
+                    }
+                });
+                let mut out = stdout.lock();
+                let _ = writeln!(out, "{}", error_response);
+                let _ = out.flush();
+                continue;
+            }
+        };
+
+        let response = handle_request(&request, &registry);
+
+        if let Some(resp) = response {
+            let mut out = stdout.lock();
+            let _ = writeln!(out, "{}", resp);
+            let _ = out.flush();
+        }
+    }
+}
+
+fn handle_request(request: &Value, registry: &RuleRegistry) -> Option<Value> {
+    let method = request.get("method")?.as_str()?;
+    let id = request.get("id");
+
+    // Notifications (no id) are handled silently
+    let id = id?.clone();
+
+    let result = match method {
+        "initialize" => handle_initialize(),
+        "tools/list" => handle_tools_list(),
+        "tools/call" => handle_tools_call(request, registry),
+        _ => {
+            return Some(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": {
+                    "code": -32601,
+                    "message": format!("Method not found: {}", method)
+                }
+            }));
+        }
+    };
+
+    match result {
+        Ok(value) => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": value
+        })),
+        Err(err) => Some(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": -32602,
+                "message": err
+            }
+        })),
+    }
+}
+
+fn handle_initialize() -> Result<Value, String> {
+    Ok(json!({
+        "protocolVersion": "2024-11-05",
+        "capabilities": { "tools": {} },
+        "serverInfo": {
+            "name": "foxguard",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    }))
+}
+
+fn handle_tools_list() -> Result<Value, String> {
+    Ok(json!({
+        "tools": [
+            {
+                "name": "scan_file",
+                "description": "Run foxguard security scan on a single file",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute path to the file to scan"
+                        }
+                    },
+                    "required": ["path"]
+                }
+            },
+            {
+                "name": "scan_directory",
+                "description": "Run foxguard security scan on a directory",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute path to the directory to scan"
+                        }
+                    },
+                    "required": ["path"]
+                }
+            }
+        ]
+    }))
+}
+
+fn handle_tools_call(request: &Value, registry: &RuleRegistry) -> Result<Value, String> {
+    let params = request
+        .get("params")
+        .ok_or_else(|| "Missing params".to_string())?;
+
+    let tool_name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing tool name".to_string())?;
+
+    let arguments = params
+        .get("arguments")
+        .ok_or_else(|| "Missing arguments".to_string())?;
+
+    let path = arguments
+        .get("path")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Missing path argument".to_string())?;
+
+    match tool_name {
+        "scan_file" => {
+            let p = Path::new(path);
+            if !p.exists() {
+                return Err(format!("Path does not exist: {}", path));
+            }
+            if !p.is_file() {
+                return Err(format!("Path is not a file: {}", path));
+            }
+            let result = scan_directory(path, registry);
+            Ok(format_scan_result(result))
+        }
+        "scan_directory" => {
+            let p = Path::new(path);
+            if !p.exists() {
+                return Err(format!("Path does not exist: {}", path));
+            }
+            if !p.is_dir() {
+                return Err(format!("Path is not a directory: {}", path));
+            }
+            let result = scan_directory(path, registry);
+            Ok(format_scan_result(result))
+        }
+        _ => Err(format!("Unknown tool: {}", tool_name)),
+    }
+}
+
+fn format_scan_result(result: ScanResult) -> Value {
+    let output = json!({
+        "findings": result.findings,
+        "files_scanned": result.files_scanned,
+        "duration_ms": result.duration.as_millis() as u64
+    });
+
+    json!({
+        "content": [
+            {
+                "type": "text",
+                "text": serde_json::to_string(&output).unwrap()
+            }
+        ]
+    })
+}

--- a/tests/mcp_server.rs
+++ b/tests/mcp_server.rs
@@ -1,0 +1,281 @@
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+fn send_request(stdin: &mut impl Write, stdout: &mut impl BufRead, request: &Value) -> Value {
+    let line = serde_json::to_string(request).unwrap();
+    writeln!(stdin, "{}", line).unwrap();
+    stdin.flush().unwrap();
+
+    let mut response_line = String::new();
+    stdout.read_line(&mut response_line).unwrap();
+    serde_json::from_str(response_line.trim()).unwrap()
+}
+
+fn send_notification(stdin: &mut impl Write, notification: &Value) {
+    let line = serde_json::to_string(notification).unwrap();
+    writeln!(stdin, "{}", line).unwrap();
+    stdin.flush().unwrap();
+}
+
+#[test]
+fn test_mcp_server_lifecycle() {
+    // Build the binary first
+    let status = Command::new("cargo")
+        .args(["build", "--bin", "foxguard-mcp"])
+        .status()
+        .expect("failed to build foxguard-mcp");
+    assert!(status.success(), "failed to build foxguard-mcp");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_foxguard-mcp"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn foxguard-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // 1. Send initialize request
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        }),
+    );
+
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["result"]["protocolVersion"], "2024-11-05");
+    assert_eq!(response["result"]["serverInfo"]["name"], "foxguard");
+    assert!(response["result"]["serverInfo"]["version"]
+        .as_str()
+        .is_some());
+
+    // 2. Send initialized notification (should be silently ignored)
+    send_notification(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        }),
+    );
+
+    // 3. Send tools/list request
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    );
+
+    assert_eq!(response["id"], 2);
+    let tools = response["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 2);
+
+    let tool_names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    assert!(tool_names.contains(&"scan_file"));
+    assert!(tool_names.contains(&"scan_directory"));
+
+    // Verify input schemas
+    for tool in tools {
+        let schema = &tool["inputSchema"];
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["path"].is_object());
+        assert_eq!(schema["required"].as_array().unwrap(), &[json!("path")]);
+    }
+
+    // 4. Send tools/call with scan_file on a known vulnerable fixture
+    let fixture_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/vulnerable.py")
+        .canonicalize()
+        .unwrap();
+
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "scan_file",
+                "arguments": {
+                    "path": fixture_path.to_str().unwrap()
+                }
+            }
+        }),
+    );
+
+    assert_eq!(response["id"], 3);
+    let content = response["result"]["content"].as_array().unwrap();
+    assert_eq!(content.len(), 1);
+    assert_eq!(content[0]["type"], "text");
+
+    let scan_output: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+    assert_eq!(scan_output["files_scanned"], 1);
+    assert!(scan_output["duration_ms"].as_u64().is_some());
+
+    let findings = scan_output["findings"].as_array().unwrap();
+    assert!(
+        !findings.is_empty(),
+        "Expected findings for vulnerable.py fixture"
+    );
+
+    // Verify finding structure
+    let first = &findings[0];
+    assert!(first["rule_id"].as_str().is_some());
+    assert!(first["severity"].as_str().is_some());
+    assert!(first["description"].as_str().is_some());
+    assert!(first["file"].as_str().is_some());
+    assert!(first["line"].as_u64().is_some());
+    assert!(first["snippet"].as_str().is_some());
+
+    // 5. Test unknown method
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "unknown/method",
+            "params": {}
+        }),
+    );
+
+    assert_eq!(response["id"], 4);
+    assert!(response["error"].is_object());
+    assert_eq!(response["error"]["code"], -32601);
+
+    // Clean up
+    drop(stdin);
+    let _ = child.wait();
+}
+
+#[test]
+fn test_mcp_scan_directory() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_foxguard-mcp"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn foxguard-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // Initialize first
+    let _ = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        }),
+    );
+
+    // Scan the fixtures directory
+    let fixtures_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .canonicalize()
+        .unwrap();
+
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "scan_directory",
+                "arguments": {
+                    "path": fixtures_path.to_str().unwrap()
+                }
+            }
+        }),
+    );
+
+    assert_eq!(response["id"], 2);
+    let content = response["result"]["content"].as_array().unwrap();
+    let scan_output: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+    assert!(scan_output["files_scanned"].as_u64().unwrap() > 1);
+    assert!(!scan_output["findings"].as_array().unwrap().is_empty());
+
+    drop(stdin);
+    let _ = child.wait();
+}
+
+#[test]
+fn test_mcp_scan_nonexistent_path() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_foxguard-mcp"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn foxguard-mcp");
+
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = BufReader::new(child.stdout.take().unwrap());
+
+    // Initialize
+    let _ = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test", "version": "1.0" }
+            }
+        }),
+    );
+
+    // Try scanning a nonexistent file
+    let response = send_request(
+        &mut stdin,
+        &mut stdout,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "scan_file",
+                "arguments": {
+                    "path": "/nonexistent/path/file.py"
+                }
+            }
+        }),
+    );
+
+    assert_eq!(response["id"], 2);
+    assert!(response["error"].is_object());
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("does not exist"));
+
+    drop(stdin);
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- Adds a new `foxguard-mcp` binary that implements a minimal MCP (Model Context Protocol) server over stdio using JSON-RPC 2.0
- Exposes `scan_file` and `scan_directory` tools so AI coding agents can call foxguard programmatically
- Zero new dependencies -- uses existing `serde_json` for the JSON-RPC protocol

## Details
The server handles the full MCP lifecycle: `initialize`, `notifications/initialized`, `tools/list`, and `tools/call`. Each tool accepts an absolute path and returns findings as JSON with file count and duration metadata.

New files:
- `src/bin/foxguard_mcp.rs` -- MCP server binary (~180 lines)
- `tests/mcp_server.rs` -- integration tests that spawn the binary and exercise the full protocol lifecycle

Refs #58

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 132 tests pass (129 existing + 3 new MCP server tests)
- [x] Manual test: `echo '{"jsonrpc":"2.0","id":1,"method":"initialize",...}' | cargo run --bin foxguard-mcp` returns correct response
- [x] Integration tests cover: initialize, tools/list, scan_file on vulnerable fixture, scan_directory, nonexistent path error handling, unknown method error

none