### PR TITLE
feat: add Java XSS and C# path traversal rules (refs #123, #124)

### DIFF
--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -335,6 +335,7 @@ impl Rule for NoPathTraversal {
             "File.OpenRead",
             "File.WriteAllText",
             "File.Delete",
+            "File.Exists",
         ];
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -354,14 +355,16 @@ impl Rule for NoPathTraversal {
                                 if !is_string_literal(first_arg) {
                                     let arg_text = &src[first_arg.byte_range()];
                                     if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
-                                        findings.push(make_finding(
+                                        let mut f = make_finding(
                                             self.id(),
                                             self.severity(),
                                             self.cwe(),
                                             "File operation with dynamic path — validate and sanitize to prevent path traversal",
                                             node,
                                             src,
-                                        ));
+                                        );
+                                        f.fix_suggestion = Some("Validate file paths with Path.GetFullPath() and ensure they don't escape the intended directory".to_string());
+                                        findings.push(f);
                                         return;
                                     }
                                 }
@@ -375,10 +378,12 @@ impl Rule for NoPathTraversal {
                 let _ = has_stream_reader;
             }
 
-            // new StreamReader(userInput)
+            // new StreamReader(userInput) / new FileStream(userInput, ...)
             if node.kind() == "object_creation_expression" {
                 let node_text = &src[node.byte_range()];
-                if node_text.contains("StreamReader") {
+                let is_stream_reader = node_text.contains("StreamReader");
+                let is_file_stream = node_text.contains("FileStream");
+                if is_stream_reader || is_file_stream {
                     let mut cursor = node.walk();
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" {
@@ -386,14 +391,24 @@ impl Rule for NoPathTraversal {
                                 if !is_string_literal(first_arg) {
                                     let arg_text = &src[first_arg.byte_range()];
                                     if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
-                                        findings.push(make_finding(
+                                        let type_name = if is_stream_reader {
+                                            "StreamReader"
+                                        } else {
+                                            "FileStream"
+                                        };
+                                        let mut f = make_finding(
                                             self.id(),
                                             self.severity(),
                                             self.cwe(),
-                                            "new StreamReader with dynamic path — validate and sanitize to prevent path traversal",
+                                            &format!(
+                                                "new {} with dynamic path — validate and sanitize to prevent path traversal",
+                                                type_name
+                                            ),
                                             node,
                                             src,
-                                        ));
+                                        );
+                                        f.fix_suggestion = Some("Validate file paths with Path.GetFullPath() and ensure they don't escape the intended directory".to_string());
+                                        findings.push(f);
                                         return;
                                     }
                                 }

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -684,7 +684,76 @@ impl Rule for SpringCsrfDisabled {
     }
 }
 
-// ─── Rule 10: spring-cors-permissive ────────────────────────────────────────
+// ─── Rule 10: no-xss ──────────────────────────────────────────────────────
+
+pub struct NoXss;
+
+impl Rule for NoXss {
+    fn id(&self) -> &str {
+        "java/no-xss"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-79")
+    }
+    fn description(&self) -> &str {
+        "Potential XSS via direct write of user input to HTTP response"
+    }
+    fn language(&self) -> Language {
+        Language::Java
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() == "method_invocation" {
+                if let Some(name) = node.child_by_field_name("name") {
+                    let name_text = &src[name.byte_range()];
+                    if name_text == "write" || name_text == "println" || name_text == "print" {
+                        if let Some(obj) = node.child_by_field_name("object") {
+                            let obj_text = &src[obj.byte_range()];
+                            // Match response.getWriter().write/println, out.write/println,
+                            // or PrintWriter.write/println
+                            if obj_text.contains("getWriter()")
+                                || obj_text == "out"
+                                || obj_text.contains("PrintWriter")
+                                || obj_text == "writer"
+                                || obj_text == "pw"
+                            {
+                                if let Some(args) = node.child_by_field_name("arguments") {
+                                    if let Some(first_arg) = args.named_child(0) {
+                                        // Flag if the argument is not a pure literal
+                                        // (i.e. it's a variable, concatenation, method call, etc.)
+                                        if !is_literal(first_arg)
+                                            && first_arg.kind() != "string_literal"
+                                        {
+                                            let mut f = make_finding(
+                                                self.id(),
+                                                self.severity(),
+                                                self.cwe(),
+                                                "User input written directly to HTTP response — risk of XSS",
+                                                node,
+                                                src,
+                                            );
+                                            f.fix_suggestion = Some("HTML-encode user input before writing to response: use OWASP Java Encoder or StringEscapeUtils.escapeHtml4()".to_string());
+                                            findings.push(f);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        findings
+    }
+}
+
+// ─── Rule 11: spring-cors-permissive ────────────────────────────────────────
 
 pub struct SpringCorsPermissive;
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -207,6 +207,7 @@ impl RuleRegistry {
         registry.register(Box::new(java::NoXxe));
         registry.register(Box::new(java::SpringCsrfDisabled));
         registry.register(Box::new(java::SpringCorsPermissive));
+        registry.register(Box::new(java::NoXss));
 
         // Register PHP rules
         registry.register(Box::new(php::NoEval));

--- a/tests/fixtures/vulnerable.cs
+++ b/tests/fixtures/vulnerable.cs
@@ -46,6 +46,8 @@ namespace VulnerableApp
         {
             var content = File.ReadAllText(userPath);
             var reader = new StreamReader(userPath);
+            var exists = File.Exists(userPath);
+            var stream = new FileStream(userPath, FileMode.Open);
         }
 
         // Rule 6: Weak cryptography

--- a/tests/fixtures/vulnerable.java
+++ b/tests/fixtures/vulnerable.java
@@ -62,4 +62,15 @@ public class Vulnerable {
     void cors() {
         registry.allowedOrigins("*");
     }
+
+    // java/no-xss
+    void xss(String userInput, HttpServletResponse response) throws Exception {
+        response.getWriter().write(userInput);
+        response.getWriter().println(userInput);
+        out.write(userInput);
+        out.println(userInput);
+        PrintWriter pw = response.getWriter();
+        pw.write("<h1>" + userInput);
+        pw.println("<div>" + userInput);
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -910,8 +910,8 @@ fn test_vulnerable_java_finds_all_rules() {
 
     assert_eq!(
         findings.len(),
-        16,
-        "vulnerable.java should have 16 findings, got {}",
+        22,
+        "vulnerable.java should have 22 findings, got {}",
         findings.len()
     );
 
@@ -931,6 +931,7 @@ fn test_vulnerable_java_finds_all_rules() {
         "java/no-xxe",
         "java/spring-csrf-disabled",
         "java/spring-cors-permissive",
+        "java/no-xss",
     ];
 
     for rule in &expected_rules {
@@ -1036,8 +1037,8 @@ fn test_vulnerable_csharp_finds_all_rules() {
 
     assert_eq!(
         findings.len(),
-        15,
-        "vulnerable.cs should have 15 findings, got {}",
+        17,
+        "vulnerable.cs should have 17 findings, got {}",
         findings.len()
     );
 

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -143,6 +143,7 @@ const javaRules: Rule[] = [
   { id: 'java/no-ssrf', cwe: 'CWE-918', desc: 'Potential SSRF via URL or RestTemplate with dynamic input', severity: 'high' },
   { id: 'java/no-unsafe-deserialization', cwe: 'CWE-502', desc: 'Unsafe deserialization can lead to remote code execution', severity: 'critical' },
   { id: 'java/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic algorithm', severity: 'medium' },
+  { id: 'java/no-xss', cwe: 'CWE-79', desc: 'Potential XSS via direct write of user input to HTTP response', severity: 'high' },
   { id: 'java/no-xxe', cwe: 'CWE-611', desc: 'XML parser created without disabling external entities (XXE)', severity: 'high' },
   { id: 'java/spring-cors-permissive', cwe: 'CWE-942', desc: 'Permissive CORS configuration allows any origin', severity: 'medium' },
   { id: 'java/spring-csrf-disabled', cwe: 'CWE-352', desc: 'Spring Security CSRF protection is disabled', severity: 'high' },


### PR DESCRIPTION
## Summary
- Add `java/no-xss` rule (CWE-79, High) to flag user input written directly to HTTP response via `response.getWriter().write/println`, `out.write/println`, and `PrintWriter.write/println` with non-literal arguments
- Extend `cs/no-path-traversal` rule to additionally cover `File.Exists(path)` and `new FileStream(path, ...)` with dynamic path arguments
- Both rules include `fix_suggestion` fields for remediation guidance
- Updated test fixtures, integration tests (Java: 16->22 findings, C#: 15->17 findings), and regenerated `www/src/data/rules.ts`

## Test plan
- [x] `cargo fmt` -- no formatting issues
- [x] `cargo clippy` -- no warnings
- [x] `cargo test` -- all tests pass (integration, rule inventory parity, semgrep parity)
- [ ] Verify `java/no-xss` does not flag string literal arguments (safe code)
- [ ] Verify `cs/no-path-traversal` fires on `File.Exists(userInput)` and `new FileStream(userInput, ...)`

none