### PR TITLE
feat(go): add SSTI, XPath, LDAP taint rules

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -783,6 +783,196 @@ impl Rule for TaintSqlInjection {
     }
 }
 
+// ─── Rule: taint-ssti ─────────────────────────────────────────────────────
+
+pub struct TaintSsti;
+
+impl TaintSsti {
+    fn spec() -> GoTaintSpec {
+        GoTaintSpec {
+            sources: go_taint_sources(),
+            sinks: vec![
+                GoNodeMatcher::MethodName {
+                    method: "Parse".into(),
+                    description: "template.Parse".into(),
+                },
+                go_call_sink("template.Must"),
+                go_call_sink("template.New"),
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintSsti {
+    fn id(&self) -> &str {
+        "go/taint-ssti"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-1336")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches template parsing sink (potential SSTI)"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some("Use pre-defined template files with template.ParseFiles() instead of parsing user-controlled template strings"),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can inject server-side templates",
+                src, sink
+            )
+        })
+    }
+}
+
+// ─── Rule: taint-xpath-injection ──────────────────────────────────────────
+
+pub struct TaintXpathInjection;
+
+impl TaintXpathInjection {
+    fn spec() -> GoTaintSpec {
+        GoTaintSpec {
+            sources: go_taint_sources(),
+            sinks: vec![
+                go_call_sink("xmlpath.Compile"),
+                go_call_sink("xpath.Compile"),
+                go_call_sink("xmlquery.QueryAll"),
+                go_call_sink("xmlquery.Query"),
+                go_call_sink("htmlquery.QueryAll"),
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintXpathInjection {
+    fn id(&self) -> &str {
+        "go/taint-xpath-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-643")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches XPath query sink (potential XPath injection)"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some(
+                "Validate and sanitize user input before building XPath expressions",
+            ),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can inject XPath queries",
+                src, sink
+            )
+        })
+    }
+}
+
+// ─── Rule: taint-ldap-injection ───────────────────────────────────────────
+
+pub struct TaintLdapInjection;
+
+impl TaintLdapInjection {
+    fn spec() -> GoTaintSpec {
+        GoTaintSpec {
+            sources: go_taint_sources(),
+            sinks: vec![
+                go_call_sink("ldap.NewSearchRequest"),
+                go_call_sink("ldap.SearchRequest"),
+                GoNodeMatcher::MethodName {
+                    method: "Search".into(),
+                    description: "ldap.Conn.Search".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintLdapInjection {
+    fn id(&self) -> &str {
+        "go/taint-ldap-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-90")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches LDAP search sink (potential LDAP injection)"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some("Use ldap.EscapeFilter() to sanitize user input before building LDAP filter strings"),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can inject LDAP queries",
+                src, sink
+            )
+        })
+    }
+}
+
 // ─── Rule: taint-ssrf ──────────────────────────────────────────────────────
 
 pub struct TaintSsrf;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -156,6 +156,9 @@ impl RuleRegistry {
         registry.register(Box::new(go::TaintCommandInjection));
         registry.register(Box::new(go::TaintSqlInjection));
         registry.register(Box::new(go::TaintSsrf));
+        registry.register(Box::new(go::TaintSsti));
+        registry.register(Box::new(go::TaintXpathInjection));
+        registry.register(Box::new(go::TaintLdapInjection));
 
         // Register Java rules
         registry.register(Box::new(java::NoSqlInjection));

--- a/tests/fixtures/vulnerable_go_taint.go
+++ b/tests/fixtures/vulnerable_go_taint.go
@@ -7,6 +7,7 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"html/template"
 	"net/http"
 	"os/exec"
 )
@@ -63,6 +64,31 @@ func httpQueryToTxExec(w http.ResponseWriter, r *http.Request, tx *sql.Tx) {
 func ginPostFormToQueryRow(c *gin.Context, db *sql.DB) {
 	email := c.PostForm("email")
 	db.QueryRow("SELECT id FROM users WHERE email = " + email)
+}
+
+// ─── go/taint-ssti ────────────────────────────────────────────────────────
+
+// 12. gin Context.Query → template.Parse
+func ginQueryToTemplateParse(c *gin.Context) {
+	tmplStr := c.Query("template")
+	t := template.New("page")
+	t.Parse(tmplStr)
+}
+
+// ─── go/taint-xpath-injection ─────────────────────────────────────────────
+
+// 13. net/http r.FormValue → xmlpath.Compile
+func httpFormValueToXpathCompile(w http.ResponseWriter, r *http.Request) {
+	expr := r.FormValue("xpath")
+	xmlpath.Compile(expr)
+}
+
+// ─── go/taint-ldap-injection ──────────────────────────────────────────────
+
+// 14. gin Context.Query → ldap.NewSearchRequest
+func ginQueryToLdapSearch(c *gin.Context) {
+	filter := c.Query("filter")
+	ldap.NewSearchRequest("dc=example,dc=com", 2, 0, 0, 0, false, filter, nil, nil)
 }
 
 // ─── go/taint-ssrf ────────────────────────────────────────────────────────

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2391,7 +2391,8 @@ fn test_vulnerable_go_taint_catches_every_flow() {
         }
     }
 
-    // Five command-injection handlers, three SQL, three SSRF.
+    // Five command-injection handlers, three SQL, three SSRF,
+    // one SSTI, one XPath, one LDAP.
     for (taint_rule, conservative_rule, expected) in [
         (
             "go/taint-command-injection",
@@ -2417,6 +2418,22 @@ fn test_vulnerable_go_taint_catches_every_flow() {
             counts
         );
     }
+
+    // New taint rules without conservative counterparts.
+    for (taint_rule, expected) in [
+        ("go/taint-ssti", 1usize),
+        ("go/taint-xpath-injection", 1),
+        ("go/taint-ldap-injection", 1),
+    ] {
+        assert_eq!(
+            counts.get(taint_rule).copied(),
+            Some(expected),
+            "{} should fire exactly {} time(s) on vulnerable_go_taint.go. counts={:?}",
+            taint_rule,
+            expected,
+            counts
+        );
+    }
 }
 
 /// Negative counterpart for the Go taint engine. Every handler in
@@ -2437,6 +2454,9 @@ fn test_safe_go_taint_has_no_taint_findings() {
         "go/taint-command-injection",
         "go/taint-sql-injection",
         "go/taint-ssrf",
+        "go/taint-ssti",
+        "go/taint-xpath-injection",
+        "go/taint-ldap-injection",
     ] {
         let n = findings
             .iter()

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -94,8 +94,11 @@ const goRules: Rule[] = [
   { id: 'go/no-ssrf', cwe: 'CWE-918', desc: 'Potential SSRF via http.Get/http.Post with variable URL', severity: 'high' },
   { id: 'go/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic hash (MD5/SHA1)', severity: 'medium' },
   { id: 'go/taint-command-injection', cwe: 'CWE-78', desc: 'Untrusted input reaches os/exec command execution sink', severity: 'critical' },
+  { id: 'go/taint-ldap-injection', cwe: 'CWE-90', desc: 'Untrusted input reaches LDAP search sink (potential LDAP injection)', severity: 'high' },
   { id: 'go/taint-sql-injection', cwe: 'CWE-89', desc: 'Untrusted input reaches database Query/Exec sink', severity: 'critical' },
   { id: 'go/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches outbound net/http sink (potential SSRF)', severity: 'high' },
+  { id: 'go/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches template parsing sink (potential SSTI)', severity: 'critical' },
+  { id: 'go/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches XPath query sink (potential XPath injection)', severity: 'high' },
 ];
 
 const rubyRules: Rule[] = [


### PR DESCRIPTION
## Summary
- Add `go/taint-ssti` rule (CWE-1336, Critical) detecting user input flowing into `template.Parse`, `template.Must`, and `template.New`
- Add `go/taint-xpath-injection` rule (CWE-643, High) detecting user input flowing into `xmlpath.Compile`, `xpath.Compile`, `xmlquery.QueryAll`, `xmlquery.Query`, `htmlquery.QueryAll`
- Add `go/taint-ldap-injection` rule (CWE-90, High) detecting user input flowing into `ldap.NewSearchRequest`, `ldap.SearchRequest`, and `conn.Search`

## Test plan
- [x] Added positive test fixtures for each new rule in `vulnerable_go_taint.go`
- [x] Updated integration test to assert each new rule fires exactly once
- [x] Updated safe taint negative test to verify no false positives
- [x] Regenerated `www/src/data/rules.ts` inventory
- [x] All 246 tests pass (`cargo test`)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` clean

none