### PR TITLE
feat: block comment support for inline ignores

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -152,6 +152,40 @@ fn inline_ignore_regex() -> &'static Regex {
     })
 }
 
+fn block_comment_ignore_regex() -> &'static Regex {
+    static BLOCK_IGNORE_REGEX: OnceLock<Regex> = OnceLock::new();
+    BLOCK_IGNORE_REGEX.get_or_init(|| {
+        Regex::new(r"/\*\s*foxguard[\s:-]*ignore(?:\[(?P<rules>[^\]]*)\])?\s*\*/")
+            .expect("invalid block comment ignore regex")
+    })
+}
+
+fn parse_block_comment_ignore(line: &str) -> Option<(bool, InlineIgnoreSpec)> {
+    let captures = block_comment_ignore_regex().captures(line)?;
+    let full_match = captures.get(0).unwrap();
+
+    let mut spec = InlineIgnoreSpec::default();
+    match captures.name("rules").map(|rules| rules.as_str().trim()) {
+        None | Some("") => spec.all_rules = true,
+        Some(rules) => {
+            for rule_id in rules
+                .split(',')
+                .map(str::trim)
+                .filter(|rule| !rule.is_empty())
+            {
+                spec.rule_ids.insert(rule_id.to_string());
+            }
+            if spec.rule_ids.is_empty() {
+                spec.all_rules = true;
+            }
+        }
+    }
+
+    let comment_only =
+        line[..full_match.start()].trim().is_empty() && line[full_match.end()..].trim().is_empty();
+    Some((comment_only, spec))
+}
+
 fn inline_ignore_directives(source: &str, language: Language) -> HashMap<usize, InlineIgnoreSpec> {
     let lines: Vec<&str> = source.lines().collect();
     let mut directives = HashMap::new();
@@ -222,6 +256,11 @@ fn parse_inline_ignore(line: &str, language: Language) -> Option<(bool, InlineIg
 
         let comment_only = line[..index].trim().is_empty();
         return Some((comment_only, spec));
+    }
+
+    // Fallback: block comment /* foxguard: ignore */ or /* foxguard-ignore */
+    if let Some(result) = parse_block_comment_ignore(line) {
+        return Some(result);
     }
 
     None

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -258,9 +258,20 @@ fn parse_inline_ignore(line: &str, language: Language) -> Option<(bool, InlineIg
         return Some((comment_only, spec));
     }
 
-    // Fallback: block comment /* foxguard: ignore */ or /* foxguard-ignore */
-    if let Some(result) = parse_block_comment_ignore(line) {
-        return Some(result);
+    // Fallback: block comment /* foxguard: ignore */ — only for languages with /* */ syntax
+    if matches!(
+        language,
+        Language::JavaScript
+            | Language::Go
+            | Language::Java
+            | Language::Rust
+            | Language::CSharp
+            | Language::Swift
+            | Language::Php
+    ) {
+        if let Some(result) = parse_block_comment_ignore(line) {
+            return Some(result);
+        }
     }
 
     None
@@ -410,4 +421,52 @@ fn scan_root(path: &Path) -> &Path {
 
 fn relative_scan_path(scan_root: &Path, path: &Path) -> PathBuf {
     path.strip_prefix(scan_root).unwrap_or(path).to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_comment_ignore_js() {
+        let result = parse_inline_ignore("/* foxguard: ignore */", Language::JavaScript);
+        assert!(result.is_some());
+        let (comment_only, spec) = result.unwrap();
+        assert!(comment_only);
+        assert!(spec.all_rules);
+    }
+
+    #[test]
+    fn block_comment_ignore_go() {
+        let result = parse_inline_ignore("/* foxguard: ignore */", Language::Go);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn block_comment_ignore_java() {
+        let result = parse_inline_ignore("/* foxguard: ignore */", Language::Java);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn block_comment_ignore_not_python() {
+        let result = parse_inline_ignore("/* foxguard: ignore */", Language::Python);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn block_comment_ignore_not_ruby() {
+        let result = parse_inline_ignore("/* foxguard: ignore */", Language::Ruby);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn block_comment_ignore_with_rule_id() {
+        let result =
+            parse_inline_ignore("/* foxguard: ignore[js/no-eval] */", Language::JavaScript);
+        assert!(result.is_some());
+        let (_, spec) = result.unwrap();
+        assert!(!spec.all_rules);
+        assert!(spec.rule_ids.contains("js/no-eval"));
+    }
 }


### PR DESCRIPTION
- Adds `/* foxguard: ignore */` support alongside existing `// foxguard: ignore`
- Supports rule-specific ignores: `/* foxguard: ignore[rule-id] */`
- Also handles `/* foxguard-ignore */` variant
- Fallback after line-comment markers, no behavior change for existing ignores