### PR TITLE
feat(rb): add SSRF and path traversal rules (refs #120)

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -231,6 +231,8 @@ impl RuleRegistry {
         registry.register(Box::new(ruby::NoHtmlSafe));
         registry.register(Box::new(ruby::NoHardcodedSecret));
         registry.register(Box::new(ruby::NoWeakCrypto));
+        registry.register(Box::new(ruby::NoSsrf));
+        registry.register(Box::new(ruby::NoPathTraversal));
 
         // Register C# rules
         registry.register(Box::new(csharp::NoSqlInjection));

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -556,7 +556,286 @@ impl Rule for NoHardcodedSecret {
     }
 }
 
-// ─── Rule 10: no-weak-crypto ──────────────────────────────────────────────────
+// ─── Rule 10: no-ssrf ────────────────────────────────────────────────────────
+
+pub struct NoSsrf;
+
+impl Rule for NoSsrf {
+    fn id(&self) -> &str {
+        "rb/no-ssrf"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-918")
+    }
+    fn description(&self) -> &str {
+        "Potential SSRF via dynamic outbound HTTP request URL"
+    }
+    fn language(&self) -> Language {
+        Language::Ruby
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            match node.kind() {
+                // Calls with a receiver: URI.open(...), Net::HTTP.get(...),
+                // HTTParty.get(...), Faraday.get(...), RestClient.get(...)
+                // Also bare calls: open(url), open url
+                "call" => {
+                    let method = node.child_by_field_name("method");
+                    let receiver = node.child_by_field_name("receiver");
+
+                    let http_methods = ["get", "post", "put", "patch", "delete", "head"];
+
+                    let (is_ssrf_call, label) = match (receiver, method) {
+                        (Some(recv_node), Some(meth_node)) => {
+                            let recv = &src[recv_node.byte_range()];
+                            let meth = &src[meth_node.byte_range()];
+                            let matched = (recv == "URI" && meth == "open")
+                                || (recv == "Net::HTTP" && http_methods.contains(&meth))
+                                || (recv == "HTTParty" && http_methods.contains(&meth))
+                                || (recv == "Faraday" && http_methods.contains(&meth))
+                                || (recv == "RestClient" && http_methods.contains(&meth));
+                            (matched, format!("{}.{}", recv, meth))
+                        }
+                        // Bare call: open url  (no receiver, method = "open")
+                        (None, Some(meth_node)) => {
+                            let meth = &src[meth_node.byte_range()];
+                            (meth == "open", "open".to_string())
+                        }
+                        _ => (false, String::new()),
+                    };
+
+                    if !is_ssrf_call {
+                        return;
+                    }
+
+                    // Check if the first argument is dynamic (not a string literal)
+                    // Arguments can be in an "arguments" field or as argument_list named child
+                    let first_arg = node
+                        .child_by_field_name("arguments")
+                        .and_then(|a| a.named_child(0))
+                        .or_else(|| {
+                            // For bare calls like `open url`, args are in an argument_list child
+                            node.named_child(1).and_then(|c| {
+                                if c.kind() == "argument_list" {
+                                    c.named_child(0)
+                                } else {
+                                    Some(c)
+                                }
+                            })
+                        });
+
+                    if let Some(arg) = first_arg {
+                        if arg.kind() != "string" {
+                            let mut finding = make_finding(
+                                self.id(),
+                                self.severity(),
+                                self.cwe(),
+                                &format!(
+                                    "{} called with dynamic URL — validate against an allowlist to prevent SSRF",
+                                    label
+                                ),
+                                node,
+                                src,
+                            );
+                            finding.fix_suggestion = Some(
+                                "Validate URLs against an allowlist before making HTTP requests"
+                                    .to_string(),
+                            );
+                            findings.push(finding);
+                        }
+                    }
+                }
+
+                // Command-style bare calls (e.g. open url without parens)
+                "command" => {
+                    let Some(name_node) = node.child_by_field_name("name") else {
+                        return;
+                    };
+                    let name = &src[name_node.byte_range()];
+                    if name != "open" {
+                        return;
+                    }
+
+                    // For command nodes, check if the argument is a string literal
+                    let is_literal = if let Some(arg) = node.named_child(1) {
+                        arg.kind() == "string"
+                            || (arg.kind() == "argument_list"
+                                && arg.named_child(0).is_some_and(|a| a.kind() == "string"))
+                    } else {
+                        false
+                    };
+
+                    if !is_literal {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "open called with dynamic URL — validate against an allowlist to prevent SSRF",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion = Some(
+                            "Validate URLs against an allowlist before making HTTP requests"
+                                .to_string(),
+                        );
+                        findings.push(finding);
+                    }
+                }
+                _ => {}
+            }
+        });
+        findings
+    }
+}
+
+// ─── Rule 11: no-path-traversal ──────────────────────────────────────────────
+
+pub struct NoPathTraversal;
+
+impl Rule for NoPathTraversal {
+    fn id(&self) -> &str {
+        "rb/no-path-traversal"
+    }
+    fn severity(&self) -> Severity {
+        Severity::High
+    }
+    fn cwe(&self) -> Option<&str> {
+        Some("CWE-22")
+    }
+    fn description(&self) -> &str {
+        "Potential path traversal via dynamic file path"
+    }
+    fn language(&self) -> Language {
+        Language::Ruby
+    }
+
+    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            match node.kind() {
+                // Calls with a receiver: File.read(...), File.open(...),
+                // IO.read(...), File.write(...), FileUtils.cp(...)
+                // Also bare calls: send_file(path), send_file path
+                "call" => {
+                    let method = node.child_by_field_name("method");
+                    let receiver = node.child_by_field_name("receiver");
+
+                    let (is_path_sink, label) = match (receiver, method) {
+                        (Some(recv_node), Some(meth_node)) => {
+                            let recv = &src[recv_node.byte_range()];
+                            let meth = &src[meth_node.byte_range()];
+                            let matched = (recv == "File"
+                                && (meth == "read"
+                                    || meth == "open"
+                                    || meth == "write"
+                                    || meth == "delete"
+                                    || meth == "readlines"
+                                    || meth == "binread"))
+                                || (recv == "IO" && (meth == "read" || meth == "readlines"))
+                                || (recv == "FileUtils"
+                                    && (meth == "cp"
+                                        || meth == "mv"
+                                        || meth == "rm"
+                                        || meth == "mkdir_p"));
+                            (matched, format!("{}.{}", recv, meth))
+                        }
+                        // Bare call: send_file path  (no receiver)
+                        (None, Some(meth_node)) => {
+                            let meth = &src[meth_node.byte_range()];
+                            (meth == "send_file", "send_file".to_string())
+                        }
+                        _ => (false, String::new()),
+                    };
+
+                    if !is_path_sink {
+                        return;
+                    }
+
+                    // Check if the first argument is dynamic (not a string literal)
+                    let first_arg = node
+                        .child_by_field_name("arguments")
+                        .and_then(|a| a.named_child(0))
+                        .or_else(|| {
+                            node.named_child(1).and_then(|c| {
+                                if c.kind() == "argument_list" {
+                                    c.named_child(0)
+                                } else {
+                                    Some(c)
+                                }
+                            })
+                        });
+
+                    if let Some(arg) = first_arg {
+                        if arg.kind() != "string" {
+                            let mut finding = make_finding(
+                                self.id(),
+                                self.severity(),
+                                self.cwe(),
+                                &format!(
+                                    "{} called with dynamic path — validate to prevent path traversal",
+                                    label
+                                ),
+                                node,
+                                src,
+                            );
+                            finding.fix_suggestion = Some(
+                                "Validate file paths and ensure they don't escape the intended directory"
+                                    .to_string(),
+                            );
+                            findings.push(finding);
+                        }
+                    }
+                }
+
+                // Command-style bare calls (e.g. send_file path without parens)
+                "command" => {
+                    let Some(name_node) = node.child_by_field_name("name") else {
+                        return;
+                    };
+                    let name = &src[name_node.byte_range()];
+                    if name != "send_file" {
+                        return;
+                    }
+
+                    let is_literal = if let Some(arg) = node.named_child(1) {
+                        arg.kind() == "string"
+                            || (arg.kind() == "argument_list"
+                                && arg.named_child(0).is_some_and(|a| a.kind() == "string"))
+                    } else {
+                        false
+                    };
+
+                    if !is_literal {
+                        let mut finding = make_finding(
+                            self.id(),
+                            self.severity(),
+                            self.cwe(),
+                            "send_file called with dynamic path — validate to prevent path traversal",
+                            node,
+                            src,
+                        );
+                        finding.fix_suggestion = Some(
+                            "Validate file paths and ensure they don't escape the intended directory"
+                                .to_string(),
+                        );
+                        findings.push(finding);
+                    }
+                }
+                _ => {}
+            }
+        });
+        findings
+    }
+}
+
+// ─── Rule 12: no-weak-crypto ──────────────────────────────────────────────────
 
 pub struct NoWeakCrypto;
 
