### PR TITLE
feat: add XXE taint rules for Python and JavaScript (refs #92)

### DIFF
--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2480,6 +2480,79 @@ impl Rule for TaintLdapInjection {
     }
 }
 
+// ─── js/taint-xxe ─────────────────────────────────────────────────────
+
+pub struct TaintXxe;
+
+impl TaintXxe {
+    pub(crate) fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::MethodName {
+                    method: "parseString".into(),
+                    description: "xml2js parseString".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "parseXml".into(),
+                    description: "libxmljs parseXml".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "parseFromString".into(),
+                    description: "DOMParser.parseFromString".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "XMLReader".into(),
+                    description: "XMLReader".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintXxe {
+    fn id(&self) -> &str {
+        "js/taint-xxe"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-611")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an XML parsing sink — potential XXE"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = JsTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some("Disable external entity resolution in XML parser configuration"),
+        };
+        map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input may enable XML external entity injection",
+                src, sink
+            )
+        })
+    }
+}
+
 /// Returns the taint rule ID and spec pairs for all JavaScript taint rules.
 /// Used by the scanner's pass 1 to extract cross-file summaries: each
 /// rule's sinks are tested against function bodies with synthetic
@@ -2494,5 +2567,6 @@ pub fn js_taint_rule_specs() -> Vec<(&'static str, JsTaintSpec)> {
         ("js/taint-ssti", TaintSsti::spec()),
         ("js/taint-xpath-injection", TaintXpathInjection::spec()),
         ("js/taint-ldap-injection", TaintLdapInjection::spec()),
+        ("js/taint-xxe", TaintXxe::spec()),
     ]
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -127,6 +127,7 @@ impl RuleRegistry {
         registry.register(Box::new(javascript::TaintSsti));
         registry.register(Box::new(javascript::TaintXpathInjection));
         registry.register(Box::new(javascript::TaintLdapInjection));
+        registry.register(Box::new(javascript::TaintXxe));
 
         // Register Python rules
         registry.register(Box::new(python::NoEval));
@@ -164,6 +165,7 @@ impl RuleRegistry {
         registry.register(Box::new(python::TaintSsti));
         registry.register(Box::new(python::TaintXpathInjection));
         registry.register(Box::new(python::TaintLdapInjection));
+        registry.register(Box::new(python::TaintXxe));
 
         // Register Go rules
         registry.register(Box::new(go::NoSqlInjection));

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -2430,6 +2430,93 @@ impl Rule for TaintLdapInjection {
     }
 }
 
+// ─── py/taint-xxe ─────────────────────────────────────────────────────
+
+pub struct TaintXxe;
+
+impl TaintXxe {
+    fn spec() -> TaintSpec {
+        TaintSpec {
+            sources: python_taint_sources(),
+            sinks: vec![
+                call_sink("xml.etree.ElementTree.parse"),
+                call_sink("xml.etree.ElementTree.fromstring"),
+                call_sink("xml.etree.cElementTree.parse"),
+                call_sink("xml.etree.cElementTree.fromstring"),
+                call_sink("etree.parse"),
+                call_sink("etree.fromstring"),
+                call_sink("ElementTree.parse"),
+                call_sink("ElementTree.fromstring"),
+                call_sink("xml.sax.parseString"),
+                call_sink("xml.dom.minidom.parseString"),
+                call_sink("xml.dom.pulldom.parse"),
+                call_sink("minidom.parseString"),
+                call_sink("pulldom.parse"),
+                NodeMatcher::MethodName {
+                    method: "parseString".into(),
+                    description: "xml.sax.parseString".into(),
+                },
+            ],
+            sanitizers: vec![
+                call_sink("defusedxml.parse"),
+                call_sink("defusedxml.fromstring"),
+                call_sink("defusedxml.parseString"),
+                call_sink("defusedxml.ElementTree.parse"),
+                call_sink("defusedxml.ElementTree.fromstring"),
+                call_sink("defusedxml.minidom.parse"),
+                call_sink("defusedxml.minidom.parseString"),
+                call_sink("defusedxml.pulldom.parse"),
+                call_sink("defusedxml.sax.parse"),
+                call_sink("defusedxml.sax.parseString"),
+            ],
+        }
+    }
+}
+
+impl Rule for TaintXxe {
+    fn id(&self) -> &str {
+        "py/taint-xxe"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-611")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches XML parsing sink — potential XXE"
+    }
+    fn language(&self) -> Language {
+        Language::Python
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some(
+                "Use defusedxml instead of xml.etree.ElementTree for untrusted XML input",
+            ),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input may enable XML external entity injection",
+                src, sink
+            )
+        })
+    }
+}
+
 // ─── Cross-file summary extraction ──────────────────────────────────────
 
 /// Returns all Python taint rule specs paired with their rule IDs.
