### PR TITLE
feat: add --max-file-size flag to skip oversized files

### DIFF
--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -161,7 +161,7 @@ fn handle_tools_call(request: &Value, registry: &RuleRegistry) -> Result<Value, 
             if !p.is_file() {
                 return Err(format!("Path is not a file: {}", path));
             }
-            let result = scan_directory(path, registry);
+            let result = scan_directory(path, registry, 1_048_576);
             Ok(format_scan_result(result))
         }
         "scan_directory" => {
@@ -172,7 +172,7 @@ fn handle_tools_call(request: &Value, registry: &RuleRegistry) -> Result<Value, 
             if !p.is_dir() {
                 return Err(format!("Path is not a directory: {}", path));
             }
-            let result = scan_directory(path, registry);
+            let result = scan_directory(path, registry, 1_048_576);
             Ok(format_scan_result(result))
         }
         _ => Err(format!("Unknown tool: {}", tool_name)),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,10 @@ pub struct ScanArgs {
     /// Show source-to-sink dataflow traces on taint findings
     #[arg(long, default_value_t = false)]
     pub explain: bool,
+
+    /// Maximum file size in bytes to scan (default: 1 MB)
+    #[arg(long, default_value_t = 1_048_576)]
+    pub max_file_size: u64,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -139,6 +143,10 @@ pub struct SecretsArgs {
     /// Ignore a specific built-in secrets rule ID (repeatable)
     #[arg(long = "ignore-rule")]
     pub ignored_rules: Vec<String>,
+
+    /// Maximum file size in bytes to scan (default: 1 MB)
+    #[arg(long, default_value_t = 1_048_576)]
+    pub max_file_size: u64,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -53,7 +53,7 @@ fn detect_language(path: &Path) -> Option<Language> {
 }
 
 /// Scan a directory (or single file) and return findings with metadata.
-pub fn scan_directory(root: &str, registry: &RuleRegistry) -> ScanResult {
+pub fn scan_directory(root: &str, registry: &RuleRegistry, max_file_size: u64) -> ScanResult {
     let root_path = Path::new(root);
 
     let files: Vec<_> = if root_path.is_file() {
@@ -76,21 +76,26 @@ pub fn scan_directory(root: &str, registry: &RuleRegistry) -> ScanResult {
             .collect()
     };
 
-    scan_files(scan_root(root_path), files, registry)
+    scan_files(scan_root(root_path), files, registry, max_file_size)
 }
 
 /// Scan an explicit list of paths.
-pub fn scan_paths(paths: &[PathBuf], registry: &RuleRegistry) -> ScanResult {
-    scan_paths_with_root(Path::new("."), paths, registry)
+pub fn scan_paths(paths: &[PathBuf], registry: &RuleRegistry, max_file_size: u64) -> ScanResult {
+    scan_paths_with_root(Path::new("."), paths, registry, max_file_size)
 }
 
 /// Scan an explicit list of paths relative to a scan root.
-pub fn scan_paths_with_root(root: &Path, paths: &[PathBuf], registry: &RuleRegistry) -> ScanResult {
+pub fn scan_paths_with_root(
+    root: &Path,
+    paths: &[PathBuf],
+    registry: &RuleRegistry,
+    max_file_size: u64,
+) -> ScanResult {
     let files = paths
         .iter()
         .filter_map(|path| detect_language(path).map(|lang| (path.clone(), lang)))
         .collect();
-    scan_files(scan_root(root), files, registry)
+    scan_files(scan_root(root), files, registry, max_file_size)
 }
 
 /// Check if a file path is in a directory that typically contains
@@ -277,6 +282,7 @@ fn scan_files(
     scan_root: &Path,
     files: Vec<(PathBuf, Language)>,
     registry: &RuleRegistry,
+    max_file_size: u64,
 ) -> ScanResult {
     let start = Instant::now();
     let file_count = files.len();
@@ -287,6 +293,25 @@ fn scan_files(
             // Skip files in test/vendor/fixture directories
             if is_noise_path(path) {
                 return Vec::new();
+            }
+
+            match std::fs::metadata(path) {
+                Ok(m) if m.len() > max_file_size => {
+                    eprintln!(
+                        "warning: skipping {} ({} bytes exceeds --max-file-size)",
+                        path.display(),
+                        m.len()
+                    );
+                    return Vec::new();
+                }
+                Err(_) => {
+                    eprintln!(
+                        "warning: skipping {} (cannot read metadata)",
+                        path.display()
+                    );
+                    return Vec::new();
+                }
+                _ => {}
             }
 
             let Ok(source) = std::fs::read_to_string(path) else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,9 +111,9 @@ fn scan_findings(scan: &ScanArgs) -> Result<ScanResult, i32> {
     let targets = collect_changed_targets(&scan.path, scan.changed)?;
 
     let mut result = if let Some(files) = targets {
-        scan_paths_with_root(Path::new(&scan.path), &files, &registry)
+        scan_paths_with_root(Path::new(&scan.path), &files, &registry, scan.max_file_size)
     } else {
-        scan_directory(&scan.path, &registry)
+        scan_directory(&scan.path, &registry, scan.max_file_size)
     };
 
     // Filter by severity if specified
@@ -238,9 +238,9 @@ fn run_secrets(args: &SecretsArgs) -> i32 {
     };
 
     let mut findings = if let Some(files) = targets {
-        scan_secrets_paths(scan_path, &files, &config)
+        scan_secrets_paths(scan_path, &files, &config, args.max_file_size)
     } else {
-        scan_secrets_directory(&args.path, &config)
+        scan_secrets_directory(&args.path, &config, args.max_file_size)
     };
 
     if let Some(ref path) = args.write_baseline {
@@ -372,6 +372,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 baseline: None,
                 write_baseline: None,
                 explain: false,
+                max_file_size: 1_048_576,
             },
             output: repo_root.join(&args.baseline).display().to_string(),
         };
@@ -391,6 +392,7 @@ fn run_init(args: &InitArgs) -> i32 {
             exclude_paths: Vec::new(),
             exclude_path_file: None,
             ignored_rules: Vec::new(),
+            max_file_size: 1_048_576,
         };
 
         let code = run_secrets(&secrets_args);

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -154,11 +154,15 @@ fn redact_match(line: &str, start: usize, end: usize) -> String {
     redacted
 }
 
-pub fn scan_directory(root: &str) -> Vec<Finding> {
-    scan_directory_with_config(root, &SecretScanConfig::default())
+pub fn scan_directory(root: &str, max_file_size: u64) -> Vec<Finding> {
+    scan_directory_with_config(root, &SecretScanConfig::default(), max_file_size)
 }
 
-pub fn scan_directory_with_config(root: &str, config: &SecretScanConfig) -> Vec<Finding> {
+pub fn scan_directory_with_config(
+    root: &str,
+    config: &SecretScanConfig,
+    max_file_size: u64,
+) -> Vec<Finding> {
     let root_path = Path::new(root);
     let files: Vec<PathBuf> = if root_path.is_file() {
         vec![root_path.to_path_buf()]
@@ -173,17 +177,23 @@ pub fn scan_directory_with_config(root: &str, config: &SecretScanConfig) -> Vec<
             .collect()
     };
 
-    scan_paths_with_config(root_path, &files, config)
+    scan_paths_with_config(root_path, &files, config, max_file_size)
 }
 
-pub fn scan_paths(paths: &[PathBuf]) -> Vec<Finding> {
-    scan_paths_with_config(Path::new("."), paths, &SecretScanConfig::default())
+pub fn scan_paths(paths: &[PathBuf], max_file_size: u64) -> Vec<Finding> {
+    scan_paths_with_config(
+        Path::new("."),
+        paths,
+        &SecretScanConfig::default(),
+        max_file_size,
+    )
 }
 
 pub fn scan_paths_with_config(
     root: &Path,
     paths: &[PathBuf],
     config: &SecretScanConfig,
+    max_file_size: u64,
 ) -> Vec<Finding> {
     let patterns = patterns();
     let mut findings = Vec::new();
@@ -191,6 +201,25 @@ pub fn scan_paths_with_config(
     for path in paths {
         if config.should_skip_path(root, path) {
             continue;
+        }
+
+        match std::fs::metadata(path) {
+            Ok(m) if m.len() > max_file_size => {
+                eprintln!(
+                    "warning: skipping {} ({} bytes exceeds --max-file-size)",
+                    path.display(),
+                    m.len()
+                );
+                continue;
+            }
+            Err(_) => {
+                eprintln!(
+                    "warning: skipping {} (cannot read metadata)",
+                    path.display()
+                );
+                continue;
+            }
+            _ => {}
         }
 
         let Some(source) = read_scannable_text(path) else {


### PR DESCRIPTION
- Adds `--max-file-size` (default 1 MB) to both scan and secrets subcommands
- Checks `fs::metadata().len()` before reading — fails closed on metadata errors
- Warns on stderr when skipping