@@ -601,5 +880,73 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tree_sitter::Parser;
+
+    fn parse_ruby(source: &str) -> tree_sitter::Tree {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_ruby::LANGUAGE.into())
+            .unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    #[allow(dead_code)]
+    fn dump_tree(node: tree_sitter::Node, src: &str, depth: usize) {
+        let indent = "  ".repeat(depth);
+        let text = &src[node.byte_range()];
+        let short = if text.len() > 60 { &text[..60] } else { text };
+        eprintln!(
+            "{}kind={:?} named_children={} text={:?}",
+            indent,
+            node.kind(),
+            node.named_child_count(),
+            short.replace('\n', "\\n")
+        );
+        for i in 0..node.named_child_count() {
+            if let Some(c) = node.named_child(i) {
+                dump_tree(c, src, depth + 1);
+            }
+        }
+    }
+
+    #[test]
+    fn debug_open_url_tree() {
+        let source = "open url\nsend_file path\n";
+        let tree = parse_ruby(source);
+        dump_tree(tree.root_node(), source, 0);
+    }
+
+    #[test]
+    fn test_ssrf_detects_all_patterns() {
+        let source = "URI.open(user_input)\nNet::HTTP.get(user_url)\nHTTParty.get(url)\nFaraday.get(url)\nRestClient.get(url)\nopen url\n";
+        let tree = parse_ruby(source);
+        let rule = NoSsrf;
+        let findings = rule.check(source, &tree);
+        assert_eq!(
+            findings.len(),
+            6,
+            "Expected 6 SSRF findings, got {}",
+            findings.len()
+        );
+    }
+
+    #[test]
+    fn test_path_traversal_detects_all_patterns() {
+        let source = "File.read(user_input)\nFile.open(user_input)\nIO.read(user_input)\nFile.write(path, data)\nFileUtils.cp(src, dst)\nsend_file path\n";
+        let tree = parse_ruby(source);
+        let rule = NoPathTraversal;
+        let findings = rule.check(source, &tree);
+        assert_eq!(
+            findings.len(),
+            6,
+            "Expected 6 path traversal findings, got {}",
+            findings.len()
+        );
     }
 }

