### PR TITLE
fix: add missing sanitizers (shlex.quote, DOMPurify, etc.) to taint rules (refs #139)

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -905,7 +905,7 @@ impl Rule for TaintCommandInjection {
             rule_id: self.id(),
             severity: self.severity(),
             cwe: self.cwe(),
-            fix_suggestion: Some("Pass arguments as separate elements to `exec.Command(name, arg1, arg2)` instead of a single shell string"),
+            fix_suggestion: Some("Go has no standard shell-escape function. Pass arguments as separate elements to `exec.Command(name, arg1, arg2)` instead of building a shell string — this avoids shell interpretation entirely"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!(

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1947,7 +1947,28 @@ impl TaintXssInnerHtml {
                     description: "document.writeln".into(),
                 },
             ],
-            sanitizers: vec![],
+            sanitizers: vec![
+                JsNodeMatcher::Call {
+                    canonical: "DOMPurify.sanitize".into(),
+                    description: "DOMPurify.sanitize".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "sanitizeHtml".into(),
+                    description: "sanitizeHtml".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "xss".into(),
+                    description: "xss".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "escape".into(),
+                    description: "escape".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "encodeURIComponent".into(),
+                    description: "encodeURIComponent".into(),
+                },
+            ],
         }
     }
 }
@@ -2021,7 +2042,16 @@ impl TaintSqlInjection {
                     description: "SQL .raw() call (knex-style)".into(),
                 },
             ],
-            sanitizers: vec![],
+            sanitizers: vec![
+                JsNodeMatcher::MethodName {
+                    method: "escape".into(),
+                    description: "mysql .escape()".into(),
+                },
+                JsNodeMatcher::MethodName {
+                    method: "escapeLiteral".into(),
+                    description: "pg .escapeLiteral()".into(),
+                },
+            ],
         }
     }
 }
@@ -2169,7 +2199,20 @@ impl TaintCommandInjection {
                     description: "child_process.execFile()".into(),
                 },
             ],
-            sanitizers: vec![],
+            sanitizers: vec![
+                JsNodeMatcher::Call {
+                    canonical: "shellescape".into(),
+                    description: "shellescape".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "shell-escape".into(),
+                    description: "shell-escape".into(),
+                },
+                JsNodeMatcher::Call {
+                    canonical: "escapeShellArg".into(),
+                    description: "escapeShellArg".into(),
+                },
+            ],
         }
     }
 }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1764,11 +1764,20 @@ fn is_sanitizer_call(
         Some(a) => a.resolve(callee_text),
         None => Cow::Borrowed(callee_text),
     };
+    let final_segment = resolved.rsplit('.').next().unwrap_or(&resolved);
     for matcher in &spec.sanitizers {
-        if let NodeMatcher::Call { canonical, .. } = matcher {
-            if callee_text == canonical.as_str() || resolved.as_ref() == canonical.as_str() {
-                return true;
+        match matcher {
+            NodeMatcher::Call { canonical, .. } => {
+                if callee_text == canonical.as_str() || resolved.as_ref() == canonical.as_str() {
+                    return true;
+                }
             }
+            NodeMatcher::MethodName { method, .. } => {
+                if method == final_segment {
+                    return true;
+                }
+            }
+            _ => {}
         }
     }
     false

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -2136,7 +2136,11 @@ impl TaintCommandInjectionFromRequest {
                 call_sink("subprocess.check_call"),
                 call_sink("subprocess.check_output"),
             ],
-            sanitizers: vec![],
+            sanitizers: vec![
+                call_sink("shlex.quote"),
+                call_sink("shlex.join"),
+                call_sink("subprocess.list2cmdline"),
+            ],
         }
     }
 }
@@ -2336,7 +2340,7 @@ impl TaintSqlInjectionFromRequest {
                     description: "sqlite3.Cursor.executescript".into(),
                 },
             ],
-            sanitizers: vec![],
+            sanitizers: vec![call_sink("escape_string"), call_sink("quote_ident")],
         }
     }
 }
@@ -2397,7 +2401,13 @@ impl TaintSsti {
                 call_sink("jinja2.Environment.from_string"),
                 call_sink("mako.template.Template"),
             ],
-            sanitizers: vec![call_sink("markupsafe.escape"), call_sink("jinja2.escape")],
+            sanitizers: vec![
+                call_sink("markupsafe.escape"),
+                call_sink("jinja2.escape"),
+                call_sink("html.escape"),
+                call_sink("cgi.escape"),
+                call_sink("bleach.clean"),
+            ],
         }
     }
 }
