### PR TITLE
feat: add fix suggestions for taint findings (refs #61)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,4 +79,6 @@ pub struct Finding {
     pub sink_line: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sink_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fix_suggestion: Option<String>,
 }

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -10,7 +10,7 @@ pub fn print_sarif(findings: &[Finding]) {
                 props.insert("tags".to_string(), json!([cwe]));
             }
 
-            json!({
+            let mut result = json!({
                 "ruleId": f.rule_id,
                 "level": match f.severity {
                     crate::Severity::Critical | crate::Severity::High => "error",
@@ -34,7 +34,17 @@ pub fn print_sarif(findings: &[Finding]) {
                     }
                 }],
                 "properties": props
-            })
+            });
+
+            if let Some(fix) = &f.fix_suggestion {
+                result["fixes"] = json!([{
+                    "description": {
+                        "text": fix
+                    }
+                }]);
+            }
+
+            result
         })
         .collect();
 

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -85,6 +85,9 @@ pub fn print_findings_with_options(
                     snk_desc,
                 );
             }
+            if let Some(fix) = f.fix_suggestion.as_ref() {
+                println!("  {} {}", "Fix:".green().bold(), fix);
+            }
         }
     }
 

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -113,6 +113,7 @@ pub fn make_finding(
         source_description: None,
         sink_line: None,
         sink_description: None,
+        fix_suggestion: None,
     }
 }
 
@@ -153,6 +154,7 @@ pub fn make_finding_from_offsets(
         source_description: None,
         sink_line: None,
         sink_description: None,
+        fix_suggestion: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -835,7 +835,9 @@ impl Rule for TaintSsrf {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
+            fix_suggestion: Some(
+                "Validate URLs against an allowlist of permitted hosts before making requests",
+            ),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -595,6 +595,7 @@ struct GoTaintRuleMeta<'a> {
     rule_id: &'a str,
     severity: Severity,
     cwe: Option<&'a str>,
+    fix_suggestion: Option<&'a str>,
 }
 
 fn map_go_taint_findings(
@@ -631,6 +632,7 @@ fn map_go_taint_findings(
             source_description: Some(t.source_description),
             sink_line: Some(t.sink_line),
             sink_description: Some(t.sink_description),
+            fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
         })
         .collect()
 }
@@ -683,6 +685,7 @@ impl Rule for TaintCommandInjection {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Pass arguments as separate elements to `exec.Command(name, arg1, arg2)` instead of a single shell string"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -772,6 +775,7 @@ impl Rule for TaintSqlInjection {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use parameterized queries: `db.Query(\"SELECT * FROM users WHERE name = $1\", name)`"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can inject SQL", src, sink)
@@ -831,6 +835,7 @@ impl Rule for TaintSsrf {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1869,6 +1869,7 @@ impl Rule for TaintXssInnerHtml {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: Some("Use `DOMPurify.sanitize()` or `textContent` instead of `innerHTML`/`document.write`".to_string()),
             })
             .collect()
     }
@@ -1958,6 +1959,7 @@ impl Rule for TaintSqlInjection {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: Some("Use parameterized queries: `db.query(\"SELECT * FROM users WHERE name = $1\", [name])`".to_string()),
             })
             .collect()
     }
@@ -2039,6 +2041,7 @@ impl Rule for TaintEval {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: Some("Remove `eval()`/`new Function()` and use safe alternatives like `JSON.parse()`".to_string()),
             })
             .collect()
     }
@@ -2131,6 +2134,7 @@ impl Rule for TaintCommandInjection {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: Some("Pass arguments as an array to `child_process.execFile()` instead of building a shell string".to_string()),
             })
             .collect()
     }
@@ -2247,6 +2251,7 @@ impl Rule for TaintSsrf {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests".to_string()),
             })
             .collect()
     }

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2251,7 +2251,10 @@ impl Rule for TaintSsrf {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
-                fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests".to_string()),
+                fix_suggestion: Some(
+                    "Validate URLs against an allowlist of permitted hosts before making requests"
+                        .to_string(),
+                ),
             })
             .collect()
     }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1796,6 +1796,7 @@ struct TaintRuleMeta<'a> {
     rule_id: &'a str,
     severity: Severity,
     cwe: Option<&'a str>,
+    fix_suggestion: Option<&'a str>,
 }
 
 fn map_taint_findings(
@@ -1823,6 +1824,7 @@ fn map_taint_findings(
             source_description: Some(t.source_description),
             sink_line: Some(t.sink_line),
             sink_description: Some(t.sink_description),
+            fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
         })
         .collect()
 }
