### PR TITLE
feat: cross-file taint analysis with Python import resolution (refs #46)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1,6 +1,8 @@
+use crate::rules::cross_file::CrossFileSummaryMap;
 use crate::rules::go_taint::go_aliases_from_tree;
 use crate::rules::javascript_taint::js_aliases_from_tree;
-use crate::rules::python_aliases::from_tree as py_aliases_from_tree;
+use crate::rules::python_aliases::{from_tree as py_aliases_from_tree, resolve_imports_to_paths};
+use crate::rules::python_taint;
 use crate::rules::{FileContext, RuleRegistry};
 use crate::{Finding, Language};
 use ignore::WalkBuilder;
@@ -289,6 +291,47 @@ fn scan_files(
     let start = Instant::now();
     let file_count = files.len();
 
+    // ── Pass 1: Extract cross-file taint summaries (Python only) ─────
+    // Only run pass 1 if there are multiple Python files — single-file
+    // scans cannot benefit from cross-file analysis.
+    let python_files: Vec<&(PathBuf, Language)> = files
+        .iter()
+        .filter(|(path, lang)| matches!(lang, Language::Python) && !is_noise_path(path))
+        .collect();
+
+    let cross_file_summaries: CrossFileSummaryMap = if python_files.len() > 1 {
+        let rule_specs = crate::rules::python::python_taint_rule_specs();
+        python_files
+            .par_iter()
+            .filter_map(|(path, _)| {
+                let source = std::fs::read_to_string(path).ok()?;
+                if is_minified(&source) {
+                    return None;
+                }
+                let tree = super::parser::parse_file(&source, Language::Python)?;
+                let aliases = py_aliases_from_tree(&source, &tree);
+                let summaries = python_taint::extract_cross_file_summaries(
+                    tree.root_node(),
+                    &source,
+                    Some(&aliases),
+                    &rule_specs,
+                );
+                if summaries.is_empty() {
+                    None
+                } else {
+                    // Canonicalize the path for consistent lookups.
+                    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    Some((canonical, summaries))
+                }
+            })
+            .collect()
+    } else {
+        CrossFileSummaryMap::new()
+    };
+
+    let has_cross_file = !cross_file_summaries.is_empty();
+
+    // ── Pass 2: Full analysis with cross-file summaries available ─────
     let mut results: Vec<Finding> = files
         .par_iter()
         .flat_map(|(path, language)| {
@@ -353,10 +396,33 @@ fn scan_files(
             } else {
                 None
             };
+
+            // Build Python import-to-path map for cross-file resolution.
+            let python_import_paths = if has_cross_file && matches!(language, Language::Python) {
+                let mut imports = resolve_imports_to_paths(&source, &tree, path);
+                // Canonicalize all paths to match the summary map keys.
+                let canonical: HashMap<String, PathBuf> = imports
+                    .drain()
+                    .map(|(k, v)| {
+                        let canon = std::fs::canonicalize(&v).unwrap_or(v);
+                        (k, canon)
+                    })
+                    .collect();
+                Some(canonical)
+            } else {
+                None
+            };
+
             let ctx = FileContext {
                 python_aliases: python_aliases.as_ref(),
                 javascript_aliases: javascript_aliases.as_ref(),
                 go_aliases: go_aliases.as_ref(),
+                cross_file_summaries: if has_cross_file {
+                    Some(&cross_file_summaries)
+                } else {
+                    None
+                },
+                python_import_paths: python_import_paths.as_ref(),
             };
 
             let mut file_findings = Vec::new();

--- a/src/rules/cross_file.rs
+++ b/src/rules/cross_file.rs
@@ -1,0 +1,37 @@
+//! Cross-file taint analysis infrastructure.
+//!
+//! Provides [`FunctionTaintSummary`] — a compact description of how a function
+//! propagates taint from its parameters to sinks and return values. Summaries
+//! are generated in pass 1 of the scanner (one per exported function) and
+//! consumed in pass 2 by the per-file taint engines.
+//!
+//! The summary extraction reuses the existing single-file taint engine: each
+//! parameter is treated as a synthetic taint source, and any findings or
+//! return-taint that result are recorded in the summary.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+/// Summary of a function's taint behavior for cross-file analysis.
+/// Generated in pass 1, consumed in pass 2.
+#[derive(Debug, Clone)]
+pub struct FunctionTaintSummary {
+    /// Function name as exported.
+    pub name: String,
+    /// Which parameter indices, when tainted, cause the return value to be tainted.
+    pub params_to_return: Vec<usize>,
+    /// Which parameter indices, when tainted, reach a sink.
+    pub params_to_sink: Vec<ParamSinkFlow>,
+}
+
+/// Records that when parameter at `param_index` is tainted, it reaches
+/// a specific sink identified by the rule that would fire.
+#[derive(Debug, Clone)]
+pub struct ParamSinkFlow {
+    pub param_index: usize,
+    pub sink_rule_id: String,
+    pub sink_description: String,
+}
+
+/// Map from file path to the summaries of all exported functions in that file.
+pub type CrossFileSummaryMap = HashMap<PathBuf, Vec<FunctionTaintSummary>>;

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod cross_file;
 pub mod csharp;
 pub mod go;
 pub mod go_taint;
@@ -32,6 +33,12 @@ pub struct FileContext<'a> {
     pub javascript_aliases: Option<&'a common::AliasTable>,
     /// Go import alias table. `None` for non-Go files.
     pub go_aliases: Option<&'a common::AliasTable>,
+    /// Cross-file taint summaries from pass 1. Keyed by canonical file path.
+    /// `None` when cross-file analysis is not available (e.g. single-file scan).
+    pub cross_file_summaries: Option<&'a cross_file::CrossFileSummaryMap>,
+    /// Python import-to-file-path resolution map for the current file.
+    /// Maps local import names to resolved file paths on disk.
+    pub python_import_paths: Option<&'a std::collections::HashMap<String, std::path::PathBuf>>,
 }
 
 /// A security rule that checks parsed source code for vulnerabilities.

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1807,7 +1807,22 @@ fn map_taint_findings(
     spec: &TaintSpec,
     format_description: impl Fn(&str, &str) -> String,
 ) -> Vec<Finding> {
-    let raw = python_taint::analyze_tree(tree.root_node(), source, spec, ctx.python_aliases);
+    // Build cross-file info if both summaries and import paths are available.
+    let cross_file_info = match (ctx.cross_file_summaries, ctx.python_import_paths) {
+        (Some(summaries), Some(import_paths)) => Some(python_taint::CrossFileInfo {
+            import_to_path: import_paths,
+            summaries,
+            current_rule_id: meta.rule_id,
+        }),
+        _ => None,
+    };
+    let raw = python_taint::analyze_tree_with_cross_file(
+        tree.root_node(),
+        source,
+        spec,
+        ctx.python_aliases,
+        cross_file_info.as_ref(),
+    );
     raw.into_iter()
         .map(|t| Finding {
             rule_id: meta.rule_id.to_string(),
@@ -2413,4 +2428,35 @@ impl Rule for TaintLdapInjection {
             )
         })
     }
+}
+
+// ─── Cross-file summary extraction ──────────────────────────────────────
+
+/// Returns all Python taint rule specs paired with their rule IDs.
+///
+/// Used by the cross-file summary extractor (pass 1) to determine which
+/// sinks a function's parameters can reach. Each spec's *sources* are
+/// replaced with synthetic `ParamName` entries by the caller — only the
+/// sinks and sanitizers are meaningful here.
+pub fn python_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
+    vec![
+        (
+            "py/taint-pickle-deserialization",
+            TaintPickleDeserialization::spec(),
+        ),
+        ("py/taint-eval", TaintEvalFromRequest::spec()),
+        (
+            "py/taint-command-injection",
+            TaintCommandInjectionFromRequest::spec(),
+        ),
+        ("py/taint-ssrf", TaintSsrfFromRequest::spec()),
+        ("py/taint-yaml-load", TaintYamlLoadFromRequest::spec()),
+        (
+            "py/taint-sql-injection",
+            TaintSqlInjectionFromRequest::spec(),
+        ),
+        ("py/taint-ssti", TaintSsti::spec()),
+        ("py/taint-xpath-injection", TaintXpathInjection::spec()),
+        ("py/taint-ldap-injection", TaintLdapInjection::spec()),
+    ]
 }

--- a/src/rules/python_aliases.rs
+++ b/src/rules/python_aliases.rs
@@ -112,6 +112,196 @@ fn collect_import_from(aliases: &mut AliasTable, node: Node, source: &str) {
     }
 }
 
