### PR TITLE
feat(go): analyze closures in Go taint engine (refs #55)

### DIFF
--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -280,9 +280,10 @@ We rely on the explicit method-call matchers above instead. The
 - **Interface dispatch**: a call through an interface type
   (`handler.ServeHTTP(w, r)`) is resolved as a method-name lookup
   only. Concrete implementers of the interface are not considered.
-- **Closure bodies**: only top-level `function_declaration` and
-  `method_declaration` are summarized. `func_literal` closures are
-  skipped by the walker.
+- **Closure bodies**: `func_literal` closures (anonymous functions)
+  are now analyzed alongside top-level `function_declaration` and
+  `method_declaration` nodes (issue #55). Each closure gets its own
+  independent taint state seeded from its parameter list.
 - **Cross-package imports**: alias resolution only covers the
   file-local `import` statement; calls to functions in imported
   packages are matched by canonical dotted path, not by tracing into

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -9,8 +9,9 @@
 //!
 //! # Scope (same as Python/JS)
 //!
-//! - **Per function / method.** Each `function_declaration` and
-//!   `method_declaration` body is analyzed independently.
+//! - **Per function / method / closure.** Each `function_declaration`,
+//!   `method_declaration`, and `func_literal` (closure / anonymous
+//!   function) body is analyzed independently.
 //! - **Per file.** No cross-file analysis.
 //! - **Flow-insensitive.** Statements are processed in source order; a
 //!   reassignment with a clean RHS clears the target's taint.
@@ -263,16 +264,24 @@ impl GoImportAliases {
 
 // ─── Internals ────────────────────────────────────────────────────────────
 
-/// Walk `root` and visit every top-level function/method declaration.
-/// Does NOT descend into their bodies, since each function body gets
-/// its own independent analysis.
+/// Walk `root` and visit every function/method declaration **and**
+/// every `func_literal` (closure / anonymous function). Named
+/// declarations and closures both get independent taint analysis.
+/// We recurse into function bodies so that closures nested inside
+/// call arguments (e.g. `r.GET("/path", func(c *gin.Context) { … })`)
+/// are discovered.
 fn collect_function_defs<'tree, F>(node: Node<'tree>, visit: &mut F)
 where
     F: FnMut(Node<'tree>),
 {
-    if matches!(node.kind(), "function_declaration" | "method_declaration") {
+    if matches!(
+        node.kind(),
+        "function_declaration" | "method_declaration" | "func_literal"
+    ) {
         visit(node);
-        return;
+        // Continue recursing: the body may contain nested func_literals
+        // (closures passed as arguments, goroutines, etc.) that also
+        // need independent analysis.
     }
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
@@ -353,8 +362,8 @@ fn walk_body_for_summary(
     return_taint: &mut Option<String>,
 ) {
     // Don't descend into nested function literals / closures — their
-    // own returns belong to their own summary (though v1 only
-    // analyzes top-level function / method declarations).
+    // own returns belong to their own summary. Each closure gets its
+    // own independent analysis via `collect_function_defs`.
     if node.kind() == "func_literal" {
         return;
     }
@@ -475,9 +484,9 @@ fn walk_body(
     findings: &mut Vec<TaintFinding>,
     summaries: &ReturnSummary,
 ) {
-    // Nested function literal / closure. Skip — analyze_tree picks up
-    // only top-level `function_declaration` / `method_declaration` in
-    // v1, so closures are intentionally not analyzed.
+    // Nested function literal / closure — skip. Each closure gets its
+    // own independent analysis via `collect_function_defs`, so we must
+    // not walk into its body here (that would mix taint states).
     if node.kind() == "func_literal" {
         return;
     }
@@ -1447,6 +1456,54 @@ func handler(c *gin.Context) {
 "#;
         let findings = run_with(src, &spec);
         assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn closure_gin_handler_fires_taint() {
+        // Closures passed as arguments to Gin router methods must be
+        // analyzed. This is the idiomatic way to write Gin handlers.
+        let src = r#"
+package main
+
+import (
+    "os/exec"
+    "github.com/gin-gonic/gin"
+)
+
+func main() {
+    r := gin.Default()
+    r.GET("/run", func(c *gin.Context) {
+        cmd := c.Query("cmd")
+        exec.Command(cmd).Output()
+    })
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("gin"));
+        assert_eq!(f[0].sink_description, "exec.Command");
+    }
+
+    #[test]
+    fn closure_net_http_handler_fires_taint() {
+        // net/http handler written as a closure.
+        let src = r#"
+package main
+
+import (
+    "net/http"
+    "os/exec"
+)
+
+func main() {
+    http.HandleFunc("/run", func(w http.ResponseWriter, r *http.Request) {
+        cmd := r.FormValue("cmd")
+        exec.Command(cmd)
+    })
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
     }
 
     #[test]

--- a/tests/fixtures/realistic/gin_service/handlers.go
+++ b/tests/fixtures/realistic/gin_service/handlers.go
@@ -6,7 +6,7 @@
 // counts will need to be updated.
 //
 // Hand-counted expected findings under the current engine:
-//   go/taint-command-injection : 1   (in-file runCmd)
+//   go/taint-command-injection : 1   (in-file closure in Register)
 //   go/taint-ssrf              : 1   (in-file proxyFetch)
 
 package gin_service
@@ -18,15 +18,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// In-file flow — should fire today.
-func runCmd(c *gin.Context) {
-	// go/taint-command-injection — source and sink in the same function
-	cmd := c.Query("cmd")
-	_, _ = exec.Command(cmd).Output()
-	c.String(http.StatusOK, "ok")
-}
-
-// In-file SSRF — should fire today.
+// In-file SSRF — should fire today (named function form).
 func proxyFetch(c *gin.Context) {
 	// go/taint-ssrf
 	url := c.Query("url")
@@ -41,15 +33,19 @@ func search(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-// NEAR-MISS — literal, no source
-func healthz(c *gin.Context) {
-	_, _ = exec.Command("uptime").Output()
-	c.String(http.StatusOK, "ok")
-}
-
 func Register(r *gin.Engine) {
-	r.GET("/run", runCmd)
+	// In-file flow as a closure — should fire today (issue #55).
+	// go/taint-command-injection — source and sink in the same closure
+	r.GET("/run", func(c *gin.Context) {
+		cmd := c.Query("cmd")
+		_, _ = exec.Command(cmd).Output()
+		c.String(http.StatusOK, "ok")
+	})
 	r.GET("/fetch", proxyFetch)
 	r.GET("/search", search)
-	r.GET("/healthz", healthz)
+	// NEAR-MISS — literal, no source
+	r.GET("/healthz", func(c *gin.Context) {
+		_, _ = exec.Command("uptime").Output()
+		c.String(http.StatusOK, "ok")
+	})
 }


### PR DESCRIPTION
## Summary
- Extends `collect_function_defs` in the Go taint engine to also visit `func_literal` nodes (closures / anonymous functions), so closure-based Gin handlers like `r.GET("/path", func(c *gin.Context) { ... })` are now analyzed for taint flows.
- Adds two unit tests: one for a Gin closure handler and one for a net/http closure handler.
- Converts the `runCmd` handler in the `gin_service` realistic fixture from a named function to a closure to exercise the new path in integration tests.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — all 226 tests pass
- [x] `realistic_gin_app` fixture still reports 7 findings (unchanged)
- [x] `realistic_gin_service_multifile` fixture still reports 5 findings (1 command injection + 1 SSRF)
- [x] New unit tests `closure_gin_handler_fires_taint` and `closure_net_http_handler_fires_taint` pass

none