### PR TITLE
fix: JS spread taint, noise path exclusions, always-visible fix suggestions (refs #119, #121, #122)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -110,11 +110,17 @@ fn is_noise_path(path: &Path) -> bool {
         "/node_modules/",
         "/__fixtures__/",
         "/__mocks__/",
+        "/__tests__/",
+        "/__snapshots__/",
         "/dist/",
         "/build/",
         "/.next/",
         "/coverage/",
         "/.cache/",
+        "/spec/",
+        "/stubs/",
+        "/generated/",
+        "/gen/",
     ];
     for dir in &noise_dirs {
         if path_str.contains(dir) {

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -85,9 +85,11 @@ pub fn print_findings_with_options(
                     snk_desc,
                 );
             }
-            if let Some(fix) = f.fix_suggestion.as_ref() {
-                println!("  {} {}", "Fix:".green().bold(), fix);
-            }
+        }
+
+        // Always show fix suggestion when available (not gated on --explain)
+        if let Some(fix) = f.fix_suggestion.as_ref() {
+            println!("  {} {}", "Fix:".green().bold(), fix);
         }
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1663,6 +1663,28 @@ fn expression_taint(
         }
     }
 
+    // Array / object literals: propagate taint from any element.
+    // This lets `[...req.body]` and `[tainted, clean]` carry taint.
+    if matches!(expr.kind(), "array" | "object") {
+        let mut cursor = expr.walk();
+        for child in expr.named_children(&mut cursor) {
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
+    // Spread element: `...inner` — unwrap and recurse into the inner expression
+    // so that `[...req.body]` and `func(...tainted)` propagate taint.
+    if expr.kind() == "spread_element" {
+        let mut cursor = expr.walk();
+        for child in expr.named_children(&mut cursor) {
+            if let Some(result) = expression_taint(child, ctx, state) {
+                return Some(result);
+            }
+        }
+    }
+
     // Parenthesized / unary / sequence wrappers: recurse into children.
     if matches!(
         expr.kind(),

--- a/tests/fixtures/vulnerable_js_taint.js
+++ b/tests/fixtures/vulnerable_js_taint.js
@@ -65,6 +65,12 @@ function methodCallOnTaintedRoot(req) {
     document.getElementById("x").innerHTML = req.body.toString();
 }
 
+// ─── Spread element: [...source] propagates taint (issue #119) ───────
+function spreadTaint(req) {
+    const arr = [...req.body];
+    document.getElementById("x").innerHTML = arr[0];
+}
+
 // ─── js/taint-log-injection ──────────────────────────────────────────
 function logInjection(req) {
     const userInput = req.body.username;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -637,14 +637,15 @@ fn test_vulnerable_js_taint_catches_every_flow() {
         }
     }
 
-    // Nine handlers, each with exactly one source→sink flow (six
+    // Ten handlers, each with exactly one source→sink flow (six
     // original + two added by #19 for same-file interprocedural return
     // propagation + one added by #27 for method-call propagation on a
-    // tainted root `req.body.toString()`).
+    // tainted root `req.body.toString()` + one added by #119 for spread
+    // element taint propagation `[...req.body]`).
     assert_eq!(
         counts.get("js/taint-xss-innerhtml").copied(),
-        Some(9),
-        "js/taint-xss-innerhtml should fire exactly nine times. counts={:?}",
+        Some(10),
+        "js/taint-xss-innerhtml should fire exactly ten times. counts={:?}",
         counts
     );
     // The conservative rules must still coexist on the same fixture.


### PR DESCRIPTION
## Summary
- **#119**: Add `spread_element` and `array`/`object` literal handlers to `expression_taint` in the JS taint engine so `[...req.body]` and `func(...tainted)` correctly propagate taint instead of silently dropping it.
- **#121**: Add six missing noise path exclusions to `is_noise_path`: `/spec/`, `/stubs/`, `/generated/`, `/gen/`, `/__tests__/`, `/__snapshots__/`.
- **#122**: Move `fix_suggestion` rendering outside the `if explain` block in terminal output so it always appears on taint findings, not only with `--explain`.

## Test plan
- [x] New test case in `vulnerable_js_taint.js` for spread element taint (`const arr = [...req.body]; document.getElementById("x").innerHTML = arr[0];`)
- [x] Integration test count updated from 9 to 10 for `js/taint-xss-innerhtml`
- [x] `cargo test` passes (73 tests)
- [x] `cargo fmt` and `cargo clippy` clean

none