### PR TITLE
Convert walk_tree from recursive to iterative

### DIFF
--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -73,17 +73,21 @@ pub fn get_source_line(source: &str, byte_offset: usize) -> String {
     source[start..end].to_string()
 }
 
-/// Recursively walk every node in a tree-sitter tree, calling `callback` on
-/// each node.
+/// Iteratively walk every node in a tree-sitter tree (DFS pre-order), calling
+/// `callback` on each node.
 pub fn walk_tree(
     node: tree_sitter::Node,
     source: &str,
     callback: &mut dyn FnMut(tree_sitter::Node, &str),
 ) {
-    callback(node, source);
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_tree(child, source, callback);
+    let mut stack: Vec<tree_sitter::Node> = vec![node];
+    while let Some(current) = stack.pop() {
+        callback(current, source);
+        let mut cursor = current.walk();
+        let children: Vec<_> = current.children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push(child);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace recursive `walk_tree` in `src/rules/common.rs` with an iterative version using an explicit `Vec` stack
- Children pushed in reverse order to preserve DFS pre-order traversal
- Eliminates stack overflow risk on deeply nested ASTs

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 252 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)