### PR TITLE
fix: restrict LDAP sink matchers to avoid String.search/Function.bind false positives (refs #133, #136)

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1141,10 +1141,9 @@ impl TaintLdapInjection {
             sinks: vec![
                 go_call_sink("ldap.NewSearchRequest"),
                 go_call_sink("ldap.SearchRequest"),
-                GoNodeMatcher::MethodName {
-                    method: "Search".into(),
-                    description: "ldap.Conn.Search".into(),
-                },
+                go_call_sink("conn.Search"),
+                go_call_sink("client.Search"),
+                go_call_sink("l.Search"),
             ],
             sanitizers: vec![],
         }

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -2504,13 +2504,29 @@ impl TaintLdapInjection {
         JsTaintSpec {
             sources: javascript_taint_sources(),
             sinks: vec![
-                JsNodeMatcher::MethodName {
-                    method: "search".into(),
-                    description: "LDAP .search() call".into(),
+                JsNodeMatcher::Call {
+                    canonical: "client.search".into(),
+                    description: "LDAP client.search() call".into(),
                 },
-                JsNodeMatcher::MethodName {
-                    method: "bind".into(),
-                    description: "LDAP .bind() call".into(),
+                JsNodeMatcher::Call {
+                    canonical: "ldap.search".into(),
+                    description: "LDAP ldap.search() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "conn.search".into(),
+                    description: "LDAP conn.search() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "client.bind".into(),
+                    description: "LDAP client.bind() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "ldap.bind".into(),
+                    description: "LDAP ldap.bind() call".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "conn.bind".into(),
+                    description: "LDAP conn.bind() call".into(),
                 },
             ],
             sanitizers: vec![],

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -2578,7 +2578,9 @@ function handler(req, res) {
             !findings.is_empty(),
             "expected LDAP injection finding for .search()"
         );
-        assert!(findings[0].sink_description.contains("LDAP .search()"));
+        assert!(findings[0]
+            .sink_description
+            .contains("LDAP client.search()"));
     }
 
     #[test]
@@ -2593,6 +2595,44 @@ function handler(req, res) {
         let aliases = js_aliases_from_tree(src, &tree);
         let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
         assert!(findings.is_empty(), "static LDAP filter should not fire");
+    }
+
+    // Issue #133: String.prototype.search() must not trigger LDAP rule.
+    #[test]
+    fn ldap_no_finding_for_string_search() {
+        let spec = super::super::javascript::TaintLdapInjection::spec();
+        let src = r#"
+function handler(req, res) {
+    const pattern = req.body.pattern;
+    "hello world".search(pattern);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(
+            findings.is_empty(),
+            "String.prototype.search() should not fire LDAP rule"
+        );
+    }
+
+    // Issue #133: Function.prototype.bind() must not trigger LDAP rule.
+    #[test]
+    fn ldap_no_finding_for_function_bind() {
+        let spec = super::super::javascript::TaintLdapInjection::spec();
+        let src = r#"
+function handler(req, res) {
+    const ctx = req.body.context;
+    handler.bind(ctx);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("parse");
+        let aliases = js_aliases_from_tree(src, &tree);
+        let findings = analyze_tree(tree.root_node(), src, &spec, Some(&aliases));
+        assert!(
+            findings.is_empty(),
+            "Function.prototype.bind() should not fire LDAP rule"
+        );
     }
 
     #[test]

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -2523,18 +2523,12 @@ impl TaintLdapInjection {
                 call_sink("ldap.search_st"),
                 call_sink("ldap.search_ext_s"),
                 call_sink("ldap3.Connection.search"),
-                NodeMatcher::MethodName {
-                    method: "search_s".into(),
-                    description: "ldap.search_s".into(),
-                },
-                NodeMatcher::MethodName {
-                    method: "search_st".into(),
-                    description: "ldap.search_st".into(),
-                },
-                NodeMatcher::MethodName {
-                    method: "search_ext_s".into(),
-                    description: "ldap.search_ext_s".into(),
-                },
+                call_sink("conn.search_s"),
+                call_sink("conn.search_st"),
+                call_sink("conn.search_ext_s"),
+                call_sink("l.search_s"),
+                call_sink("l.search_st"),
+                call_sink("l.search_ext_s"),
             ],
             sanitizers: vec![
                 call_sink("ldap.filter.escape_filter_chars"),

--- a/tests/fixtures/safe_js_taint.js
+++ b/tests/fixtures/safe_js_taint.js
@@ -46,3 +46,23 @@ function interproceduralCleanHelper() {
 function literalMethodCall() {
     document.getElementById("x").innerHTML = "literal".toUpperCase();
 }
+
+// ─── Negative cases for LDAP false positives (issue #133) ───────────
+// String.prototype.search() must NOT fire js/taint-ldap-injection.
+function stringSearch(req) {
+    const pattern = req.body.pattern;
+    "hello world".search(pattern);
+}
+
+// Function.prototype.bind() must NOT fire js/taint-ldap-injection.
+function functionBind(req) {
+    const ctx = req.body.context;
+    handler.bind(ctx);
+}
+
+// ─── Negative case for NoSQL false positives (issue #136) ───────────
+// Array.prototype.find() must NOT fire js/taint-nosql-injection.
+function arrayFind(req) {
+    const tainted = req.body.value;
+    [1, 2, 3].find(x => x === tainted);
+}

--- a/tests/fixtures/vulnerable_js_taint.js
+++ b/tests/fixtures/vulnerable_js_taint.js
@@ -89,3 +89,9 @@ function nosqlInjection(req) {
     const filter = req.body.filter;
     db.collection("users").find(filter);
 }
+
+// ─── js/taint-ldap-injection ───────────────────────────────────────
+function ldapSearchInjection(req) {
+    const filter = req.body.filter;
+    client.search(filter);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -659,6 +659,14 @@ fn test_vulnerable_js_taint_catches_every_flow() {
         "js/no-document-write must coexist with the taint rule. counts={:?}",
         counts
     );
+
+    // LDAP injection test added for issue #133.
+    assert_eq!(
+        counts.get("js/taint-ldap-injection").copied(),
+        Some(1),
+        "js/taint-ldap-injection should fire exactly once. counts={:?}",
+        counts
+    );
 }
 
 /// Negative counterpart for the JS/TS taint POC. Every innerHTML/
@@ -676,15 +684,21 @@ fn test_safe_js_taint_has_no_taint_findings() {
     let findings: Vec<serde_json::Value> =
         serde_json::from_slice(&output.stdout).expect("invalid JSON output");
 
-    let n = findings
-        .iter()
-        .filter(|f| f["rule_id"].as_str() == Some("js/taint-xss-innerhtml"))
-        .count();
-    assert_eq!(
-        n, 0,
-        "js/taint-xss-innerhtml should not fire on safe_js_taint.js, got {} findings",
-        n
-    );
+    for taint_rule in [
+        "js/taint-xss-innerhtml",
+        "js/taint-ldap-injection",
+        "js/taint-nosql-injection",
+    ] {
+        let n = findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some(taint_rule))
+            .count();
+        assert_eq!(
+            n, 0,
+            "{} should not fire on safe_js_taint.js, got {} findings",
+            taint_rule, n
+        );
+    }
 }
 
 /// Issue #32 — Next.js App Router taint sources. `request` is the


### PR DESCRIPTION
## Summary
- Replace overly broad `MethodName` matchers (`search`, `bind`) in `js/taint-ldap-injection` with specific `Call` matchers for known LDAP client variable names (`client.search`, `ldap.search`, `conn.search`, `client.bind`, `ldap.bind`, `conn.bind`). This eliminates false positives from `String.prototype.search()` and `Function.prototype.bind()`.
- Apply the same fix to `go/taint-ldap-injection` (replace `MethodName { Search }` with `Call` matchers for `conn.Search`, `client.Search`, `l.Search`) and `py/taint-ldap-injection` (replace `MethodName` matchers for `search_s`/`search_st`/`search_ext_s` with `Call` matchers for `conn.*` and `l.*` variants).
- Add negative test cases (unit + integration) confirming `"hello".search(pattern)`, `handler.bind(ctx)`, and `[1,2,3].find(...)` do not trigger LDAP or NoSQL rules.

## Test plan
- [x] All existing unit tests pass (224 tests)
- [x] All integration tests pass (74 tests)
- [x] New unit tests: `ldap_no_finding_for_string_search`, `ldap_no_finding_for_function_bind`
- [x] Updated integration test: `test_safe_js_taint_has_no_taint_findings` now checks LDAP and NoSQL rules
- [x] Updated integration test: `test_vulnerable_js_taint_catches_every_flow` now asserts LDAP positive case
- [x] `cargo fmt` and `cargo clippy` clean

none