### PR TITLE
feat(js): add remaining JS server-side taint rules

### DIFF
--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2045,29 +2045,25 @@ impl TaintCommandInjection {
         JsTaintSpec {
             sources: javascript_taint_sources(),
             sinks: vec![
-                JsNodeMatcher::MethodName {
-                    method: "exec".into(),
-                    description: "child_process .exec() call".into(),
-                },
-                JsNodeMatcher::MethodName {
-                    method: "execSync".into(),
-                    description: "child_process .execSync() call".into(),
-                },
-                JsNodeMatcher::MethodName {
-                    method: "spawn".into(),
-                    description: "child_process .spawn() call".into(),
-                },
-                JsNodeMatcher::MethodName {
-                    method: "spawnSync".into(),
-                    description: "child_process .spawnSync() call".into(),
-                },
                 JsNodeMatcher::Call {
                     canonical: "child_process.exec".into(),
-                    description: "child_process.exec() call".into(),
+                    description: "child_process.exec()".into(),
                 },
                 JsNodeMatcher::Call {
                     canonical: "child_process.execSync".into(),
-                    description: "child_process.execSync() call".into(),
+                    description: "child_process.execSync()".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "child_process.spawn".into(),
+                    description: "child_process.spawn()".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "child_process.spawnSync".into(),
+                    description: "child_process.spawnSync()".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "child_process.execFile".into(),
+                    description: "child_process.execFile()".into(),
                 },
             ],
             sanitizers: vec![],

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1955,3 +1955,284 @@ impl Rule for TaintSqlInjection {
             .collect()
     }
 }
+
+// ─── js/taint-eval ──────────────────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches `eval()`
+// or `new Function(...)`. CWE-95 (Improper Neutralization of Directives
+// in Dynamically Evaluated Code).
+
+pub struct TaintEval;
+
+impl TaintEval {
+    fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::Call {
+                    canonical: "eval".into(),
+                    description: "eval() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "Function".into(),
+                    description: "new Function() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintEval {
+    fn id(&self) -> &str {
+        "js/taint-eval"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-95")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches eval or Function — arbitrary code execution"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can execute arbitrary code",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}
+
+// ─── js/taint-command-injection ─────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches a
+// child-process execution sink. CWE-78 (OS Command Injection).
+
+pub struct TaintCommandInjection;
+
+impl TaintCommandInjection {
+    fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::MethodName {
+                    method: "exec".into(),
+                    description: "child_process .exec() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "execSync".into(),
+                    description: "child_process .execSync() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "spawn".into(),
+                    description: "child_process .spawn() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "spawnSync".into(),
+                    description: "child_process .spawnSync() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "child_process.exec".into(),
+                    description: "child_process.exec() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "child_process.execSync".into(),
+                    description: "child_process.execSync() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintCommandInjection {
+    fn id(&self) -> &str {
+        "js/taint-command-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-78")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches a command execution sink — OS command injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can inject OS commands",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}
+
+// ─── js/taint-ssrf ──────────────────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches an
+// outbound HTTP request sink. CWE-918 (Server-Side Request Forgery).
+
+pub struct TaintSsrf;
+
+impl TaintSsrf {
+    fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::Call {
+                    canonical: "fetch".into(),
+                    description: "fetch() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "http.get".into(),
+                    description: "http.get() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "http.request".into(),
+                    description: "http.request() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "https.get".into(),
+                    description: "https.get() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "https.request".into(),
+                    description: "https.request() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "axios.get".into(),
+                    description: "axios.get() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "axios.post".into(),
+                    description: "axios.post() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "axios.request".into(),
+                    description: "axios.request() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "got".into(),
+                    description: "got() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "got.get".into(),
+                    description: "got.get() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "got.post".into(),
+                    description: "got.post() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintSsrf {
+    fn id(&self) -> &str {
+        "js/taint-ssrf"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-918")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an HTTP request sink — possible SSRF"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can cause server-side request forgery",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+            })
+            .collect()
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -106,6 +106,9 @@ impl RuleRegistry {
         registry.register(Box::new(javascript::NoUnsafeFormatString));
         registry.register(Box::new(javascript::TaintXssInnerHtml));
         registry.register(Box::new(javascript::TaintSqlInjection));
+        registry.register(Box::new(javascript::TaintEval));
+        registry.register(Box::new(javascript::TaintCommandInjection));
+        registry.register(Box::new(javascript::TaintSsrf));
 
         // Register Python rules
         registry.register(Box::new(python::NoEval));

--- a/tests/fixtures/realistic/express_api/routes.js
+++ b/tests/fixtures/realistic/express_api/routes.js
@@ -8,9 +8,12 @@
 // fixture need to be updated to include the new cross-file findings.
 //
 // Hand-counted expected findings under the current engine:
-//   js/taint-sql-injection : 1  (in-file /user handler)
+//   js/taint-sql-injection        : 1  (in-file /user handler)
+//   js/taint-command-injection    : 1  (in-file /exec handler)
+//   js/taint-eval                 : 1  (in-file /eval handler)
 
 const express = require("express");
+const child_process = require("child_process");
 const services = require("./services");
 
 const app = express();
@@ -21,6 +24,22 @@ app.get("/user", (req, res) => {
     // js/taint-sql-injection — source and sink in the same function
     const name = req.query.name;
     db.query("SELECT * FROM users WHERE name = '" + name + "'");
+    res.send("ok");
+});
+
+// ─── In-file flow — command injection ────────────────────────────────
+app.get("/exec", (req, res) => {
+    // js/taint-command-injection — source and sink in the same function
+    const cmd = req.query.cmd;
+    child_process.exec(cmd);
+    res.send("ok");
+});
+
+// ─── In-file flow — eval injection ──────────────────────────────────
+app.get("/eval", (req, res) => {
+    // js/taint-eval — source and sink in the same function
+    const expr = req.query.expr;
+    eval(expr);
     res.send("ok");
 });
 

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -179,7 +179,15 @@ fn realistic_django_shop_multifile() {
 /// summaries).
 #[test]
 fn realistic_express_api_multifile() {
-    assert_fixture("express_api", 5, &[("js/taint-sql-injection", 1)]);
+    assert_fixture(
+        "express_api",
+        9,
+        &[
+            ("js/taint-sql-injection", 1),
+            ("js/taint-command-injection", 1),
+            ("js/taint-eval", 1),
+        ],
+    );
 }
 
 /// Multi-file Next.js App Router fixture (issue #48). Same shape as

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -42,7 +42,10 @@ const jsRules: Rule[] = [
   { id: 'js/no-unsafe-regex', cwe: 'CWE-1333', desc: 'Potentially catastrophic backtracking regex pattern', severity: 'medium' },
   { id: 'js/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic hash (MD5/SHA1)', severity: 'medium' },
   { id: 'js/no-xss-innerhtml', cwe: 'CWE-79', desc: 'Assignment to innerHTML may lead to XSS', severity: 'high' },
+  { id: 'js/taint-command-injection', cwe: 'CWE-78', desc: 'Untrusted input reaches a command execution sink — OS command injection', severity: 'critical' },
+  { id: 'js/taint-eval', cwe: 'CWE-95', desc: 'Untrusted input reaches eval or Function — arbitrary code execution', severity: 'critical' },
   { id: 'js/taint-sql-injection', cwe: 'CWE-89', desc: 'Untrusted input reaches a SQL execute sink — possible SQL injection', severity: 'critical' },
+  { id: 'js/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches an HTTP request sink — possible SSRF', severity: 'high' },
   { id: 'js/taint-xss-innerhtml', cwe: 'CWE-79', desc: 'Untrusted input reaches innerHTML or document.write sink', severity: 'high' },
 ];
 


### PR DESCRIPTION
## Summary
- Add three new JavaScript taint rules: `js/taint-eval` (CWE-95, Critical), `js/taint-command-injection` (CWE-78, Critical), and `js/taint-ssrf` (CWE-918, High)
- Each rule follows the same `TaintSqlInjection` pattern: sources from `javascript_taint_sources()`, custom sinks, intraprocedural taint analysis via `javascript_taint::analyze_tree`
- Update `express_api` fixture with `/exec` and `/eval` handlers exercising the new command-injection and eval rules

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` all passing (including updated `realistic_express_api_multifile` counts: 9 total, 1 sql-injection + 1 command-injection + 1 eval)
- [x] Dogfood count (`./target/release/foxguard src/`) steady at 108
- [x] `www/src/data/rules.ts` regenerated and parity test passes

Closes #54

none