### PR TITLE
refactor: single-pass language partition in scanner + fix XSS severity consistency (refs #146, #147)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -298,19 +298,22 @@ fn scan_files(
     let file_count = files.len();
 
     // ── Pass 1: Extract cross-file taint summaries ────────────────────
-    // Run pass 1 for Python and Go files when there are multiple files
-    // of the same language — single-file scans cannot benefit from
+    // Run pass 1 for Python, Go, and JS files when there are multiple
+    // files of the same language — single-file scans cannot benefit from
     // cross-file analysis.
 
-    let python_files: Vec<&(PathBuf, Language)> = files
-        .iter()
-        .filter(|(path, lang)| matches!(lang, Language::Python) && !is_noise_path(path))
-        .collect();
-
-    let go_files: Vec<&(PathBuf, Language)> = files
-        .iter()
-        .filter(|(path, lang)| matches!(lang, Language::Go) && !is_noise_path(path))
-        .collect();
+    // Build a per-language file index in a single pass over the file list.
+    let mut files_by_lang: HashMap<Language, Vec<&(PathBuf, Language)>> = HashMap::new();
+    for entry in &files {
+        if !is_noise_path(&entry.0) {
+            files_by_lang.entry(entry.1).or_default().push(entry);
+        }
+    }
+    let python_files: Vec<_> = files_by_lang.remove(&Language::Python).unwrap_or_default();
+    let go_files: Vec<_> = files_by_lang.remove(&Language::Go).unwrap_or_default();
+    let js_files: Vec<_> = files_by_lang
+        .remove(&Language::JavaScript)
+        .unwrap_or_default();
 
     let mut cross_file_summaries: CrossFileSummaryMap = if python_files.len() > 1 {
         let rule_specs = crate::rules::python::python_taint_rule_specs();
@@ -341,11 +344,6 @@ fn scan_files(
     } else {
         CrossFileSummaryMap::new()
     };
-
-    let js_files: Vec<&(PathBuf, Language)> = files
-        .iter()
-        .filter(|(path, lang)| matches!(lang, Language::JavaScript) && !is_noise_path(path))
-        .collect();
 
     // JavaScript cross-file summaries: extract from all JS/TS files.
     if js_files.len() > 1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ impl std::fmt::Display for Severity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Language {
     JavaScript,


### PR DESCRIPTION
## Summary
- **Scanner optimization (#146):** Replace three separate `.filter()` passes that iterated the full file list for Python, Go, and JS with a single-pass `HashMap<Language, Vec<...>>` partition. Added `Hash` derive to the `Language` enum to support `HashMap` keying.
- **XSS severity audit (#147):** Verified all XSS-related rules across JS (`js/no-xss-innerhtml`, `js/taint-xss-innerhtml`, `js/no-document-write`, `js/express-direct-response-write`), Java (`java/no-xss`), and Ruby (`rb/no-html-safe`) are consistently `Severity::High`. SSTI rules remain `Severity::Critical` as intended. No severity changes were needed.
- Confirmed all three language groups (Python, Go, JS) already correctly guard cross-file analysis behind a `len() > 1` check.

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatted

none