### PR TITLE
refactor: deduplicate import alias tables into shared AliasTable

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1,6 +1,6 @@
-use crate::rules::go_taint::GoImportAliases;
-use crate::rules::javascript_taint::JsImportAliases;
-use crate::rules::python_aliases::ImportAliases;
+use crate::rules::go_taint::go_aliases_from_tree;
+use crate::rules::javascript_taint::js_aliases_from_tree;
+use crate::rules::python_aliases::from_tree as py_aliases_from_tree;
 use crate::rules::{FileContext, RuleRegistry};
 use crate::{Finding, Language};
 use ignore::WalkBuilder;
@@ -312,17 +312,17 @@ fn scan_files(
         // rules can resolve aliased callees (`import pickle as p; p.loads(x)`)
         // back to their canonical dotted paths before sink matching.
         let python_aliases = if matches!(language, Language::Python) {
-            Some(ImportAliases::from_tree(&source, &tree))
+            Some(py_aliases_from_tree(&source, &tree))
         } else {
             None
         };
         let javascript_aliases = if matches!(language, Language::JavaScript) {
-            Some(JsImportAliases::from_tree(&source, &tree))
+            Some(js_aliases_from_tree(&source, &tree))
         } else {
             None
         };
         let go_aliases = if matches!(language, Language::Go) {
-            Some(GoImportAliases::from_tree(&source, &tree))
+            Some(go_aliases_from_tree(&source, &tree))
         } else {
             None
         };

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -1,4 +1,61 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
 use crate::{Finding, Severity};
+
+/// Shared per-file import alias table.
+///
+/// Maps a local identifier (as it appears in source) to its canonical
+/// dotted/qualified path. Each language populates the table with its own
+/// tree-walking logic, but the resolution algorithm is identical.
+#[derive(Debug, Default, Clone)]
+pub struct AliasTable {
+    pub(crate) map: HashMap<String, String>,
+}
+
+impl AliasTable {
+    /// Create a new empty alias table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert an alias mapping.
+    pub fn insert(&mut self, local: String, canonical: String) {
+        self.map.insert(local, canonical);
+    }
+
+    /// Insert only if the key is not already present.
+    pub fn entry_or_insert(&mut self, local: String, canonical: String) {
+        self.map.entry(local).or_insert(canonical);
+    }
+
+    /// Resolve a call-site callee text (as it appears in the source) back to
+    /// its canonical dotted path. Returns the input unchanged when no alias
+    /// matches. For example, with `import pickle as p`:
+    ///   `p.loads`        → `pickle.loads`
+    ///   `pickle.loads`   → `pickle.loads`
+    ///   `eval`           → `eval`
+    pub fn resolve<'a>(&'a self, callee: &'a str) -> Cow<'a, str> {
+        if let Some((head, tail)) = callee.split_once('.') {
+            if let Some(canonical_root) = self.map.get(head) {
+                if canonical_root == head {
+                    return Cow::Borrowed(callee);
+                }
+                return Cow::Owned(format!("{}.{}", canonical_root, tail));
+            }
+            return Cow::Borrowed(callee);
+        }
+        if let Some(canonical) = self.map.get(callee) {
+            return Cow::Borrowed(canonical.as_str());
+        }
+        Cow::Borrowed(callee)
+    }
+
+    #[cfg(test)]
+    pub fn get(&self, local: &str) -> Option<&str> {
+        self.map.get(local).map(String::as_str)
+    }
+}
 
 /// Extract the full source line containing the given byte offset.
 ///

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1,6 +1,8 @@
+use crate::rules::common::AliasTable;
 use crate::rules::common::{get_source_line, make_finding, make_finding_from_offsets, walk_tree};
 use crate::rules::go_taint::{
-    self, go_taint_sources, GoImportAliases, NodeMatcher as GoNodeMatcher, TaintSpec as GoTaintSpec,
+    self, go_aliases_from_tree, go_taint_sources, NodeMatcher as GoNodeMatcher,
+    TaintSpec as GoTaintSpec,
 };
 use crate::rules::{FileContext, Rule};
 use crate::{Finding, Language, Severity};
@@ -606,12 +608,12 @@ fn map_go_taint_findings(
     // If the scanner never built a per-file Go alias table (e.g.
     // rules are invoked without FileContext), fall back to building
     // one locally so the rule still works.
-    let local_aliases: Option<GoImportAliases> = if ctx.go_aliases.is_none() {
-        Some(GoImportAliases::from_tree(source, tree))
+    let local_aliases: Option<AliasTable> = if ctx.go_aliases.is_none() {
+        Some(go_aliases_from_tree(source, tree))
     } else {
         None
     };
-    let aliases: Option<&GoImportAliases> = ctx.go_aliases.or(local_aliases.as_ref());
+    let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
     let raw = go_taint::analyze_tree(tree.root_node(), source, spec, aliases);
     raw.into_iter()
         .map(|t| Finding {

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -34,6 +34,7 @@
 //! Everything specific to a library is expressed declaratively via
 //! `TaintSpec`.
 
+use super::common::AliasTable;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
@@ -125,7 +126,7 @@ pub type ReturnSummary = HashMap<String, Option<String>>;
 struct AnalysisContext<'a> {
     source: &'a str,
     spec: &'a TaintSpec,
-    aliases: Option<&'a GoImportAliases>,
+    aliases: Option<&'a AliasTable>,
     summaries: &'a ReturnSummary,
 }
 
@@ -139,7 +140,7 @@ pub fn analyze_tree(
     root: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Vec<TaintFinding> {
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
@@ -179,106 +180,75 @@ pub fn analyze_tree(
 ///
 /// Handles:
 ///
-/// - `import "fmt"`              → `fmt`  → `fmt`
-/// - `import f "fmt"`            → `f`    → `fmt`
-/// - `import "net/http"`         → `http` → `http`
-/// - `import net "net/http"`     → `net`  → `http`
+/// - `import "fmt"`              -> `fmt`  -> `fmt`
+/// - `import f "fmt"`            -> `f`    -> `fmt`
+/// - `import "net/http"`         -> `http` -> `http`
+/// - `import net "net/http"`     -> `net`  -> `http`
 /// - Grouped imports inside `import ( ... )` blocks.
 ///
 /// Out of scope for v1 (documented):
 ///
-/// - `import . "fmt"`  — dot imports make names unqualified, rare.
-/// - `import _ "foo"`  — side-effect imports introduce no names.
+/// - `import . "fmt"`  -- dot imports make names unqualified, rare.
+/// - `import _ "foo"`  -- side-effect imports introduce no names.
 ///
 /// File-scope only; function-local rebindings are not tracked.
-#[derive(Debug, Default, Clone)]
-pub struct GoImportAliases {
-    /// Local alias → canonical short package name (e.g. `net` → `http`).
-    map: HashMap<String, String>,
+pub fn go_aliases_from_tree(source: &str, tree: &Tree) -> AliasTable {
+    let mut aliases = AliasTable::new();
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    for child in root.children(&mut cursor) {
+        if child.kind() == "import_declaration" {
+            go_collect_import_decl(&mut aliases, child, source);
+        }
+    }
+    aliases
 }
 
-impl GoImportAliases {
-    pub fn from_tree(source: &str, tree: &Tree) -> Self {
-        let mut aliases = Self::default();
-        let root = tree.root_node();
-        let mut cursor = root.walk();
-        for child in root.children(&mut cursor) {
-            if child.kind() == "import_declaration" {
-                aliases.collect_import_decl(child, source);
-            }
-        }
-        aliases
-    }
-
-    fn collect_import_decl(&mut self, node: Node<'_>, source: &str) {
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            match child.kind() {
-                "import_spec" => self.collect_import_spec(child, source),
-                "import_spec_list" => {
-                    let mut inner = child.walk();
-                    for spec in child.children(&mut inner) {
-                        if spec.kind() == "import_spec" {
-                            self.collect_import_spec(spec, source);
-                        }
+fn go_collect_import_decl(aliases: &mut AliasTable, node: Node<'_>, source: &str) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "import_spec" => go_collect_import_spec(aliases, child, source),
+            "import_spec_list" => {
+                let mut inner = child.walk();
+                for spec in child.children(&mut inner) {
+                    if spec.kind() == "import_spec" {
+                        go_collect_import_spec(aliases, spec, source);
                     }
                 }
-                _ => {}
             }
+            _ => {}
         }
     }
+}
 
-    fn collect_import_spec(&mut self, node: Node<'_>, source: &str) {
-        let Some(path_node) = node.child_by_field_name("path") else {
-            return;
-        };
-        let raw = node_text(path_node, source);
-        let path = raw.trim_matches(|c: char| c == '"' || c == '`');
-        if path.is_empty() {
-            return;
-        }
-        // Canonical: last segment of the import path, e.g. `net/http` → `http`.
-        let canonical = path.rsplit('/').next().unwrap_or(path).to_string();
-
-        let name_node = node.child_by_field_name("name");
-        match name_node.map(|n| n.kind()) {
-            // `import . "fmt"` — out of scope; record nothing.
-            Some("dot") => {}
-            // `import _ "foo"` — out of scope; record nothing.
-            Some("blank_identifier") => {}
-            // `import f "fmt"` — local alias `f` → canonical `fmt`.
-            Some("package_identifier") => {
-                let local = node_text(name_node.unwrap(), source).to_string();
-                self.map.insert(local, canonical);
-            }
-            // Plain `import "fmt"` — the local name is the canonical.
-            _ => {
-                self.map.insert(canonical.clone(), canonical);
-            }
-        }
+fn go_collect_import_spec(aliases: &mut AliasTable, node: Node<'_>, source: &str) {
+    let Some(path_node) = node.child_by_field_name("path") else {
+        return;
+    };
+    let raw = node_text(path_node, source);
+    let path = raw.trim_matches(|c: char| c == '"' || c == '`');
+    if path.is_empty() {
+        return;
     }
+    // Canonical: last segment of the import path, e.g. `net/http` -> `http`.
+    let canonical = path.rsplit('/').next().unwrap_or(path).to_string();
 
-    /// Resolve a call-site callee text back to its canonical dotted
-    /// path. `f.Println` → `fmt.Println` when `f` is aliased to `fmt`.
-    pub fn resolve<'a>(&'a self, callee: &'a str) -> Cow<'a, str> {
-        if let Some((head, tail)) = callee.split_once('.') {
-            if let Some(canonical_root) = self.map.get(head) {
-                if canonical_root == head {
-                    return Cow::Borrowed(callee);
-                }
-                return Cow::Owned(format!("{}.{}", canonical_root, tail));
-            }
-            return Cow::Borrowed(callee);
+    let name_node = node.child_by_field_name("name");
+    match name_node.map(|n| n.kind()) {
+        // `import . "fmt"` -- out of scope; record nothing.
+        Some("dot") => {}
+        // `import _ "foo"` -- out of scope; record nothing.
+        Some("blank_identifier") => {}
+        // `import f "fmt"` -- local alias `f` -> canonical `fmt`.
+        Some("package_identifier") => {
+            let local = node_text(name_node.unwrap(), source).to_string();
+            aliases.insert(local, canonical);
         }
-        if let Some(canonical) = self.map.get(callee) {
-            return Cow::Borrowed(canonical.as_str());
+        // Plain `import "fmt"` -- the local name is the canonical.
+        _ => {
+            aliases.insert(canonical.clone(), canonical);
         }
-        Cow::Borrowed(callee)
-    }
-
-    #[cfg(test)]
-    pub fn get(&self, local: &str) -> Option<&str> {
-        self.map.get(local).map(String::as_str)
     }
 }
 
@@ -857,7 +827,7 @@ fn is_sanitizer_call(
     call_node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> bool {
     if call_node.kind() != "call_expression" {
         return false;
@@ -884,7 +854,7 @@ fn match_source(
     node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&GoImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Option<String> {
     for matcher in &spec.sources {
         match matcher {
@@ -1104,7 +1074,7 @@ mod tests {
 
     fn run_with(source: &str, spec: &TaintSpec) -> Vec<TaintFinding> {
         let tree = parse_file(source, Language::Go).expect("parse");
-        let aliases = GoImportAliases::from_tree(source, &tree);
+        let aliases = go_aliases_from_tree(source, &tree);
         analyze_tree(tree.root_node(), source, spec, Some(&aliases))
     }
 
@@ -1463,7 +1433,7 @@ import (
 )
 "#;
         let tree = parse_file(src, Language::Go).expect("parse");
-        let a = GoImportAliases::from_tree(src, &tree);
+        let a = go_aliases_from_tree(src, &tree);
         assert_eq!(a.get("f"), Some("fmt"));
         assert_eq!(a.get("http"), Some("http"));
         assert_eq!(a.get("alias"), Some("deep"));

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -24,6 +24,7 @@
 //!
 //! Everything specific to a library is expressed declaratively via `TaintSpec`.
 
+use super::common::AliasTable;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use tree_sitter::{Node, Tree};
@@ -119,7 +120,7 @@ pub type ReturnSummary = HashMap<String, Option<String>>;
 struct AnalysisContext<'a> {
     source: &'a str,
     spec: &'a TaintSpec,
-    aliases: Option<&'a JsImportAliases>,
+    aliases: Option<&'a AliasTable>,
     summaries: &'a ReturnSummary,
 }
 
@@ -135,7 +136,7 @@ pub fn analyze_tree(
     root: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Vec<TaintFinding> {
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
@@ -292,157 +293,98 @@ fn walk_body_for_summary(
 
 /// Per-file JavaScript/TypeScript import alias table.
 ///
+/// Build a JavaScript/TypeScript import alias table from a parsed tree.
+///
 /// Maps a local identifier (as it appears in the source) to its canonical
 /// dotted path. Handles the common forms:
 ///
-/// - `import { loads } from "pickle"`      → `loads` → `pickle.loads`
-/// - `import { loads as d } from "pickle"` → `d`     → `pickle.loads`
-/// - `import foo from "bar"`               → `foo`   → `bar` (default)
-/// - `import * as ns from "mod"`           → `ns`    → `mod`
-/// - `const pk = require("pickle")`        → `pk`    → `pickle`
-/// - `const { loads } = require("pickle")` → `loads` → `pickle.loads`
-/// - `const { loads: l2 } = require("pickle")` → `l2` → `pickle.loads`
+/// - `import { loads } from "pickle"`      -> `loads` -> `pickle.loads`
+/// - `import { loads as d } from "pickle"` -> `d`     -> `pickle.loads`
+/// - `import foo from "bar"`               -> `foo`   -> `bar` (default)
+/// - `import * as ns from "mod"`           -> `ns`    -> `mod`
+/// - `const pk = require("pickle")`        -> `pk`    -> `pickle`
+/// - `const { loads } = require("pickle")` -> `loads` -> `pickle.loads`
+/// - `const { loads: l2 } = require("pickle")` -> `l2` -> `pickle.loads`
 ///
 /// File-scope only; function-local rebindings are not tracked. Dynamic
 /// forms (`import("mod")`) are out of scope.
-#[derive(Debug, Default, Clone)]
-pub struct JsImportAliases {
-    map: HashMap<String, String>,
+pub fn js_aliases_from_tree(source: &str, tree: &Tree) -> AliasTable {
+    let mut aliases = AliasTable::new();
+    js_walk_for_imports(&mut aliases, tree.root_node(), source);
+    aliases
 }
 
-impl JsImportAliases {
-    pub fn from_tree(source: &str, tree: &Tree) -> Self {
-        let mut aliases = Self::default();
-        aliases.walk_for_imports(tree.root_node(), source);
-        aliases
-    }
-
-    fn walk_for_imports(&mut self, node: Node<'_>, source: &str) {
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            match child.kind() {
-                "import_statement" => self.collect_import(child, source),
-                "lexical_declaration" | "variable_declaration" => {
-                    self.collect_require_decl(child, source);
-                }
-                // Recurse into top-level blocks/conditionals but stop at
-                // function bodies — alias resolution there is out of scope.
-                "program" | "statement_block" | "if_statement" | "try_statement"
-                | "labeled_statement" | "export_statement" => {
-                    self.walk_for_imports(child, source);
-                }
-                _ => {}
+fn js_walk_for_imports(aliases: &mut AliasTable, node: Node<'_>, source: &str) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "import_statement" => js_collect_import(aliases, child, source),
+            "lexical_declaration" | "variable_declaration" => {
+                js_collect_require_decl(aliases, child, source);
             }
+            // Recurse into top-level blocks/conditionals but stop at
+            // function bodies — alias resolution there is out of scope.
+            "program" | "statement_block" | "if_statement" | "try_statement"
+            | "labeled_statement" | "export_statement" => {
+                js_walk_for_imports(aliases, child, source);
+            }
+            _ => {}
         }
     }
+}
 
-    fn collect_import(&mut self, node: Node<'_>, source: &str) {
-        // import_statement has a `source` field holding a `string` with an
-        // inner `string_fragment` that carries the module specifier.
-        let Some(src_node) = node.child_by_field_name("source") else {
-            return;
-        };
-        let module = string_literal_text(src_node, source);
-        if module.is_empty() {
-            return;
-        }
-
-        // The import clause is the unnamed child between `import` and `from`.
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() != "import_clause" {
-                continue;
-            }
-            let mut inner = child.walk();
-            for spec in child.children(&mut inner) {
-                match spec.kind() {
-                    // `import foo from "bar"` — default import.
-                    "identifier" => {
-                        let local = node_text(spec, source).to_string();
-                        self.map.insert(local, module.clone());
-                    }
-                    // `import * as ns from "mod"` — namespace import.
-                    "namespace_import" => {
-                        let mut ns_cursor = spec.walk();
-                        for c in spec.children(&mut ns_cursor) {
-                            if c.kind() == "identifier" {
-                                let local = node_text(c, source).to_string();
-                                self.map.insert(local, module.clone());
-                            }
-                        }
-                    }
-                    // `import { a, b as c } from "mod"` — named imports.
-                    "named_imports" => {
-                        let mut n_cursor = spec.walk();
-                        for isp in spec.children(&mut n_cursor) {
-                            if isp.kind() != "import_specifier" {
-                                continue;
-                            }
-                            let name = isp
-                                .child_by_field_name("name")
-                                .map(|n| node_text(n, source).to_string());
-                            let alias = isp
-                                .child_by_field_name("alias")
-                                .map(|n| node_text(n, source).to_string());
-                            if let Some(real) = name {
-                                let canonical = format!("{}.{}", module, real);
-                                let local = alias.unwrap_or(real);
-                                self.map.insert(local, canonical);
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
+fn js_collect_import(aliases: &mut AliasTable, node: Node<'_>, source: &str) {
+    // import_statement has a `source` field holding a `string` with an
+    // inner `string_fragment` that carries the module specifier.
+    let Some(src_node) = node.child_by_field_name("source") else {
+        return;
+    };
+    let module = string_literal_text(src_node, source);
+    if module.is_empty() {
+        return;
     }
 
-    fn collect_require_decl(&mut self, node: Node<'_>, source: &str) {
-        // Walk each variable_declarator under the decl.
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            if child.kind() != "variable_declarator" {
-                continue;
-            }
-            let Some(value) = child.child_by_field_name("value") else {
-                continue;
-            };
-            // Match `require("mod")` on the RHS.
-            let Some(module) = require_call_module(value, source) else {
-                continue;
-            };
-            let Some(name_node) = child.child_by_field_name("name") else {
-                continue;
-            };
-            match name_node.kind() {
+    // The import clause is the unnamed child between `import` and `from`.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() != "import_clause" {
+            continue;
+        }
+        let mut inner = child.walk();
+        for spec in child.children(&mut inner) {
+            match spec.kind() {
+                // `import foo from "bar"` — default import.
                 "identifier" => {
-                    // `const pk = require("pickle")` → pk → pickle
-                    let local = node_text(name_node, source).to_string();
-                    self.map.insert(local, module);
+                    let local = node_text(spec, source).to_string();
+                    aliases.insert(local, module.clone());
                 }
-                "object_pattern" => {
-                    // `const { loads, dumps: d } = require("pickle")`
-                    let mut p_cursor = name_node.walk();
-                    for p in name_node.children(&mut p_cursor) {
-                        match p.kind() {
-                            "shorthand_property_identifier_pattern" => {
-                                let local = node_text(p, source).to_string();
-                                let canonical = format!("{}.{}", module, local);
-                                self.map.insert(local, canonical);
-                            }
-                            "pair_pattern" => {
-                                let key = p
-                                    .child_by_field_name("key")
-                                    .map(|n| node_text(n, source).to_string());
-                                let value = p
-                                    .child_by_field_name("value")
-                                    .map(|n| node_text(n, source).to_string());
-                                if let (Some(key), Some(value)) = (key, value) {
-                                    let canonical = format!("{}.{}", module, key);
-                                    self.map.insert(value, canonical);
-                                }
-                            }
-                            _ => {}
+                // `import * as ns from "mod"` — namespace import.
+                "namespace_import" => {
+                    let mut ns_cursor = spec.walk();
+                    for c in spec.children(&mut ns_cursor) {
+                        if c.kind() == "identifier" {
+                            let local = node_text(c, source).to_string();
+                            aliases.insert(local, module.clone());
+                        }
+                    }
+                }
+                // `import { a, b as c } from "mod"` — named imports.
+                "named_imports" => {
+                    let mut n_cursor = spec.walk();
+                    for isp in spec.children(&mut n_cursor) {
+                        if isp.kind() != "import_specifier" {
+                            continue;
+                        }
+                        let name = isp
+                            .child_by_field_name("name")
+                            .map(|n| node_text(n, source).to_string());
+                        let alias = isp
+                            .child_by_field_name("alias")
+                            .map(|n| node_text(n, source).to_string());
+                        if let Some(real) = name {
+                            let canonical = format!("{}.{}", module, real);
+                            let local = alias.unwrap_or(real);
+                            aliases.insert(local, canonical);
                         }
                     }
                 }
@@ -450,28 +392,59 @@ impl JsImportAliases {
             }
         }
     }
+}
 
-    /// Resolve a call-site callee text back to its canonical dotted path.
-    /// `p.loads` → `pickle.loads` when `p` is aliased to `pickle`.
-    pub fn resolve<'a>(&'a self, callee: &'a str) -> Cow<'a, str> {
-        if let Some((head, tail)) = callee.split_once('.') {
-            if let Some(canonical_root) = self.map.get(head) {
-                if canonical_root == head {
-                    return Cow::Borrowed(callee);
-                }
-                return Cow::Owned(format!("{}.{}", canonical_root, tail));
+fn js_collect_require_decl(aliases: &mut AliasTable, node: Node<'_>, source: &str) {
+    // Walk each variable_declarator under the decl.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() != "variable_declarator" {
+            continue;
+        }
+        let Some(value) = child.child_by_field_name("value") else {
+            continue;
+        };
+        // Match `require("mod")` on the RHS.
+        let Some(module) = require_call_module(value, source) else {
+            continue;
+        };
+        let Some(name_node) = child.child_by_field_name("name") else {
+            continue;
+        };
+        match name_node.kind() {
+            "identifier" => {
+                // `const pk = require("pickle")` -> pk -> pickle
+                let local = node_text(name_node, source).to_string();
+                aliases.insert(local, module);
             }
-            return Cow::Borrowed(callee);
+            "object_pattern" => {
+                // `const { loads, dumps: d } = require("pickle")`
+                let mut p_cursor = name_node.walk();
+                for p in name_node.children(&mut p_cursor) {
+                    match p.kind() {
+                        "shorthand_property_identifier_pattern" => {
+                            let local = node_text(p, source).to_string();
+                            let canonical = format!("{}.{}", module, local);
+                            aliases.insert(local, canonical);
+                        }
+                        "pair_pattern" => {
+                            let key = p
+                                .child_by_field_name("key")
+                                .map(|n| node_text(n, source).to_string());
+                            let value = p
+                                .child_by_field_name("value")
+                                .map(|n| node_text(n, source).to_string());
+                            if let (Some(key), Some(value)) = (key, value) {
+                                let canonical = format!("{}.{}", module, key);
+                                aliases.insert(value, canonical);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
         }
-        if let Some(canonical) = self.map.get(callee) {
-            return Cow::Borrowed(canonical.as_str());
-        }
-        Cow::Borrowed(callee)
-    }
-
-    #[cfg(test)]
-    pub fn get(&self, local: &str) -> Option<&str> {
-        self.map.get(local).map(String::as_str)
     }
 }
 
@@ -981,7 +954,7 @@ fn is_sanitizer_call(
     call_node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> bool {
     if call_node.kind() != "call_expression" {
         return false;
@@ -1008,7 +981,7 @@ fn match_source(
     node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&JsImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Option<String> {
     for matcher in &spec.sources {
         match matcher {
@@ -1294,7 +1267,7 @@ mod tests {
 
     fn run(source: &str) -> Vec<TaintFinding> {
         let tree = parse_file(source, Language::JavaScript).expect("parse");
-        let aliases = JsImportAliases::from_tree(source, &tree);
+        let aliases = js_aliases_from_tree(source, &tree);
         analyze_tree(
             tree.root_node(),
             source,
@@ -1451,7 +1424,7 @@ function handler(req) {
             sanitizers: vec![],
         };
         let tree = parse_file(src, Language::JavaScript).expect("parse");
-        let aliases = JsImportAliases::from_tree(src, &tree);
+        let aliases = js_aliases_from_tree(src, &tree);
         let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
         assert_eq!(findings.len(), 1);
     }
@@ -1473,7 +1446,7 @@ function handler(req) {
             sanitizers: vec![],
         };
         let tree = parse_file(src, Language::JavaScript).expect("parse");
-        let aliases = JsImportAliases::from_tree(src, &tree);
+        let aliases = js_aliases_from_tree(src, &tree);
         let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
         assert_eq!(findings.len(), 1);
     }
@@ -1482,7 +1455,7 @@ function handler(req) {
     fn require_default_binding_resolves() {
         let src = r#"const pk = require("pickle");"#;
         let tree = parse_file(src, Language::JavaScript).expect("parse");
-        let a = JsImportAliases::from_tree(src, &tree);
+        let a = js_aliases_from_tree(src, &tree);
         assert_eq!(a.get("pk"), Some("pickle"));
         assert_eq!(a.resolve("pk.loads"), "pickle.loads");
     }
@@ -1491,7 +1464,7 @@ function handler(req) {
     fn named_import_with_alias_resolves() {
         let src = r#"import { loads as l2 } from "pickle";"#;
         let tree = parse_file(src, Language::JavaScript).expect("parse");
-        let a = JsImportAliases::from_tree(src, &tree);
+        let a = js_aliases_from_tree(src, &tree);
         assert_eq!(a.get("l2"), Some("pickle.loads"));
     }
 
@@ -1672,7 +1645,7 @@ function handler(req) {
 }
 "#;
         let tree = parse_file(src, Language::JavaScript).expect("parse");
-        let aliases = JsImportAliases::from_tree(src, &tree);
+        let aliases = js_aliases_from_tree(src, &tree);
         assert_eq!(
             analyze_tree(tree.root_node(), src, &spec, Some(&aliases)).len(),
             0

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -26,11 +26,11 @@ use std::path::Path;
 #[derive(Default)]
 pub struct FileContext<'a> {
     /// Python import alias table. `None` for non-Python files.
-    pub python_aliases: Option<&'a python_aliases::ImportAliases>,
+    pub python_aliases: Option<&'a common::AliasTable>,
     /// JavaScript/TypeScript import alias table. `None` for non-JS files.
-    pub javascript_aliases: Option<&'a javascript_taint::JsImportAliases>,
+    pub javascript_aliases: Option<&'a common::AliasTable>,
     /// Go import alias table. `None` for non-Go files.
-    pub go_aliases: Option<&'a go_taint::GoImportAliases>,
+    pub go_aliases: Option<&'a common::AliasTable>,
 }
 
 /// A security rule that checks parsed source code for vulnerabilities.

--- a/src/rules/python_aliases.rs
+++ b/src/rules/python_aliases.rs
@@ -1,8 +1,7 @@
-use std::borrow::Cow;
-use std::collections::HashMap;
+use super::common::AliasTable;
 use tree_sitter::{Node, Tree};
 
-/// Per-file Python import alias table.
+/// Build a Python import alias table from a parsed tree.
 ///
 /// Maps a local identifier (as it appears in the source) to its canonical
 /// dotted path. For example `import pickle as p` produces `p -> pickle`,
@@ -16,134 +15,100 @@ use tree_sitter::{Node, Tree};
 /// `pickle = something_else` inside one function are not tracked. Dynamic
 /// forms such as `importlib.import_module(...)` are also out of scope and
 /// tracked separately under the dataflow roadmap.
-#[derive(Debug, Default, Clone)]
-pub struct ImportAliases {
-    map: HashMap<String, String>,
+pub fn from_tree(source: &str, tree: &Tree) -> AliasTable {
+    let mut aliases = AliasTable::new();
+    walk_for_imports(&mut aliases, tree.root_node(), source);
+    aliases
 }
 
-impl ImportAliases {
-    pub fn from_tree(source: &str, tree: &Tree) -> Self {
-        let mut aliases = Self::default();
-        aliases.walk_for_imports(tree.root_node(), source);
-        aliases
-    }
-
-    fn walk_for_imports(&mut self, node: Node, source: &str) {
-        let mut cursor = node.walk();
-        for child in node.children(&mut cursor) {
-            match child.kind() {
-                "import_statement" => self.collect_import(child, source),
-                "import_from_statement" => self.collect_import_from(child, source),
-                // Recurse into top-level blocks so `if sys.version_info: import foo`
-                // at the module level still contributes. Stop at function and class
-                // bodies — alias resolution there is explicitly out of scope.
-                "if_statement" | "try_statement" | "with_statement" | "block" | "module" => {
-                    self.walk_for_imports(child, source);
-                }
-                _ => {}
+fn walk_for_imports(aliases: &mut AliasTable, node: Node, source: &str) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "import_statement" => collect_import(aliases, child, source),
+            "import_from_statement" => collect_import_from(aliases, child, source),
+            // Recurse into top-level blocks so `if sys.version_info: import foo`
+            // at the module level still contributes. Stop at function and class
+            // bodies — alias resolution there is explicitly out of scope.
+            "if_statement" | "try_statement" | "with_statement" | "block" | "module" => {
+                walk_for_imports(aliases, child, source);
             }
+            _ => {}
         }
     }
+}
 
-    fn collect_import(&mut self, node: Node, source: &str) {
-        // `import X`, `import X as Y`, `import X.Y`, `import X.Y as Z`
-        let mut cursor = node.walk();
-        for name in node.children_by_field_name("name", &mut cursor) {
-            match name.kind() {
-                "dotted_name" => {
-                    // `import urllib.request` makes the *first* identifier
-                    // (`urllib`) the accessible local name, and the full dotted
-                    // path (`urllib.request`) is what the source will write for
-                    // callees. Record both so either form resolves correctly.
-                    let full = node_text(name, source).to_string();
-                    if let Some(first) = name.child(0) {
-                        let root = node_text(first, source).to_string();
-                        self.map.entry(root.clone()).or_insert(root);
-                    }
-                    self.map.entry(full.clone()).or_insert(full);
+fn collect_import(aliases: &mut AliasTable, node: Node, source: &str) {
+    // `import X`, `import X as Y`, `import X.Y`, `import X.Y as Z`
+    let mut cursor = node.walk();
+    for name in node.children_by_field_name("name", &mut cursor) {
+        match name.kind() {
+            "dotted_name" => {
+                // `import urllib.request` makes the *first* identifier
+                // (`urllib`) the accessible local name, and the full dotted
+                // path (`urllib.request`) is what the source will write for
+                // callees. Record both so either form resolves correctly.
+                let full = node_text(name, source).to_string();
+                if let Some(first) = name.child(0) {
+                    let root = node_text(first, source).to_string();
+                    aliases.entry_or_insert(root.clone(), root);
                 }
-                "aliased_import" => {
-                    // `import X.Y as Z`  →  local `Z` → canonical `X.Y`
-                    let canonical = name
-                        .child_by_field_name("name")
-                        .map(|n| node_text(n, source).to_string());
-                    let alias = name
-                        .child_by_field_name("alias")
-                        .map(|n| node_text(n, source).to_string());
-                    if let (Some(canonical), Some(alias)) = (canonical, alias) {
-                        self.map.insert(alias, canonical);
-                    }
-                }
-                _ => {}
+                aliases.entry_or_insert(full.clone(), full);
             }
-        }
-    }
-
-    fn collect_import_from(&mut self, node: Node, source: &str) {
-        // `from MODULE import NAME [as ALIAS], ...`
-        let Some(module_node) = node.child_by_field_name("module_name") else {
-            return;
-        };
-        let module = node_text(module_node, source).to_string();
-        if module.is_empty() {
-            return;
-        }
-
-        let mut cursor = node.walk();
-        for name in node.children_by_field_name("name", &mut cursor) {
-            match name.kind() {
-                "dotted_name" | "identifier" => {
-                    // `from pickle import loads`  →  `loads` → `pickle.loads`
-                    let local = node_text(name, source).to_string();
-                    if local.is_empty() {
-                        continue;
-                    }
-                    let canonical = format!("{}.{}", module, local);
-                    self.map.insert(local, canonical);
+            "aliased_import" => {
+                // `import X.Y as Z`  →  local `Z` → canonical `X.Y`
+                let canonical = name
+                    .child_by_field_name("name")
+                    .map(|n| node_text(n, source).to_string());
+                let alias = name
+                    .child_by_field_name("alias")
+                    .map(|n| node_text(n, source).to_string());
+                if let (Some(canonical), Some(alias)) = (canonical, alias) {
+                    aliases.insert(alias, canonical);
                 }
-                "aliased_import" => {
-                    // `from pickle import loads as d`  →  `d` → `pickle.loads`
-                    let real = name
-                        .child_by_field_name("name")
-                        .map(|n| node_text(n, source).to_string());
-                    let alias = name
-                        .child_by_field_name("alias")
-                        .map(|n| node_text(n, source).to_string());
-                    if let (Some(real), Some(alias)) = (real, alias) {
-                        let canonical = format!("{}.{}", module, real);
-                        self.map.insert(alias, canonical);
-                    }
-                }
-                _ => {}
             }
+            _ => {}
         }
     }
+}
 
-    /// Resolve a call-site callee text (as it appears in the source) back to
-    /// its canonical dotted path. Returns the input unchanged when no alias
-    /// matches. For example, with `import pickle as p`:
-    ///   `p.loads`        → `pickle.loads`
-    ///   `pickle.loads`   → `pickle.loads`
-    ///   `eval`           → `eval`
-    pub fn resolve<'a>(&'a self, callee: &'a str) -> Cow<'a, str> {
-        if let Some((head, tail)) = callee.split_once('.') {
-            if let Some(canonical_root) = self.map.get(head) {
-                if canonical_root == head {
-                    return Cow::Borrowed(callee);
+fn collect_import_from(aliases: &mut AliasTable, node: Node, source: &str) {
+    // `from MODULE import NAME [as ALIAS], ...`
+    let Some(module_node) = node.child_by_field_name("module_name") else {
+        return;
+    };
+    let module = node_text(module_node, source).to_string();
+    if module.is_empty() {
+        return;
+    }
+
+    let mut cursor = node.walk();
+    for name in node.children_by_field_name("name", &mut cursor) {
+        match name.kind() {
+            "dotted_name" | "identifier" => {
+                // `from pickle import loads`  →  `loads` → `pickle.loads`
+                let local = node_text(name, source).to_string();
+                if local.is_empty() {
+                    continue;
                 }
-                return Cow::Owned(format!("{}.{}", canonical_root, tail));
+                let canonical = format!("{}.{}", module, local);
+                aliases.insert(local, canonical);
             }
-            return Cow::Borrowed(callee);
+            "aliased_import" => {
+                // `from pickle import loads as d`  →  `d` → `pickle.loads`
+                let real = name
+                    .child_by_field_name("name")
+                    .map(|n| node_text(n, source).to_string());
+                let alias = name
+                    .child_by_field_name("alias")
+                    .map(|n| node_text(n, source).to_string());
+                if let (Some(real), Some(alias)) = (real, alias) {
+                    let canonical = format!("{}.{}", module, real);
+                    aliases.insert(alias, canonical);
+                }
+            }
+            _ => {}
         }
-        if let Some(canonical) = self.map.get(callee) {
-            return Cow::Borrowed(canonical.as_str());
-        }
-        Cow::Borrowed(callee)
-    }
-
-    #[cfg(test)]
-    pub fn get(&self, local: &str) -> Option<&str> {
-        self.map.get(local).map(String::as_str)
     }
 }
 
@@ -157,9 +122,9 @@ mod tests {
     use crate::engine::parser::parse_file;
     use crate::Language;
 
-    fn build(source: &str) -> ImportAliases {
+    fn build(source: &str) -> AliasTable {
         let tree = parse_file(source, Language::Python).expect("parse");
-        ImportAliases::from_tree(source, &tree)
+        from_tree(source, &tree)
     }
 
     #[test]

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -30,7 +30,7 @@
 //! built-in rule as the first consumer; future rules (including
 //! Semgrep-compatible `mode: taint` YAML) will plug into the same API.
 
-use crate::rules::python_aliases::ImportAliases;
+use crate::rules::common::AliasTable;
 use std::collections::HashMap;
 use tree_sitter::Node;
 
@@ -145,7 +145,7 @@ pub type ReturnSummary = HashMap<String, Option<String>>;
 struct AnalysisContext<'a> {
     source: &'a str,
     spec: &'a TaintSpec,
-    aliases: Option<&'a ImportAliases>,
+    aliases: Option<&'a AliasTable>,
     summaries: &'a ReturnSummary,
 }
 
@@ -176,7 +176,7 @@ pub fn analyze_tree(
     root: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Vec<TaintFinding> {
     // Pass 1: build return summaries using an empty summary map so that
     // calls to local helpers inside helper bodies fall through to the
@@ -717,7 +717,7 @@ fn is_sanitizer_call(
     call_node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> bool {
     if call_node.kind() != "call" {
         return false;
@@ -744,7 +744,7 @@ fn match_source(
     node: Node<'_>,
     source: &str,
     spec: &TaintSpec,
-    aliases: Option<&ImportAliases>,
+    aliases: Option<&AliasTable>,
 ) -> Option<String> {
     for matcher in &spec.sources {
         match matcher {
@@ -1015,6 +1015,7 @@ fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
 mod tests {
     use super::*;
     use crate::engine::parser::parse_file;
+    use crate::rules::python_aliases::from_tree as py_aliases_from_tree;
     use crate::Language;
 
     fn spec_pickle_from_request() -> TaintSpec {
@@ -1060,7 +1061,7 @@ mod tests {
 
     fn run(source: &str) -> Vec<TaintFinding> {
         let tree = parse_file(source, Language::Python).expect("parse");
-        let aliases = ImportAliases::from_tree(source, &tree);
+        let aliases = py_aliases_from_tree(source, &tree);
         analyze_tree(
             tree.root_node(),
             source,
@@ -1233,7 +1234,7 @@ def handler():
 
     fn run_with(source: &str, spec: &TaintSpec) -> Vec<TaintFinding> {
         let tree = parse_file(source, Language::Python).expect("parse");
-        let aliases = ImportAliases::from_tree(source, &tree);
+        let aliases = py_aliases_from_tree(source, &tree);
         analyze_tree(tree.root_node(), source, spec, Some(&aliases))
     }
 


### PR DESCRIPTION
## Summary

- Extracted a shared `AliasTable` type into `src/rules/common.rs` with the `resolve()` method that was previously copy-pasted across three separate structs (`ImportAliases`, `JsImportAliases`, `GoImportAliases`)
- Converted each language's tree-walking constructor into free functions (`python_aliases::from_tree`, `js_aliases_from_tree`, `go_aliases_from_tree`) that all produce the shared `AliasTable` type
- Updated `FileContext` in `src/rules/mod.rs` and all callers in `scanner.rs`, `go.rs`, `python_taint.rs` to use the unified type

Closes #67

## Test plan

- [x] `cargo fmt` -- no formatting issues
- [x] `cargo clippy --all-targets -- -D warnings` -- zero warnings
- [x] `cargo test` -- all 236 tests pass (134 unit + 68 integration + 12 semgrep + 6 parity + others)
- [x] No changes to tree-walking logic or public `analyze_tree` signatures

none