### PR TITLE
feat: add XXE taint rules for Python and JavaScript (refs #92)

### DIFF
--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2555,6 +2555,74 @@ impl Rule for TaintLogInjection {
     }
 }
 
+// ─── js/taint-xxe ─────────────────────────────────────────────────────
+pub struct TaintXxe;
+
+impl TaintXxe {
+    pub(crate) fn spec() -> JsTaintSpec {
+        JsTaintSpec {
+            sources: javascript_taint_sources(),
+            sinks: vec![
+                JsNodeMatcher::MethodName {
+                    method: "parseString".into(),
+                    description: "xml2js.parseString / xml parser".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "parseXml".into(),
+                    description: "libxmljs.parseXml".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "parseFromString".into(),
+                    description: "DOMParser.parseFromString".into(),
+                },
+            ],
+            sanitizers: vec![],
+        }
+    }
+}
+
+impl Rule for TaintXxe {
+    fn id(&self) -> &str {
+        "js/taint-xxe"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-611")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection"
+    }
+    fn language(&self) -> Language {
+        Language::JavaScript
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = JsTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some("Disable external entity resolution in XML parser configuration"),
+        };
+        map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can trigger XML External Entity processing",
+                src, sink
+            )
+        })
+    }
+}
+
 /// Returns the taint rule ID and spec pairs for all JavaScript taint rules.
 /// Used by the scanner's pass 1 to extract cross-file summaries: each
 /// rule's sinks are tested against function bodies with synthetic
@@ -2570,5 +2638,6 @@ pub fn js_taint_rule_specs() -> Vec<(&'static str, JsTaintSpec)> {
         ("js/taint-xpath-injection", TaintXpathInjection::spec()),
         ("js/taint-ldap-injection", TaintLdapInjection::spec()),
         ("js/taint-log-injection", TaintLogInjection::spec()),
+        ("js/taint-xxe", TaintXxe::spec()),
     ]
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -128,6 +128,7 @@ impl RuleRegistry {
         registry.register(Box::new(javascript::TaintXpathInjection));
         registry.register(Box::new(javascript::TaintLdapInjection));
         registry.register(Box::new(javascript::TaintLogInjection));
+        registry.register(Box::new(javascript::TaintXxe));
 
         // Register Python rules
         registry.register(Box::new(python::NoEval));
@@ -166,6 +167,7 @@ impl RuleRegistry {
         registry.register(Box::new(python::TaintXpathInjection));
         registry.register(Box::new(python::TaintLdapInjection));
         registry.register(Box::new(python::TaintLogInjection));
+        registry.register(Box::new(python::TaintXxe));
 
         // Register Go rules
         registry.register(Box::new(go::NoSqlInjection));

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -2516,6 +2516,81 @@ impl Rule for TaintLogInjection {
     }
 }
 
+// ─── py/taint-xxe ─────────────────────────────────────────────────────
+pub struct TaintXxe;
+
+impl TaintXxe {
+    fn spec() -> TaintSpec {
+        TaintSpec {
+            sources: python_taint_sources(),
+            sinks: vec![
+                call_sink("etree.parse"),
+                call_sink("etree.fromstring"),
+                call_sink("xml.etree.ElementTree.parse"),
+                call_sink("xml.etree.ElementTree.fromstring"),
+                call_sink("ElementTree.parse"),
+                call_sink("ElementTree.fromstring"),
+                call_sink("xml.sax.parseString"),
+                call_sink("sax.parseString"),
+                call_sink("minidom.parseString"),
+                call_sink("xml.dom.minidom.parseString"),
+                call_sink("pulldom.parse"),
+                call_sink("xml.dom.pulldom.parse"),
+            ],
+            sanitizers: vec![
+                call_sink("defusedxml.parse"),
+                call_sink("defusedxml.fromstring"),
+                call_sink("defusedxml.ElementTree.parse"),
+                call_sink("defusedxml.minidom.parseString"),
+            ],
+        }
+    }
+}
+
+impl Rule for TaintXxe {
+    fn id(&self) -> &str {
+        "py/taint-xxe"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-611")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection"
+    }
+    fn language(&self) -> Language {
+        Language::Python
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = TaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some(
+                "Use defusedxml instead of xml.etree.ElementTree for untrusted XML input",
+            ),
+        };
+        map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can trigger XML External Entity processing",
+                src, sink
+            )
+        })
+    }
+}
+
 // ─── Cross-file summary extraction ──────────────────────────────────────
 
 /// Returns all Python taint rule specs paired with their rule IDs.
