### PR TITLE
feat: add --explain flag for source-to-sink dataflow traces

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ pub struct ScanArgs {
     /// Write the current findings to a baseline file
     #[arg(long)]
     pub write_baseline: Option<String>,
+
+    /// Show source-to-sink dataflow traces on taint findings
+    #[arg(long, default_value_t = false)]
+    pub explain: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,4 +71,12 @@ pub struct Finding {
     pub end_line: usize,
     pub end_column: usize,
     pub snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sink_line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sink_description: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,12 @@ fn run_scan(scan: &ScanArgs) -> i32 {
 
     match scan.format {
         OutputFormat::Terminal => {
-            foxguard::report::terminal::print_findings(&findings, files_scanned, duration);
+            foxguard::report::terminal::print_findings_with_options(
+                &findings,
+                files_scanned,
+                duration,
+                scan.explain,
+            );
         }
         OutputFormat::Json => foxguard::report::json::print_json(&findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&findings),
@@ -366,6 +371,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 changed: false,
                 baseline: None,
                 write_baseline: None,
+                explain: false,
             },
             output: repo_root.join(&args.baseline).display().to_string(),
         };

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -2,6 +2,15 @@ use crate::{Finding, Severity};
 use colored::Colorize;
 
 pub fn print_findings(findings: &[Finding], files_scanned: usize, duration: std::time::Duration) {
+    print_findings_with_options(findings, files_scanned, duration, false);
+}
+
+pub fn print_findings_with_options(
+    findings: &[Finding],
+    files_scanned: usize,
+    duration: std::time::Duration,
+    explain: bool,
+) {
     if findings.is_empty() {
         if files_scanned > 0 {
             println!(
@@ -50,6 +59,31 @@ pub fn print_findings(findings: &[Finding], files_scanned: usize, duration: std:
         if !f.snippet.is_empty() {
             for line in f.snippet.lines() {
                 println!("    {}", line.dimmed());
+            }
+        }
+
+        // When --explain is active, print source/sink trace for taint findings
+        if explain {
+            if let (Some(src_line), Some(src_desc)) = (f.source_line, f.source_description.as_ref())
+            {
+                println!(
+                    "    {} {} {}:{}   {}",
+                    "source".yellow().bold(),
+                    "\u{2192}".dimmed(),
+                    f.file.dimmed(),
+                    src_line.to_string().dimmed(),
+                    src_desc,
+                );
+            }
+            if let (Some(snk_line), Some(snk_desc)) = (f.sink_line, f.sink_description.as_ref()) {
+                println!(
+                    "    {} {} {}:{}   {}",
+                    "sink  ".yellow().bold(),
+                    "\u{2192}".dimmed(),
+                    f.file.dimmed(),
+                    snk_line.to_string().dimmed(),
+                    snk_desc,
+                );
             }
         }
     }

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -109,6 +109,10 @@ pub fn make_finding(
         end_line: end.row + 1,
         end_column: end.column + 1,
         snippet: get_source_line(source, node.start_byte()),
+        source_line: None,
+        source_description: None,
+        sink_line: None,
+        sink_description: None,
     }
 }
 
@@ -145,6 +149,10 @@ pub fn make_finding_from_offsets(
         end_line,
         end_column,
         snippet: get_source_line(source, start_byte),
+        source_line: None,
+        source_description: None,
+        sink_line: None,
+        sink_description: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -627,6 +627,10 @@ fn map_go_taint_findings(
             end_line: t.sink_end_line,
             end_column: t.sink_end_column,
             snippet: get_source_line(source, t.sink_start_byte),
+            source_line: Some(t.source_line),
+            source_description: Some(t.source_description),
+            sink_line: Some(t.sink_line),
+            sink_description: Some(t.sink_description),
         })
         .collect()
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -110,6 +110,8 @@ pub struct TaintFinding {
     pub sink_end_column: usize,
     pub source_description: String,
     pub sink_description: String,
+    /// 1-indexed line where the taint source was introduced.
+    pub source_line: usize,
 }
 
 /// Return-taint summary map keyed by a function / method simple name.
@@ -288,22 +290,28 @@ fn function_simple_name<'a>(func_node: Node<'_>, source: &'a str) -> Option<&'a 
         .map(|n| node_text(n, source))
 }
 
+#[derive(Clone, Debug)]
+struct TaintInfo {
+    description: String,
+    line: usize,
+}
+
 #[derive(Default)]
 struct TaintState {
-    tainted: HashMap<String, String>,
+    tainted: HashMap<String, TaintInfo>,
 }
 
 impl TaintState {
-    fn taint(&mut self, name: String, description: String) {
-        self.tainted.insert(name, description);
+    fn taint(&mut self, name: String, description: String, line: usize) {
+        self.tainted.insert(name, TaintInfo { description, line });
     }
 
     fn clear(&mut self, name: &str) {
         self.tainted.remove(name);
     }
 
-    fn describe(&self, name: &str) -> Option<&str> {
-        self.tainted.get(name).map(String::as_str)
+    fn info(&self, name: &str) -> Option<&TaintInfo> {
+        self.tainted.get(name)
     }
 }
 
@@ -363,12 +371,12 @@ fn walk_body_for_summary(
                     if child.kind() == "expression_list" {
                         let mut inner = child.walk();
                         for expr in child.named_children(&mut inner) {
-                            if let Some(desc) = expression_taint(expr, ctx, state) {
+                            if let Some((desc, _line)) = expression_taint(expr, ctx, state) {
                                 *return_taint = Some(desc);
                                 break;
                             }
                         }
-                    } else if let Some(desc) = expression_taint(child, ctx, state) {
+                    } else if let Some((desc, _line)) = expression_taint(child, ctx, state) {
                         *return_taint = Some(desc);
                     }
                     if return_taint.is_some() {
@@ -424,7 +432,8 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
             for matcher in &spec.sources {
                 if let NodeMatcher::ParamName { names, description } = matcher {
                     if names.iter().any(|n| n == param_name) {
-                        state.taint(param_name.to_string(), description.clone());
+                        let line = inner.start_position().row + 1;
+                        state.taint(param_name.to_string(), description.clone(), line);
                         break;
                     }
                 }
@@ -583,14 +592,14 @@ fn apply_multi_assign_semantics(
     state: &mut TaintState,
 ) {
     if lhs_names.len() == rhs_exprs.len() {
-        // Collect desc first to avoid borrow conflicts.
-        let descs: Vec<Option<String>> = rhs_exprs
+        // Collect (desc, line) first to avoid borrow conflicts.
+        let descs: Vec<Option<(String, usize)>> = rhs_exprs
             .iter()
             .map(|rhs| expression_taint(*rhs, ctx, state))
             .collect();
         for (name, desc) in lhs_names.iter().zip(descs.into_iter()) {
             match desc {
-                Some(d) => state.taint((*name).to_string(), d),
+                Some((d, line)) => state.taint((*name).to_string(), d, line),
                 None => state.clear(name),
             }
         }
@@ -599,17 +608,17 @@ fn apply_multi_assign_semantics(
 
     // Conservative broadcast: if *any* RHS expression is tainted, taint
     // every LHS name; otherwise clear them all.
-    let mut broadcast: Option<String> = None;
+    let mut broadcast: Option<(String, usize)> = None;
     for rhs in rhs_exprs {
-        if let Some(d) = expression_taint(*rhs, ctx, state) {
-            broadcast = Some(d);
+        if let Some(result) = expression_taint(*rhs, ctx, state) {
+            broadcast = Some(result);
             break;
         }
     }
     match broadcast {
-        Some(desc) => {
+        Some((desc, line)) => {
             for name in lhs_names {
-                state.taint((*name).to_string(), desc.clone());
+                state.taint((*name).to_string(), desc.clone(), line);
             }
         }
         None => {
@@ -666,7 +675,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, ctx, state) {
+        if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -678,29 +687,32 @@ fn handle_call(
                 sink_end_column: end.column + 1,
                 source_description: source_desc,
                 sink_description: sink_desc.clone(),
+                source_line: src_line,
             });
             break;
         }
     }
 }
 
-/// Returns the source description if `expr` evaluates to (or
+/// Returns the (source description, source line) if `expr` evaluates to (or
 /// references) a tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
     ctx: &AnalysisContext<'_>,
     state: &TaintState,
-) -> Option<String> {
+) -> Option<(String, usize)> {
+    let expr_line = expr.start_position().row + 1;
+
     // Direct source match on this expression.
     if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
-        return Some(desc);
+        return Some((desc, expr_line));
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
         let name = node_text(expr, ctx.source);
-        if let Some(desc) = state.describe(name) {
-            return Some(desc.to_string());
+        if let Some(info) = state.info(name) {
+            return Some((info.description.clone(), info.line));
         }
     }
 
@@ -708,8 +720,8 @@ fn expression_taint(
     // any deeper chain rooted at a tainted value).
     if expr.kind() == "selector_expression" {
         if let Some(operand) = expr.child_by_field_name("operand") {
-            if let Some(desc) = expression_taint(operand, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(operand, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -717,8 +729,8 @@ fn expression_taint(
     // Tainted index expression: `m[k]` where `m` is tainted.
     if expr.kind() == "index_expression" {
         if let Some(operand) = expr.child_by_field_name("operand") {
-            if let Some(desc) = expression_taint(operand, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(operand, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -728,8 +740,8 @@ fn expression_taint(
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -738,8 +750,8 @@ fn expression_taint(
     if matches!(expr.kind(), "parenthesized_expression" | "unary_expression") {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -752,8 +764,8 @@ fn expression_taint(
             if child.kind() == "literal_value" {
                 let mut inner = child.walk();
                 for elem in child.named_children(&mut inner) {
-                    if let Some(desc) = expression_taint(elem, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(elem, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -762,8 +774,8 @@ fn expression_taint(
     if expr.kind() == "keyed_element" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -778,8 +790,8 @@ fn expression_taint(
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, ctx, state) {
-                    return Some(desc);
+                if let Some(result) = expression_taint(arg, ctx, state) {
+                    return Some(result);
                 }
             }
         }
@@ -789,8 +801,8 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "selector_expression" {
                 if let Some(operand) = func.child_by_field_name("operand") {
-                    if let Some(desc) = expression_taint(operand, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(operand, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -803,7 +815,7 @@ fn expression_taint(
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
                 if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some(format!("{desc} (via {callee})"));
+                    return Some((format!("{desc} (via {callee})"), expr_line));
                 }
             }
             // Method call on an arbitrary receiver with a summary
@@ -813,7 +825,7 @@ fn expression_taint(
                 if let Some(field) = func.child_by_field_name("field") {
                     let method = node_text(field, ctx.source);
                     if let Some(Some(desc)) = ctx.summaries.get(method) {
-                        return Some(format!("{desc} (via {method})"));
+                        return Some((format!("{desc} (via {method})"), expr_line));
                     }
                 }
             }

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1865,6 +1865,10 @@ impl Rule for TaintXssInnerHtml {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }
@@ -1950,6 +1954,10 @@ impl Rule for TaintSqlInjection {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }
@@ -2027,6 +2035,10 @@ impl Rule for TaintEval {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }
@@ -2115,6 +2127,10 @@ impl Rule for TaintCommandInjection {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }
@@ -2227,6 +2243,10 @@ impl Rule for TaintSsrf {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -104,6 +104,8 @@ pub struct TaintFinding {
     pub sink_end_column: usize,
     pub source_description: String,
     pub sink_description: String,
+    /// 1-indexed line where the taint source was introduced.
+    pub source_line: usize,
 }
 
 /// Return-taint summary map keyed by a function's simple name. Mirrors
@@ -225,7 +227,8 @@ fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<
             for matcher in &ctx.spec.sources {
                 if let NodeMatcher::ParamName { names, description } = matcher {
                     if names.iter().any(|n| n == name) {
-                        state.taint(name.to_string(), description.clone());
+                        let line = single.start_position().row + 1;
+                        state.taint(name.to_string(), description.clone(), line);
                         break;
                     }
                 }
@@ -239,7 +242,7 @@ fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<
     // is no `return_statement` node to visit. Evaluate taint on it up
     // front so the summary still reflects the implicit return.
     if func_node.kind() == "arrow_function" && body.kind() != "statement_block" {
-        return expression_taint(body, ctx, &state);
+        return expression_taint(body, ctx, &state).map(|(desc, _line)| desc);
     }
 
     let mut scratch: Vec<TaintFinding> = Vec::new();
@@ -273,7 +276,7 @@ fn walk_body_for_summary(
             if return_taint.is_none() {
                 let mut cursor = node.walk();
                 for child in node.named_children(&mut cursor) {
-                    if let Some(desc) = expression_taint(child, ctx, state) {
+                    if let Some((desc, _line)) = expression_taint(child, ctx, state) {
                         *return_taint = Some(desc);
                         break;
                     }
@@ -510,22 +513,28 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
+struct TaintInfo {
+    description: String,
+    line: usize,
+}
+
 #[derive(Default)]
 struct TaintState {
-    tainted: HashMap<String, String>,
+    tainted: HashMap<String, TaintInfo>,
 }
 
 impl TaintState {
-    fn taint(&mut self, name: String, description: String) {
-        self.tainted.insert(name, description);
+    fn taint(&mut self, name: String, description: String, line: usize) {
+        self.tainted.insert(name, TaintInfo { description, line });
     }
 
     fn clear(&mut self, name: &str) {
         self.tainted.remove(name);
     }
 
-    fn describe(&self, name: &str) -> Option<&str> {
-        self.tainted.get(name).map(String::as_str)
+    fn info(&self, name: &str) -> Option<&TaintInfo> {
+        self.tainted.get(name)
     }
 }
 
@@ -546,10 +555,11 @@ fn analyze_function(
     if let Some(single) = func_node.child_by_field_name("parameter") {
         if single.kind() == "identifier" {
             let name = node_text(single, ctx.source);
+            let line = single.start_position().row + 1;
             for matcher in &ctx.spec.sources {
                 if let NodeMatcher::ParamName { names, description } = matcher {
                     if names.iter().any(|n| n == name) {
-                        state.taint(name.to_string(), description.clone());
+                        state.taint(name.to_string(), description.clone(), line);
                         break;
                     }
                 }
@@ -600,7 +610,8 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
         for matcher in &spec.sources {
             if let NodeMatcher::ParamName { names, description } = matcher {
                 if names.iter().any(|n| n == param_name) {
-                    state.taint(param_name.to_string(), description.clone());
+                    let line = child.start_position().row + 1;
+                    state.taint(param_name.to_string(), description.clone(), line);
                     break;
                 }
             }
@@ -644,8 +655,8 @@ fn handle_variable_declarator(node: Node<'_>, ctx: &AnalysisContext<'_>, state: 
 
     if name.kind() == "identifier" {
         let lhs = node_text(name, ctx.source).to_string();
-        if let Some(desc) = expression_taint(value, ctx, state) {
-            state.taint(lhs, desc);
+        if let Some((desc, src_line)) = expression_taint(value, ctx, state) {
+            state.taint(lhs, desc, src_line);
         } else {
             state.clear(&lhs);
         }
@@ -658,9 +669,9 @@ fn handle_variable_declarator(node: Node<'_>, ctx: &AnalysisContext<'_>, state: 
     // destructuring shapes are more varied than Python's tuple unpack.
     if matches!(name.kind(), "object_pattern" | "array_pattern") {
         let targets = collect_destructuring_targets(name, ctx.source);
-        if let Some(desc) = expression_taint(value, ctx, state) {
+        if let Some((desc, src_line)) = expression_taint(value, ctx, state) {
             for t in &targets {
-                state.taint(t.clone(), desc.clone());
+                state.taint(t.clone(), desc.clone(), src_line);
             }
         } else {
             for t in &targets {
@@ -727,7 +738,7 @@ fn handle_assignment(
                 }
                 _ => None,
             }) {
-                if let Some(src_desc) = expression_taint(right, ctx, state) {
+                if let Some((src_desc, src_line)) = expression_taint(right, ctx, state) {
                     let start = node.start_position();
                     let end = node.end_position();
                     findings.push(TaintFinding {
@@ -739,6 +750,7 @@ fn handle_assignment(
                         sink_end_column: end.column + 1,
                         source_description: src_desc,
                         sink_description: sink_desc,
+                        source_line: src_line,
                     });
                 }
             }
@@ -749,8 +761,8 @@ fn handle_assignment(
 
     if left.kind() == "identifier" {
         let lhs = node_text(left, ctx.source).to_string();
-        if let Some(desc) = expression_taint(right, ctx, state) {
-            state.taint(lhs, desc);
+        if let Some((desc, src_line)) = expression_taint(right, ctx, state) {
+            state.taint(lhs, desc, src_line);
         } else {
             state.clear(&lhs);
         }
@@ -760,9 +772,9 @@ fn handle_assignment(
     // Destructuring LHS: `({ a } = req.body)` or `[a, b] = arr`.
     if matches!(left.kind(), "object_pattern" | "array_pattern") {
         let targets = collect_destructuring_targets(left, ctx.source);
-        if let Some(desc) = expression_taint(right, ctx, state) {
+        if let Some((desc, src_line)) = expression_taint(right, ctx, state) {
             for t in &targets {
-                state.taint(t.clone(), desc.clone());
+                state.taint(t.clone(), desc.clone(), src_line);
             }
         } else {
             for t in &targets {
@@ -808,7 +820,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, ctx, state) {
+        if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -820,6 +832,7 @@ fn handle_call(
                 sink_end_column: end.column + 1,
                 source_description: source_desc,
                 sink_description: sink_desc.clone(),
+                source_line: src_line,
             });
             break;
         }
@@ -830,25 +843,27 @@ fn expression_taint(
     expr: Node<'_>,
     ctx: &AnalysisContext<'_>,
     state: &TaintState,
-) -> Option<String> {
+) -> Option<(String, usize)> {
+    let expr_line = expr.start_position().row + 1;
+
     // Direct source match on this expression.
     if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
-        return Some(desc);
+        return Some((desc, expr_line));
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
         let name = node_text(expr, ctx.source);
-        if let Some(desc) = state.describe(name) {
-            return Some(desc.to_string());
+        if let Some(info) = state.info(name) {
+            return Some((info.description.clone(), info.line));
         }
     }
 
     // Tainted member-expression root: `x.y` where `x` is tainted.
     if expr.kind() == "member_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(object, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -856,8 +871,8 @@ fn expression_taint(
     // Tainted subscript: `x[k]` where `x` is tainted (no key sensitivity).
     if expr.kind() == "subscript_expression" {
         if let Some(object) = expr.child_by_field_name("object") {
-            if let Some(desc) = expression_taint(object, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(object, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -870,8 +885,8 @@ fn expression_taint(
             if child.kind() == "template_substitution" {
                 let mut inner = child.walk();
                 for inner_child in child.named_children(&mut inner) {
-                    if let Some(desc) = expression_taint(inner_child, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(inner_child, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -882,8 +897,8 @@ fn expression_taint(
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -895,8 +910,8 @@ fn expression_taint(
     ) {
         let mut cursor = expr.walk();
         for child in expr.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -910,8 +925,8 @@ fn expression_taint(
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, ctx, state) {
-                    return Some(desc);
+                if let Some(result) = expression_taint(arg, ctx, state) {
+                    return Some(result);
                 }
             }
         }
@@ -926,8 +941,8 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "member_expression" {
                 if let Some(object) = func.child_by_field_name("object") {
-                    if let Some(desc) = expression_taint(object, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(object, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -941,7 +956,7 @@ fn expression_taint(
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
                 if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some(format!("{desc} (via {callee})"));
+                    return Some((format!("{desc} (via {callee})"), expr_line));
                 }
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1819,6 +1819,10 @@ fn map_taint_findings(
             end_line: t.sink_end_line,
             end_column: t.sink_end_column,
             snippet: get_source_line(source, t.sink_start_byte),
+            source_line: Some(t.source_line),
+            source_description: Some(t.source_description),
+            sink_line: Some(t.sink_line),
+            sink_description: Some(t.sink_description),
         })
         .collect()
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -128,6 +128,8 @@ pub struct TaintFinding {
     pub source_description: String,
     /// Description of the sink matcher that flagged this flow.
     pub sink_description: String,
+    /// 1-indexed line where the taint source was introduced.
+    pub source_line: usize,
 }
 
 /// Return-taint summary for a single function. Keyed by the function's
@@ -262,7 +264,7 @@ fn walk_body_for_summary(
         // The return's argument is the first named child, if any.
         let mut cursor = node.walk();
         for child in node.named_children(&mut cursor) {
-            if let Some(desc) = expression_taint(child, ctx, state) {
+            if let Some((desc, _line)) = expression_taint(child, ctx, state) {
                 *return_taint = Some(desc);
                 break;
             }
@@ -290,24 +292,32 @@ where
     }
 }
 
+/// Taint metadata carried alongside a tainted variable: the human-readable
+/// description and the 1-indexed source line where the taint was introduced.
+#[derive(Clone, Debug)]
+struct TaintInfo {
+    description: String,
+    line: usize,
+}
+
 /// State maintained while walking a single function body. Maps local
 /// identifier names to a description of the source that tainted them.
 #[derive(Default)]
 struct TaintState {
-    tainted: HashMap<String, String>,
+    tainted: HashMap<String, TaintInfo>,
 }
 
 impl TaintState {
-    fn taint(&mut self, name: String, description: String) {
-        self.tainted.insert(name, description);
+    fn taint(&mut self, name: String, description: String, line: usize) {
+        self.tainted.insert(name, TaintInfo { description, line });
     }
 
     fn clear(&mut self, name: &str) {
         self.tainted.remove(name);
     }
 
-    fn describe(&self, name: &str) -> Option<&str> {
-        self.tainted.get(name).map(String::as_str)
+    fn info(&self, name: &str) -> Option<&TaintInfo> {
+        self.tainted.get(name)
     }
 }
 
@@ -357,7 +367,8 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
         for matcher in &spec.sources {
             if let NodeMatcher::ParamName { names, description } = matcher {
                 if names.iter().any(|n| n == param_name) {
-                    state.taint(param_name.to_string(), description.clone());
+                    let line = child.start_position().row + 1;
+                    state.taint(param_name.to_string(), description.clone(), line);
                     break;
                 }
             }
@@ -405,8 +416,8 @@ fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut Tain
     // Simple identifier LHS: the common case.
     if left.kind() == "identifier" {
         let lhs_name = node_text(left, ctx.source).to_string();
-        if let Some(desc) = expression_taint(right, ctx, state) {
-            state.taint(lhs_name, desc);
+        if let Some((desc, src_line)) = expression_taint(right, ctx, state) {
+            state.taint(lhs_name, desc, src_line);
         } else {
             // Reassignment with a clean RHS kills any previous taint on LHS.
             state.clear(&lhs_name);
@@ -430,8 +441,8 @@ fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut Tain
         if let Some(rhs_elems) = tuple_like_elements(right) {
             if rhs_elems.len() == lhs_targets.len() {
                 for (target, rhs) in lhs_targets.iter().zip(rhs_elems.iter()) {
-                    if let Some(desc) = expression_taint(*rhs, ctx, state) {
-                        state.taint(target.clone(), desc);
+                    if let Some((desc, src_line)) = expression_taint(*rhs, ctx, state) {
+                        state.taint(target.clone(), desc, src_line);
                     } else {
                         state.clear(target);
                     }
@@ -441,9 +452,9 @@ fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut Tain
         }
 
         // Arity mismatch or opaque RHS: apply conservative semantics.
-        if let Some(desc) = expression_taint(right, ctx, state) {
+        if let Some((desc, src_line)) = expression_taint(right, ctx, state) {
             for target in &lhs_targets {
-                state.taint(target.clone(), desc.clone());
+                state.taint(target.clone(), desc.clone(), src_line);
             }
         } else {
             for target in &lhs_targets {
@@ -544,7 +555,7 @@ fn handle_call(
     };
     let mut cursor = args.walk();
     for arg in args.named_children(&mut cursor) {
-        if let Some(source_desc) = expression_taint(arg, ctx, state) {
+        if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
             findings.push(TaintFinding {
@@ -556,6 +567,7 @@ fn handle_call(
                 sink_end_column: end.column + 1,
                 source_description: source_desc,
                 sink_description: sink_desc.clone(),
+                source_line: src_line,
             });
             // One finding per sink call is enough — don't double-report
             // when multiple args are tainted.
@@ -564,23 +576,25 @@ fn handle_call(
     }
 }
 
-/// Returns the source description if `expr` evaluates to (or references) a
-/// tainted value, otherwise `None`.
+/// Returns the (source description, source line) if `expr` evaluates to (or
+/// references) a tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
     ctx: &AnalysisContext<'_>,
     state: &TaintState,
-) -> Option<String> {
+) -> Option<(String, usize)> {
+    let expr_line = expr.start_position().row + 1;
+
     // Direct source match on this expression.
     if let Some(desc) = match_source(expr, ctx.source, ctx.spec, ctx.aliases) {
-        return Some(desc);
+        return Some((desc, expr_line));
     }
 
     // Tainted identifier reference.
     if expr.kind() == "identifier" {
         let name = node_text(expr, ctx.source);
-        if let Some(desc) = state.describe(name) {
-            return Some(desc.to_string());
+        if let Some(info) = state.info(name) {
+            return Some((info.description.clone(), info.line));
         }
     }
 
@@ -589,8 +603,8 @@ fn expression_taint(
         if let Some(object) = expr.child_by_field_name("object") {
             if object.kind() == "identifier" {
                 let name = node_text(object, ctx.source);
-                if let Some(desc) = state.describe(name) {
-                    return Some(desc.to_string());
+                if let Some(info) = state.info(name) {
+                    return Some((info.description.clone(), info.line));
                 }
             }
         }
@@ -604,8 +618,8 @@ fn expression_taint(
     // identifier roots via the recursive call.
     if expr.kind() == "subscript" {
         if let Some(value) = expr.child_by_field_name("value") {
-            if let Some(desc) = expression_taint(value, ctx, state) {
-                return Some(desc);
+            if let Some(result) = expression_taint(value, ctx, state) {
+                return Some(result);
             }
         }
     }
@@ -622,8 +636,8 @@ fn expression_taint(
             if child.kind() == "interpolation" {
                 let mut inner = child.walk();
                 for inner_child in child.named_children(&mut inner) {
-                    if let Some(desc) = expression_taint(inner_child, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(inner_child, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -640,13 +654,13 @@ fn expression_taint(
         if let Some(op) = expr.child_by_field_name("operator") {
             if node_text(op, ctx.source) == "+" {
                 if let Some(left) = expr.child_by_field_name("left") {
-                    if let Some(desc) = expression_taint(left, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(left, ctx, state) {
+                        return Some(result);
                     }
                 }
                 if let Some(right) = expr.child_by_field_name("right") {
-                    if let Some(desc) = expression_taint(right, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(right, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -667,8 +681,8 @@ fn expression_taint(
         if let Some(args) = expr.child_by_field_name("arguments") {
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
-                if let Some(desc) = expression_taint(arg, ctx, state) {
-                    return Some(desc);
+                if let Some(result) = expression_taint(arg, ctx, state) {
+                    return Some(result);
                 }
             }
         }
@@ -683,8 +697,8 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "attribute" {
                 if let Some(object) = func.child_by_field_name("object") {
-                    if let Some(desc) = expression_taint(object, ctx, state) {
-                        return Some(desc);
+                    if let Some(result) = expression_taint(object, ctx, state) {
+                        return Some(result);
                     }
                 }
             }
@@ -701,7 +715,7 @@ fn expression_taint(
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
                 if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some(format!("{desc} (via {callee})"));
+                    return Some((format!("{desc} (via {callee})"), expr_line));
                 }
             }
         }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -197,6 +197,10 @@ impl Rule for SemgrepRule {
                 end_line: matched_node_range.end_line,
                 end_column: matched_node_range.end_column,
                 snippet: matched_node_range.snippet,
+                source_line: None,
+                source_description: None,
+                sink_line: None,
+                sink_description: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -200,6 +200,7 @@ struct TaintFindingView {
     sink_end_column: usize,
     source_description: String,
     sink_description: String,
+    source_line: usize,
 }
 
 impl TaintFindingView {
@@ -212,6 +213,7 @@ impl TaintFindingView {
             sink_end_column: f.sink_end_column,
             source_description: f.source_description,
             sink_description: f.sink_description,
+            source_line: f.source_line,
         }
     }
     fn from_js(f: javascript_taint::TaintFinding) -> Self {
@@ -223,6 +225,7 @@ impl TaintFindingView {
             sink_end_column: f.sink_end_column,
             source_description: f.source_description,
             sink_description: f.sink_description,
+            source_line: f.source_line,
         }
     }
     fn from_go(f: go_taint::TaintFinding) -> Self {
@@ -234,6 +237,7 @@ impl TaintFindingView {
             sink_end_column: f.sink_end_column,
             source_description: f.source_description,
             sink_description: f.sink_description,
+            source_line: f.source_line,
         }
     }
 }
@@ -311,6 +315,10 @@ impl Rule for SemgrepTaintRule {
                 end_line: t.sink_end_line,
                 end_column: t.sink_end_column,
                 snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -215,6 +215,10 @@ pub fn scan_paths_with_config(
                         end_line: line_idx + 1,
                         end_column: matched.end() + 1,
                         snippet: redact_match(line, matched.start(), matched.end()),
+                        source_line: None,
+                        source_description: None,
+                        sink_line: None,
+                        sink_description: None,
                     });
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2486,3 +2486,114 @@ fn test_realistic_gin_app_findings() {
         );
     }
 }
+
+// ─── --explain flag tests (issue #47) ─────────────────────────────────────
+
+/// With --explain, taint findings show source/sink trace lines.
+#[test]
+fn test_explain_flag_shows_trace_on_taint_findings() {
+    let output = foxguard_cmd()
+        .args(["--explain", "tests/fixtures/realistic/flask_app.py"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Taint findings should have source/sink trace lines
+    assert!(
+        stdout.contains("source"),
+        "expected 'source' trace line in --explain output"
+    );
+    assert!(
+        stdout.contains("sink"),
+        "expected 'sink' trace line in --explain output"
+    );
+    // Check that source arrow points to a file:line pattern
+    assert!(
+        stdout.contains("flask_app.py:"),
+        "expected file:line in trace output"
+    );
+}
+
+/// Without --explain, taint findings must NOT show source/sink trace lines.
+#[test]
+fn test_no_explain_flag_hides_trace() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/realistic/flask_app.py"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The "source →" trace line should not appear
+    assert!(
+        !stdout.contains("source \u{2192}"),
+        "trace lines should not appear without --explain"
+    );
+    assert!(
+        !stdout.contains("sink   \u{2192}"),
+        "trace lines should not appear without --explain"
+    );
+}
+
+/// JSON output with --explain includes source/sink fields on taint findings.
+#[test]
+fn test_explain_json_includes_trace_fields() {
+    let output = foxguard_cmd()
+        .args([
+            "--explain",
+            "-f",
+            "json",
+            "tests/fixtures/realistic/flask_app.py",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let taint_findings: Vec<&serde_json::Value> = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str().is_some_and(|r| r.contains("taint")))
+        .collect();
+
+    assert!(
+        !taint_findings.is_empty(),
+        "should have at least one taint finding"
+    );
+
+    for f in &taint_findings {
+        assert!(
+            f["source_line"].is_number(),
+            "taint finding {} should have source_line",
+            f["rule_id"]
+        );
+        assert!(
+            f["source_description"].is_string(),
+            "taint finding {} should have source_description",
+            f["rule_id"]
+        );
+        assert!(
+            f["sink_line"].is_number(),
+            "taint finding {} should have sink_line",
+            f["rule_id"]
+        );
+        assert!(
+            f["sink_description"].is_string(),
+            "taint finding {} should have sink_description",
+            f["rule_id"]
+        );
+    }
+
+    // Non-taint findings should NOT have trace fields
+    let nontaint_findings: Vec<&serde_json::Value> = findings
+        .iter()
+        .filter(|f| f["rule_id"].as_str().is_some_and(|r| !r.contains("taint")))
+        .collect();
+
+    for f in &nontaint_findings {
+        assert!(
+            f.get("source_line").is_none() || f["source_line"].is_null(),
+            "non-taint finding {} should not have source_line",
+            f["rule_id"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--explain` CLI flag that prints source-to-sink dataflow traces on taint findings, showing where untrusted data enters and where it reaches a dangerous sink
- Extends the `Finding` struct with optional `source_line`, `source_description`, `sink_line`, `sink_description` fields (skipped in JSON/serde when `None`)
- Tracks source line numbers through `TaintState` in all three taint engines (Python, JavaScript, Go) via a new `TaintInfo` struct
- Populates trace fields when mapping `TaintFinding` -> `Finding` in all taint rule implementations

## Example output

```
tests/fixtures/realistic/flask_app.py
  88:5  CRITICAL  py/taint-sql-injection (CWE-89) flask.request.args reaches cursor/connection.execute
        cur.execute(name)
    source -> flask_app.py:85   flask.request.args
    sink   -> flask_app.py:88   cursor/connection.execute
```

Without `--explain`, output is identical to before.

## Test plan

- [x] `test_explain_flag_shows_trace_on_taint_findings` - verifies trace lines appear with `--explain`
- [x] `test_no_explain_flag_hides_trace` - verifies default output is unchanged
- [x] `test_explain_json_includes_trace_fields` - verifies JSON includes source/sink fields on taint findings and omits them on non-taint findings
- [x] Full test suite passes (239 tests, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean

## SARIF codeFlows

SARIF `codeFlows` / `threadFlows` population is deferred to a follow-up PR. The data is now available in the `Finding` struct, so the SARIF reporter can be extended without further engine changes.

Refs #47

none