### PR TITLE
feat(go): add Echo, Fiber, Chi framework taint sources (refs #129)

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -1289,7 +1289,17 @@ pub fn go_taint_sources() -> Vec<NodeMatcher> {
             canonical: "c.Params".into(),
             description: "fiber Ctx.Params".into(),
         },
+        NodeMatcher::Call {
+            canonical: "c.Body".into(),
+            description: "fiber Ctx.Body".into(),
+        },
         // (c.Query / c.FormValue are shared with Gin above.)
+        // ─── Chi (github.com/go-chi/chi) ────────────────────────────
+        NodeMatcher::Call {
+            canonical: "chi.URLParam".into(),
+            description: "chi.URLParam".into(),
+        },
+        // (r.URL.Query().Get is already covered by net/http sources.)
         // ─── Generic ────────────────────────────────────────────────
         NodeMatcher::Call {
             canonical: "os.Getenv".into(),
@@ -1759,5 +1769,62 @@ func handler(c *gin.Context) {
         let f = run(src);
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].sink_description, "exec.Command");
+    }
+
+    #[test]
+    fn fiber_ctx_body_to_exec() {
+        let src = r#"
+package main
+
+import "os/exec"
+
+func handler(c *fiber.Ctx) error {
+    data := c.Body()
+    exec.Command(string(data))
+    return nil
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("fiber"));
+    }
+
+    #[test]
+    fn fiber_ctx_params_to_exec() {
+        let src = r#"
+package main
+
+import "os/exec"
+
+func handler(c *fiber.Ctx) error {
+    id := c.Params("id")
+    exec.Command(id)
+    return nil
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("fiber"));
+    }
+
+    #[test]
+    fn chi_url_param_to_exec() {
+        let src = r#"
+package main
+
+import (
+    "net/http"
+    "os/exec"
+    "github.com/go-chi/chi/v5"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+    slug := chi.URLParam(r, "slug")
+    exec.Command(slug)
+}
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert!(f[0].source_description.contains("chi"));
     }
 }


### PR DESCRIPTION
## Summary
- Add `c.Body()` as a Fiber taint source for raw request body reads
- Add `chi.URLParam()` as a Chi router taint source for URL path parameters
- Other sources from #129 (Echo's `QueryParam`, `Param`, `FormValue`; Fiber's `Query`, `Params`, `FormValue`; Chi's `r.URL.Query().Get()`) were already covered by existing matchers
- Add tests for `fiber_ctx_body_to_exec`, `fiber_ctx_params_to_exec`, and `chi_url_param_to_exec`

## Test plan
- [x] `cargo test` — all 214 tests pass
- [x] `cargo fmt` — no formatting changes
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] New tests verify taint flows from each new source to `exec.Command` sink

none