### PR TITLE
refactor: delete dead debug code, stale annotations, extract constants

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -125,25 +125,24 @@ fn is_noise_path(path: &Path) -> bool {
     false
 }
 
-/// Detect minified files: very long lines suggest bundled/compiled code.
+const MIN_SIZE_FOR_MINIFY_CHECK: usize = 2000;
+const MAX_FIRST_LINE_LEN: usize = 1000;
+const MAX_AVG_LINE_LEN: usize = 300;
+
 fn is_minified(source: &str) -> bool {
-    // If file is small, it's not minified
-    if source.len() < 2000 {
+    if source.len() < MIN_SIZE_FOR_MINIFY_CHECK {
         return false;
     }
-    // Check the first line — minified files usually have one huge line
     if let Some(first_newline) = source.find('\n') {
-        if first_newline > 1000 {
+        if first_newline > MAX_FIRST_LINE_LEN {
             return true;
         }
     } else {
-        // No newline at all and file is over 2KB — definitely minified
-        return source.len() > 2000;
+        return source.len() > MIN_SIZE_FOR_MINIFY_CHECK;
     }
-    // Check average line length
     let line_count = source.bytes().filter(|b| *b == b'\n').count().max(1);
     let avg_line_len = source.len() / line_count;
-    avg_line_len > 300
+    avg_line_len > MAX_AVG_LINE_LEN
 }
 
 fn inline_ignore_regex() -> &'static Regex {

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -36,7 +36,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use tree_sitter::{Node, Tree, TreeCursor};
+use tree_sitter::{Node, Tree};
 
 // ─── Public API ───────────────────────────────────────────────────────────
 
@@ -1129,23 +1129,6 @@ fn leftmost_identifier<'a>(mut node: Node<'_>, source: &'a str) -> Option<&'a st
 
 fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
     &source[node.byte_range()]
-}
-
-#[allow(dead_code)]
-fn debug_tree(node: Node<'_>, depth: usize) {
-    let mut cursor: TreeCursor = node.walk();
-    for _ in 0..depth {
-        eprint!("  ");
-    }
-    eprintln!(
-        "{} [{}..{}]",
-        node.kind(),
-        node.start_byte(),
-        node.end_byte()
-    );
-    for child in node.children(&mut cursor) {
-        debug_tree(child, depth + 1);
-    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1,7 +1,6 @@
 use crate::rules::common::{get_source_line, make_finding, walk_tree};
 use crate::rules::{FileContext, Rule};
 use crate::{Finding, Language, Severity};
-#[allow(unused_imports)]
 use regex::Regex;
 
 // ─── Rule 1: no-eval ─────────────────────────────────────────────────────────

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -26,7 +26,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use tree_sitter::{Node, Tree, TreeCursor};
+use tree_sitter::{Node, Tree};
 
 // ─── Public API ───────────────────────────────────────────────────────────
 
@@ -1302,18 +1302,6 @@ fn leftmost_identifier<'a>(mut node: Node<'_>, source: &'a str) -> Option<&'a st
 
 fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
     &source[node.byte_range()]
-}
-
-#[allow(dead_code)]
-fn debug_tree(node: Node<'_>, depth: usize) {
-    let mut cursor: TreeCursor = node.walk();
-    for _ in 0..depth {
-        eprint!("  ");
-    }
-    eprintln!("{}", node.kind());
-    for child in node.children(&mut cursor) {
-        debug_tree(child, depth + 1);
-    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -32,7 +32,7 @@
 
 use crate::rules::python_aliases::ImportAliases;
 use std::collections::HashMap;
-use tree_sitter::{Node, TreeCursor};
+use tree_sitter::Node;
 
 // ─── Public API ───────────────────────────────────────────────────────────
 
@@ -1043,18 +1043,6 @@ fn leftmost_identifier<'a>(mut node: Node<'_>, source: &'a str) -> Option<&'a st
 
 fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
     &source[node.byte_range()]
-}
-
-#[allow(dead_code)]
-fn debug_tree(node: Node<'_>, depth: usize) {
-    let mut cursor: TreeCursor = node.walk();
-    for _ in 0..depth {
-        eprint!("  ");
-    }
-    eprintln!("{}", node.kind());
-    for child in node.children(&mut cursor) {
-        debug_tree(child, depth + 1);
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Codebase audit cleanup. Net -43 lines, zero behavior changes.

## Changes

- **Deleted 3× identical dead \`debug_tree()\` functions** from \`python_taint.rs\`, \`javascript_taint.rs\`, \`go_taint.rs\` — all marked \`#[allow(dead_code)]\`, never called, existed as copy-pasted dev debugging helpers. Also removes their now-unused \`TreeCursor\` imports.

- **Removed stale \`#[allow(unused_imports)]\`** on \`Regex\` in \`javascript.rs\` — \`Regex\` is actively used (lines 76, 170, 802, 1204+). The annotation was wrong.

- **Extracted hardcoded minification thresholds** in \`scanner.rs\` to named constants: \`MIN_SIZE_FOR_MINIFY_CHECK\` (2000), \`MAX_FIRST_LINE_LEN\` (1000), \`MAX_AVG_LINE_LEN\` (300). Same values, just readable names instead of magic numbers.

## Not in scope (tracked separately)

The audit also identified structural improvements (import alias dedup across engines, large file splitting, builder pattern for \`analyze_tree\` signatures) — those are multi-hour refactors, not quick cleanup. Left for future PRs.

## Test plan

- [x] \`cargo fmt --check\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo test\` — all 98 tests pass
- [x] No behavior changes — pure dead code removal and constant extraction