+/// Resolve Python imports to file paths for cross-file taint analysis.
+///
+/// Given the source of a Python file and the path of that file, returns a
+/// mapping from local import names to the resolved file paths. Only resolves:
+/// - `from . import foo` (relative sibling import) -> `<dir>/foo.py`
+/// - `from .foo import bar` (relative import) -> `<dir>/foo.py`
+/// - `import foo` / `from foo import bar` -> `<dir>/foo.py` (sibling only)
+///
+/// Does not attempt full Python package resolution (sys.path, site-packages).
+pub fn resolve_imports_to_paths(
+    source: &str,
+    tree: &Tree,
+    current_file: &std::path::Path,
+) -> std::collections::HashMap<String, std::path::PathBuf> {
+    let mut result = std::collections::HashMap::new();
+    let Some(parent_dir) = current_file.parent() else {
+        return result;
+    };
+
+    resolve_imports_walk(&mut result, tree.root_node(), source, parent_dir);
+    result
+}
+
+fn resolve_imports_walk(
+    result: &mut std::collections::HashMap<String, std::path::PathBuf>,
+    node: Node,
+    source: &str,
+    parent_dir: &std::path::Path,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "import_from_statement" => {
+                resolve_import_from(result, child, source, parent_dir);
+            }
+            "import_statement" => {
+                resolve_plain_import(result, child, source, parent_dir);
+            }
+            "if_statement" | "try_statement" | "with_statement" | "block" | "module" => {
+                resolve_imports_walk(result, child, source, parent_dir);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn resolve_import_from(
+    result: &mut std::collections::HashMap<String, std::path::PathBuf>,
+    node: Node,
+    source: &str,
+    parent_dir: &std::path::Path,
+) {
+    let Some(module_node) = node.child_by_field_name("module_name") else {
+        return;
+    };
+    let module = node_text(module_node, source);
+
+    // `from . import queries` — module_name is ".", name is "queries"
+    if module == "." {
+        let mut cursor = node.walk();
+        for name in node.children_by_field_name("name", &mut cursor) {
+            let local = match name.kind() {
+                "dotted_name" | "identifier" => node_text(name, source),
+                "aliased_import" => {
+                    // `from . import queries as q` — use the alias as the local name
+                    // but resolve the real name to a file
+                    if let Some(real_name) = name.child_by_field_name("name") {
+                        let real = node_text(real_name, source);
+                        let local = name
+                            .child_by_field_name("alias")
+                            .map(|a| node_text(a, source))
+                            .unwrap_or(real);
+                        let candidate = parent_dir.join(format!("{}.py", real));
+                        if candidate.exists() {
+                            result.insert(local.to_string(), candidate);
+                        }
+                        continue;
+                    }
+                    continue;
+                }
+                _ => continue,
+            };
+            let candidate = parent_dir.join(format!("{}.py", local));
+            if candidate.exists() {
+                result.insert(local.to_string(), candidate);
+            }
+        }
+        return;
+    }
+
+    // `from .queries import run_query` — relative import with a module name
+    if let Some(stripped) = module.strip_prefix('.') {
+        if !stripped.is_empty() && !stripped.contains('.') {
+            let candidate = parent_dir.join(format!("{}.py", stripped));
+            if candidate.exists() {
+                // Map each imported name to the module file
+                let mut cursor = node.walk();
+                for name in node.children_by_field_name("name", &mut cursor) {
+                    let local = match name.kind() {
+                        "dotted_name" | "identifier" => node_text(name, source),
+                        "aliased_import" => name
+                            .child_by_field_name("alias")
+                            .or_else(|| name.child_by_field_name("name"))
+                            .map(|n| node_text(n, source))
+                            .unwrap_or(""),
+                        _ => continue,
+                    };
+                    if !local.is_empty() {
+                        // For `from .queries import run_query`, we want to be
+                        // able to look up `run_query` as a function in `queries.py`.
+                        // Store the module path keyed by the *module* name for
+                        // attribute access (`queries.run_query`), but this form
+                        // imports the function directly. We store it keyed by
+                        // a special format: `__from_module__:<local_name>` ->
+                        // file path, plus the module itself.
+                        result.insert(
+                            format!("__from__:{}:{}", stripped, local),
+                            candidate.clone(),
+                        );
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    // `from queries import run_query` — bare module name, try sibling
+    if !module.contains('.') {
+        let candidate = parent_dir.join(format!("{}.py", module));
+        if candidate.exists() {
+            let mut cursor = node.walk();
+            for name in node.children_by_field_name("name", &mut cursor) {
+                let local = match name.kind() {
+                    "dotted_name" | "identifier" => node_text(name, source),
+                    "aliased_import" => name
+                        .child_by_field_name("alias")
+                        .or_else(|| name.child_by_field_name("name"))
+                        .map(|n| node_text(n, source))
+                        .unwrap_or(""),
+                    _ => continue,
+                };
+                if !local.is_empty() {
+                    result.insert(format!("__from__:{}:{}", module, local), candidate.clone());
+                }
+            }
+        }
+    }
+}
+
+fn resolve_plain_import(
+    result: &mut std::collections::HashMap<String, std::path::PathBuf>,
+    node: Node,
+    source: &str,
+    parent_dir: &std::path::Path,
+) {
+    // `import queries` — try sibling file
+    let mut cursor = node.walk();
+    for name in node.children_by_field_name("name", &mut cursor) {
+        let (local, module_name) = match name.kind() {
+            "dotted_name" => {
+                let text = node_text(name, source);
+                // Only resolve simple (non-dotted) module names to siblings
+                if text.contains('.') {
+                    continue;
+                }
+                (text.to_string(), text)
+            }
+            "aliased_import" => {
+                let real = name
+                    .child_by_field_name("name")
+                    .map(|n| node_text(n, source))
+                    .unwrap_or("");
+                let alias = name
+                    .child_by_field_name("alias")
+                    .map(|n| node_text(n, source))
+                    .unwrap_or(real);
+                if real.contains('.') {
+                    continue;
+                }
+                (alias.to_string(), real)
+            }
+            _ => continue,
+        };
+        let candidate = parent_dir.join(format!("{}.py", module_name));
+        if candidate.exists() {
+            result.insert(local, candidate);
+        }
+    }
+}
+
 fn node_text<'a>(node: Node, source: &'a str) -> &'a str {
     &source[node.byte_range()]
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -31,8 +31,25 @@
 //! Semgrep-compatible `mode: taint` YAML) will plug into the same API.
 
 use crate::rules::common::AliasTable;
+use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tree_sitter::Node;
+
+/// Cross-file context passed to `analyze_tree` to enable cross-file taint
+/// propagation. When `Some`, the engine resolves calls to imported functions
+/// via the summary map and emits findings when tainted arguments reach
+/// cross-file sinks.
+#[derive(Clone)]
+pub struct CrossFileInfo<'a> {
+    /// Map from local import name (e.g. "queries") to the resolved file path.
+    pub import_to_path: &'a HashMap<String, PathBuf>,
+    /// Cross-file summaries keyed by canonical file path.
+    pub summaries: &'a CrossFileSummaryMap,
+    /// The rule ID currently being analyzed. Cross-file findings are only
+    /// emitted when the summary's `sink_rule_id` matches this value.
+    pub current_rule_id: &'a str,
+}
 
 // ─── Public API ───────────────────────────────────────────────────────────
 
@@ -149,6 +166,8 @@ struct AnalysisContext<'a> {
     spec: &'a TaintSpec,
     aliases: Option<&'a AliasTable>,
     summaries: &'a ReturnSummary,
+    /// Cross-file info for resolving imported function calls.
+    cross_file: Option<&'a CrossFileInfo<'a>>,
 }
 
 /// Run the taint engine over every function definition inside `root` and
@@ -180,6 +199,22 @@ pub fn analyze_tree(
     spec: &TaintSpec,
     aliases: Option<&AliasTable>,
 ) -> Vec<TaintFinding> {
+    analyze_tree_with_cross_file(root, source, spec, aliases, None)
+}
+
+/// Like [`analyze_tree`] but with optional cross-file taint summaries.
+///
+/// When `cross_file` is `Some`, calls to imported functions are resolved
+/// against the summary map. If a tainted argument reaches a sink in the
+/// imported function (per its summary), a finding is emitted in the
+/// caller's file.
+pub fn analyze_tree_with_cross_file<'a>(
+    root: Node<'_>,
+    source: &'a str,
+    spec: &'a TaintSpec,
+    aliases: Option<&'a AliasTable>,
+    cross_file: Option<&'a CrossFileInfo<'a>>,
+) -> Vec<TaintFinding> {
     // Pass 1: build return summaries using an empty summary map so that
     // calls to local helpers inside helper bodies fall through to the
     // default behavior. This is the one-level interprocedural limit.
@@ -190,6 +225,7 @@ pub fn analyze_tree(
         spec,
         aliases,
         summaries: &empty_summary,
+        cross_file: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -205,12 +241,151 @@ pub fn analyze_tree(
         spec,
         aliases,
         summaries: &summaries,
+        cross_file,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
         analyze_function(func_node, &ctx, &mut findings);
     });
     findings
+}
+
+/// Extract cross-file function taint summaries for all top-level functions
+/// in a parsed Python file.
+///
+/// For each function, every parameter is treated as a synthetic taint source.
+/// Each rule spec's sinks are tested against the function body. If a
+/// parameter reaches a sink, a [`ParamSinkFlow`] is recorded. If a
+/// parameter flows to a return value, `params_to_return` records the index.
+///
+/// The `rule_specs` argument should be the output of
+/// [`crate::rules::python::python_taint_rule_specs()`].
+pub fn extract_cross_file_summaries(
+    root: Node<'_>,
+    source: &str,
+    aliases: Option<&AliasTable>,
+    rule_specs: &[(&str, TaintSpec)],
+) -> Vec<FunctionTaintSummary> {
+    let mut summaries = Vec::new();
+
+    collect_function_defs(root, &mut |func_node| {
+        let Some(name_node) = func_node.child_by_field_name("name") else {
+            return;
+        };
+        let func_name = node_text(name_node, source).to_string();
+
+        // Collect parameter names in order.
+        let param_names = collect_param_names(func_node, source);
+        if param_names.is_empty() {
+            return;
+        }
+
+        let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
+        let mut params_to_return: Vec<usize> = Vec::new();
+
+        // For each parameter, create a synthetic spec that treats ONLY
+        // that parameter as a taint source, then run each rule's sinks.
+        for (param_idx, param_name) in param_names.iter().enumerate() {
+            let synthetic_source = NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            };
+
+            // Check return-taint: does this parameter flow to a return value?
+            // Use a minimal spec with no sinks just to check return flow.
+            let return_spec = TaintSpec {
+                sources: vec![synthetic_source.clone()],
+                sinks: vec![],
+                sanitizers: vec![],
+            };
+            let empty_summary = ReturnSummary::new();
+            let return_ctx = AnalysisContext {
+                source,
+                spec: &return_spec,
+                aliases,
+                summaries: &empty_summary,
+                cross_file: None,
+            };
+            let (_, ret_taint) = summarize_function(func_node, &return_ctx);
+            if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
+                params_to_return.push(param_idx);
+            }
+
+            // Check sink-taint: does this parameter reach any sink?
+            for (rule_id, rule_spec) in rule_specs {
+                let synthetic_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: rule_spec.sinks.clone(),
+                    sanitizers: rule_spec.sanitizers.clone(),
+                };
+                let sink_ctx = AnalysisContext {
+                    source,
+                    spec: &synthetic_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &sink_ctx, &mut findings);
+                if !findings.is_empty() {
+                    // Deduplicate: only record one flow per (param, rule) pair.
+                    let already = params_to_sink
+                        .iter()
+                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
+                    if !already {
+                        params_to_sink.push(ParamSinkFlow {
+                            param_index: param_idx,
+                            sink_rule_id: rule_id.to_string(),
+                            sink_description: findings[0].sink_description.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        if !params_to_sink.is_empty() || !params_to_return.is_empty() {
+            summaries.push(FunctionTaintSummary {
+                name: func_name,
+                params_to_return,
+                params_to_sink,
+            });
+        }
+    });
+
+    summaries
+}
+
+/// Collect parameter names from a function definition, in order.
+fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
+    let Some(params) = func_node.child_by_field_name("parameters") else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    let mut cursor = params.walk();
+    for child in params.children(&mut cursor) {
+        let param_name = match child.kind() {
+            "identifier" => Some(node_text(child, source)),
+            "typed_parameter" | "default_parameter" | "typed_default_parameter" => {
+                let mut inner_cursor = child.walk();
+                let mut found: Option<&str> = None;
+                for inner in child.children(&mut inner_cursor) {
+                    if inner.kind() == "identifier" {
+                        found = Some(node_text(inner, source));
+                        break;
+                    }
+                }
+                found
+            }
+            _ => None,
+        };
+        if let Some(name) = param_name {
+            // Skip `self` and `cls` — they are not user-controlled.
+            if name != "self" && name != "cls" {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
 }
 
 /// Pass-1 walker: compute a function's return-taint summary by scanning
@@ -545,16 +720,92 @@ fn handle_call(
         } if method == final_segment => Some(description.clone()),
         _ => None,
     });
-    let Some(sink_desc) = sink_desc else {
+
+    if let Some(sink_desc) = sink_desc {
+        // Check each argument for taint.
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let mut cursor = args.walk();
+        for arg in args.named_children(&mut cursor) {
+            if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
+                let start = node.start_position();
+                let end = node.end_position();
+                findings.push(TaintFinding {
+                    sink_start_byte: node.start_byte(),
+                    sink_end_byte: node.end_byte(),
+                    sink_line: start.row + 1,
+                    sink_column: start.column + 1,
+                    sink_end_line: end.row + 1,
+                    sink_end_column: end.column + 1,
+                    source_description: source_desc,
+                    sink_description: sink_desc.clone(),
+                    source_line: src_line,
+                });
+                // One finding per sink call is enough — don't double-report
+                // when multiple args are tainted.
+                break;
+            }
+        }
+        return;
+    }
+
+    // ── Cross-file summary check ─────────────────────────────────────
+    // If the callee is an imported function with cross-file summaries,
+    // check whether any tainted argument reaches a sink in the imported
+    // function (per its summary).
+    if let Some(cross_file) = ctx.cross_file {
+        handle_cross_file_call(node, func, callee_text, ctx, state, findings, cross_file);
+    }
+}
+
+/// Check if a call targets an imported function with cross-file summaries.
+///
+/// Handles two import patterns:
+/// - `from . import queries; queries.run_query(x)` — attribute call on imported module
+/// - `from .queries import run_query; run_query(x)` — direct call to imported function
+fn handle_cross_file_call(
+    node: Node<'_>,
+    func: Node<'_>,
+    callee_text: &str,
+    ctx: &AnalysisContext<'_>,
+    state: &TaintState,
+    findings: &mut Vec<TaintFinding>,
+    cross_file: &CrossFileInfo<'_>,
+) {
+    // Try to resolve the callee to a (file_path, function_name) pair.
+    let resolved = resolve_cross_file_callee(func, callee_text, ctx.source, cross_file);
+    let Some((file_path, func_name)) = resolved else {
         return;
     };
 
-    // Check each argument for taint.
+    // Look up summaries for the resolved file.
+    let Some(file_summaries) = cross_file.summaries.get(&file_path) else {
+        return;
+    };
+
+    // Find the function summary.
+    let Some(summary) = file_summaries.iter().find(|s| s.name == func_name) else {
+        return;
+    };
+
+    // Collect argument nodes.
     let Some(args) = node.child_by_field_name("arguments") else {
         return;
     };
     let mut cursor = args.walk();
-    for arg in args.named_children(&mut cursor) {
+    let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+
+    // For each tainted argument, check if the corresponding parameter
+    // has a ParamSinkFlow whose rule ID matches the current rule.
+    for flow in &summary.params_to_sink {
+        if flow.sink_rule_id != cross_file.current_rule_id {
+            continue;
+        }
+        if flow.param_index >= arg_nodes.len() {
+            continue;
+        }
+        let arg = arg_nodes[flow.param_index];
         if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
@@ -566,14 +817,58 @@ fn handle_call(
                 sink_end_line: end.row + 1,
                 sink_end_column: end.column + 1,
                 source_description: source_desc,
-                sink_description: sink_desc.clone(),
+                sink_description: format!(
+                    "{} (via cross-file call to {})",
+                    flow.sink_description, func_name
+                ),
                 source_line: src_line,
             });
-            // One finding per sink call is enough — don't double-report
-            // when multiple args are tainted.
-            break;
+            // One finding per cross-file call is enough.
+            return;
         }
     }
+}
+
+/// Resolve a call-site callee to (file_path, function_name) using the
+/// cross-file import map.
+fn resolve_cross_file_callee(
+    func: Node<'_>,
+    callee_text: &str,
+    source: &str,
+    cross_file: &CrossFileInfo<'_>,
+) -> Option<(PathBuf, String)> {
+    // Pattern 1: attribute call `module.func(...)` where `module` is an
+    // imported module name (e.g. `queries.run_query`).
+    if func.kind() == "attribute" {
+        if let Some(object) = func.child_by_field_name("object") {
+            if object.kind() == "identifier" {
+                let module_name = node_text(object, source);
+                if let Some(file_path) = cross_file.import_to_path.get(module_name) {
+                    if let Some(attr) = func.child_by_field_name("attribute") {
+                        let func_name = node_text(attr, source).to_string();
+                        return Some((file_path.clone(), func_name));
+                    }
+                }
+            }
+        }
+    }
+
+    // Pattern 2: direct call `func(...)` where `func` was imported from
+    // another module (e.g. `from .queries import run_query; run_query(x)`).
+    if func.kind() == "identifier" {
+        // Check all __from__:<module>:<name> entries
+        for (key, file_path) in cross_file.import_to_path.iter() {
+            if let Some(rest) = key.strip_prefix("__from__:") {
+                if let Some((_module, name)) = rest.split_once(':') {
+                    if name == callee_text {
+                        return Some((file_path.clone(), name.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 /// Returns the (source description, source line) if `expr` evaluates to (or

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -155,20 +155,23 @@ fn realistic_hono_app() {
     assert_fixture("hono_app.ts", 7, &[("js/taint-xss-innerhtml", 3)]);
 }
 
-/// Multi-file Django fixture (issue #48). Scans a directory rather
-/// than a single file. The current engine is intraprocedural +
-/// same-file interprocedural only, so cross-file flows from
-/// `views.py` into `queries.py` helpers do NOT fire yet. This test
-/// pins that limit explicitly: in-file taint flows fire, cross-file
-/// ones do not. Once issue #46 (cross-file summaries) lands, the
-/// expected total and taint counts below will need to be updated to
-/// reflect the new cross-file sql-injection and pickle findings.
+/// Multi-file Django fixture (issue #48). Cross-file taint analysis
+/// (issue #46) propagates taint from `views.py` into `queries.py`
+/// helpers via function taint summaries. In-file flows fire as before,
+/// plus two new cross-file flows:
+///   - `py/taint-sql-injection`: request.GET["name"] → queries.run_query → cur.execute
+///   - `py/taint-pickle-deserialization`: request.body → queries.load_blob → pickle.loads
 #[test]
 fn realistic_django_shop_multifile() {
     assert_fixture(
         "django_shop",
-        6,
-        &[("py/taint-command-injection", 1), ("py/taint-ssrf", 1)],
+        8,
+        &[
+            ("py/taint-command-injection", 1),
+            ("py/taint-ssrf", 1),
+            ("py/taint-sql-injection", 1),
+            ("py/taint-pickle-deserialization", 1),
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary
- Implements two-pass cross-file interprocedural taint analysis, starting with Python
- Pass 1 extracts function taint summaries by running each parameter as a synthetic taint source against all rule specs; pass 2 resolves imported function calls against summaries to detect tainted data flowing across file boundaries
- Adds Python import resolution for sibling files (`from . import mod`, `from .mod import func`, `import mod`) with canonical path matching
- Django shop fixture now correctly detects `py/taint-sql-injection` (request.GET -> queries.run_query -> cur.execute) and `py/taint-pickle-deserialization` (request.body -> queries.load_blob -> pickle.loads)

## Architecture
- `src/rules/cross_file.rs` — `FunctionTaintSummary` and `ParamSinkFlow` types
- `src/rules/python_taint.rs` — `extract_cross_file_summaries()` reuses existing taint engine with synthetic ParamName sources; `analyze_tree_with_cross_file()` + `handle_cross_file_call()` consume summaries
- `src/rules/python_aliases.rs` — `resolve_imports_to_paths()` maps Python imports to file paths
- `src/engine/scanner.rs` — two-pass scan: parallel summary extraction then parallel analysis with read-only summary map
- `src/rules/python.rs` — `python_taint_rule_specs()` exposes all taint rule specs; `map_taint_findings()` builds `CrossFileInfo` from FileContext

## Test plan
- [ ] All 275 existing tests pass (verified locally)
- [ ] `cargo fmt` and `cargo clippy` clean
- [ ] django_shop fixture expects 8 total findings (was 6), with new `py/taint-sql-injection` and `py/taint-pickle-deserialization` cross-file findings
- [ ] Single-file scans unaffected (pass 1 skipped when < 2 Python files)
- [ ] NEAR-MISS functions in fixtures still produce zero taint findings

none