### PR TITLE
feat(go): add path traversal taint rule (refs #114)

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1414,6 +1414,91 @@ impl Rule for TaintNosqlInjection {
     }
 }
 
+// ─── Rule: taint-path-traversal ──────────────────────────────────────────
+
+pub struct TaintPathTraversal;
+
+impl TaintPathTraversal {
+    fn spec() -> GoTaintSpec {
+        GoTaintSpec {
+            sources: go_taint_sources(),
+            sinks: vec![
+                go_call_sink("os.Open"),
+                go_call_sink("os.OpenFile"),
+                go_call_sink("os.ReadFile"),
+                go_call_sink("os.WriteFile"),
+                go_call_sink("os.Remove"),
+                go_call_sink("os.Stat"),
+                go_call_sink("os.MkdirAll"),
+                go_call_sink("filepath.Join"),
+                go_call_sink("ioutil.ReadFile"),
+                go_call_sink("ioutil.WriteFile"),
+                GoNodeMatcher::MethodName {
+                    method: "Open".into(),
+                    description: "http.Dir.Open".into(),
+                },
+                GoNodeMatcher::MethodName {
+                    method: "Create".into(),
+                    description: "os.Create".into(),
+                },
+                GoNodeMatcher::MethodName {
+                    method: "ReadFile".into(),
+                    description: "afero.ReadFile".into(),
+                },
+                GoNodeMatcher::MethodName {
+                    method: "WriteFile".into(),
+                    description: "afero.WriteFile".into(),
+                },
+            ],
+            sanitizers: vec![go_call_sink("filepath.Clean"), go_call_sink("filepath.Abs")],
+        }
+    }
+}
+
+impl Rule for TaintPathTraversal {
+    fn id(&self) -> &str {
+        "go/taint-path-traversal"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-22")
+    }
+    fn description(&self) -> &str {
+        "Untrusted input reaches a filesystem path sink — possible path traversal"
+    }
+    fn language(&self) -> Language {
+        Language::Go
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        self.check_with_context(source, tree, &FileContext::default())
+    }
+
+    fn check_with_context(
+        &self,
+        source: &str,
+        tree: &tree_sitter::Tree,
+        ctx: &FileContext<'_>,
+    ) -> Vec<Finding> {
+        let meta = GoTaintRuleMeta {
+            rule_id: self.id(),
+            severity: self.severity(),
+            cwe: self.cwe(),
+            fix_suggestion: Some(
+                "Validate file paths with filepath.Clean() and ensure they don't escape the intended directory",
+            ),
+        };
+        map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
+            format!(
+                "{} reaches {} — untrusted input can traverse the filesystem",
+                src, sink
+            )
+        })
+    }
+}
+
 /// All Go taint rule IDs paired with their specs.
 ///
 /// Used by the scanner's pass 1 to extract cross-file summaries: each