--- a/tests/fixtures/safe.rb
+++ b/tests/fixtures/safe.rb
@@ -1,0 +1,17 @@
+# Ruby test fixture — safe code that should NOT trigger foxguard rules
+
+# Safe: string literal URLs (no SSRF)
+URI.open("https://example.com/api")
+Net::HTTP.get("https://api.example.com/data")
+HTTParty.get("https://api.example.com/data")
+Faraday.get("https://api.example.com/data")
+RestClient.get("https://api.example.com/data")
+open "https://example.com"
+
+# Safe: string literal file paths (no path traversal)
+File.read("config/settings.yml")
+File.open("log/app.log")
+IO.read("data/seed.json")
+File.write("tmp/cache.txt", data)
+FileUtils.cp("src/file.rb", "dst/file.rb")
+send_file "public/downloads/report.pdf"

--- a/tests/fixtures/vulnerable.rb
+++ b/tests/fixtures/vulnerable.rb
@@ -37,3 +37,19 @@ api_token = "sk-live-abcdef123456789"
 # rb/no-weak-crypto
 Digest::MD5.hexdigest("data")
 Digest::SHA1.hexdigest("data")
+
+# rb/no-ssrf
+URI.open(user_input)
+Net::HTTP.get(user_url)
+HTTParty.get(url)
+Faraday.get(url)
+RestClient.get(url)
+open url
+
+# rb/no-path-traversal
+File.read(user_input)
+File.open(user_input)
+IO.read(user_input)
+File.write(path, data)
+FileUtils.cp(src, dst)
+send_file path

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -994,8 +994,8 @@ fn test_vulnerable_ruby_finds_all_rules() {
 
     assert_eq!(
         findings.len(),
-        18,
-        "vulnerable.rb should have 18 findings, got {}",
+        30,
+        "vulnerable.rb should have 30 findings, got {}",
         findings.len()
     );
 
@@ -1015,10 +1015,34 @@ fn test_vulnerable_ruby_finds_all_rules() {
         "rb/no-html-safe",
         "rb/no-hardcoded-secret",
         "rb/no-weak-crypto",
+        "rb/no-ssrf",
+        "rb/no-path-traversal",
     ];
 
     for rule in &expected_rules {
         assert!(rule_ids.contains(rule), "missing expected rule: {}", rule);
+    }
+}
+
+#[test]
+fn test_safe_ruby_no_findings() {
+    let output = foxguard_cmd()
+        .args(["tests/fixtures/safe.rb", "-f", "json"])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.trim().is_empty() {
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_str(stdout.trim()).unwrap_or_default();
+        assert_eq!(
+            findings.len(),
+            0,
+            "safe.rb should have 0 findings, got {}",
+            findings.len()
+        );
     }
 }
 

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -130,7 +130,9 @@ const rubyRules: Rule[] = [
   { id: 'rb/no-html-safe', cwe: 'CWE-79', desc: 'Potential XSS via html_safe or raw()', severity: 'high' },
   { id: 'rb/no-mass-assignment', cwe: 'CWE-915', desc: 'Mass assignment via permit! allows all parameters', severity: 'high' },
   { id: 'rb/no-open-redirect', cwe: 'CWE-601', desc: 'Potential open redirect via redirect_to with dynamic argument', severity: 'high' },
+  { id: 'rb/no-path-traversal', cwe: 'CWE-22', desc: 'Potential path traversal via dynamic file path', severity: 'high' },
   { id: 'rb/no-sql-injection', cwe: 'CWE-89', desc: 'Potential SQL injection via string interpolation in query methods', severity: 'critical' },
+  { id: 'rb/no-ssrf', cwe: 'CWE-918', desc: 'Potential SSRF via dynamic outbound HTTP request URL', severity: 'high' },
   { id: 'rb/no-unsafe-deserialization', cwe: 'CWE-502', desc: 'Unsafe deserialization via Marshal.load or YAML.load', severity: 'critical' },
   { id: 'rb/no-weak-crypto', cwe: 'CWE-327', desc: 'Use of weak cryptographic hash (MD5/SHA1)', severity: 'medium' },
 ];


### PR DESCRIPTION
## Summary
- Add `rb/no-ssrf` rule (CWE-918, High): detects `URI.open`, `Net::HTTP.get`, `HTTParty.get`, `Faraday.get`, `RestClient.get`, and bare `open()` with dynamic URL arguments
- Add `rb/no-path-traversal` rule (CWE-22, High): detects `File.read`, `File.open`, `IO.read`, `File.write`, `FileUtils.cp`, and `send_file` with dynamic path arguments
- Both rules include `fix_suggestion` fields and handle Ruby's no-parens call syntax via tree-sitter AST analysis
- Registered in `mod.rs`, added to `rules.ts`, updated vulnerable.rb fixture (18 -> 30 findings), added safe.rb fixture with zero-finding assertion

## Test plan
- [x] `cargo test` -- all 319 tests pass (211 unit + 74 integration + others)
- [x] `cargo fmt` -- clean
- [x] `cargo clippy` -- clean
- [x] Unit tests for both rules verify detection of all 6 SSRF and 6 path traversal patterns
- [x] Integration test verifies safe.rb produces zero findings
- [x] Integration test verifies vulnerable.rb produces 30 findings covering all 12 Ruby rules

none