### PR TITLE
feat: propagate taint through ternary/conditional expressions (refs #93)

### DIFF
--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1575,6 +1575,21 @@ fn expression_taint(
         }
     }
 
+    // Ternary expression: `cond ? tainted : safe`.
+    // Conservative: if EITHER branch is tainted, the result is tainted.
+    if expr.kind() == "ternary_expression" {
+        if let Some(consequence) = expr.child_by_field_name("consequence") {
+            if let Some(result) = expression_taint(consequence, ctx, state) {
+                return Some(result);
+            }
+        }
+        if let Some(alternative) = expr.child_by_field_name("alternative") {
+            if let Some(result) = expression_taint(alternative, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
     // Binary plus (string concat): `"x" + tainted` is tainted.
     if expr.kind() == "binary_expression" {
         let mut cursor = expr.walk();
@@ -2507,5 +2522,42 @@ module.exports = { runQuery, evalExpression };
             "expected evalExpression to have eval sink flow, got {:?}",
             ee.params_to_sink
         );
+    }
+
+    #[test]
+    fn ternary_tainted_consequence_propagates() {
+        let src = r#"
+function handler(req) {
+    const data = true ? req.body : "safe";
+    document.getElementById("x").innerHTML = data;
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("req.body"));
+    }
+
+    #[test]
+    fn ternary_tainted_alternative_propagates() {
+        let src = r#"
+function handler(req) {
+    const data = false ? "safe" : req.body;
+    document.getElementById("x").innerHTML = data;
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("req.body"));
+    }
+
+    #[test]
+    fn ternary_clean_both_branches_is_clean() {
+        let src = r#"
+function handler(req) {
+    const data = true ? "a" : "b";
+    document.getElementById("x").innerHTML = data;
+}
+"#;
+        assert!(run(src).is_empty());
     }
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -952,6 +952,24 @@ fn expression_taint(
         }
     }
 
+    // Conditional expression (ternary): `x = tainted if cond else safe`.
+    // Conservative: if EITHER branch is tainted, the result is tainted.
+    // tree-sitter-python lays out `conditional_expression` without field
+    // names: named_child(0) = body, named_child(1) = condition,
+    // named_child(2) = alternative. We check body and alternative only.
+    if expr.kind() == "conditional_expression" {
+        if let Some(body) = expr.named_child(0) {
+            if let Some(result) = expression_taint(body, ctx, state) {
+                return Some(result);
+            }
+        }
+        if let Some(alternative) = expr.named_child(2) {
+            if let Some(result) = expression_taint(alternative, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
     // Binary `+` / `%` propagation: `"prefix " + tainted`, `tainted + "suffix"`,
     // and `"SELECT %s" % tainted` are all tainted. The `%` operator covers
     // Python's old-style string formatting (`"... %s ..." % val`), which is
@@ -2147,5 +2165,48 @@ def handler():
     pickle.loads(data)
 "#;
         assert!(!run(src).is_empty());
+    }
+
+    #[test]
+    fn conditional_expression_tainted_body_propagates() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = request.data if True else "safe"
+    pickle.loads(data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("request.data"));
+    }
+
+    #[test]
+    fn conditional_expression_tainted_alternative_propagates() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = "safe" if True else request.data
+    pickle.loads(data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("request.data"));
+    }
+
+    #[test]
+    fn conditional_expression_clean_both_branches_is_clean() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    data = "a" if True else "b"
+    pickle.loads(data)
+"#;
+        assert!(run(src).is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Add `conditional_expression` handling to Python taint engine (`expression_taint`) — checks body and alternative branches (positional named children 0 and 2, since tree-sitter-python uses no field names for this node)
- Add `ternary_expression` handling to JavaScript taint engine (`expression_taint`) — checks `consequence` and `alternative` fields
- Go has no ternary operator so no change needed
- Conservative/sound: if either branch is tainted, the result is tainted

## Test plan
- [x] 3 new Python tests: tainted body propagates, tainted alternative propagates, clean both branches is clean
- [x] 3 new JavaScript tests: tainted consequence propagates, tainted alternative propagates, clean both branches is clean
- [x] Full `cargo test` passes (175 tests)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean

none