@@ -2545,5 +2620,6 @@ pub fn python_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
         ("py/taint-xpath-injection", TaintXpathInjection::spec()),
         ("py/taint-ldap-injection", TaintLdapInjection::spec()),
         ("py/taint-log-injection", TaintLogInjection::spec()),
+        ("py/taint-xxe", TaintXxe::spec()),
     ]
 }

--- a/tests/fixtures/vulnerable_js_taint.js
+++ b/tests/fixtures/vulnerable_js_taint.js
@@ -70,3 +70,10 @@ function logInjection(req) {
     const userInput = req.body.username;
     console.log(userInput);
 }
+
+// ─── js/taint-xxe ───────────────────────────────────────────────────
+function xxeInjection(req) {
+    const xmlData = req.body.xml;
+    const parser = new DOMParser();
+    parser.parseFromString(xmlData, "text/xml");
+}

--- a/tests/fixtures/vulnerable_py_taint.py
+++ b/tests/fixtures/vulnerable_py_taint.py
@@ -227,3 +227,11 @@ import logging  # noqa: E402
 def log_injection_from_request():
     user_input = request.args["username"]
     logging.info(user_input)
+
+
+# ═══ py/taint-xxe ══════════════════════════════════════════════════════
+from xml.etree import ElementTree  # noqa: E402
+
+def xxe_from_request():
+    xml_data = request.data
+    return ElementTree.fromstring(xml_data)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -344,6 +344,7 @@ fn test_vulnerable_py_taint_catches_every_flow() {
         ("py/taint-xpath-injection", 1),
         ("py/taint-ldap-injection", 1),
         ("py/taint-log-injection", 1),
+        ("py/taint-xxe", 1),
     ] {
         assert_eq!(
             counts.get(taint_rule).copied(),
@@ -384,6 +385,7 @@ fn test_safe_py_taint_has_no_taint_findings() {
         "py/taint-xpath-injection",
         "py/taint-ldap-injection",
         "py/taint-log-injection",
+        "py/taint-xxe",
     ] {
         let n = findings
             .iter()

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -51,6 +51,7 @@ const jsRules: Rule[] = [
   { id: 'js/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches a template rendering sink — possible server-side template injection', severity: 'critical' },
   { id: 'js/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches an XPath evaluation sink — possible XPath injection', severity: 'high' },
   { id: 'js/taint-xss-innerhtml', cwe: 'CWE-79', desc: 'Untrusted input reaches innerHTML or document.write sink', severity: 'high' },
+  { id: 'js/taint-xxe', cwe: 'CWE-611', desc: 'Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection', severity: 'high' },
 ];
 
 const pyRules: Rule[] = [
@@ -87,6 +88,7 @@ const pyRules: Rule[] = [
   { id: 'py/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches outbound HTTP sink (potential SSRF)', severity: 'high' },
   { id: 'py/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches template rendering sink (potential SSTI)', severity: 'critical' },
   { id: 'py/taint-xpath-injection', cwe: 'CWE-643', desc: 'Untrusted input reaches XPath query sink', severity: 'high' },
+  { id: 'py/taint-xxe', cwe: 'CWE-611', desc: 'Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection', severity: 'high' },
   { id: 'py/taint-yaml-load', cwe: 'CWE-502', desc: 'Untrusted input reaches unsafe YAML loader', severity: 'critical' },
   { id: 'py/wtf-csrf-check-default-disabled', cwe: 'CWE-352', desc: 'Flask-WTF default CSRF checks disabled in source code', severity: 'high' },
   { id: 'py/wtf-csrf-disabled', cwe: 'CWE-352', desc: 'Flask-WTF CSRF protection disabled in source code', severity: 'high' },


### PR DESCRIPTION
## Summary
- Add `py/taint-xxe` rule detecting untrusted input flowing into Python XML parsers (etree, ElementTree, xml.sax, minidom, pulldom) with defusedxml sanitizers
- Add `js/taint-xxe` rule detecting untrusted input flowing into JavaScript XML parsers (parseString, parseXml, parseFromString)
- Both rules: CWE-611, Severity High, registered for cross-file taint analysis

## Test plan
- [x] Vulnerable Python fixture (`vulnerable_py_taint.py`) fires `py/taint-xxe` exactly once
- [x] Vulnerable JS fixture (`vulnerable_js_taint.js`) fires `js/taint-xxe` exactly once
- [x] Safe fixtures do not fire XXE rules (negative tests)
- [x] `cargo test` passes all 73+ tests including integration tests
- [x] `cargo fmt` and `cargo clippy` clean
- [x] `www/src/data/rules.ts` regenerated

none