### PR TITLE
feat: add JWT security rules for Python and Go (refs #98)

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -570,6 +570,217 @@ impl Rule for InsecureTlsSkipVerify {
     }
 }
 
+// ─── Rule 9: jwt-no-verify ─────────────────────────────────────────────────
+
+pub struct JwtNoVerify;
+
+impl Rule for JwtNoVerify {
+    fn id(&self) -> &str {
+        "go/jwt-no-verify"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-347")
+    }
+    fn description(&self) -> &str {
+        "JWT parsed without proper signature verification"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() != "call_expression" {
+                return;
+            }
+
+            let Some(func) = node.child_by_field_name("function") else {
+                return;
+            };
+            let func_text = &src[func.byte_range()];
+
+            // Pattern 1: jwt.Parse(token, nil) — nil key function
+            if func_text == "jwt.Parse"
+                || func_text == "jwt.ParseWithClaims"
+                || func_text == "jwt.ParseUnverified"
+            {
+                // ParseUnverified is always a finding
+                if func_text == "jwt.ParseUnverified" {
+                    let mut finding = make_finding(
+                        self.id(),
+                        self.severity(),
+                        self.cwe(),
+                        "jwt.ParseUnverified skips signature verification — tokens can be forged",
+                        node,
+                        src,
+                    );
+                    finding.fix_suggestion =
+                        Some("Always provide a valid key function to jwt.Parse()".to_string());
+                    findings.push(finding);
+                    return;
+                }
+
+                let Some(args) = node.child_by_field_name("arguments") else {
+                    return;
+                };
+
+                // Check if the key function argument is nil
+                let key_func_idx = if func_text == "jwt.ParseWithClaims" {
+                    2
+                } else {
+                    1
+                };
+                if let Some(key_arg) = args.named_child(key_func_idx) {
+                    let key_text = &src[key_arg.byte_range()];
+                    if key_text == "nil" {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "JWT key function is nil — signature will not be verified",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion =
+                            Some("Always provide a valid key function to jwt.Parse()".to_string());
+                        findings.push(finding);
+                        return;
+                    }
+
+                    // Check if the key function returns nil
+                    let key_func_text = &src[key_arg.byte_range()];
+                    if key_func_text.contains("return nil") {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "JWT key function returns nil — signature will not be verified",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion =
+                            Some("Always provide a valid key function to jwt.Parse()".to_string());
+                        findings.push(finding);
+                    }
+                }
+            }
+        });
+
+        findings
+    }
+}
+
+// ─── Rule 10: jwt-hardcoded-secret ─────────────────────────────────────────
+
+pub struct JwtHardcodedSecret;
+
+impl Rule for JwtHardcodedSecret {
+    fn id(&self) -> &str {
+        "go/jwt-hardcoded-secret"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-798")
+    }
+    fn description(&self) -> &str {
+        "JWT signing or verification with a hardcoded secret"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() != "call_expression" {
+                return;
+            }
+
+            let Some(func) = node.child_by_field_name("function") else {
+                return;
+            };
+            let func_text = &src[func.byte_range()];
+
+            // jwt.Parse or jwt.ParseWithClaims with an inline key function
+            // containing []byte("secret")
+            if func_text != "jwt.Parse"
+                && func_text != "jwt.ParseWithClaims"
+                && func_text != "token.SignedString"
+            {
+                return;
+            }
+
+            let Some(args) = node.child_by_field_name("arguments") else {
+                return;
+            };
+
+            if func_text == "token.SignedString" {
+                // token.SignedString([]byte("secret"))
+                if let Some(first_arg) = args.named_child(0) {
+                    let arg_text = &src[first_arg.byte_range()];
+                    if is_go_hardcoded_byte_slice(arg_text) {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "JWT signing secret is hardcoded — load keys from environment or a secrets manager",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion =
+                            Some("Load JWT secrets from environment variables".to_string());
+                        findings.push(finding);
+                    }
+                }
+                return;
+            }
+
+            // jwt.Parse / jwt.ParseWithClaims — check the key function body
+            let key_func_idx = if func_text == "jwt.ParseWithClaims" {
+                2
+            } else {
+                1
+            };
+            if let Some(key_arg) = args.named_child(key_func_idx) {
+                let key_func_text = &src[key_arg.byte_range()];
+                if key_func_text.contains("[]byte(\"") || key_func_text.contains("[]byte(`") {
+                    // Extract the string content to check length
+                    let re = Regex::new(r#"\[\]byte\(["` ]([^"` ]{4,})["` ]\)"#).unwrap();
+                    if re.is_match(key_func_text) {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "JWT secret is hardcoded in key function — load keys from environment or a secrets manager",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion =
+                            Some("Load JWT secrets from environment variables".to_string());
+                        findings.push(finding);
+                    }
+                }
+            }
+        });
+
+        findings
+    }
+}
+
+/// Check if a Go expression is a hardcoded byte slice like `[]byte("secret")`.
+fn is_go_hardcoded_byte_slice(text: &str) -> bool {
+    let re = Regex::new(r#"^\[\]byte\(["` ]([^"` ]{4,})["` ]\)$"#).unwrap();
+    re.is_match(text.trim())
+}
+
 // ─── Taint rules ───────────────────────────────────────────────────────────
 //
 // These rules consume the intraprocedural taint engine in

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -156,6 +156,8 @@ impl RuleRegistry {
         registry.register(Box::new(python::WtfCsrfCheckDefaultDisabled));
         registry.register(Box::new(python::DjangoAllowedHostsWildcard));
         registry.register(Box::new(python::SecureSslRedirectDisabled));
+        registry.register(Box::new(python::JwtNoVerify));
+        registry.register(Box::new(python::JwtHardcodedSecret));
         registry.register(Box::new(python::TaintPickleDeserialization));
         registry.register(Box::new(python::TaintEvalFromRequest));
         registry.register(Box::new(python::TaintCommandInjectionFromRequest));
@@ -176,6 +178,8 @@ impl RuleRegistry {
         registry.register(Box::new(go::InsecureTlsSkipVerify));
         registry.register(Box::new(go::GinNoTrustedProxies));
         registry.register(Box::new(go::NetHttpNoTimeout));
+        registry.register(Box::new(go::JwtNoVerify));
+        registry.register(Box::new(go::JwtHardcodedSecret));
         registry.register(Box::new(go::TaintCommandInjection));
         registry.register(Box::new(go::TaintSqlInjection));
         registry.register(Box::new(go::TaintSsrf));

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1761,6 +1761,195 @@ impl Rule for SecureSslRedirectDisabled {
     }
 }
 
+// ─── Rule 26: jwt-no-verify ────────────────────────────────────────────────
+
+pub struct JwtNoVerify;
+
+impl Rule for JwtNoVerify {
+    fn id(&self) -> &str {
+        "py/jwt-no-verify"
+    }
+    fn severity(&self) -> Severity {
+        Severity::Critical
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-347")
+    }
+    fn description(&self) -> &str {
+        "JWT decoded without signature verification"
+    }
+    fn language(&self) -> Language {
+        Language::Python
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() != "call" {
+                return;
+            }
+
+            let Some(func) = node.child_by_field_name("function") else {
+                return;
+            };
+            let func_text = &src[func.byte_range()];
+            let resolved = resolve_callee(func_text, ctx);
+            if resolved.as_ref() != "jwt.decode" && resolved.as_ref() != "PyJWT.decode" {
+                return;
+            }
+
+            let Some(args) = node.child_by_field_name("arguments") else {
+                return;
+            };
+            let args_text = &src[args.byte_range()];
+
+            // Pattern 1: options={"verify_signature": False} or
+            //            options={"verify_signature":False}
+            let disables_verify = args_text.contains("\"verify_signature\": False")
+                || args_text.contains("\"verify_signature\":False")
+                || args_text.contains("'verify_signature': False")
+                || args_text.contains("'verify_signature':False")
+                || args_text.contains("\"verify_exp\": False")
+                || args_text.contains("\"verify_exp\":False")
+                || args_text.contains("'verify_exp': False")
+                || args_text.contains("'verify_exp':False");
+
+            // Pattern 2: algorithms=["none"] or algorithms=['none']
+            let uses_none = args_text.contains("algorithms=[\"none\"]")
+                || args_text.contains("algorithms=['none']")
+                || args_text.contains("algorithms=[\"None\"]")
+                || args_text.contains("algorithms=['None']");
+
+            if disables_verify || uses_none {
+                let mut finding = make_finding(
+                    self.id(),
+                    self.severity(),
+                    self.cwe(),
+                    "JWT signature verification is disabled — tokens can be forged",
+                    node,
+                    src,
+                );
+                finding.fix_suggestion = Some(
+                    "Always verify JWT signatures: jwt.decode(token, key, algorithms=['HS256'])"
+                        .to_string(),
+                );
+                findings.push(finding);
+            }
+        });
+
+        findings
+    }
+}
+
+// ─── Rule 27: jwt-hardcoded-secret ─────────────────────────────────────────
+
+pub struct JwtHardcodedSecret;
+
+impl Rule for JwtHardcodedSecret {
+    fn id(&self) -> &str {
+        "py/jwt-hardcoded-secret"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-798")
+    }
+    fn description(&self) -> &str {
+        "JWT signing or verification with a hardcoded secret"
+    }
+    fn language(&self) -> Language {
+        Language::Python
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() != "call" {
+                return;
+            }
+
+            let Some(func) = node.child_by_field_name("function") else {
+                return;
+            };
+            let func_text = &src[func.byte_range()];
+            let resolved = resolve_callee(func_text, ctx);
+            if resolved.as_ref() != "jwt.encode"
+                && resolved.as_ref() != "jwt.decode"
+                && resolved.as_ref() != "PyJWT.encode"
+                && resolved.as_ref() != "PyJWT.decode"
+            {
+                return;
+            }
+
+            let Some(args) = node.child_by_field_name("arguments") else {
+                return;
+            };
+
+            // The second positional argument is the secret/key
+            let Some(secret_arg) = args.named_child(1) else {
+                return;
+            };
+
+            // Skip keyword arguments — only check positional string literals
+            if secret_arg.kind() == "keyword_argument" {
+                return;
+            }
+
+            if secret_arg.kind() != "string" && secret_arg.kind() != "concatenated_string" {
+                return;
+            }
+
+            let secret = &src[secret_arg.byte_range()];
+            // Strip quotes to get the inner value
+            let inner = secret
+                .trim_matches(|c| c == '"' || c == '\'')
+                .trim_start_matches("f\"")
+                .trim_start_matches("f'")
+                .trim_start_matches("b\"")
+                .trim_start_matches("b'");
+            if inner.len() < 4 {
+                return;
+            }
+
+            let mut finding = make_finding(
+                self.id(),
+                self.severity(),
+                self.cwe(),
+                "JWT secret is hardcoded — load signing keys from environment or a secrets manager",
+                node,
+                src,
+            );
+            finding.fix_suggestion = Some(
+                "Load JWT secrets from environment variables, not hardcoded strings".to_string(),
+            );
+            findings.push(finding);
+        });
+
+        findings
+    }
+}
+
 // ─── Rule: taint-pickle-deserialization ────────────────────────────────────
 //
 // Proof-of-concept rule exercising the new per-function taint engine.

