### PR TITLE
refactor: introduce AnalysisContext struct for taint engine signatures

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -589,11 +589,14 @@ fn go_call_sink(canonical: &str) -> GoNodeMatcher {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn map_go_taint_findings(
-    rule_id: &str,
+struct GoTaintRuleMeta<'a> {
+    rule_id: &'a str,
     severity: Severity,
-    cwe: Option<&str>,
+    cwe: Option<&'a str>,
+}
+
+fn map_go_taint_findings(
+    meta: &GoTaintRuleMeta<'_>,
     source: &str,
     tree: &tree_sitter::Tree,
     ctx: &FileContext<'_>,
@@ -612,9 +615,9 @@ fn map_go_taint_findings(
     let raw = go_taint::analyze_tree(tree.root_node(), source, spec, aliases);
     raw.into_iter()
         .map(|t| Finding {
-            rule_id: rule_id.to_string(),
-            severity,
-            cwe: cwe.map(|s| s.to_string()),
+            rule_id: meta.rule_id.to_string(),
+            severity: meta.severity,
+            cwe: meta.cwe.map(|s| s.to_string()),
             description: format_description(&t.source_description, &t.sink_description),
             file: String::new(),
             line: t.sink_line,
@@ -670,21 +673,17 @@ impl Rule for TaintCommandInjection {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_go_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can inject OS commands",
-                    src, sink
-                )
-            },
-        )
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can inject OS commands",
+                src, sink
+            )
+        })
     }
 }
 
@@ -763,16 +762,14 @@ impl Rule for TaintSqlInjection {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_go_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| format!("{} reaches {} — untrusted input can inject SQL", src, sink),
-        )
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!("{} reaches {} — untrusted input can inject SQL", src, sink)
+        })
     }
 }
 
@@ -824,20 +821,16 @@ impl Rule for TaintSsrf {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_go_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can drive server-side request forgery",
-                    src, sink
-                )
-            },
-        )
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can drive server-side request forgery",
+                src, sink
+            )
+        })
     }
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -120,6 +120,15 @@ pub struct TaintFinding {
 /// v1 limitation.
 pub type ReturnSummary = HashMap<String, Option<String>>;
 
+/// Bundles the read-only context that every internal walker needs,
+/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
+struct AnalysisContext<'a> {
+    source: &'a str,
+    spec: &'a TaintSpec,
+    aliases: Option<&'a GoImportAliases>,
+    summaries: &'a ReturnSummary,
+}
+
 /// Run the taint engine over every function/method body inside `root`
 /// and return one `TaintFinding` per source→sink flow.
 ///
@@ -134,18 +143,29 @@ pub fn analyze_tree(
 ) -> Vec<TaintFinding> {
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
+    let pass1_ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &empty_summary,
+    };
     collect_function_defs(root, &mut |func_node| {
-        let (name, ret_taint) =
-            summarize_function(func_node, source, spec, aliases, &empty_summary);
+        let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
         if let Some(name) = name {
             // Last-write-wins on name collisions (v1 limitation).
             summaries.insert(name, ret_taint);
         }
     });
 
+    let ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &summaries,
+    };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
-        analyze_function(func_node, source, spec, aliases, &summaries, &mut findings);
+        analyze_function(func_node, &ctx, &mut findings);
     });
     findings
 }