@@ -1429,5 +1514,6 @@ pub fn go_taint_rule_specs() -> Vec<(&'static str, GoTaintSpec)> {
         ("go/taint-ssrf", TaintSsrf::spec()),
         ("go/taint-log-injection", TaintLogInjection::spec()),
         ("go/taint-nosql-injection", TaintNosqlInjection::spec()),
+        ("go/taint-path-traversal", TaintPathTraversal::spec()),
     ]
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -194,6 +194,7 @@ impl RuleRegistry {
         registry.register(Box::new(go::JwtNoVerify));
         registry.register(Box::new(go::JwtHardcodedSecret));
         registry.register(Box::new(go::TaintNosqlInjection));
+        registry.register(Box::new(go::TaintPathTraversal));
 
         // Register Java rules
         registry.register(Box::new(java::NoSqlInjection));

--- a/tests/fixtures/safe_go_taint.go
+++ b/tests/fixtures/safe_go_taint.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // 1. Static literal argument — no taint source at all.
@@ -76,4 +78,16 @@ func sprintfStatic() {
 func unusedHandler(w http.ResponseWriter, r *http.Request) {
 	_ = r
 	exec.Command("/bin/true")
+}
+
+// 9. filepath.Clean sanitizes path traversal.
+func sanitizedPathClean(c *gin.Context) {
+	name := c.Query("file")
+	safe := filepath.Clean(name)
+	os.Open(safe)
+}
+
+// 10. Static literal path — no taint source.
+func staticFilePath() {
+	os.Open("/etc/hostname")
 }

--- a/tests/fixtures/vulnerable_go_taint.go
+++ b/tests/fixtures/vulnerable_go_taint.go
@@ -10,7 +10,9 @@ import (
 	"html/template"
 	"log"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // ─── go/taint-command-injection ───────────────────────────────────────────
@@ -126,4 +128,24 @@ func ginQueryToLogPrintf(c *gin.Context) {
 func ginQueryToMongoFind(c *gin.Context, collection *mongo.Collection) {
 	filter := c.Query("filter")
 	collection.Find(context.TODO(), filter)
+}
+
+// ─── go/taint-path-traversal ────────────────────────────────────────────
+
+// 17. net/http r.URL.Query().Get → os.Open
+func httpQueryToOsOpen(w http.ResponseWriter, r *http.Request) {
+	file := r.URL.Query().Get("file")
+	os.Open(file)
+}
+
+// 18. gin Context.Query → filepath.Join
+func ginQueryToFilepathJoin(c *gin.Context) {
+	name := c.Query("name")
+	filepath.Join("/uploads", name)
+}
+
+// 19. gin Context.Param → os.ReadFile
+func ginParamToOsReadFile(c *gin.Context) {
+	path := c.Param("path")
+	os.ReadFile(path)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2458,6 +2458,7 @@ fn test_vulnerable_go_taint_catches_every_flow() {
         ("go/taint-ldap-injection", 1),
         ("go/taint-log-injection", 1),
         ("go/taint-nosql-injection", 1),
+        ("go/taint-path-traversal", 3),
     ] {
         assert_eq!(
             counts.get(taint_rule).copied(),
@@ -2493,6 +2494,7 @@ fn test_safe_go_taint_has_no_taint_findings() {
         "go/taint-ldap-injection",
         "go/taint-log-injection",
         "go/taint-nosql-injection",
+        "go/taint-path-traversal",
     ] {
         let n = findings
             .iter()

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -115,6 +115,7 @@ const goRules: Rule[] = [
   { id: 'go/taint-ldap-injection', cwe: 'CWE-90', desc: 'Untrusted input reaches LDAP search sink (potential LDAP injection)', severity: 'high' },
   { id: 'go/taint-log-injection', cwe: 'CWE-117', desc: 'Untrusted input reaches a logging sink — possible log injection', severity: 'medium' },
   { id: 'go/taint-nosql-injection', cwe: 'CWE-943', desc: 'Untrusted input reaches a MongoDB query sink — possible NoSQL injection', severity: 'critical' },
+  { id: 'go/taint-path-traversal', cwe: 'CWE-22', desc: 'Untrusted input reaches a filesystem path sink — possible path traversal', severity: 'high' },
   { id: 'go/taint-sql-injection', cwe: 'CWE-89', desc: 'Untrusted input reaches database Query/Exec sink', severity: 'critical' },
   { id: 'go/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input reaches outbound net/http sink (potential SSRF)', severity: 'high' },
   { id: 'go/taint-ssti', cwe: 'CWE-1336', desc: 'Untrusted input reaches template parsing sink (potential SSTI)', severity: 'critical' },


### PR DESCRIPTION
## Summary
- Add `go/taint-path-traversal` rule detecting untrusted input flowing to filesystem sinks (`os.Open`, `os.OpenFile`, `os.ReadFile`, `os.WriteFile`, `os.Remove`, `os.Stat`, `os.MkdirAll`, `filepath.Join`, `ioutil.ReadFile`, `ioutil.WriteFile`) and method-name sinks (`Open`, `Create`, `ReadFile`, `WriteFile`)
- Include `filepath.Clean` and `filepath.Abs` as sanitizers — the first Go taint rule with non-empty sanitizers
- CWE-22, High severity, with fix suggestion guiding users toward `filepath.Clean()`

## Test plan
- [x] Three positive fixtures in `vulnerable_go_taint.go` (os.Open, filepath.Join, os.ReadFile from HTTP/Gin sources)
- [x] Two negative fixtures in `safe_go_taint.go` (filepath.Clean sanitizer, static literal path)
- [x] Integration test asserts exactly 3 findings on vulnerable fixture
- [x] Safe fixture asserts zero taint-path-traversal findings
- [x] `cargo test`, `cargo fmt`, `cargo clippy` all pass
- [x] Rule inventory test validates rules.ts matches registry

none