--- a/tests/fixtures/vulnerable.go
+++ b/tests/fixtures/vulnerable.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func vulnerable() {
@@ -40,10 +42,20 @@ func vulnerable() {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
+	// 10. go/jwt-no-verify (Critical) — nil key function
+	token1, _ := jwt.Parse(userInput, nil)
+
+	// 11. go/jwt-hardcoded-secret (High) — hardcoded key in key function
+	token2, _ := jwt.Parse(userInput, func(token *jwt.Token) (interface{}, error) {
+		return []byte("my-secret-key-1234"), nil
+	})
+
 	_ = query1
 	_ = query2
 	_ = apiKey
 	_ = transport
+	_ = token1
+	_ = token2
 }
 
 func getUserInput() string {

--- a/tests/fixtures/vulnerable.py
+++ b/tests/fixtures/vulnerable.py
@@ -4,6 +4,7 @@ import hashlib
 import pickle
 import requests
 import yaml
+import jwt
 from flask import Flask, redirect, request
 from django.views.decorators.csrf import csrf_exempt
 
@@ -103,3 +104,11 @@ CORS_ALLOW_ALL_ORIGINS = True
 
 # py/flask-debug-mode
 app.run(debug=True)
+
+# py/jwt-no-verify
+def decode_jwt_insecure(token):
+    return jwt.decode(token, options={"verify_signature": False})
+
+# py/jwt-hardcoded-secret
+def sign_jwt_hardcoded(payload):
+    return jwt.encode(payload, "super-secret-key-1234", algorithms=["HS256"])

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -167,10 +167,11 @@ fn test_vulnerable_py_finds_all_rules() {
     // #29/#30): `dangerous()` now additionally fires py/taint-eval on
     // `eval(input("Enter code: "))` alongside the conservative
     // py/no-eval finding.
+    // Count grew to 33 after adding JWT rules (issue #98).
     assert_eq!(
         findings.len(),
-        31,
-        "vulnerable.py should have 31 findings, got {}",
+        33,
+        "vulnerable.py should have 33 findings, got {}",
         findings.len()
     );
 
@@ -206,6 +207,8 @@ fn test_vulnerable_py_finds_all_rules() {
         "py/wtf-csrf-check-default-disabled",
         "py/django-allowed-hosts-wildcard",
         "py/secure-ssl-redirect-disabled",
+        "py/jwt-no-verify",
+        "py/jwt-hardcoded-secret",
     ];
 
     for rule in &expected_rules {
@@ -861,8 +864,8 @@ fn test_vulnerable_go_finds_all_rules() {
 
     assert_eq!(
         findings.len(),
-        10,
-        "vulnerable.go should have 10 findings, got {}",
+        12,
+        "vulnerable.go should have 12 findings, got {}",
         findings.len()
     );
 
@@ -879,6 +882,8 @@ fn test_vulnerable_go_finds_all_rules() {
         "go/no-ssrf",
         "go/insecure-tls-skip-verify",
         "go/net-http-no-timeout",
+        "go/jwt-no-verify",
+        "go/jwt-hardcoded-secret",
     ];
 
     for rule in &expected_rules {

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -62,6 +62,8 @@ const pyRules: Rule[] = [
   { id: 'py/django-secret-key-hardcoded', cwe: 'CWE-798', desc: 'Django SECRET_KEY hardcoded in source code', severity: 'high' },
   { id: 'py/flask-debug-mode', cwe: 'CWE-489', desc: 'Flask app.run(debug=True) exposes debugger and reloader in production', severity: 'high' },
   { id: 'py/flask-secret-key-hardcoded', cwe: 'CWE-798', desc: 'Flask SECRET_KEY hardcoded in source code', severity: 'high' },
+  { id: 'py/jwt-hardcoded-secret', cwe: 'CWE-798', desc: 'JWT signing or verification with a hardcoded secret', severity: 'high' },
+  { id: 'py/jwt-no-verify', cwe: 'CWE-347', desc: 'JWT decoded without signature verification', severity: 'critical' },
   { id: 'py/no-command-injection', cwe: 'CWE-78', desc: 'Potential command injection via os.system/subprocess with user input', severity: 'critical' },
   { id: 'py/no-cors-star', cwe: 'CWE-942', desc: 'CORS misconfiguration allowing all origins', severity: 'medium' },
   { id: 'py/no-debug-true', cwe: 'CWE-489', desc: 'DEBUG = True left enabled — disable in production', severity: 'medium' },
@@ -95,6 +97,8 @@ const pyRules: Rule[] = [
 const goRules: Rule[] = [
   { id: 'go/gin-no-trusted-proxies', cwe: 'CWE-346', desc: 'Gin engine created without SetTrustedProxies configuration', severity: 'medium' },
   { id: 'go/insecure-tls-skip-verify', cwe: 'CWE-295', desc: 'TLS certificate verification disabled with InsecureSkipVerify', severity: 'high' },
+  { id: 'go/jwt-hardcoded-secret', cwe: 'CWE-798', desc: 'JWT signing or verification with a hardcoded secret', severity: 'high' },
+  { id: 'go/jwt-no-verify', cwe: 'CWE-347', desc: 'JWT parsed without proper signature verification', severity: 'critical' },
   { id: 'go/net-http-no-timeout', cwe: 'CWE-400', desc: 'http.ListenAndServe without timeout configuration enables slowloris attacks', severity: 'medium' },
   { id: 'go/no-command-injection', cwe: 'CWE-78', desc: 'Potential command injection via exec.Command with dynamic input', severity: 'critical' },
   { id: 'go/no-hardcoded-secret', cwe: 'CWE-798', desc: 'Hardcoded secret or credential detected', severity: 'high' },


### PR DESCRIPTION
## Summary
- Adds 2 Python JWT rules: `py/jwt-no-verify` (CWE-347, Critical) detects disabled signature verification and `algorithms=["none"]`; `py/jwt-hardcoded-secret` (CWE-798, High) detects hardcoded secret strings in `jwt.encode`/`jwt.decode`
- Adds 2 Go JWT rules: `go/jwt-no-verify` (CWE-347, Critical) detects `jwt.Parse` with nil key function and `jwt.ParseUnverified`; `go/jwt-hardcoded-secret` (CWE-798, High) detects hardcoded `[]byte("...")` secrets in key functions and `token.SignedString`
- All 4 rules include `fix_suggestion` fields, registered in mod.rs, with test fixtures and integration tests updated; `rules.ts` regenerated

## Test plan
- [x] `cargo test` passes (all 289 tests)
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Verified Python rules fire on `jwt.decode(token, options={"verify_signature": False})` and `jwt.encode(payload, "hardcoded")`
- [x] Verified Go rules fire on `jwt.Parse(token, nil)` and `jwt.Parse` with hardcoded `[]byte("secret")` key function
- [x] Safe fixtures produce no false positives
- [x] `www/src/data/rules.ts` regenerated and rule inventory test passes

none