@@ -320,16 +340,13 @@ impl TaintState {
 /// Pass-1 walker: compute a function/method's return-taint summary.
 fn summarize_function(
     func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
-    summaries: &ReturnSummary,
+    ctx: &AnalysisContext<'_>,
 ) -> (Option<String>, Option<String>) {
-    let name = function_simple_name(func_node, source).map(|s| s.to_string());
+    let name = function_simple_name(func_node, ctx.source).map(|s| s.to_string());
 
     let mut state = TaintState::default();
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
     let Some(body) = func_node.child_by_field_name("body") else {
         return (name, None);
@@ -337,28 +354,15 @@ fn summarize_function(
 
     let mut return_taint: Option<String> = None;
     let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary(
-        body,
-        source,
-        spec,
-        aliases,
-        &mut state,
-        &mut scratch,
-        summaries,
-        &mut return_taint,
-    );
+    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_body_for_summary(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
     return_taint: &mut Option<String>,
 ) {
     // Don't descend into nested function literals / closures — their
@@ -370,16 +374,16 @@ fn walk_body_for_summary(
 
     match node.kind() {
         "short_var_declaration" => {
-            handle_short_var_declaration(node, source, spec, aliases, state, summaries);
+            handle_short_var_declaration(node, ctx, state);
         }
         "var_spec" => {
-            handle_var_spec(node, source, spec, aliases, state, summaries);
+            handle_var_spec(node, ctx, state);
         }
         "assignment_statement" => {
-            handle_assignment(node, source, spec, aliases, state, findings, summaries);
+            handle_assignment(node, ctx, state, findings);
         }
         "call_expression" => {
-            handle_call(node, source, spec, aliases, state, findings, summaries);
+            handle_call(node, ctx, state, findings);
         }
         "return_statement" => {
             if return_taint.is_none() {
@@ -389,16 +393,12 @@ fn walk_body_for_summary(
                     if child.kind() == "expression_list" {
                         let mut inner = child.walk();
                         for expr in child.named_children(&mut inner) {
-                            if let Some(desc) =
-                                expression_taint(expr, source, spec, aliases, state, summaries)
-                            {
+                            if let Some(desc) = expression_taint(expr, ctx, state) {
                                 *return_taint = Some(desc);
                                 break;
                             }
                         }
-                    } else if let Some(desc) =
-                        expression_taint(child, source, spec, aliases, state, summaries)
-                    {
+                    } else if let Some(desc) = expression_taint(child, ctx, state) {
                         *return_taint = Some(desc);
                     }
                     if return_taint.is_some() {
@@ -412,37 +412,25 @@ fn walk_body_for_summary(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body_for_summary(
-            child,
-            source,
-            spec,
-            aliases,
-            state,
-            findings,
-            summaries,
-            return_taint,
-        );
+        walk_body_for_summary(child, ctx, state, findings, return_taint);
     }
 }
 
 fn analyze_function(
     func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
-    summaries: &ReturnSummary,
+    ctx: &AnalysisContext<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
 
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
 
     let Some(body) = func_node.child_by_field_name("body") else {
         return;
     };
-    walk_body(body, source, spec, aliases, &mut state, findings, summaries);
+    walk_body(body, ctx, &mut state, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -477,12 +465,9 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     // Nested function literal / closure — skip. Each closure gets its
     // own independent analysis via `collect_function_defs`, so we must
@@ -493,23 +478,23 @@ fn walk_body(
 
     match node.kind() {
         "short_var_declaration" => {
-            handle_short_var_declaration(node, source, spec, aliases, state, summaries);
+            handle_short_var_declaration(node, ctx, state);
         }
         "var_spec" => {
-            handle_var_spec(node, source, spec, aliases, state, summaries);
+            handle_var_spec(node, ctx, state);
         }
         "assignment_statement" => {
-            handle_assignment(node, source, spec, aliases, state, findings, summaries);
+            handle_assignment(node, ctx, state, findings);
         }
         "call_expression" => {
-            handle_call(node, source, spec, aliases, state, findings, summaries);
+            handle_call(node, ctx, state, findings);
         }
         _ => {}
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body(child, source, spec, aliases, state, findings, summaries);
+        walk_body(child, ctx, state, findings);
     }
 }
 
@@ -539,32 +524,18 @@ fn collect_expression_list<'tree>(list: Node<'tree>) -> Vec<Node<'tree>> {
 }
 
 /// Handle `a := ...`, `a, b := ...`, `a, b := f()`.
-fn handle_short_var_declaration(
-    node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
-    state: &mut TaintState,
-    summaries: &ReturnSummary,
-) {
+fn handle_short_var_declaration(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
         node.child_by_field_name("right"),
     ) else {
         return;
     };
-    propagate_multi_assign(left, right, source, spec, aliases, state, summaries);
+    propagate_multi_assign(left, right, ctx, state);
 }
 
 /// Handle `var x = ...`, `var x, y = f()`, `var x T = ...`.
-fn handle_var_spec(
-    node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
-    state: &mut TaintState,
-    summaries: &ReturnSummary,
-) {
+fn handle_var_spec(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
     // var_spec has multiple `name` fields and an optional `value`
     // expression_list.
     let Some(value) = node.child_by_field_name("value") else {
@@ -576,7 +547,7 @@ fn handle_var_spec(
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "identifier" {
-            lhs_names.push(node_text(child, source));
+            lhs_names.push(node_text(child, ctx.source));
         }
     }
     if lhs_names.is_empty() {
@@ -585,20 +556,15 @@ fn handle_var_spec(
 
     // `value` is an expression_list. Pair it with LHS names.
     let rhs_exprs = collect_expression_list(value);
-    apply_multi_assign_semantics(
-        &lhs_names, &rhs_exprs, source, spec, aliases, state, summaries,
-    );
+    apply_multi_assign_semantics(&lhs_names, &rhs_exprs, ctx, state);
 }
 
 /// Handle `x = ...`, `x, y = ...`, `x += ...`.
 fn handle_assignment(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     _findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
@@ -606,21 +572,18 @@ fn handle_assignment(
     ) else {
         return;
     };
-    propagate_multi_assign(left, right, source, spec, aliases, state, summaries);
+    propagate_multi_assign(left, right, ctx, state);
 }
 
 fn propagate_multi_assign(
     left: Node<'_>,
     right: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
-    summaries: &ReturnSummary,
 ) {
     // Both sides are `expression_list`s in tree-sitter-go.
     let lhs_names = if left.kind() == "expression_list" {
-        collect_identifier_targets(left, source)
+        collect_identifier_targets(left, ctx.source)
     } else {
         return;
     };
@@ -632,9 +595,7 @@ fn propagate_multi_assign(
     } else {
         vec![right]
     };
-    apply_multi_assign_semantics(
-        &lhs_names, &rhs_exprs, source, spec, aliases, state, summaries,
-    );
+    apply_multi_assign_semantics(&lhs_names, &rhs_exprs, ctx, state);
 }
 
 /// Shared LHS/RHS pairing semantics for short_var_declaration,
@@ -648,17 +609,14 @@ fn propagate_multi_assign(
 fn apply_multi_assign_semantics(
     lhs_names: &[&str],
     rhs_exprs: &[Node<'_>],
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
-    summaries: &ReturnSummary,
 ) {
     if lhs_names.len() == rhs_exprs.len() {
         // Collect desc first to avoid borrow conflicts.
         let descs: Vec<Option<String>> = rhs_exprs
             .iter()
-            .map(|rhs| expression_taint(*rhs, source, spec, aliases, state, summaries))
+            .map(|rhs| expression_taint(*rhs, ctx, state))
             .collect();
         for (name, desc) in lhs_names.iter().zip(descs.into_iter()) {
             match desc {
@@ -673,7 +631,7 @@ fn apply_multi_assign_semantics(
     // every LHS name; otherwise clear them all.
     let mut broadcast: Option<String> = None;
     for rhs in rhs_exprs {
-        if let Some(d) = expression_taint(*rhs, source, spec, aliases, state, summaries) {
+        if let Some(d) = expression_taint(*rhs, ctx, state) {
             broadcast = Some(d);
             break;
         }
@@ -702,17 +660,14 @@ fn callee_text<'a>(call: Node<'_>, source: &'a str) -> Option<Cow<'a, str>> {
 
 fn handle_call(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
-    let Some(callee_raw) = callee_text(node, source) else {
+    let Some(callee_raw) = callee_text(node, ctx.source) else {
         return;
     };
-    let resolved: Cow<'_, str> = match aliases {
+    let resolved: Cow<'_, str> = match ctx.aliases {
         Some(a) => a.resolve(callee_raw.as_ref()),
         None => Cow::Borrowed(callee_raw.as_ref()),
     };
@@ -721,7 +676,7 @@ fn handle_call(
     // it's `"exec"`.
     let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_ref());
 
-    let sink_desc = spec.sinks.iter().find_map(|m| match m {
+    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
         NodeMatcher::Call {
             canonical,
             description,
@@ -741,7 +696,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+        if let Some(source_desc) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -763,20 +718,17 @@ fn handle_call(
 /// references) a tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &TaintState,
-    summaries: &ReturnSummary,
 ) -> Option<String> {
     // Direct source match on this expression.
-    if let Some(desc) = match_source(expr, source, spec, aliases) {
+    if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
         return Some(desc);
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
-        let name = node_text(expr, source);
+        let name = node_text(expr, ctx.source);
         if let Some(desc) = state.describe(name) {
             return Some(desc.to_string());
         }
@@ -786,7 +738,7 @@ fn expression_taint(
     // any deeper chain rooted at a tainted value).
     if expr.kind() == "selector_expression" {
         if let Some(operand) = expr.child_by_field_name("operand") {
-            if let Some(desc) = expression_taint(operand, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(operand, ctx, state) {
                 return Some(desc);
             }
         }
@@ -795,7 +747,7 @@ fn expression_taint(
     // Tainted index expression: `m[k]` where `m` is tainted.
     if expr.kind() == "index_expression" {
         if let Some(operand) = expr.child_by_field_name("operand") {
-            if let Some(desc) = expression_taint(operand, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(operand, ctx, state) {
                 return Some(desc);
             }
         }
@@ -806,7 +758,7 @@ fn expression_taint(
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 return Some(desc);
             }
         }
@@ -816,7 +768,7 @@ fn expression_taint(
     if matches!(expr.kind(), "parenthesized_expression" | "unary_expression") {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 return Some(desc);
             }
         }
@@ -830,9 +782,7 @@ fn expression_taint(
             if child.kind() == "literal_value" {
                 let mut inner = child.walk();
                 for elem in child.named_children(&mut inner) {
-                    if let Some(desc) =
-                        expression_taint(elem, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(elem, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -842,7 +792,7 @@ fn expression_taint(
     if expr.kind() == "keyed_element" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 return Some(desc);
             }
         }
@@ -852,13 +802,13 @@ fn expression_taint(
     // `[]byte(tainted)`. Sanitizers short-circuit this and collapse to
     // clean.
     if expr.kind() == "call_expression" {
-        if is_sanitizer_call(expr, source, spec, aliases) {
+        if is_sanitizer_call(expr, ctx.source, ctx.spec, ctx.aliases) {
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+                if let Some(desc) = expression_taint(arg, ctx, state) {
                     return Some(desc);
                 }
             }
@@ -869,9 +819,7 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "selector_expression" {
                 if let Some(operand) = func.child_by_field_name("operand") {
-                    if let Some(desc) =
-                        expression_taint(operand, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(operand, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -883,8 +831,8 @@ fn expression_taint(
         // propagates the summary's taint through the call result.
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
-                let callee = node_text(func, source);
-                if let Some(Some(desc)) = summaries.get(callee) {
+                let callee = node_text(func, ctx.source);
+                if let Some(Some(desc)) = ctx.summaries.get(callee) {
                     return Some(format!("{desc} (via {callee})"));
                 }
             }
@@ -893,8 +841,8 @@ fn expression_taint(
             // policy documented in the module header.
             if func.kind() == "selector_expression" {
                 if let Some(field) = func.child_by_field_name("field") {
-                    let method = node_text(field, source);
-                    if let Some(Some(desc)) = summaries.get(method) {
+                    let method = node_text(field, ctx.source);
+                    if let Some(Some(desc)) = ctx.summaries.get(method) {
                         return Some(format!("{desc} (via {method})"));
                     }
                 }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -114,6 +114,15 @@ pub struct TaintFinding {
 /// last-write-wins (known v1 limitation).
 pub type ReturnSummary = HashMap<String, Option<String>>;
 
+/// Bundles the read-only context that every internal walker needs,
+/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
+struct AnalysisContext<'a> {
+    source: &'a str,
+    spec: &'a TaintSpec,
+    aliases: Option<&'a JsImportAliases>,
+    summaries: &'a ReturnSummary,
+}
+
 /// Run the taint engine over every function/method body inside `root` and
 /// return one `TaintFinding` per source→sink flow.
 ///
@@ -130,14 +139,26 @@ pub fn analyze_tree(
 ) -> Vec<TaintFinding> {
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
+    let pass1_ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &empty_summary,
+    };
     collect_summary_targets(root, source, &mut |name, func_node| {
-        let ret = summarize_function(func_node, source, spec, aliases, &empty_summary);
+        let ret = summarize_function(func_node, &pass1_ctx);
         summaries.insert(name, ret);
     });
 
+    let ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &summaries,
+    };
     let mut findings = Vec::new();
     collect_function_scopes(root, &mut |func_node| {
-        analyze_function(func_node, source, spec, aliases, &summaries, &mut findings);
+        analyze_function(func_node, &ctx, &mut findings);
     });
     findings
 }
@@ -192,21 +213,15 @@ where
 /// Pass-1 walker: compute the return-taint summary for a single function
 /// scope. Walks the body with the normal state machinery but throws away
 /// sink findings and records the first tainted return expression it sees.
-fn summarize_function(
-    func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
-    summaries: &ReturnSummary,
-) -> Option<String> {
+fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<String> {
     let mut state = TaintState::default();
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
     if let Some(single) = func_node.child_by_field_name("parameter") {
         if single.kind() == "identifier" {
-            let name = node_text(single, source);
-            for matcher in &spec.sources {
+            let name = node_text(single, ctx.source);
+            for matcher in &ctx.spec.sources {
                 if let NodeMatcher::ParamName { names, description } = matcher {
                     if names.iter().any(|n| n == name) {
                         state.taint(name.to_string(), description.clone());
@@ -223,33 +238,20 @@ fn summarize_function(
     // is no `return_statement` node to visit. Evaluate taint on it up
     // front so the summary still reflects the implicit return.
     if func_node.kind() == "arrow_function" && body.kind() != "statement_block" {
-        return expression_taint(body, source, spec, aliases, &state, summaries);
+        return expression_taint(body, ctx, &state);
     }
 
     let mut scratch: Vec<TaintFinding> = Vec::new();
     let mut return_taint: Option<String> = None;
-    walk_body_for_summary(
-        body,
-        source,
-        spec,
-        aliases,
-        &mut state,
-        &mut scratch,
-        summaries,
-        &mut return_taint,
-    );
+    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     return_taint
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_body_for_summary(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
     return_taint: &mut Option<String>,
 ) {
     if is_function_scope(node.kind()) {
@@ -258,21 +260,19 @@ fn walk_body_for_summary(
 
     match node.kind() {
         "variable_declarator" => {
-            handle_variable_declarator(node, source, spec, aliases, state, summaries);
+            handle_variable_declarator(node, ctx, state);
         }
         "assignment_expression" => {
-            handle_assignment(node, source, spec, aliases, state, findings, summaries);
+            handle_assignment(node, ctx, state, findings);
         }
         "call_expression" => {
-            handle_call(node, source, spec, aliases, state, findings, summaries);
+            handle_call(node, ctx, state, findings);
         }
         "return_statement" => {
             if return_taint.is_none() {
                 let mut cursor = node.walk();
                 for child in node.named_children(&mut cursor) {
-                    if let Some(desc) =
-                        expression_taint(child, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(child, ctx, state) {
                         *return_taint = Some(desc);
                         break;
                     }
@@ -284,16 +284,7 @@ fn walk_body_for_summary(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body_for_summary(
-            child,
-            source,
-            spec,
-            aliases,
-            state,
-            findings,
-            summaries,
-            return_taint,
-        );
+        walk_body_for_summary(child, ctx, state, findings, return_taint);
     }
 }
 
@@ -567,16 +558,13 @@ impl TaintState {
 
 fn analyze_function(
     func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
-    summaries: &ReturnSummary,
+    ctx: &AnalysisContext<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
 
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
     // Arrow functions with a single bare parameter have `parameter` instead
     // of `parameters` (e.g. `x => x + 1`). tree-sitter-javascript actually
@@ -584,8 +572,8 @@ fn analyze_function(
     // identifier parameter is an `identifier` child field-named `parameter`.
     if let Some(single) = func_node.child_by_field_name("parameter") {
         if single.kind() == "identifier" {
-            let name = node_text(single, source);
-            for matcher in &spec.sources {
+            let name = node_text(single, ctx.source);
+            for matcher in &ctx.spec.sources {
                 if let NodeMatcher::ParamName { names, description } = matcher {
                     if names.iter().any(|n| n == name) {
                         state.taint(name.to_string(), description.clone());
@@ -599,7 +587,7 @@ fn analyze_function(
     let Some(body) = func_node.child_by_field_name("body") else {
         return;
     };
-    walk_body(body, source, spec, aliases, &mut state, findings, summaries);
+    walk_body(body, ctx, &mut state, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -649,12 +637,9 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     // Nested function scopes have their own taint state — skip them; they'll
     // be picked up independently by analyze_tree.
@@ -663,30 +648,19 @@ fn walk_body(
     }
 
     match node.kind() {
-        "variable_declarator" => {
-            handle_variable_declarator(node, source, spec, aliases, state, summaries)
-        }
-        "assignment_expression" => {
-            handle_assignment(node, source, spec, aliases, state, findings, summaries)
-        }
-        "call_expression" => handle_call(node, source, spec, aliases, state, findings, summaries),
+        "variable_declarator" => handle_variable_declarator(node, ctx, state),
+        "assignment_expression" => handle_assignment(node, ctx, state, findings),
+        "call_expression" => handle_call(node, ctx, state, findings),
         _ => {}
     }
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body(child, source, spec, aliases, state, findings, summaries);
+        walk_body(child, ctx, state, findings);
     }
 }
 
-fn handle_variable_declarator(
-    node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
-    state: &mut TaintState,
-    summaries: &ReturnSummary,
-) {
+fn handle_variable_declarator(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
     let Some(name) = node.child_by_field_name("name") else {
         return;
     };
@@ -696,8 +670,8 @@ fn handle_variable_declarator(
     };
 
     if name.kind() == "identifier" {
-        let lhs = node_text(name, source).to_string();
-        if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
+        let lhs = node_text(name, ctx.source).to_string();
+        if let Some(desc) = expression_taint(value, ctx, state) {
             state.taint(lhs, desc);
         } else {
             state.clear(&lhs);
@@ -710,8 +684,8 @@ fn handle_variable_declarator(
     // bound name. We do not attempt per-slot pairing for JS because
     // destructuring shapes are more varied than Python's tuple unpack.
     if matches!(name.kind(), "object_pattern" | "array_pattern") {
-        let targets = collect_destructuring_targets(name, source);
-        if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
+        let targets = collect_destructuring_targets(name, ctx.source);
+        if let Some(desc) = expression_taint(value, ctx, state) {
             for t in &targets {
                 state.taint(t.clone(), desc.clone());
             }
@@ -759,12 +733,9 @@ fn collect_destructuring_targets(node: Node<'_>, source: &str) -> Vec<String> {
 
 fn handle_assignment(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
@@ -776,16 +747,14 @@ fn handle_assignment(
     // Check MemberAssign sinks first: `el.innerHTML = tainted`.
     if left.kind() == "member_expression" {
         if let Some(prop) = left.child_by_field_name("property") {
-            let prop_name = node_text(prop, source);
-            if let Some(sink_desc) = spec.sinks.iter().find_map(|m| match m {
+            let prop_name = node_text(prop, ctx.source);
+            if let Some(sink_desc) = ctx.spec.sinks.iter().find_map(|m| match m {
                 NodeMatcher::MemberAssign { field, description } if field == prop_name => {
                     Some(description.clone())
                 }
                 _ => None,
             }) {
-                if let Some(src_desc) =
-                    expression_taint(right, source, spec, aliases, state, summaries)
-                {
+                if let Some(src_desc) = expression_taint(right, ctx, state) {
                     let start = node.start_position();
                     let end = node.end_position();
                     findings.push(TaintFinding {
@@ -806,8 +775,8 @@ fn handle_assignment(
     }
 
     if left.kind() == "identifier" {
-        let lhs = node_text(left, source).to_string();
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
+        let lhs = node_text(left, ctx.source).to_string();
+        if let Some(desc) = expression_taint(right, ctx, state) {
             state.taint(lhs, desc);
         } else {
             state.clear(&lhs);
@@ -817,8 +786,8 @@ fn handle_assignment(
 
     // Destructuring LHS: `({ a } = req.body)` or `[a, b] = arr`.
     if matches!(left.kind(), "object_pattern" | "array_pattern") {
-        let targets = collect_destructuring_targets(left, source);
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
+        let targets = collect_destructuring_targets(left, ctx.source);
+        if let Some(desc) = expression_taint(right, ctx, state) {
             for t in &targets {
                 state.taint(t.clone(), desc.clone());
             }
@@ -832,24 +801,21 @@ fn handle_assignment(
 
 fn handle_call(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     let Some(func) = node.child_by_field_name("function") else {
         return;
     };
-    let callee_text = node_text(func, source);
-    let resolved: Cow<'_, str> = match aliases {
+    let callee_text = node_text(func, ctx.source);
+    let resolved: Cow<'_, str> = match ctx.aliases {
         Some(a) => a.resolve(callee_text),
         None => Cow::Borrowed(callee_text),
     };
     let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_ref());
 
-    let sink_desc = spec.sinks.iter().find_map(|m| match m {
+    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
         NodeMatcher::Call {
             canonical,
             description,
@@ -869,7 +835,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+        if let Some(source_desc) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -889,20 +855,17 @@ fn handle_call(
 
 fn expression_taint(
     expr: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &TaintState,
-    summaries: &ReturnSummary,
 ) -> Option<String> {
     // Direct source match on this expression.
-    if let Some(desc) = match_source(expr, source, spec, aliases) {
+    if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
         return Some(desc);
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
-        let name = node_text(expr, source);
+        let name = node_text(expr, ctx.source);
         if let Some(desc) = state.describe(name) {
             return Some(desc.to_string());
         }
@@ -911,7 +874,7 @@ fn expression_taint(
     // Tainted member-expression root: `x.y` where `x` is tainted.
     if expr.kind() == "member_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(object, ctx, state) {
                 return Some(desc);
             }
         }
@@ -920,7 +883,7 @@ fn expression_taint(
     // Tainted subscript: `x[k]` where `x` is tainted (no key sensitivity).
     if expr.kind() == "subscript_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(object, ctx, state) {
                 return Some(desc);
             }
         }
@@ -934,9 +897,7 @@ fn expression_taint(
             if child.kind() == "template_substitution" {
                 let mut inner = child.walk();
                 for inner_child in child.named_children(&mut inner) {
-                    if let Some(desc) =
-                        expression_taint(inner_child, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(inner_child, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -948,7 +909,7 @@ fn expression_taint(
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 return Some(desc);
             }
         }
@@ -961,7 +922,7 @@ fn expression_taint(
     ) {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 return Some(desc);
             }
         }
@@ -970,13 +931,13 @@ fn expression_taint(
     // Wrapping call: `String(tainted)` / `bytes(tainted)`. Sanitizers short
     // circuit this and collapse to clean.
     if expr.kind() == "call_expression" {
-        if is_sanitizer_call(expr, source, spec, aliases) {
+        if is_sanitizer_call(expr, ctx.source, ctx.spec, ctx.aliases) {
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+                if let Some(desc) = expression_taint(arg, ctx, state) {
                     return Some(desc);
                 }
             }
@@ -992,9 +953,7 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "member_expression" {
                 if let Some(object) = func.child_by_field_name("object") {
-                    if let Some(desc) =
-                        expression_taint(object, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(object, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -1007,8 +966,8 @@ fn expression_taint(
         // (`obj.helper()`) are out of scope for v1.
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
-                let callee = node_text(func, source);
-                if let Some(Some(desc)) = summaries.get(callee) {
+                let callee = node_text(func, ctx.source);
+                if let Some(Some(desc)) = ctx.summaries.get(callee) {
                     return Some(format!("{desc} (via {callee})"));
                 }
             }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1792,11 +1792,14 @@ fn call_sink(canonical: &str) -> NodeMatcher {
 /// Shared mapper from engine-level `TaintFinding` to the public `Finding`
 /// shape, parameterized by the rule's metadata and a description template
 /// that receives the source and sink descriptions.
-#[allow(clippy::too_many_arguments)]
-fn map_taint_findings(
-    rule_id: &str,
+struct TaintRuleMeta<'a> {
+    rule_id: &'a str,
     severity: Severity,
-    cwe: Option<&str>,
+    cwe: Option<&'a str>,
+}
+
+fn map_taint_findings(
+    meta: &TaintRuleMeta<'_>,
     source: &str,
     tree: &tree_sitter::Tree,
     ctx: &FileContext<'_>,
@@ -1806,9 +1809,9 @@ fn map_taint_findings(
     let raw = python_taint::analyze_tree(tree.root_node(), source, spec, ctx.python_aliases);
     raw.into_iter()
         .map(|t| Finding {
-            rule_id: rule_id.to_string(),
-            severity,
-            cwe: cwe.map(|s| s.to_string()),
+            rule_id: meta.rule_id.to_string(),
+            severity: meta.severity,
+            cwe: meta.cwe.map(|s| s.to_string()),
             description: format_description(&t.source_description, &t.sink_description),
             file: String::new(),
             line: t.sink_line,
@@ -1864,21 +1867,17 @@ impl Rule for TaintPickleDeserialization {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can execute arbitrary code via pickle",
-                    src, sink
-                )
-            },
-        )
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can execute arbitrary code via pickle",
+                src, sink
+            )
+        })
     }
 }
 
@@ -1922,21 +1921,17 @@ impl Rule for TaintEvalFromRequest {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can execute arbitrary Python code",
-                    src, sink
-                )
-            },
-        )
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can execute arbitrary Python code",
+                src, sink
+            )
+        })
     }
 }
 
@@ -1988,21 +1983,17 @@ impl Rule for TaintCommandInjectionFromRequest {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can inject OS commands",
-                    src, sink
-                )
-            },
-        )
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can inject OS commands",
+                src, sink
+            )
+        })
     }
 }
 
@@ -2055,21 +2046,17 @@ impl Rule for TaintSsrfFromRequest {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
-                    "{} reaches {} — untrusted input can drive server-side request forgery",
-                    src, sink
-                )
-            },
-        )
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can drive server-side request forgery",
+                src, sink
+            )
+        })
     }
 }
 
@@ -2117,21 +2104,17 @@ impl Rule for TaintYamlLoadFromRequest {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| {
-                format!(
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
                     "{} reaches {} — untrusted input can execute arbitrary code via YAML deserialization",
                     src, sink
                 )
-            },
-        )
+        })
     }
 }
 
@@ -2193,15 +2176,13 @@ impl Rule for TaintSqlInjectionFromRequest {
         tree: &tree_sitter::Tree,
         ctx: &FileContext<'_>,
     ) -> Vec<Finding> {
-        map_taint_findings(
-            self.id(),
-            self.severity(),
-            self.cwe(),
-            source,
-            tree,
-            ctx,
-            &Self::spec(),
-            |src, sink| format!("{} reaches {} — untrusted input can inject SQL", src, sink),
-        )
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!("{} reaches {} — untrusted input can inject SQL", src, sink)
+        })
     }
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -140,6 +140,15 @@ pub struct TaintFinding {
 /// last-write-wins, which is a known v1 limitation.
 pub type ReturnSummary = HashMap<String, Option<String>>;
 
+/// Bundles the read-only context that every internal walker needs,
+/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
+struct AnalysisContext<'a> {
+    source: &'a str,
+    spec: &'a TaintSpec,
+    aliases: Option<&'a ImportAliases>,
+    summaries: &'a ReturnSummary,
+}
+
 /// Run the taint engine over every function definition inside `root` and
 /// return one [`TaintFinding`] per source→sink flow discovered.
 ///
@@ -174,9 +183,14 @@ pub fn analyze_tree(
     // default behavior. This is the one-level interprocedural limit.
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
+    let pass1_ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &empty_summary,
+    };
     collect_function_defs(root, &mut |func_node| {
-        let (name, ret_taint) =
-            summarize_function(func_node, source, spec, aliases, &empty_summary);
+        let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
         if let Some(name) = name {
             // Last-write-wins on name collisions (v1 limitation).
             summaries.insert(name, ret_taint);
@@ -184,9 +198,15 @@ pub fn analyze_tree(
     });
 
     // Pass 2: full analysis with the summary map available.
+    let ctx = AnalysisContext {
+        source,
+        spec,
+        aliases,
+        summaries: &summaries,
+    };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
-        analyze_function(func_node, source, spec, aliases, &summaries, &mut findings);
+        analyze_function(func_node, &ctx, &mut findings);
     });
     findings
 }
@@ -197,18 +217,15 @@ pub fn analyze_tree(
 /// function bodies, which have their own summary).
 fn summarize_function(
     func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
-    summaries: &ReturnSummary,
+    ctx: &AnalysisContext<'_>,
 ) -> (Option<String>, Option<String>) {
     let name = func_node
         .child_by_field_name("name")
-        .map(|n| node_text(n, source).to_string());
+        .map(|n| node_text(n, ctx.source).to_string());
 
     let mut state = TaintState::default();
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
     let Some(body) = func_node.child_by_field_name("body") else {
         return (name, None);
@@ -218,28 +235,15 @@ fn summarize_function(
     // Reuse the normal walker but throw away sink findings — we only want
     // to update the taint state and inspect return statements.
     let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary(
-        body,
-        source,
-        spec,
-        aliases,
-        &mut state,
-        &mut scratch,
-        summaries,
-        &mut return_taint,
-    );
+    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
 }
 
-#[allow(clippy::too_many_arguments)]
 fn walk_body_for_summary(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
     return_taint: &mut Option<String>,
 ) {
     // Don't descend into nested function definitions — their own returns
@@ -249,16 +253,16 @@ fn walk_body_for_summary(
     }
 
     if node.kind() == "assignment" {
-        handle_assignment(node, source, spec, aliases, state, summaries);
+        handle_assignment(node, ctx, state);
     }
     if node.kind() == "call" {
-        handle_call(node, source, spec, aliases, state, findings, summaries);
+        handle_call(node, ctx, state, findings);
     }
     if node.kind() == "return_statement" && return_taint.is_none() {
         // The return's argument is the first named child, if any.
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(child, ctx, state) {
                 *return_taint = Some(desc);
                 break;
             }
@@ -267,16 +271,7 @@ fn walk_body_for_summary(
 
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body_for_summary(
-            child,
-            source,
-            spec,
-            aliases,
-            state,
-            findings,
-            summaries,
-            return_taint,
-        );
+        walk_body_for_summary(child, ctx, state, findings, return_taint);
     }
 }
 
@@ -318,17 +313,14 @@ impl TaintState {
 
 fn analyze_function(
     func_node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
-    summaries: &ReturnSummary,
+    ctx: &AnalysisContext<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
 
     // Seed the state with any parameters marked as implicit sources.
     if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, source, spec, &mut state);
+        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
     }
 
     // Walk the body in source order, updating taint state at assignments
@@ -336,7 +328,7 @@ fn analyze_function(
     let Some(body) = func_node.child_by_field_name("body") else {
         return;
     };
-    walk_body(body, source, spec, aliases, &mut state, findings, summaries);
+    walk_body(body, ctx, &mut state, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -375,12 +367,9 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     // Nested function definitions have their own scope. Skip them — they'll
     // be picked up independently by analyze_tree.
@@ -389,11 +378,11 @@ fn walk_body(
     }
 
     if node.kind() == "assignment" {
-        handle_assignment(node, source, spec, aliases, state, summaries);
+        handle_assignment(node, ctx, state);
     }
 
     if node.kind() == "call" {
-        handle_call(node, source, spec, aliases, state, findings, summaries);
+        handle_call(node, ctx, state, findings);
     }
 
     // Tree-sitter's cursor walks in document order, which is exactly the
@@ -401,18 +390,11 @@ fn walk_body(
     // semantics the POC wants.
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_body(child, source, spec, aliases, state, findings, summaries);
+        walk_body(child, ctx, state, findings);
     }
 }
 
-fn handle_assignment(
-    node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
-    state: &mut TaintState,
-    summaries: &ReturnSummary,
-) {
+fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
         node.child_by_field_name("right"),
@@ -422,8 +404,8 @@ fn handle_assignment(
 
     // Simple identifier LHS: the common case.
     if left.kind() == "identifier" {
-        let lhs_name = node_text(left, source).to_string();
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
+        let lhs_name = node_text(left, ctx.source).to_string();
+        if let Some(desc) = expression_taint(right, ctx, state) {
             state.taint(lhs_name, desc);
         } else {
             // Reassignment with a clean RHS kills any previous taint on LHS.
@@ -440,7 +422,7 @@ fn handle_assignment(
     // fall back to conservative semantics: if the RHS is tainted at all,
     // taint every LHS target (we lack type info to pick the slot).
     if is_destructuring_pattern(left) {
-        let lhs_targets = collect_destructuring_targets(left, source);
+        let lhs_targets = collect_destructuring_targets(left, ctx.source);
         if lhs_targets.is_empty() {
             return;
         }
@@ -448,9 +430,7 @@ fn handle_assignment(
         if let Some(rhs_elems) = tuple_like_elements(right) {
             if rhs_elems.len() == lhs_targets.len() {
                 for (target, rhs) in lhs_targets.iter().zip(rhs_elems.iter()) {
-                    if let Some(desc) =
-                        expression_taint(*rhs, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(*rhs, ctx, state) {
                         state.taint(target.clone(), desc);
                     } else {
                         state.clear(target);
@@ -461,7 +441,7 @@ fn handle_assignment(
         }
 
         // Arity mismatch or opaque RHS: apply conservative semantics.
-        if let Some(desc) = expression_taint(right, source, spec, aliases, state, summaries) {
+        if let Some(desc) = expression_taint(right, ctx, state) {
             for target in &lhs_targets {
                 state.taint(target.clone(), desc.clone());
             }
@@ -524,18 +504,15 @@ fn tuple_like_elements<'tree>(node: Node<'tree>) -> Option<Vec<Node<'tree>>> {
 
 fn handle_call(
     node: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
-    summaries: &ReturnSummary,
 ) {
     let Some(func) = node.child_by_field_name("function") else {
         return;
     };
-    let callee_text = node_text(func, source);
-    let resolved = match aliases {
+    let callee_text = node_text(func, ctx.source);
+    let resolved = match ctx.aliases {
         Some(a) => a.resolve(callee_text).into_owned(),
         None => callee_text.to_string(),
     };
@@ -546,7 +523,7 @@ fn handle_call(
     let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_str());
 
     // Is this a sink?
-    let sink_desc = spec.sinks.iter().find_map(|m| match m {
+    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
         NodeMatcher::Call {
             canonical,
             description,
@@ -567,7 +544,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+        if let Some(source_desc) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -591,20 +568,17 @@ fn handle_call(
 /// tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
-    source: &str,
-    spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    ctx: &AnalysisContext<'_>,
     state: &TaintState,
-    summaries: &ReturnSummary,
 ) -> Option<String> {
     // Direct source match on this expression.
-    if let Some(desc) = match_source(expr, source, spec, aliases) {
+    if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
         return Some(desc);
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
-        let name = node_text(expr, source);
+        let name = node_text(expr, ctx.source);
         if let Some(desc) = state.describe(name) {
             return Some(desc.to_string());
         }
@@ -614,7 +588,7 @@ fn expression_taint(
     if expr.kind() == "attribute" {
         if let Some(object) = expr.child_by_field_name("object") {
             if object.kind() == "identifier" {
-                let name = node_text(object, source);
+                let name = node_text(object, ctx.source);
                 if let Some(desc) = state.describe(name) {
                     return Some(desc.to_string());
                 }
@@ -630,7 +604,7 @@ fn expression_taint(
     // identifier roots via the recursive call.
     if expr.kind() == "subscript" {
         if let Some(value) = expr.child_by_field_name("value") {
-            if let Some(desc) = expression_taint(value, source, spec, aliases, state, summaries) {
+            if let Some(desc) = expression_taint(value, ctx, state) {
                 return Some(desc);
             }
         }
@@ -648,9 +622,7 @@ fn expression_taint(
             if child.kind() == "interpolation" {
                 let mut inner = child.walk();
                 for inner_child in child.named_children(&mut inner) {
-                    if let Some(desc) =
-                        expression_taint(inner_child, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(inner_child, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -666,18 +638,14 @@ fn expression_taint(
     // both recursive calls return None.
     if expr.kind() == "binary_operator" {
         if let Some(op) = expr.child_by_field_name("operator") {
-            if node_text(op, source) == "+" {
+            if node_text(op, ctx.source) == "+" {
                 if let Some(left) = expr.child_by_field_name("left") {
-                    if let Some(desc) =
-                        expression_taint(left, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(left, ctx, state) {
                         return Some(desc);
                     }
                 }
                 if let Some(right) = expr.child_by_field_name("right") {
-                    if let Some(desc) =
-                        expression_taint(right, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(right, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -693,13 +661,13 @@ fn expression_taint(
     // clean regardless of whether any argument was tainted. This is the
     // "collapse to clean" semantics documented at the top of the module.
     if expr.kind() == "call" {
-        if is_sanitizer_call(expr, source, spec, aliases) {
+        if is_sanitizer_call(expr, ctx.source, ctx.spec, ctx.aliases) {
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, source, spec, aliases, state, summaries) {
+                if let Some(desc) = expression_taint(arg, ctx, state) {
                     return Some(desc);
                 }
             }
@@ -715,9 +683,7 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "attribute" {
                 if let Some(object) = func.child_by_field_name("object") {
-                    if let Some(desc) =
-                        expression_taint(object, source, spec, aliases, state, summaries)
-                    {
+                    if let Some(desc) = expression_taint(object, ctx, state) {
                         return Some(desc);
                     }
                 }
@@ -733,8 +699,8 @@ fn expression_taint(
         // different semantics and are out of scope for v1.
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
-                let callee = node_text(func, source);
-                if let Some(Some(desc)) = summaries.get(callee) {
+                let callee = node_text(func, ctx.source);
+                if let Some(Some(desc)) = ctx.summaries.get(callee) {
                     return Some(format!("{desc} (via {callee})"));
                 }
             }


### PR DESCRIPTION
## Summary

- Introduce a module-private `AnalysisContext` struct in each of the three taint engines (`python_taint.rs`, `javascript_taint.rs`, `go_taint.rs`) that bundles the `(source, spec, aliases, summaries)` parameters passed through every internal walker function
- Add `TaintRuleMeta` / `GoTaintRuleMeta` structs in the caller modules (`python.rs`, `go.rs`) to bundle `(rule_id, severity, cwe)` and eliminate their `#[allow(clippy::too_many_arguments)]` annotations
- Remove all `#[allow(clippy::too_many_arguments)]` suppressions across the codebase (5 total)
- Net reduction of ~150 lines due to shorter function signatures and call sites

## Test plan

- [x] `cargo fmt` -- no formatting issues
- [x] `cargo clippy --all-targets -- -D warnings` -- passes with zero `too_many_arguments` allows
- [x] `cargo test` -- all tests pass, no behavior changes
- [x] Verified no remaining `too_many_arguments` annotations via grep

Refs #69

none