### PR TITLE
fix: handle walrus operator, await expressions, and Go type assertions in taint engines (refs #109, #110, #113)

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -1001,6 +1001,15 @@ fn expression_taint(
         }
     }
 
+    // Type assertion: `val.(string)` — propagate taint from operand.
+    if expr.kind() == "type_assertion_expression" {
+        if let Some(operand) = expr.child_by_field_name("operand") {
+            if let Some(result) = expression_taint(operand, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
     // Parenthesized / unary wrappers: recurse into children.
     if matches!(expr.kind(), "parenthesized_expression" | "unary_expression") {
         let mut cursor = expr.walk();
@@ -1732,5 +1741,23 @@ func handler(c *gin.Context) {
         let f = run(src);
         assert_eq!(f.len(), 1);
         assert!(f[0].source_description.contains("Fetch"));
+    }
+
+    #[test]
+    fn type_assertion_propagates_taint() {
+        let src = r#"
+package main
+
+import "os/exec"
+
+func handler(c *gin.Context) {
+    var val interface{} = c.Query("cmd")
+    cmd := val.(string)
+    exec.Command(cmd)
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].sink_description, "exec.Command");
     }
 }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1600,6 +1600,17 @@ fn expression_taint(
         }
     }
 
+    // Await expression: `await <inner>` — unwrap and recurse so that
+    // `await req.json()` propagates the taint of the inner call.
+    if expr.kind() == "await_expression" {
+        let mut cursor = expr.walk();
+        for child in expr.named_children(&mut cursor) {
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
     // Parenthesized / unary / sequence wrappers: recurse into children.
     if matches!(
         expr.kind(),
@@ -2702,5 +2713,18 @@ function handler(headers) {
 }
 "#;
         assert_eq!(run(src).len(), 1);
+    }
+
+    #[test]
+    fn await_expression_propagates_taint() {
+        let src = r#"
+async function handler(req) {
+    const data = await req.json();
+    document.getElementById("x").innerHTML = data;
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].sink_description, "innerHTML assignment");
     }
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -567,6 +567,24 @@ fn walk_body(
         handle_assignment(node, ctx, state);
     }
 
+    // Walrus operator: `name := value` (named_expression). The `:=` both
+    // assigns and returns a value, so we need to track the binding.
+    if node.kind() == "named_expression" {
+        if let (Some(name), Some(value)) = (
+            node.child_by_field_name("name"),
+            node.child_by_field_name("value"),
+        ) {
+            if name.kind() == "identifier" {
+                let lhs = node_text(name, ctx.source).to_string();
+                if let Some((desc, src_line)) = expression_taint(value, ctx, state) {
+                    state.taint(lhs, desc, src_line);
+                } else {
+                    state.clear(&lhs);
+                }
+            }
+        }
+    }
+
     if node.kind() == "call" {
         handle_call(node, ctx, state, findings);
     }
@@ -2331,5 +2349,20 @@ def handler():
 "#;
         let f = run(src);
         assert_eq!(f.len(), 1);
+    }
+
+    #[test]
+    fn walrus_operator_propagates_taint() {
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    if data := request.get_json():
+        pickle.loads(data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].sink_description, "pickle.loads");
     }
 }


### PR DESCRIPTION
## Summary
- **Python walrus operator (#109):** `named_expression` nodes (`:=`) in `walk_body` now extract the name/value and propagate taint through the binding, so `if data := request.json(): pickle.loads(data)` is detected.
- **JS await expressions (#110):** `expression_taint` now handles `await_expression` by unwrapping into the inner expression, so `const data = await req.json(); el.innerHTML = data` is detected.
- **Go type assertions (#113):** `expression_taint` now handles `type_assertion_expression` by checking taint on the operand, so `val.(string)` preserves taint from `val`.

## Test plan
- [x] Added `walrus_operator_propagates_taint` test in python_taint
- [x] Added `await_expression_propagates_taint` test in javascript_taint
- [x] Added `type_assertion_propagates_taint` test in go_taint
- [x] `cargo test` passes (all tests green)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean

none