@@ -1875,6 +1877,7 @@ impl Rule for TaintPickleDeserialization {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use `json` or `msgpack` instead of pickle for untrusted data: `json.loads(data)`"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -1929,6 +1932,7 @@ impl Rule for TaintEvalFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use `ast.literal_eval()` for safe evaluation, or remove eval/exec entirely"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -1991,6 +1995,7 @@ impl Rule for TaintCommandInjectionFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use `shlex.quote()` to escape arguments, or pass a list to `subprocess.run([...])` instead of a shell string"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -2054,6 +2059,7 @@ impl Rule for TaintSsrfFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -2112,6 +2118,7 @@ impl Rule for TaintYamlLoadFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use `yaml.safe_load()` instead of `yaml.load()` for untrusted input"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -2184,6 +2191,7 @@ impl Rule for TaintSqlInjectionFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
+            fix_suggestion: Some("Use parameterized queries: `cur.execute(\"SELECT * FROM users WHERE name = ?\", (name,))`"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can inject SQL", src, sink)

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1877,7 +1877,9 @@ impl Rule for TaintPickleDeserialization {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Use `json` or `msgpack` instead of pickle for untrusted data: `json.loads(data)`"),
+            fix_suggestion: Some(
+                "Use `json` or `msgpack` instead of pickle for untrusted data: `json.loads(data)`",
+            ),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -1932,7 +1934,9 @@ impl Rule for TaintEvalFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Use `ast.literal_eval()` for safe evaluation, or remove eval/exec entirely"),
+            fix_suggestion: Some(
+                "Use `ast.literal_eval()` for safe evaluation, or remove eval/exec entirely",
+            ),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -2059,7 +2063,9 @@ impl Rule for TaintSsrfFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
+            fix_suggestion: Some(
+                "Validate URLs against an allowlist of permitted hosts before making requests",
+            ),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(
@@ -2118,7 +2124,9 @@ impl Rule for TaintYamlLoadFromRequest {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Use `yaml.safe_load()` instead of `yaml.load()` for untrusted input"),
+            fix_suggestion: Some(
+                "Use `yaml.safe_load()` instead of `yaml.load()` for untrusted input",
+            ),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -201,6 +201,7 @@ impl Rule for SemgrepRule {
                 source_description: None,
                 sink_line: None,
                 sink_description: None,
+                fix_suggestion: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -319,6 +319,7 @@ impl Rule for SemgrepTaintRule {
                 source_description: Some(t.source_description),
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
+                fix_suggestion: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -219,6 +219,7 @@ pub fn scan_paths_with_config(
                         source_description: None,
                         sink_line: None,
                         sink_description: None,
+                        fix_suggestion: None,
                     });
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2597,3 +2597,103 @@ fn test_explain_json_includes_trace_fields() {
         );
     }
 }
+
+// ─── Fix-suggestion tests ──────────────────────────────────────────────
+
+#[test]
+fn test_taint_findings_include_fix_suggestion_in_json() {
+    // Scan the Python taint fixture in JSON mode and verify that taint
+    // findings carry a non-empty fix_suggestion field.
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_py_taint.py", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(!output.status.success(), "should exit non-zero with findings");
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+
+    let taint_findings: Vec<&serde_json::Value> = findings
+        .iter()
+        .filter(|f| {
+            f["rule_id"]
+                .as_str()
+                .map_or(false, |id| id.contains("taint"))
+        })
+        .collect();
+
+    assert!(
+        !taint_findings.is_empty(),
+        "should have at least one taint finding"
+    );
+
+    for f in &taint_findings {
+        let fix = f.get("fix_suggestion");
+        assert!(
+            fix.is_some() && fix.unwrap().is_string() && !fix.unwrap().as_str().unwrap().is_empty(),
+            "taint finding {} should have a non-empty fix_suggestion",
+            f["rule_id"]
+        );
+    }
+
+    // Non-taint findings should NOT have fix_suggestion
+    let nontaint_findings: Vec<&serde_json::Value> = findings
+        .iter()
+        .filter(|f| {
+            f["rule_id"]
+                .as_str()
+                .map_or(false, |id| !id.contains("taint"))
+        })
+        .collect();
+
+    for f in &nontaint_findings {
+        assert!(
+            f.get("fix_suggestion").is_none() || f["fix_suggestion"].is_null(),
+            "non-taint finding {} should not have fix_suggestion",
+            f["rule_id"]
+        );
+    }
+}
+
+#[test]
+fn test_fix_suggestion_appears_in_sarif_output() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/vulnerable_py_taint.py", "-f", "sarif"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    let sarif: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("invalid SARIF output");
+
+    let results = sarif["runs"][0]["results"].as_array().expect("results array");
+
+    let taint_results: Vec<&serde_json::Value> = results
+        .iter()
+        .filter(|r| {
+            r["ruleId"]
+                .as_str()
+                .map_or(false, |id| id.contains("taint"))
+        })
+        .collect();
+
+    assert!(
+        !taint_results.is_empty(),
+        "should have at least one taint result in SARIF"
+    );
+
+    for r in &taint_results {
+        let fixes = r.get("fixes");
+        assert!(
+            fixes.is_some() && fixes.unwrap().is_array(),
+            "taint SARIF result {} should have a fixes array",
+            r["ruleId"]
+        );
+        let fix_text = fixes.unwrap()[0]["description"]["text"].as_str();
+        assert!(
+            fix_text.is_some() && !fix_text.unwrap().is_empty(),
+            "SARIF fix description should be non-empty for {}",
+            r["ruleId"]
+        );
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2622,7 +2622,7 @@ fn test_taint_findings_include_fix_suggestion_in_json() {
         .filter(|f| {
             f["rule_id"]
                 .as_str()
-                .map_or(false, |id| id.contains("taint"))
+                .is_some_and(|id| id.contains("taint"))
         })
         .collect();
 
@@ -2646,7 +2646,7 @@ fn test_taint_findings_include_fix_suggestion_in_json() {
         .filter(|f| {
             f["rule_id"]
                 .as_str()
-                .map_or(false, |id| !id.contains("taint"))
+                .is_some_and(|id| !id.contains("taint"))
         })
         .collect();
 
@@ -2678,7 +2678,7 @@ fn test_fix_suggestion_appears_in_sarif_output() {
         .filter(|r| {
             r["ruleId"]
                 .as_str()
-                .map_or(false, |id| id.contains("taint"))
+                .is_some_and(|id| id.contains("taint"))
         })
         .collect();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2609,7 +2609,10 @@ fn test_taint_findings_include_fix_suggestion_in_json() {
         .output()
         .expect("failed to execute foxguard");
 
-    assert!(!output.status.success(), "should exit non-zero with findings");
+    assert!(
+        !output.status.success(),
+        "should exit non-zero with findings"
+    );
 
     let findings: Vec<serde_json::Value> =
         serde_json::from_slice(&output.stdout).expect("invalid JSON output");
@@ -2666,7 +2669,9 @@ fn test_fix_suggestion_appears_in_sarif_output() {
     let sarif: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("invalid SARIF output");
 
-    let results = sarif["runs"][0]["results"].as_array().expect("results array");
+    let results = sarif["runs"][0]["results"]
+        .as_array()
+        .expect("results array");
 
     let taint_results: Vec<&serde_json::Value> = results
         .iter()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2619,11 +2619,7 @@ fn test_taint_findings_include_fix_suggestion_in_json() {
 
     let taint_findings: Vec<&serde_json::Value> = findings
         .iter()
-        .filter(|f| {
-            f["rule_id"]
-                .as_str()
-                .is_some_and(|id| id.contains("taint"))
-        })
+        .filter(|f| f["rule_id"].as_str().is_some_and(|id| id.contains("taint")))
         .collect();
 
     assert!(
@@ -2675,11 +2671,7 @@ fn test_fix_suggestion_appears_in_sarif_output() {
 
     let taint_results: Vec<&serde_json::Value> = results
         .iter()
-        .filter(|r| {
-            r["ruleId"]
-                .as_str()
-                .is_some_and(|id| id.contains("taint"))
-        })
+        .filter(|r| r["ruleId"].as_str().is_some_and(|id| id.contains("taint")))
         .collect();
 
     assert!(


### PR DESCRIPTION
## Summary
- Adds an `Option<String>` `fix_suggestion` field to the `Finding` struct, populated for all 15 taint rules across Python (6), JavaScript (5), and Go (3)
- Surfaces fix suggestions in terminal output (printed below dataflow traces when `--explain` is active), JSON output (serialized as `fix_suggestion`), and SARIF output (populated in the standard `fixes` array)
- Non-taint rules (pattern-based and secrets) set the field to `None` so it is omitted from serialized output via `skip_serializing_if`

## Test plan
- [x] All existing tests pass (`cargo test` -- 134 unit + 71 integration + 12 semgrep + 6 parity)
- [x] New integration test `test_taint_findings_include_fix_suggestion_in_json` verifies taint findings carry a non-empty `fix_suggestion` in JSON and non-taint findings omit it
- [x] New integration test `test_fix_suggestion_appears_in_sarif_output` verifies the SARIF `fixes` array is populated for taint results

none