### PR TITLE
feat(go): cross-file taint analysis with same-package resolution (refs #46)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -1,5 +1,5 @@
 use crate::rules::cross_file::CrossFileSummaryMap;
-use crate::rules::go_taint::go_aliases_from_tree;
+use crate::rules::go_taint::{self, go_aliases_from_tree};
 use crate::rules::javascript_taint::js_aliases_from_tree;
 use crate::rules::python_aliases::{from_tree as py_aliases_from_tree, resolve_imports_to_paths};
 use crate::rules::python_taint;
@@ -291,15 +291,22 @@ fn scan_files(
     let start = Instant::now();
     let file_count = files.len();
 
-    // ── Pass 1: Extract cross-file taint summaries (Python only) ─────
-    // Only run pass 1 if there are multiple Python files — single-file
-    // scans cannot benefit from cross-file analysis.
+    // ── Pass 1: Extract cross-file taint summaries ────────────────────
+    // Run pass 1 for Python and Go files when there are multiple files
+    // of the same language — single-file scans cannot benefit from
+    // cross-file analysis.
+
     let python_files: Vec<&(PathBuf, Language)> = files
         .iter()
         .filter(|(path, lang)| matches!(lang, Language::Python) && !is_noise_path(path))
         .collect();
 
-    let cross_file_summaries: CrossFileSummaryMap = if python_files.len() > 1 {
+    let go_files: Vec<&(PathBuf, Language)> = files
+        .iter()
+        .filter(|(path, lang)| matches!(lang, Language::Go) && !is_noise_path(path))
+        .collect();
+
+    let mut cross_file_summaries: CrossFileSummaryMap = if python_files.len() > 1 {
         let rule_specs = crate::rules::python::python_taint_rule_specs();
         python_files
             .par_iter()
@@ -329,7 +336,53 @@ fn scan_files(
         CrossFileSummaryMap::new()
     };
 
+    // Go cross-file summaries: extract from all Go files.
+    if go_files.len() > 1 {
+        let go_rule_specs = crate::rules::go::go_taint_rule_specs();
+        let go_summaries: CrossFileSummaryMap = go_files
+            .par_iter()
+            .filter_map(|(path, _)| {
+                let source = std::fs::read_to_string(path).ok()?;
+                if is_minified(&source) {
+                    return None;
+                }
+                let tree = super::parser::parse_file(&source, Language::Go)?;
+                let aliases = go_aliases_from_tree(&source, &tree);
+                let summaries = go_taint::extract_cross_file_summaries(
+                    tree.root_node(),
+                    &source,
+                    Some(&aliases),
+                    &go_rule_specs,
+                );
+                if summaries.is_empty() {
+                    None
+                } else {
+                    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    Some((canonical, summaries))
+                }
+            })
+            .collect();
+        cross_file_summaries.extend(go_summaries);
+    }
+
     let has_cross_file = !cross_file_summaries.is_empty();
+
+    // Build a directory→files index for Go same-package resolution.
+    // All .go files in the same directory share the same package.
+    let go_dir_index: HashMap<PathBuf, Vec<PathBuf>> = if has_cross_file {
+        let mut index: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
+        for (path, lang) in &files {
+            if matches!(lang, Language::Go) && !is_noise_path(path) {
+                if let Some(dir) = path.parent() {
+                    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    index.entry(dir.to_path_buf()).or_default().push(canonical);
+                }
+            }
+        }
+        index
+    } else {
+        HashMap::new()
+    };
 
     // ── Pass 2: Full analysis with cross-file summaries available ─────
     let mut results: Vec<Finding> = files
@@ -413,6 +466,25 @@ fn scan_files(
                 None
             };
 
+            // Build Go same-package paths for cross-file resolution.
+            // All .go files in the same directory share a package, so
+            // we provide the paths of sibling files (excluding self).
+            let go_same_package_paths = if has_cross_file && matches!(language, Language::Go) {
+                path.parent().and_then(|dir| {
+                    let canonical_self =
+                        std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    go_dir_index.get(dir).map(|siblings| {
+                        siblings
+                            .iter()
+                            .filter(|p| **p != canonical_self)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    })
+                })
+            } else {
+                None
+            };
+
             let ctx = FileContext {
                 python_aliases: python_aliases.as_ref(),
                 javascript_aliases: javascript_aliases.as_ref(),
@@ -423,6 +495,7 @@ fn scan_files(
                     None
                 },
                 python_import_paths: python_import_paths.as_ref(),
+                go_same_package_paths,
             };
 
             let mut file_findings = Vec::new();

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -615,7 +615,23 @@ fn map_go_taint_findings(
         None
     };
     let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
-    let raw = go_taint::analyze_tree(tree.root_node(), source, spec, aliases);
+
+    // Build cross-file info if both summaries and same-package paths are available.
+    let cross_file_info = match (ctx.cross_file_summaries, ctx.go_same_package_paths.as_ref()) {
+        (Some(summaries), Some(paths)) => Some(go_taint::CrossFileInfo {
+            same_package_paths: paths,
+            summaries,
+            current_rule_id: meta.rule_id,
+        }),
+        _ => None,
+    };
+    let raw = go_taint::analyze_tree_with_cross_file(
+        tree.root_node(),
+        source,
+        spec,
+        aliases,
+        cross_file_info.as_ref(),
+    );
     raw.into_iter()
         .map(|t| Finding {
             rule_id: meta.rule_id.to_string(),
@@ -1036,4 +1052,20 @@ impl Rule for TaintSsrf {
             )
         })
     }
+}
+
+/// All Go taint rule IDs paired with their specs.
+///
+/// Used by the scanner's pass 1 to extract cross-file summaries: each
+/// rule's sinks are tested against function bodies with synthetic
+/// per-parameter sources.
+pub fn go_taint_rule_specs() -> Vec<(&'static str, GoTaintSpec)> {
+    vec![
+        ("go/taint-command-injection", TaintCommandInjection::spec()),
+        ("go/taint-sql-injection", TaintSqlInjection::spec()),
+        ("go/taint-ssti", TaintSsti::spec()),
+        ("go/taint-xpath-injection", TaintXpathInjection::spec()),
+        ("go/taint-ldap-injection", TaintLdapInjection::spec()),
+        ("go/taint-ssrf", TaintSsrf::spec()),
+    ]
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -35,8 +35,10 @@
 //! `TaintSpec`.
 
 use super::common::AliasTable;
+use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
 // ─── Public API ───────────────────────────────────────────────────────────
@@ -99,6 +101,23 @@ pub struct TaintSpec {
     pub sanitizers: Vec<NodeMatcher>,
 }
 
+/// Cross-file taint info for Go same-package resolution.
+///
+/// In Go, all `.go` files in the same directory belong to the same package
+/// and can call each other's functions without imports. This struct maps
+/// file paths in the same package to their taint summaries.
+pub struct CrossFileInfo<'a> {
+    /// Map from file path to taint summaries for that file.
+    /// For same-package resolution, these are all `.go` files in the
+    /// same directory as the current file.
+    pub same_package_paths: &'a [PathBuf],
+    /// Cross-file summaries keyed by canonical file path.
+    pub summaries: &'a CrossFileSummaryMap,
+    /// The rule ID currently being analyzed. Cross-file findings are only
+    /// emitted when the summary's `sink_rule_id` matches this value.
+    pub current_rule_id: &'a str,
+}
+
 /// A single source→sink flow reported by the engine.
 #[derive(Debug, Clone)]
 pub struct TaintFinding {
@@ -130,6 +149,8 @@ struct AnalysisContext<'a> {
     spec: &'a TaintSpec,
     aliases: Option<&'a AliasTable>,
     summaries: &'a ReturnSummary,
+    /// Cross-file info for resolving same-package function calls.
+    cross_file: Option<&'a CrossFileInfo<'a>>,
 }
 
 /// Run the taint engine over every function/method body inside `root`
@@ -144,6 +165,22 @@ pub fn analyze_tree(
     spec: &TaintSpec,
     aliases: Option<&AliasTable>,
 ) -> Vec<TaintFinding> {
+    analyze_tree_with_cross_file(root, source, spec, aliases, None)
+}
+
+/// Like [`analyze_tree`] but with optional cross-file taint summaries.
+///
+/// When `cross_file` is `Some`, calls to functions defined in other files
+/// of the same Go package are resolved against the summary map. If a
+/// tainted argument reaches a sink in the callee (per its summary), a
+/// finding is emitted in the caller's file.
+pub fn analyze_tree_with_cross_file<'a>(
+    root: Node<'_>,
+    source: &'a str,
+    spec: &'a TaintSpec,
+    aliases: Option<&'a AliasTable>,
+    cross_file: Option<&'a CrossFileInfo<'a>>,
+) -> Vec<TaintFinding> {
     let empty_summary = ReturnSummary::new();
     let mut summaries = ReturnSummary::new();
     let pass1_ctx = AnalysisContext {
@@ -151,6 +188,7 @@ pub fn analyze_tree(
         spec,
         aliases,
         summaries: &empty_summary,
+        cross_file: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -165,6 +203,7 @@ pub fn analyze_tree(
         spec,
         aliases,
         summaries: &summaries,
+        cross_file,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
@@ -252,6 +291,137 @@ fn go_collect_import_spec(aliases: &mut AliasTable, node: Node<'_>, source: &str
             aliases.insert(canonical.clone(), canonical);
         }
     }
+}
+
+// ─── Cross-file summary extraction ───────────────────────────────────────
+
+/// Collect parameter names from a Go function / method declaration.
+///
+/// For a function like `func runQuery(name string) []any`, this returns
+/// `["name"]`. For a method like `func (s *Store) Run(q string)`, this
+/// returns `["q"]` (the receiver is excluded).
+fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
+    let Some(params) = func_node.child_by_field_name("parameters") else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    let mut cursor = params.walk();
+    for child in params.children(&mut cursor) {
+        if !matches!(
+            child.kind(),
+            "parameter_declaration" | "variadic_parameter_declaration"
+        ) {
+            continue;
+        }
+        let mut name_cursor = child.walk();
+        for inner in child.children(&mut name_cursor) {
+            if inner.kind() == "identifier" {
+                names.push(node_text(inner, source).to_string());
+            }
+        }
+    }
+    names
+}
+
+/// Extract cross-file function taint summaries for all functions in a
+/// parsed Go file.
+///
+/// For each function, every parameter is treated as a synthetic taint
+/// source. Each rule spec's sinks are tested against the function body.
+/// If a parameter reaches a sink, a [`ParamSinkFlow`] is recorded. If a
+/// parameter flows to a return value, `params_to_return` records the index.
+///
+/// Unlike Python, we process *all* functions (not just exported ones)
+/// because Go same-package calls can reach unexported (lowercase) functions.
+pub fn extract_cross_file_summaries(
+    root: Node<'_>,
+    source: &str,
+    aliases: Option<&AliasTable>,
+    rule_specs: &[(&str, TaintSpec)],
+) -> Vec<FunctionTaintSummary> {
+    let mut summaries = Vec::new();
+
+    collect_function_defs(root, &mut |func_node| {
+        // Only process named functions / methods (skip closures).
+        let Some(name_node) = func_node.child_by_field_name("name") else {
+            return;
+        };
+        let func_name = node_text(name_node, source).to_string();
+
+        let param_names = collect_param_names(func_node, source);
+        if param_names.is_empty() {
+            return;
+        }
+
+        let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
+        let mut params_to_return: Vec<usize> = Vec::new();
+
+        for (param_idx, param_name) in param_names.iter().enumerate() {
+            let synthetic_source = NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            };
+
+            // Check return-taint: does this parameter flow to a return value?
+            let return_spec = TaintSpec {
+                sources: vec![synthetic_source.clone()],
+                sinks: vec![],
+                sanitizers: vec![],
+            };
+            let empty_summary = ReturnSummary::new();
+            let return_ctx = AnalysisContext {
+                source,
+                spec: &return_spec,
+                aliases,
+                summaries: &empty_summary,
+                cross_file: None,
+            };
+            let (_, ret_taint) = summarize_function(func_node, &return_ctx);
+            if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
+                params_to_return.push(param_idx);
+            }
+
+            // Check sink-taint: does this parameter reach any sink?
+            for (rule_id, rule_spec) in rule_specs {
+                let synthetic_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: rule_spec.sinks.clone(),
+                    sanitizers: rule_spec.sanitizers.clone(),
+                };
+                let sink_ctx = AnalysisContext {
+                    source,
+                    spec: &synthetic_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &sink_ctx, &mut findings);
+                if !findings.is_empty() {
+                    let already = params_to_sink
+                        .iter()
+                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
+                    if !already {
+                        params_to_sink.push(ParamSinkFlow {
+                            param_index: param_idx,
+                            sink_rule_id: rule_id.to_string(),
+                            sink_description: findings[0].sink_description.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        if !params_to_sink.is_empty() || !params_to_return.is_empty() {
+            summaries.push(FunctionTaintSummary {
+                name: func_name,
+                params_to_return,
+                params_to_sink,
+            });
+        }
+    });
+
+    summaries
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────
@@ -666,15 +836,96 @@ fn handle_call(
         } if method == final_segment => Some(description.clone()),
         _ => None,
     });
-    let Some(sink_desc) = sink_desc else {
+
+    if let Some(sink_desc) = sink_desc {
+        let Some(args) = node.child_by_field_name("arguments") else {
+            return;
+        };
+        let mut cursor = args.walk();
+        for arg in args.named_children(&mut cursor) {
+            if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
+                let start = node.start_position();
+                let end = node.end_position();
+                findings.push(TaintFinding {
+                    sink_start_byte: node.start_byte(),
+                    sink_end_byte: node.end_byte(),
+                    sink_line: start.row + 1,
+                    sink_column: start.column + 1,
+                    sink_end_line: end.row + 1,
+                    sink_end_column: end.column + 1,
+                    source_description: source_desc,
+                    sink_description: sink_desc.clone(),
+                    source_line: src_line,
+                });
+                break;
+            }
+        }
+        return;
+    }
+
+    // ── Cross-file summary check ─────────────────────────────────────
+    // If the callee is a bare identifier (same-package function call)
+    // and we have cross-file summaries, check whether any tainted
+    // argument reaches a sink in the callee function (per its summary).
+    if let Some(cross_file) = ctx.cross_file {
+        handle_cross_file_call(node, callee_raw.as_ref(), ctx, state, findings, cross_file);
+    }
+}
+
+/// Check if a call targets a same-package function with cross-file summaries.
+///
+/// In Go, all files in the same directory share the same package namespace.
+/// A bare identifier call like `runQuery(name)` may refer to a function
+/// defined in another `.go` file in the same directory.
+fn handle_cross_file_call(
+    node: Node<'_>,
+    _callee_text: &str,
+    ctx: &AnalysisContext<'_>,
+    state: &TaintState,
+    findings: &mut Vec<TaintFinding>,
+    cross_file: &CrossFileInfo<'_>,
+) {
+    // Only handle bare identifier calls (same-package function calls).
+    // Selector expressions like `pkg.Func` are external package calls
+    // which we don't resolve yet.
+    let func = match node.child_by_field_name("function") {
+        Some(f) if f.kind() == "identifier" => f,
+        _ => return,
+    };
+    let func_name = node_text(func, ctx.source);
+
+    // Search all same-package files for a function with this name.
+    let mut resolved_summary: Option<&FunctionTaintSummary> = None;
+    for pkg_path in cross_file.same_package_paths {
+        if let Some(file_summaries) = cross_file.summaries.get(pkg_path) {
+            if let Some(summary) = file_summaries.iter().find(|s| s.name == func_name) {
+                resolved_summary = Some(summary);
+                break;
+            }
+        }
+    }
+
+    let Some(summary) = resolved_summary else {
         return;
     };
 
+    // Collect argument nodes.
     let Some(args) = node.child_by_field_name("arguments") else {
         return;
     };
     let mut cursor = args.walk();
-    for arg in args.named_children(&mut cursor) {
+    let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+
+    // For each tainted argument, check if the corresponding parameter
+    // has a ParamSinkFlow whose rule ID matches the current rule.
+    for flow in &summary.params_to_sink {
+        if flow.sink_rule_id != cross_file.current_rule_id {
+            continue;
+        }
+        if flow.param_index >= arg_nodes.len() {
+            continue;
+        }
+        let arg = arg_nodes[flow.param_index];
         if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
             let start = node.start_position();
             let end = node.end_position();
@@ -686,10 +937,14 @@ fn handle_call(
                 sink_end_line: end.row + 1,
                 sink_end_column: end.column + 1,
                 source_description: source_desc,
-                sink_description: sink_desc.clone(),
+                sink_description: format!(
+                    "{} (via cross-file call to {})",
+                    flow.sink_description, func_name
+                ),
                 source_line: src_line,
             });
-            break;
+            // One finding per cross-file call is enough.
+            return;
         }
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -39,6 +39,10 @@ pub struct FileContext<'a> {
     /// Python import-to-file-path resolution map for the current file.
     /// Maps local import names to resolved file paths on disk.
     pub python_import_paths: Option<&'a std::collections::HashMap<String, std::path::PathBuf>>,
+    /// Go same-package file paths. All `.go` files in the same directory
+    /// share the same package and can call each other's functions.
+    /// Excludes the current file itself.
+    pub go_same_package_paths: Option<Vec<std::path::PathBuf>>,
 }
 
 /// A security rule that checks parsed source code for vulnerabilities.

--- a/tests/fixtures/realistic/gin_service/handlers.go
+++ b/tests/fixtures/realistic/gin_service/handlers.go
@@ -1,12 +1,12 @@
 // Multi-file Gin fixture (issue #48). Companion to django_shop/ and
 // express_api/. handlers.go holds request sources; store.go holds the
-// dangerous sinks. The current Go taint engine is intraprocedural +
-// same-file interprocedural, so cross-file flows from handlers → store
-// do not fire yet. Issue #46 will fix that and this fixture's expected
-// counts will need to be updated.
+// dangerous sinks. Cross-file taint analysis (issue #46) resolves
+// same-package function calls, so runQuery(name) in search() flows
+// through to db.Query in store.go.
 //
-// Hand-counted expected findings under the current engine:
+// Hand-counted expected findings:
 //   go/taint-command-injection : 1   (in-file closure in Register)
+//   go/taint-sql-injection     : 1   (cross-file: search → runQuery)
 //   go/taint-ssrf              : 1   (in-file proxyFetch)
 
 package gin_service
@@ -26,7 +26,7 @@ func proxyFetch(c *gin.Context) {
 	c.String(http.StatusOK, "ok")
 }
 
-// Cross-file flow — should fire after #46 lands.
+// Cross-file flow — fires via same-package taint resolution (#46).
 func search(c *gin.Context) {
 	name := c.Query("name")
 	rows := runQuery(name)

--- a/tests/fixtures/realistic/gin_service/store.go
+++ b/tests/fixtures/realistic/gin_service/store.go
@@ -1,6 +1,7 @@
 // Query helpers for the gin_service fixture. Takes a tainted argument
-// and passes it into a SQL execute sink via string concatenation. Will
-// become a cross-file taint finding after issue #46.
+// and passes it into a SQL execute sink via string concatenation.
+// Cross-file taint analysis (issue #46) detects the flow from
+// handlers.go search() → runQuery(name) → db.Query.
 
 package gin_service
 

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -204,17 +204,20 @@ fn realistic_next_app_multifile() {
 
 /// Multi-file Gin fixture (issue #48). `handlers.go` holds request
 /// sources, `store.go` holds a SQL execute helper tainted across the
-/// file boundary. In-file taint flows fire today (command injection
-/// in `runCmd`, SSRF in `proxyFetch`). Cross-file flow via
-/// `store.runQuery` does NOT fire yet — the non-taint
-/// `go/no-sql-injection` pins that behavior. After #46 lands, a new
-/// `go/taint-sql-injection` finding appears and the counts update.
+/// file boundary. In-file taint flows fire (command injection in the
+/// closure, SSRF in `proxyFetch`). Cross-file flow via
+/// `runQuery(name)` in `handlers.go` → `db.Query` in `store.go`
+/// fires as `go/taint-sql-injection` after issue #46.
 #[test]
 fn realistic_gin_service_multifile() {
     assert_fixture(
         "gin_service",
-        5,
-        &[("go/taint-command-injection", 1), ("go/taint-ssrf", 1)],
+        6,
+        &[
+            ("go/taint-command-injection", 1),
+            ("go/taint-sql-injection", 1),
+            ("go/taint-ssrf", 1),
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary
- Add Go cross-file taint analysis following the Python pattern from PR #87
- All `.go` files in the same directory share a package namespace, so bare function calls (e.g. `runQuery(name)`) are resolved against cross-file summaries extracted in scanner pass 1
- The `gin_service` fixture now detects the `handlers.go` -> `store.go` SQL injection flow (`c.Query("name")` -> `runQuery(name)` -> `db.Query`)

## Changes
- **`src/rules/go_taint.rs`**: Add `CrossFileInfo`, `extract_cross_file_summaries()`, `analyze_tree_with_cross_file()`, `handle_cross_file_call()`, and `collect_param_names()` -- mirrors the Python taint engine's cross-file support
- **`src/rules/go.rs`**: Add `go_taint_rule_specs()` and wire `map_go_taint_findings()` to pass cross-file info to the engine
- **`src/rules/mod.rs`**: Add `go_same_package_paths` field to `FileContext`
- **`src/engine/scanner.rs`**: Extend pass 1 to extract Go summaries; build directory-to-files index for same-package resolution; populate `go_same_package_paths` in pass 2
- **`tests/realistic_fixtures.rs`**: Update `gin_service` expectations from 5 to 6 findings (new `go/taint-sql-injection`)

## Test plan
- [x] `cargo test` -- all 275 tests pass
- [x] `cargo clippy` -- no warnings
- [x] `cargo fmt` -- formatted
- [x] `gin_service` fixture produces `go/taint-sql-injection` finding on the cross-file `search()` -> `runQuery()` flow

none