@@ -2458,5 +2545,6 @@ pub fn python_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
         ("py/taint-ssti", TaintSsti::spec()),
         ("py/taint-xpath-injection", TaintXpathInjection::spec()),
         ("py/taint-ldap-injection", TaintLdapInjection::spec()),
+        ("py/taint-xxe", TaintXxe::spec()),
     ]
 }

--- a/tests/fixtures/vulnerable_py_taint.py
+++ b/tests/fixtures/vulnerable_py_taint.py
@@ -215,6 +215,15 @@ def ldap_injection_from_request():
     return conn.search_s("dc=example,dc=com", ldap.SCOPE_SUBTREE, user_input)
 
 
+# ═══ py/taint-xxe ════════════════════════════════════════════════════
+from xml.etree import ElementTree  # noqa: E402
+
+
+def xxe_from_request():
+    xml_data = request.data
+    ElementTree.fromstring(xml_data)
+
+
 # ═══ os.environ.get() source ══════════════════════════════════════════
 def command_injection_from_environ_get():
     cmd = os.environ.get("USER_CMD")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -343,6 +343,7 @@ fn test_vulnerable_py_taint_catches_every_flow() {
         ("py/taint-ssti", 1usize),
         ("py/taint-xpath-injection", 1),
         ("py/taint-ldap-injection", 1),
+        ("py/taint-xxe", 1),
     ] {
         assert_eq!(
             counts.get(taint_rule).copied(),
@@ -382,6 +383,7 @@ fn test_safe_py_taint_has_no_taint_findings() {
         "py/taint-ssti",
         "py/taint-xpath-injection",
         "py/taint-ldap-injection",
+        "py/taint-xxe",
     ] {
         let n = findings
             .iter()

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -50,6 +50,7 @@ const jsRules: Rule[] = [
   { id: 'js/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches a template rendering sink — possible server-side template injection', severity: 'critical' },
   { id: 'js/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches an XPath evaluation sink — possible XPath injection', severity: 'high' },
   { id: 'js/taint-xss-innerhtml', cwe: 'CWE-79', desc: 'Untrusted input reaches innerHTML or document.write sink', severity: 'high' },
+  { id: 'js/taint-xxe', cwe: 'CWE-611', desc: 'Untrusted input reaches an XML parsing sink — potential XXE', severity: 'high' },
 ];
 
 const pyRules: Rule[] = [
@@ -85,6 +86,7 @@ const pyRules: Rule[] = [
   { id: 'py/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches outbound HTTP sink (potential SSRF)', severity: 'high' },
   { id: 'py/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches template rendering sink (potential SSTI)', severity: 'critical' },
   { id: 'py/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches XPath query sink', severity: 'high' },
+  { id: 'py/taint-xxe', cwe: 'CWE-611', desc: 'Untrusted input reaches XML parsing sink — potential XXE', severity: 'high' },
   { id: 'py/taint-yaml-load', cwe: 'CWE-502', desc: 'Untrusted input reaches unsafe YAML loader', severity: 'critical' },
   { id: 'py/wtf-csrf-check-default-disabled', cwe: 'CWE-352', desc: 'Flask-WTF default CSRF checks disabled in source code', severity: 'high' },
   { id: 'py/wtf-csrf-disabled', cwe: 'CWE-352', desc: 'Flask-WTF CSRF protection disabled in source code', severity: 'high' },


### PR DESCRIPTION
## Summary
- Add `py/taint-xxe` taint rule for Python: detects untrusted input flowing into `ElementTree.parse/fromstring`, `xml.sax.parseString`, `minidom.parseString`, and `pulldom.parse` sinks; `defusedxml.*` functions act as sanitizers
- Add `js/taint-xxe` taint rule for JavaScript: detects untrusted input flowing into `parseString` (xml2js), `parseXml` (libxmljs), `DOMParser.parseFromString`, and `XMLReader` sinks
- Both rules are CWE-611, severity High, with appropriate fix suggestions
- Registered in mod.rs, added to cross-file summary spec lists, regenerated rules.ts

## Test plan
- [x] Added vulnerable Python fixture (`xxe_from_request` in `vulnerable_py_taint.py`)
- [x] Updated integration test to assert `py/taint-xxe` fires exactly once
- [x] Updated safe taint negative test to assert `py/taint-xxe` does not fire
- [x] All 276 tests pass (`cargo test`)
- [x] `cargo fmt` and `cargo clippy` clean
- [x] `rule_inventory` parity test passes (rules.ts regenerated)

none