### PR TITLE
feat(js): add SSTI, XPath, LDAP taint rules

### DIFF
--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2259,3 +2259,287 @@ impl Rule for TaintSsrf {
             .collect()
     }
 }
+
+// ─── js/taint-ssti ─────────────────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches a
+// template rendering sink. CWE-1336 (Server-Side Template Injection).
+
+pub struct TaintSsti;
+
+impl TaintSsti {
+    pub(crate) fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::Call {
+                    canonical: "ejs.render".into(),
+                    description: "ejs.render() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "ejs.renderFile".into(),
+                    description: "ejs.renderFile() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "pug.render".into(),
+                    description: "pug.render() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "pug.renderFile".into(),
+                    description: "pug.renderFile() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "Handlebars.compile".into(),
+                    description: "Handlebars.compile() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "handlebars.compile".into(),
+                    description: "handlebars.compile() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "nunjucks.renderString".into(),
+                    description: "nunjucks.renderString() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "mustache.render".into(),
+                    description: "mustache.render() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintSsti {
+    fn id(&self) -> &str {
+        "js/taint-ssti"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-1336")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches a template rendering sink — possible server-side template injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can inject server-side templates",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: Some(
+                    "Use pre-compiled templates with auto-escaping instead of rendering user input as template strings"
+                        .to_string(),
+                ),
+            })
+            .collect()
+    }
+}
+
+// ─── js/taint-xpath-injection ──────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches an
+// XPath evaluation sink. CWE-643 (XPath Injection).
+
+pub struct TaintXpathInjection;
+
+impl TaintXpathInjection {
+    pub(crate) fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::Call {
+                    canonical: "xpath.select".into(),
+                    description: "xpath.select() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "xpath.evaluate".into(),
+                    description: "xpath.evaluate() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "document.evaluate".into(),
+                    description: "document.evaluate() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "dom.evaluate".into(),
+                    description: "dom.evaluate() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintXpathInjection {
+    fn id(&self) -> &str {
+        "js/taint-xpath-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-643")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an XPath evaluation sink — possible XPath injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can inject XPath expressions",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: Some(
+                    "Validate and sanitize user input before building XPath expressions"
+                        .to_string(),
+                ),
+            })
+            .collect()
+    }
+}
+
+// ─── js/taint-ldap-injection ───────────────────────────────────────────
+//
+// Intraprocedural taint rule: fires when untrusted input reaches an
+// LDAP operation sink. CWE-90 (LDAP Injection).
+
+pub struct TaintLdapInjection;
+
+impl TaintLdapInjection {
+    pub(crate) fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::MethodName {
+                    method: "search".into(),
+                    description: "LDAP .search() call".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "bind".into(),
+                    description: "LDAP .bind() call".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintLdapInjection {
+    fn id(&self) -> &str {
+        "js/taint-ldap-injection"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-90")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an LDAP operation sink — possible LDAP injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let spec = Self::spec();
+        let raw =
+            javascript_taint::analyze_tree(tree.root_node(), source, &spec, ctx.javascript_aliases);
+        raw.into_iter()
+            .map(|t| Finding {
+                rule_id: self.id().to_string(),
+                severity: self.severity(),
+                cwe: self.cwe().map(|s| s.to_string()),
+                description: format!(
+                    "{} reaches {} — untrusted input can inject LDAP filters",
+                    t.source_description, t.sink_description
+                ),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: Some(
+                    "Use ldap-escape or sanitize special LDAP characters before building filter strings"
+                        .to_string(),
+                ),
+            })
+            .collect()
+    }
+}

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1666,4 +1666,107 @@ function handler(req) {
             0
         );
     }
+
+    // ─── SSTI rule tests ────────────────────────────────────────────────
+
+    #[test]
+    fn ssti_ejs_render_from_req_body() {
+        let spec = super::super::javascript::TaintSsti::spec();
+        let src = r#"
+const ejs = require("ejs");
+function handler(req, res) {
+    const template = req.body.template;
+    ejs.render(template);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(!findings.is_empty(), "expected SSTI finding for ejs.render");
+        assert!(findings[0].sink_description.contains("ejs.render"));
+    }
+
+    #[test]
+    fn ssti_no_finding_when_static_template() {
+        let spec = super::super::javascript::TaintSsti::spec();
+        let src = r#"
+const ejs = require("ejs");
+function handler(req, res) {
+    ejs.render("<h1>Hello</h1>");
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(findings.is_empty(), "static template should not fire SSTI");
+    }
+
+    // ─── XPath injection rule tests ─────────────────────────────────────
+
+    #[test]
+    fn xpath_select_from_req_query() {
+        let spec = super::super::javascript::TaintXpathInjection::spec();
+        let src = r#"
+const xpath = require("xpath");
+function handler(req, res) {
+    const expr = req.query.path;
+    xpath.select(expr, doc);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(!findings.is_empty(), "expected XPath injection finding");
+        assert!(findings[0].sink_description.contains("xpath.select"));
+    }
+
+    #[test]
+    fn xpath_no_finding_when_static_expression() {
+        let spec = super::super::javascript::TaintXpathInjection::spec();
+        let src = r#"
+const xpath = require("xpath");
+function handler(req, res) {
+    xpath.select("//book/title", doc);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(findings.is_empty(), "static XPath should not fire");
+    }
+
+    // ─── LDAP injection rule tests ──────────────────────────────────────
+
+    #[test]
+    fn ldap_search_from_req_body() {
+        let spec = super::super::javascript::TaintLdapInjection::spec();
+        let src = r#"
+function handler(req, res) {
+    const filter = req.body.username;
+    client.search(filter);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(
+            !findings.is_empty(),
+            "expected LDAP injection finding for .search()"
+        );
+        assert!(findings[0].sink_description.contains("LDAP .search()"));
+    }
+
+    #[test]
+    fn ldap_no_finding_when_static_filter() {
+        let spec = super::super::javascript::TaintLdapInjection::spec();
+        let src = r#"
+function handler(req, res) {
+    client.search("dc=example", { filter: "(cn=admin)" });
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(findings.is_empty(), "static LDAP filter should not fire");
+    }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -109,6 +109,9 @@ impl RuleRegistry {
         registry.register(Box::new(javascript::TaintEval));
         registry.register(Box::new(javascript::TaintCommandInjection));
         registry.register(Box::new(javascript::TaintSsrf));
+        registry.register(Box::new(javascript::TaintSsti));
+        registry.register(Box::new(javascript::TaintXpathInjection));
+        registry.register(Box::new(javascript::TaintLdapInjection));
 
         // Register Python rules
         registry.register(Box::new(python::NoEval));

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -44,8 +44,11 @@ const jsRules: Rule[] = [
   { id: 'js/no-xss-innerhtml', cwe: 'CWE-79', desc: 'Assignment to innerHTML may lead to XSS', severity: 'high' },
   { id: 'js/taint-command-injection', cwe: 'CWE-78', desc: 'Untrusted input reaches a command execution sink — OS command injection', severity: 'critical' },
   { id: 'js/taint-eval', cwe: 'CWE-95', desc: 'Untrusted input reaches eval or Function — arbitrary code execution', severity: 'critical' },
+  { id: 'js/taint-ldap-injection', cwe: 'CWE-90', desc: 'Untrusted input reaches an LDAP operation sink — possible LDAP injection', severity: 'high' },
   { id: 'js/taint-sql-injection', cwe: 'CWE-89', desc: 'Untrusted input reaches a SQL execute sink — possible SQL injection', severity: 'critical' },
   { id: 'js/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches an HTTP request sink — possible SSRF', severity: 'high' },
+  { id: 'js/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches a template rendering sink — possible server-side template injection', severity: 'critical' },
+  { id: 'js/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches an XPath evaluation sink — possible XPath injection', severity: 'high' },
   { id: 'js/taint-xss-innerhtml', cwe: 'CWE-79', desc: 'Untrusted input reaches innerHTML or document.write sink', severity: 'high' },
 ];
 


### PR DESCRIPTION
## Summary
- Add `js/taint-ssti` rule (CWE-1336, Critical) covering ejs, pug, Handlebars, nunjucks, and mustache template rendering sinks
- Add `js/taint-xpath-injection` rule (CWE-643, High) covering xpath.select, xpath.evaluate, document.evaluate sinks
- Add `js/taint-ldap-injection` rule (CWE-90, High) covering ldapjs .search() and .bind() sinks
- Include 6 unit tests (positive + negative for each rule) and regenerate rules.ts

## Test plan
- [x] `cargo test` passes (all 145+ tests including 6 new taint tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Verify each rule fires on realistic vulnerable code snippets
- [ ] Verify no false positives on static/sanitized inputs

none