@@ -2656,7 +2666,7 @@ impl Rule for TaintLogInjection {
             severity: self.severity(),
             cwe: self.cwe(),
             fix_suggestion: Some(
-                "Sanitize user input before logging — strip newlines and control characters",
+                "Sanitize user input before logging — strip newlines and control characters (no standard sanitizer; use str.replace() or a regex to remove \\n, \\r, and ANSI escape sequences)",
             ),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {

--- a/tests/fixtures/safe_js_taint.js
+++ b/tests/fixtures/safe_js_taint.js
@@ -66,3 +66,58 @@ function arrayFind(req) {
     const tainted = req.body.value;
     [1, 2, 3].find(x => x === tainted);
 }
+
+// ─── Sanitizer tests (issue #139) ──────────────────────────────────
+// Each handler flows tainted input through a sanitizer before reaching
+// the sink. The taint rule must NOT fire.
+
+// XSS sanitizers
+function sanitizedXssDomPurify(req) {
+    const dirty = req.body.html;
+    const clean = DOMPurify.sanitize(dirty);
+    document.getElementById("x").innerHTML = clean;
+}
+
+function sanitizedXssSanitizeHtml(req) {
+    const dirty = req.body.html;
+    const clean = sanitizeHtml(dirty);
+    document.getElementById("x").innerHTML = clean;
+}
+
+function sanitizedXssXssPackage(req) {
+    const dirty = req.body.html;
+    const clean = xss(dirty);
+    document.getElementById("x").innerHTML = clean;
+}
+
+function sanitizedXssEncodeURIComponent(req) {
+    const dirty = req.body.html;
+    const clean = encodeURIComponent(dirty);
+    document.getElementById("x").innerHTML = clean;
+}
+
+// SQL injection sanitizers
+function sanitizedSqlEscape(req) {
+    const name = req.body.name;
+    const safe = connection.escape(name);
+    connection.query("SELECT * FROM users WHERE name = " + safe);
+}
+
+function sanitizedSqlEscapeLiteral(req) {
+    const name = req.body.name;
+    const safe = client.escapeLiteral(name);
+    client.query("SELECT * FROM users WHERE name = " + safe);
+}
+
+// Command injection sanitizers
+function sanitizedCmdShellescape(req) {
+    const cmd = req.body.cmd;
+    const safe = shellescape(cmd);
+    child_process.exec(safe);
+}
+
+function sanitizedCmdEscapeShellArg(req) {
+    const cmd = req.body.cmd;
+    const safe = escapeShellArg(cmd);
+    child_process.exec(safe);
+}

--- a/tests/fixtures/safe_py_taint.py
+++ b/tests/fixtures/safe_py_taint.py
@@ -147,3 +147,63 @@ import ldap  # noqa: E402
 def clean_ldap():
     conn = ldap.initialize("ldap://localhost")
     return conn.search_s("dc=example,dc=com", ldap.SCOPE_SUBTREE, "(cn=admin)")
+
+
+# ─── Sanitizer tests (issue #139) ──────────────────────────────────────
+# Each handler below flows tainted input through a sanitizer before
+# reaching the sink. The taint rule must NOT fire.
+
+import shlex  # noqa: E402
+import html as html_mod  # noqa: E402
+import bleach  # noqa: E402
+import markupsafe  # noqa: E402
+
+
+def sanitized_command_shlex_quote():
+    cmd = request.args["cmd"]
+    safe = shlex.quote(cmd)
+    os.system("echo " + safe)
+
+
+def sanitized_command_shlex_join():
+    parts = request.args.getlist("parts")
+    safe = shlex.join(parts)
+    os.system(safe)
+
+
+def sanitized_command_list2cmdline():
+    cmd = request.args["cmd"]
+    safe = subprocess.list2cmdline([cmd])
+    os.system(safe)
+
+
+def sanitized_sql_escape_string():
+    name = request.args["name"]
+    safe = escape_string(name)
+    cur = sqlite3.connect(":memory:").cursor()
+    cur.execute("SELECT * FROM users WHERE name = '" + safe + "'")
+
+
+def sanitized_sql_quote_ident():
+    col = request.args["col"]
+    safe = quote_ident(col)
+    cur = sqlite3.connect(":memory:").cursor()
+    cur.execute("SELECT " + safe + " FROM users")
+
+
+def sanitized_ssti_markupsafe_escape():
+    user_input = request.args["name"]
+    safe = markupsafe.escape(user_input)
+    return render_template_string("<h1>" + safe + "</h1>")
+
+
+def sanitized_ssti_html_escape():
+    user_input = request.args["name"]
+    safe = html_mod.escape(user_input)
+    return render_template_string("<h1>" + safe + "</h1>")
+
+
+def sanitized_ssti_bleach_clean():
+    user_input = request.args["name"]
+    safe = bleach.clean(user_input)
+    return render_template_string("<h1>" + safe + "</h1>")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -686,6 +686,8 @@ fn test_safe_js_taint_has_no_taint_findings() {
 
     for taint_rule in [
         "js/taint-xss-innerhtml",
+        "js/taint-sql-injection",
+        "js/taint-command-injection",
         "js/taint-ldap-injection",
         "js/taint-nosql-injection",
     ] {


### PR DESCRIPTION
## Summary

- Add missing sanitizer functions to 6 taint rules across Python, JavaScript, and Go so that applying the suggested fix actually suppresses the finding
- Extend the JS taint engine's `is_sanitizer_call` to support `MethodName` matchers (needed for receiver-agnostic `.escape()`/`.escapeLiteral()` matching)
- Add negative test fixtures (8 Python + 8 JS test cases) verifying sanitized code does not fire

### Rules updated

| Rule | Sanitizers added |
|---|---|
| `py/taint-command-injection` | `shlex.quote`, `shlex.join`, `subprocess.list2cmdline` |
| `py/taint-sql-injection` | `escape_string`, `quote_ident` |
| `py/taint-ssti` | `html.escape`, `cgi.escape`, `bleach.clean` |
| `py/taint-log-injection` | None (updated fix_suggestion to document this) |
| `js/taint-xss-innerhtml` | `DOMPurify.sanitize`, `sanitizeHtml`, `xss`, `escape`, `encodeURIComponent` |
| `js/taint-sql-injection` | `.escape()` (mysql), `.escapeLiteral()` (pg) |
| `js/taint-command-injection` | `shellescape`, `shell-escape`, `escapeShellArg` |
| `go/taint-command-injection` | None (updated fix_suggestion to explain exec.Command arg list) |
| `go/taint-sql-injection` | None (parameterized queries, not sanitizers) |

## Test plan

- [x] `cargo test` passes (all 73 integration tests + unit tests)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [ ] Verify manually that a Python file using `shlex.quote()` before `os.system()` no longer fires `py/taint-command-injection`
- [ ] Verify manually that a JS file using `DOMPurify.sanitize()` before `.innerHTML` no longer fires `js/taint-xss-innerhtml`

none