### PR TITLE
refactor: add impl_rule! macro to reduce rule boilerplate (refs #145)

### DIFF
--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -1,6 +1,6 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 /// Check whether a subtree contains a `binary_expression` with `+` operator.
@@ -42,24 +42,15 @@ fn is_string_literal(node: tree_sitter::Node) -> bool {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "cs/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string concatenation in database call"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "cs/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string concatenation in database call",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_methods = [
             "ExecuteReader",
@@ -77,9 +68,9 @@ impl Rule for NoSqlInjection {
                     if let Some(args) = node.child_by_field_name("arguments") {
                         if contains_string_concat(args, src) {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "SQL query built with string concatenation — use parameterized queries",
                                 node,
                                 src,
@@ -94,9 +85,9 @@ impl Rule for NoSqlInjection {
                             // Avoid duplicating if already found via field name
                             if node.child_by_field_name("arguments").is_none() {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "SQL query built with string concatenation — use parameterized queries",
                                     node,
                                     src,
@@ -108,6 +99,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -115,24 +107,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "cs/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via Process.Start with dynamic argument"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "cs/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via Process.Start with dynamic argument",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -153,9 +136,9 @@ impl Rule for NoCommandInjection {
                                         && !inner_text.starts_with("@\"")
                                     {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "Process.Start called with dynamic argument — risk of command injection",
                                             node,
                                             src,
@@ -170,6 +153,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -177,24 +161,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "cs/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Use of unsafe deserialization API"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "cs/no-unsafe-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Use of unsafe deserialization API",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let unsafe_patterns = ["BinaryFormatter", "JavaScriptSerializer"];
 
@@ -207,9 +182,9 @@ impl Rule for NoUnsafeDeserialization {
                         && node_text.contains("Deserialize"))
                 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Unsafe deserialization — BinaryFormatter/JavaScriptSerializer can execute arbitrary code",
                         node,
                         src,
@@ -223,9 +198,9 @@ impl Rule for NoUnsafeDeserialization {
                 for pattern in &unsafe_patterns {
                     if node_text.contains(pattern) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "new {}() — this type is inherently unsafe for deserialization",
                                 pattern
@@ -238,6 +213,7 @@ impl Rule for NoUnsafeDeserialization {
             }
         });
         findings
+
     }
 }
 
@@ -245,24 +221,15 @@ impl Rule for NoUnsafeDeserialization {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "cs/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via HTTP request with dynamic URL"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoSsrf,
+    id = "cs/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via HTTP request with dynamic URL",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let ssrf_methods = ["GetAsync", "PostAsync", "SendAsync", "GetStringAsync"];
 
@@ -285,9 +252,9 @@ impl Rule for NoSsrf {
                                     let arg_text = &src[first_arg.byte_range()];
                                     if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "HTTP request with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                             node,
                                             src,
@@ -302,6 +269,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -309,24 +277,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "cs/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via dynamic file path"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "cs/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via dynamic file path",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let file_methods = [
             "File.ReadAllText",
@@ -356,9 +315,9 @@ impl Rule for NoPathTraversal {
                                     let arg_text = &src[first_arg.byte_range()];
                                     if !arg_text.starts_with('"') && !arg_text.starts_with("@\"") {
                                         let mut f = make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "File operation with dynamic path — validate and sanitize to prevent path traversal",
                                             node,
                                             src,
@@ -397,9 +356,9 @@ impl Rule for NoPathTraversal {
                                             "FileStream"
                                         };
                                         let mut f = make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "new {} with dynamic path — validate and sanitize to prevent path traversal",
                                                 type_name
@@ -419,6 +378,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -426,24 +386,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "cs/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic algorithm"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "cs/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic algorithm",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let weak_algos = [
             ("MD5", "MD5.Create"),
@@ -461,9 +412,9 @@ impl Rule for NoWeakCrypto {
                 for (algo, pattern) in &weak_algos {
                     if node_text.contains(pattern) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!("{} is cryptographically weak — use AES or SHA-256+", algo),
                             node,
                             src,
@@ -474,6 +425,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -481,24 +433,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "cs/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "cs/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern = Regex::new(
             r"(?i)(password|secret|api_?key|apikey|token|credential|private_?key|connection_?string|connectionstring)",
@@ -523,9 +466,9 @@ impl Rule for NoHardcodedSecret {
                                 let trimmed = trimmed.trim_matches('"');
                                 if trimmed.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                             name
@@ -553,9 +496,9 @@ impl Rule for NoHardcodedSecret {
                                 let trimmed = trimmed.trim_matches('"');
                                 if trimmed.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                             left_text.trim()
@@ -571,6 +514,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -578,24 +522,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoXxe;
 
-impl Rule for NoXxe {
-    fn id(&self) -> &str {
-        "cs/no-xxe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-611")
-    }
-    fn description(&self) -> &str {
-        "Potential XXE vulnerability in XML parsing"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoXxe,
+    id = "cs/no-xxe",
+    severity = Severity::High,
+    cwe = Some("CWE-611"),
+    description = "Potential XXE vulnerability in XML parsing",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let has_dtd_prohibit =
             source.contains("DtdProcessing.Prohibit") || source.contains("ProhibitDtd = true");
@@ -609,9 +544,9 @@ impl Rule for NoXxe {
                     && !has_dtd_prohibit
                 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "XML parsing without DtdProcessing.Prohibit — vulnerable to XXE attacks",
                         node,
                         src,
@@ -626,9 +561,9 @@ impl Rule for NoXxe {
                     && !has_dtd_prohibit
                 {
                     findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "XML parser created without disabling DTD processing — vulnerable to XXE attacks",
                             node,
                             src,
@@ -637,6 +572,7 @@ impl Rule for NoXxe {
             }
         });
         findings
+
     }
 }
 
@@ -644,24 +580,15 @@ impl Rule for NoXxe {
 
 pub struct NoLdapInjection;
 
-impl Rule for NoLdapInjection {
-    fn id(&self) -> &str {
-        "cs/no-ldap-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-90")
-    }
-    fn description(&self) -> &str {
-        "Potential LDAP injection via string concatenation in search filter"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoLdapInjection,
+    id = "cs/no-ldap-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-90"),
+    description = "Potential LDAP injection via string concatenation in search filter",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -677,9 +604,9 @@ impl Rule for NoLdapInjection {
                         if let Some(right) = node.child_by_field_name("right") {
                             if contains_string_concat(right, src) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "LDAP filter built with string concatenation — use parameterized filters to prevent LDAP injection",
                                     node,
                                     src,
@@ -698,9 +625,9 @@ impl Rule for NoLdapInjection {
                     for child in node.children(&mut cursor) {
                         if child.kind() == "argument_list" && contains_string_concat(child, src) {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "DirectorySearcher created with concatenated filter — use parameterized filters to prevent LDAP injection",
                                 node,
                                 src,
@@ -712,6 +639,7 @@ impl Rule for NoLdapInjection {
             }
         });
         findings
+
     }
 }
 
@@ -719,24 +647,15 @@ impl Rule for NoLdapInjection {
 
 pub struct NoCorsStar;
 
-impl Rule for NoCorsStar {
-    fn id(&self) -> &str {
-        "cs/no-cors-star"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-942")
-    }
-    fn description(&self) -> &str {
-        "Overly permissive CORS configuration"
-    }
-    fn language(&self) -> Language {
-        Language::CSharp
-    }
+impl_rule! {
+    NoCorsStar,
+    id = "cs/no-cors-star",
+    severity = Severity::Medium,
+    cwe = Some("CWE-942"),
+    description = "Overly permissive CORS configuration",
+    language = Language::CSharp,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let cors_star = Regex::new(r#"WithOrigins\s*\(\s*"\*"\s*\)"#).unwrap();
 
@@ -749,9 +668,9 @@ impl Rule for NoCorsStar {
 
                 if func_text.ends_with("AllowAnyOrigin") || func_text.ends_with(".AllowAnyOrigin") {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "AllowAnyOrigin() permits requests from any domain — restrict CORS origins",
                         node,
                         src,
@@ -760,9 +679,9 @@ impl Rule for NoCorsStar {
                     let node_text = &src[node.byte_range()];
                     if cors_star.is_match(node_text) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "WithOrigins(\"*\") permits requests from any domain — restrict CORS origins",
                             node,
                             src,
@@ -772,5 +691,6 @@ impl Rule for NoCorsStar {
             }
         });
         findings
+
     }
 }

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1,10 +1,11 @@
+use crate::impl_rule;
 use crate::rules::common::AliasTable;
 use crate::rules::common::{get_source_line, make_finding, make_finding_from_offsets, walk_tree};
 use crate::rules::go_taint::{
     self, go_aliases_from_tree, go_taint_sources, NodeMatcher as GoNodeMatcher,
     TaintSpec as GoTaintSpec,
 };
-use crate::rules::{FileContext, Rule};
+use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 
@@ -12,24 +13,15 @@ use regex::Regex;
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "go/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string concatenation or fmt.Sprintf"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "go/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string concatenation or fmt.Sprintf",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_pattern =
             Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").unwrap();
@@ -47,9 +39,9 @@ impl Rule for NoSqlInjection {
                             let left_text = &src[left.byte_range()];
                             if sql_pattern.is_match(left_text) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "SQL query built with string concatenation — use parameterized queries",
                                     node,
                                     src,
@@ -73,9 +65,9 @@ impl Rule for NoSqlInjection {
                                     let arg_text = &src[first_arg.byte_range()];
                                     if sql_pattern.is_match(arg_text) {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "SQL query built with fmt.Sprintf — use parameterized queries",
                                             node,
                                             src,
@@ -89,6 +81,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -96,24 +89,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "go/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via exec.Command with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "go/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via exec.Command with dynamic input",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -128,9 +112,9 @@ impl Rule for NoCommandInjection {
                                     && first_arg.kind() != "raw_string_literal"
                                 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "exec.Command called with dynamic argument — risk of command injection",
                                         node,
                                         src,
@@ -143,6 +127,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -150,24 +135,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "go/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "go/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)")
@@ -192,9 +168,9 @@ impl Rule for NoHardcodedSecret {
                             let inner = val.trim_matches(|c| c == '"' || c == '`');
                             if inner.len() >= 4 {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     &format!(
                                         "Hardcoded secret in '{}' — use environment variables",
                                         left_text.trim()
@@ -222,9 +198,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables",
                                             name
@@ -253,9 +229,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables",
                                             name
@@ -271,6 +247,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -278,24 +255,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "go/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "go/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -314,9 +282,9 @@ impl Rule for NoWeakCrypto {
                             "SHA1"
                         };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{} is cryptographically weak — use SHA-256 or stronger",
                                 algo
@@ -339,9 +307,9 @@ impl Rule for NoWeakCrypto {
                             "SHA1"
                         };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "Import of weak crypto package {} — use crypto/sha256 or stronger",
                                 algo
@@ -354,6 +322,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -361,24 +330,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct GinNoTrustedProxies;
 
-impl Rule for GinNoTrustedProxies {
-    fn id(&self) -> &str {
-        "go/gin-no-trusted-proxies"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-346")
-    }
-    fn description(&self) -> &str {
-        "Gin engine created without SetTrustedProxies configuration"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    GinNoTrustedProxies,
+    id = "go/gin-no-trusted-proxies",
+    severity = Severity::Medium,
+    cwe = Some("CWE-346"),
+    description = "Gin engine created without SetTrustedProxies configuration",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         // Check if gin.Default() or gin.New() is called
         let has_gin_init = source.contains("gin.Default()") || source.contains("gin.New()");
@@ -391,9 +351,9 @@ impl Rule for GinNoTrustedProxies {
                         let func_text = &src[func.byte_range()];
                         if func_text == "gin.Default" || func_text == "gin.New" {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "{}() called without SetTrustedProxies — configure trusted proxies to prevent IP spoofing",
                                     func_text
@@ -407,6 +367,7 @@ impl Rule for GinNoTrustedProxies {
             });
         }
         findings
+
     }
 }
 
@@ -414,24 +375,15 @@ impl Rule for GinNoTrustedProxies {
 
 pub struct NetHttpNoTimeout;
 
-impl Rule for NetHttpNoTimeout {
-    fn id(&self) -> &str {
-        "go/net-http-no-timeout"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-400")
-    }
-    fn description(&self) -> &str {
-        "http.ListenAndServe without timeout configuration enables slowloris attacks"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NetHttpNoTimeout,
+    id = "go/net-http-no-timeout",
+    severity = Severity::Medium,
+    cwe = Some("CWE-400"),
+    description = "http.ListenAndServe without timeout configuration enables slowloris attacks",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -440,9 +392,9 @@ impl Rule for NetHttpNoTimeout {
                     let func_text = &src[func.byte_range()];
                     if func_text == "http.ListenAndServe" || func_text == "http.ListenAndServeTLS" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{} used without timeout — use http.Server with ReadTimeout/WriteTimeout to prevent slowloris",
                                 func_text
@@ -455,6 +407,7 @@ impl Rule for NetHttpNoTimeout {
             }
         });
         findings
+
     }
 }
 
@@ -462,24 +415,15 @@ impl Rule for NetHttpNoTimeout {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "go/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via http.Get/http.Post with variable URL"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoSsrf,
+    id = "go/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via http.Get/http.Post with variable URL",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -508,9 +452,9 @@ impl Rule for NoSsrf {
                                     && first_arg.kind() != "raw_string_literal"
                                 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{} called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                             func_text
@@ -526,6 +470,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -533,32 +478,23 @@ impl Rule for NoSsrf {
 
 pub struct InsecureTlsSkipVerify;
 
-impl Rule for InsecureTlsSkipVerify {
-    fn id(&self) -> &str {
-        "go/insecure-tls-skip-verify"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-295")
-    }
-    fn description(&self) -> &str {
-        "TLS certificate verification disabled with InsecureSkipVerify"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    InsecureTlsSkipVerify,
+    id = "go/insecure-tls-skip-verify",
+    severity = Severity::High,
+    cwe = Some("CWE-295"),
+    description = "TLS certificate verification disabled with InsecureSkipVerify",
+    language = Language::Go,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let pattern = Regex::new(r"InsecureSkipVerify\s*:\s*true").unwrap();
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "InsecureSkipVerify: true disables TLS certificate verification — prefer proper CA validation",
                 source,
                 matched.start(),
@@ -567,6 +503,7 @@ impl Rule for InsecureTlsSkipVerify {
         }
 
         findings
+
     }
 }
 
@@ -574,24 +511,15 @@ impl Rule for InsecureTlsSkipVerify {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "go/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Unsafe deserialization via gob or yaml.Unmarshal into interface{}/any"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "go/no-unsafe-deserialization",
+    severity = Severity::High,
+    cwe = Some("CWE-502"),
+    description = "Unsafe deserialization via gob or yaml.Unmarshal into interface{}/any",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -607,9 +535,9 @@ impl Rule for NoUnsafeDeserialization {
             // Flag gob.NewDecoder()
             if func_text == "gob.NewDecoder" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Use JSON instead of gob for untrusted input. Unmarshal into concrete types, not interface{}.",
                     node,
                     src,
@@ -622,9 +550,9 @@ impl Rule for NoUnsafeDeserialization {
                 let call_text = &src[node.byte_range()];
                 if call_text.contains("interface{}") || call_text.contains("any") {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Use JSON instead of gob for untrusted input. Unmarshal into concrete types, not interface{}.",
                         node,
                         src,
@@ -634,6 +562,7 @@ impl Rule for NoUnsafeDeserialization {
         });
 
         findings
+
     }
 }
 
@@ -641,24 +570,15 @@ impl Rule for NoUnsafeDeserialization {
 
 pub struct JwtNoVerify;
 
-impl Rule for JwtNoVerify {
-    fn id(&self) -> &str {
-        "go/jwt-no-verify"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-347")
-    }
-    fn description(&self) -> &str {
-        "JWT parsed without signature verification"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    JwtNoVerify,
+    id = "go/jwt-no-verify",
+    severity = Severity::Critical,
+    cwe = Some("CWE-347"),
+    description = "JWT parsed without signature verification",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -674,9 +594,9 @@ impl Rule for JwtNoVerify {
             // Flag jwt.ParseUnverified
             if func_text == "jwt.ParseUnverified" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "JWT parsed without verification — use jwt.Parse with a proper key function",
                     node,
                     src,
@@ -698,9 +618,9 @@ impl Rule for JwtNoVerify {
                         let key_fn_text = &src[key_fn_arg.byte_range()];
                         if key_fn_text == "nil" {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "JWT parsed with nil key function — provide a proper key validation function",
                                 node,
                                 src,
@@ -712,6 +632,7 @@ impl Rule for JwtNoVerify {
         });
 
         findings
+
     }
 }
 
@@ -719,24 +640,15 @@ impl Rule for JwtNoVerify {
 
 pub struct JwtHardcodedSecret;
 
-impl Rule for JwtHardcodedSecret {
-    fn id(&self) -> &str {
-        "go/jwt-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "JWT key function uses a hardcoded secret"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    JwtHardcodedSecret,
+    id = "go/jwt-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "JWT key function uses a hardcoded secret",
+    language = Language::Go,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let hardcoded_byte_re = Regex::new(r#"\[\]byte\(\s*"[^"]{4,}"\s*\)"#).unwrap();
 
@@ -760,9 +672,9 @@ impl Rule for JwtHardcodedSecret {
             let node_text = &src[node.byte_range()];
             if hardcoded_byte_re.is_match(node_text) {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "JWT secret is hardcoded — load signing keys from environment or a secrets manager",
                     node,
                     src,
@@ -771,6 +683,7 @@ impl Rule for JwtHardcodedSecret {
         });
 
         findings
+
     }
 }
 
@@ -874,37 +787,19 @@ impl TaintCommandInjection {
     }
 }
 
-impl Rule for TaintCommandInjection {
-    fn id(&self) -> &str {
-        "go/taint-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches os/exec command execution sink"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintCommandInjection,
+    id = "go/taint-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Untrusted input reaches os/exec command execution sink",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Go has no standard shell-escape function. Pass arguments as separate elements to `exec.Command(name, arg1, arg2)` instead of building a shell string — this avoids shell interpretation entirely"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -913,6 +808,7 @@ impl Rule for TaintCommandInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -964,42 +860,25 @@ impl TaintSqlInjection {
     }
 }
 
-impl Rule for TaintSqlInjection {
-    fn id(&self) -> &str {
-        "go/taint-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches database Query/Exec sink"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintSqlInjection,
+    id = "go/taint-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Untrusted input reaches database Query/Exec sink",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use parameterized queries: `db.Query(\"SELECT * FROM users WHERE name = $1\", name)`"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can inject SQL", src, sink)
         })
+
     }
 }
 
@@ -1024,37 +903,19 @@ impl TaintSsti {
     }
 }
 
-impl Rule for TaintSsti {
-    fn id(&self) -> &str {
-        "go/taint-ssti"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1336")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches template parsing sink (potential SSTI)"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintSsti,
+    id = "go/taint-ssti",
+    severity = Severity::Critical,
+    cwe = Some("CWE-1336"),
+    description = "Untrusted input reaches template parsing sink (potential SSTI)",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use pre-defined template files with template.ParseFiles() instead of parsing user-controlled template strings"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -1063,6 +924,7 @@ impl Rule for TaintSsti {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1086,37 +948,19 @@ impl TaintXpathInjection {
     }
 }
 
-impl Rule for TaintXpathInjection {
-    fn id(&self) -> &str {
-        "go/taint-xpath-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-643")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches XPath query sink (potential XPath injection)"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintXpathInjection,
+    id = "go/taint-xpath-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-643"),
+    description = "Untrusted input reaches XPath query sink (potential XPath injection)",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate and sanitize user input before building XPath expressions",
             ),
@@ -1127,6 +971,7 @@ impl Rule for TaintXpathInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1150,37 +995,19 @@ impl TaintLdapInjection {
     }
 }
 
-impl Rule for TaintLdapInjection {
-    fn id(&self) -> &str {
-        "go/taint-ldap-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-90")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches LDAP search sink (potential LDAP injection)"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintLdapInjection,
+    id = "go/taint-ldap-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-90"),
+    description = "Untrusted input reaches LDAP search sink (potential LDAP injection)",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use ldap.EscapeFilter() to sanitize user input before building LDAP filter strings"),
         };
         map_go_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -1189,6 +1016,7 @@ impl Rule for TaintLdapInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1213,37 +1041,19 @@ impl TaintSsrf {
     }
 }
 
-impl Rule for TaintSsrf {
-    fn id(&self) -> &str {
-        "go/taint-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches outbound net/http sink (potential SSRF)"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintSsrf,
+    id = "go/taint-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Untrusted input reaches outbound net/http sink (potential SSRF)",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate URLs against an allowlist of permitted hosts before making requests",
             ),
@@ -1254,6 +1064,7 @@ impl Rule for TaintSsrf {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1277,37 +1088,19 @@ impl TaintLogInjection {
     }
 }
 
-impl Rule for TaintLogInjection {
-    fn id(&self) -> &str {
-        "go/taint-log-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-117")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a logging sink — possible log injection"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintLogInjection,
+    id = "go/taint-log-injection",
+    severity = Severity::Medium,
+    cwe = Some("CWE-117"),
+    description = "Untrusted input reaches a logging sink — possible log injection",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Sanitize user input before logging — strip newlines and control characters",
             ),
@@ -1318,6 +1111,7 @@ impl Rule for TaintLogInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1374,37 +1168,19 @@ impl TaintNosqlInjection {
     }
 }
 
-impl Rule for TaintNosqlInjection {
-    fn id(&self) -> &str {
-        "go/taint-nosql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-943")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a MongoDB query sink — possible NoSQL injection"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintNosqlInjection,
+    id = "go/taint-nosql-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-943"),
+    description = "Untrusted input reaches a MongoDB query sink — possible NoSQL injection",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate and sanitize user input before building MongoDB queries.",
             ),
@@ -1415,6 +1191,7 @@ impl Rule for TaintNosqlInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -1459,37 +1236,19 @@ impl TaintPathTraversal {
     }
 }
 
-impl Rule for TaintPathTraversal {
-    fn id(&self) -> &str {
-        "go/taint-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a filesystem path sink — possible path traversal"
-    }
-    fn language(&self) -> Language {
-        Language::Go
-    }
+impl_rule! {
+    TaintPathTraversal,
+    id = "go/taint-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Untrusted input reaches a filesystem path sink — possible path traversal",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = GoTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate file paths with filepath.Clean() and ensure they don't escape the intended directory",
             ),
@@ -1500,6 +1259,7 @@ impl Rule for TaintPathTraversal {
                 src, sink
             )
         })
+
     }
 }
 

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -1,6 +1,6 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 /// Check whether any descendant of `node` is a `binary_expression` with a `+`
@@ -66,24 +66,15 @@ fn is_literal(node: tree_sitter::Node) -> bool {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "java/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string concatenation in query method"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "java/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string concatenation in query method",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_methods =
             Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery)$").unwrap();
@@ -96,9 +87,9 @@ impl Rule for NoSqlInjection {
                         if let Some(args) = node.child_by_field_name("arguments") {
                             if has_string_concat(args, src) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "SQL query built with string concatenation — use parameterized queries or prepared statements",
                                     node,
                                     src,
@@ -110,6 +101,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -117,24 +109,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "java/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via Runtime.exec or ProcessBuilder with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "java/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via Runtime.exec or ProcessBuilder with dynamic input",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -150,9 +133,9 @@ impl Rule for NoCommandInjection {
                                     if let Some(first_arg) = args.named_child(0) {
                                         if !is_literal(first_arg) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Runtime.exec() called with dynamic argument — risk of command injection",
                                                 node,
                                                 src,
@@ -175,9 +158,9 @@ impl Rule for NoCommandInjection {
                             if let Some(first_arg) = args.named_child(0) {
                                 if !is_literal(first_arg) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "ProcessBuilder created with dynamic argument — risk of command injection",
                                         node,
                                         src,
@@ -190,6 +173,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -197,24 +181,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "java/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Unsafe deserialization can lead to remote code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "java/no-unsafe-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Unsafe deserialization can lead to remote code execution",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -232,9 +207,9 @@ impl Rule for NoUnsafeDeserialization {
                                 || !obj_text.contains('.')
                             {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "readObject() on untrusted data can lead to remote code execution — use allowlist-based deserialization",
                                     node,
                                     src,
@@ -249,9 +224,9 @@ impl Rule for NoUnsafeDeserialization {
                             let obj_text = &src[obj.byte_range()];
                             if obj_text.contains("Yaml") || obj_text.contains("yaml") {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "Yaml.load() deserializes arbitrary objects — use Yaml.safeLoad() or a safe constructor",
                                     node,
                                     src,
@@ -263,6 +238,7 @@ impl Rule for NoUnsafeDeserialization {
             }
         });
         findings
+
     }
 }
 
@@ -270,24 +246,15 @@ impl Rule for NoUnsafeDeserialization {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "java/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via URL or RestTemplate with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoSsrf,
+    id = "java/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via URL or RestTemplate with dynamic input",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -300,9 +267,9 @@ impl Rule for NoSsrf {
                             if let Some(first_arg) = args.named_child(0) {
                                 if !is_literal(first_arg) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "new URL() with dynamic argument — validate and allowlist target hosts to prevent SSRF",
                                         node,
                                         src,
@@ -334,9 +301,9 @@ impl Rule for NoSsrf {
                                     if let Some(first_arg) = args.named_child(0) {
                                         if !is_literal(first_arg) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "RestTemplate called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                                 node,
                                                 src,
@@ -351,6 +318,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -358,24 +326,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "java/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via dynamic file path"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "java/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via dynamic file path",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -388,9 +347,9 @@ impl Rule for NoPathTraversal {
                             if let Some(first_arg) = args.named_child(0) {
                                 if !is_literal(first_arg) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "new {}() with dynamic path — sanitize input to prevent path traversal",
                                             type_text
@@ -417,9 +376,9 @@ impl Rule for NoPathTraversal {
                                     if let Some(first_arg) = args.named_child(0) {
                                         if !is_literal(first_arg) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Paths.get() with dynamic path — sanitize input to prevent path traversal",
                                                 node,
                                                 src,
@@ -434,6 +393,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -441,24 +401,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "java/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic algorithm"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "java/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic algorithm",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let weak_algo =
             Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#).unwrap();
@@ -480,9 +431,9 @@ impl Rule for NoWeakCrypto {
                                         let arg_text = &src[first_arg.byte_range()];
                                         if weak_algo.is_match(arg_text) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 &format!(
                                                     "{}.getInstance({}) uses a weak algorithm — use AES-GCM, SHA-256, or stronger",
                                                     obj_text, arg_text
@@ -500,6 +451,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -507,24 +459,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "java/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "java/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|apiKey|token|auth|credential|private_?key)")
@@ -542,9 +485,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches('"');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                             name
@@ -570,9 +513,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches('"');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                             left_text.trim()
@@ -588,6 +531,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -595,24 +539,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoXxe;
 
-impl Rule for NoXxe {
-    fn id(&self) -> &str {
-        "java/no-xxe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-611")
-    }
-    fn description(&self) -> &str {
-        "XML parser created without disabling external entities (XXE)"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoXxe,
+    id = "java/no-xxe",
+    severity = Severity::High,
+    cwe = Some("CWE-611"),
+    description = "XML parser created without disabling external entities (XXE)",
+    language = Language::Java,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let factory_pattern = Regex::new(
             r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
@@ -626,9 +561,9 @@ impl Rule for NoXxe {
         if factory_pattern.is_match(source) && !secure_pattern.is_match(source) {
             for matched in factory_pattern.find_iter(source) {
                 findings.push(make_finding_from_offsets(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "XML parser factory created without disabling external entities — set feature to prevent XXE attacks",
                     source,
                     matched.start(),
@@ -637,6 +572,7 @@ impl Rule for NoXxe {
             }
         }
         findings
+
     }
 }
 
@@ -644,24 +580,15 @@ impl Rule for NoXxe {
 
 pub struct SpringCsrfDisabled;
 
-impl Rule for SpringCsrfDisabled {
-    fn id(&self) -> &str {
-        "java/spring-csrf-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "Spring Security CSRF protection is disabled"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    SpringCsrfDisabled,
+    id = "java/spring-csrf-disabled",
+    severity = Severity::High,
+    cwe = Some("CWE-352"),
+    description = "Spring Security CSRF protection is disabled",
+    language = Language::Java,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         // .csrf().disable() or csrf(csrf -> csrf.disable()) or csrf(c -> c.disable())
         let csrf_pattern = Regex::new(
@@ -671,9 +598,9 @@ impl Rule for SpringCsrfDisabled {
 
         for matched in csrf_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "CSRF protection is disabled — enable CSRF unless this is a stateless API with token auth",
                 source,
                 matched.start(),
@@ -681,6 +608,7 @@ impl Rule for SpringCsrfDisabled {
             ));
         }
         findings
+
     }
 }
 
@@ -688,24 +616,15 @@ impl Rule for SpringCsrfDisabled {
 
 pub struct NoXss;
 
-impl Rule for NoXss {
-    fn id(&self) -> &str {
-        "java/no-xss"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "Potential XSS via direct write of user input to HTTP response"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    NoXss,
+    id = "java/no-xss",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "Potential XSS via direct write of user input to HTTP response",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -731,9 +650,9 @@ impl Rule for NoXss {
                                             && first_arg.kind() != "string_literal"
                                         {
                                             let mut f = make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "User input written directly to HTTP response — risk of XSS",
                                                 node,
                                                 src,
@@ -750,6 +669,7 @@ impl Rule for NoXss {
             }
         });
         findings
+
     }
 }
 
@@ -757,33 +677,24 @@ impl Rule for NoXss {
 
 pub struct SpringCorsPermissive;
 
-impl Rule for SpringCorsPermissive {
-    fn id(&self) -> &str {
-        "java/spring-cors-permissive"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-942")
-    }
-    fn description(&self) -> &str {
-        "Permissive CORS configuration allows any origin"
-    }
-    fn language(&self) -> Language {
-        Language::Java
-    }
+impl_rule! {
+    SpringCorsPermissive,
+    id = "java/spring-cors-permissive",
+    severity = Severity::Medium,
+    cwe = Some("CWE-942"),
+    description = "Permissive CORS configuration allows any origin",
+    language = Language::Java,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         // allowedOrigins("*")
         let wildcard_pattern = Regex::new(r#"allowedOrigins\s*\(\s*"\*"\s*\)"#).unwrap();
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "allowedOrigins(\"*\") permits any origin — restrict to trusted domains",
                 source,
                 matched.start(),
@@ -802,9 +713,9 @@ impl Rule for SpringCorsPermissive {
                         || text.contains("origins = \"*\"")
                     {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "@CrossOrigin with wildcard origin — restrict to trusted domains",
                             node,
                             src,
@@ -814,5 +725,6 @@ impl Rule for SpringCorsPermissive {
             }
         });
         findings
+
     }
 }

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1,5 +1,6 @@
+use crate::impl_rule;
 use crate::rules::common::{get_source_line, make_finding, walk_tree};
-use crate::rules::{FileContext, Rule};
+use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 
@@ -7,24 +8,15 @@ use regex::Regex;
 
 pub struct NoEval;
 
-impl Rule for NoEval {
-    fn id(&self) -> &str {
-        "js/no-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Use of eval() allows arbitrary code execution"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoEval,
+    id = "js/no-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Use of eval() allows arbitrary code execution",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Look for call_expression where the function is `eval`
@@ -33,10 +25,10 @@ impl Rule for NoEval {
                     let func_text = &src[func.byte_range()];
                     if func_text == "eval" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
-                            self.description(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
+                            _self.description(),
                             node,
                             src,
                         ));
@@ -45,6 +37,7 @@ impl Rule for NoEval {
             }
         });
         findings
+
     }
 }
 
@@ -52,24 +45,15 @@ impl Rule for NoEval {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "js/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "js/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)")
@@ -92,9 +76,9 @@ impl Rule for NoHardcodedSecret {
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "Hardcoded secret in variable '{}' — avoid committing credentials",
                                     name
@@ -122,9 +106,9 @@ impl Rule for NoHardcodedSecret {
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "Hardcoded secret assigned to '{}' — use environment variables instead",
                                     left_text
@@ -138,6 +122,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -145,24 +130,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "js/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string concatenation or template literal"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "js/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string concatenation or template literal",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         // Require SQL keyword followed by SQL structure (FROM, INTO, SET, WHERE, TABLE, VALUES)
         // This avoids matching plain English like res.send('delete ' + name)
@@ -181,9 +157,9 @@ impl Rule for NoSqlInjection {
                                 && sql_pattern.is_match(left_text)
                             {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "SQL query built with string concatenation — use parameterized queries",
                                     node,
                                     src,
@@ -205,9 +181,9 @@ impl Rule for NoSqlInjection {
                         .any(|c| c.kind() == "template_substitution");
                     if has_substitution {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "SQL query built with template literal interpolation — use parameterized queries",
                             node,
                             src,
@@ -217,6 +193,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -224,24 +201,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoXssInnerHtml;
 
-impl Rule for NoXssInnerHtml {
-    fn id(&self) -> &str {
-        "js/no-xss-innerhtml"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "Assignment to innerHTML may lead to XSS"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoXssInnerHtml,
+    id = "js/no-xss-innerhtml",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "Assignment to innerHTML may lead to XSS",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment_expression where left side ends with .innerHTML
@@ -255,9 +223,9 @@ impl Rule for NoXssInnerHtml {
                                 if let Some(right) = node.child_by_field_name("right") {
                                     if right.kind() != "string" {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "Assignment to {} with dynamic content — use textContent or sanitize HTML",
                                                 prop_text
@@ -274,6 +242,7 @@ impl Rule for NoXssInnerHtml {
             }
         });
         findings
+
     }
 }
 
@@ -281,24 +250,15 @@ impl Rule for NoXssInnerHtml {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "js/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via exec/spawn with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "js/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via exec/spawn with dynamic input",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let dangerous_fns = [
             "exec",
@@ -337,9 +297,9 @@ impl Rule for NoCommandInjection {
 
                                 if is_dynamic {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic argument — risk of command injection",
                                             func_name
@@ -355,6 +315,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -362,24 +323,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoDocumentWrite;
 
-impl Rule for NoDocumentWrite {
-    fn id(&self) -> &str {
-        "js/no-document-write"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "document.write() can lead to XSS vulnerabilities"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoDocumentWrite,
+    id = "js/no-document-write",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "document.write() can lead to XSS vulnerabilities",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -387,9 +339,9 @@ impl Rule for NoDocumentWrite {
                     let func_text = &src[func.byte_range()];
                     if func_text == "document.write" || func_text == "document.writeln" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "document.write() can inject arbitrary HTML — use DOM APIs instead",
                             node,
                             src,
@@ -399,6 +351,7 @@ impl Rule for NoDocumentWrite {
             }
         });
         findings
+
     }
 }
 
@@ -406,24 +359,15 @@ impl Rule for NoDocumentWrite {
 
 pub struct NoOpenRedirect;
 
-impl Rule for NoOpenRedirect {
-    fn id(&self) -> &str {
-        "js/no-open-redirect"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-601")
-    }
-    fn description(&self) -> &str {
-        "Open redirect via assignment to window.location with user input"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoOpenRedirect,
+    id = "js/no-open-redirect",
+    severity = Severity::Medium,
+    cwe = Some("CWE-601"),
+    description = "Open redirect via assignment to window.location with user input",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "assignment_expression" {
@@ -439,9 +383,9 @@ impl Rule for NoOpenRedirect {
                             // Flag if right side is not a string literal
                             if right.kind() != "string" {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "Assignment to window.location with dynamic value — risk of open redirect",
                                     node,
                                     src,
@@ -453,6 +397,7 @@ impl Rule for NoOpenRedirect {
             }
         });
         findings
+
     }
 }
 
@@ -460,24 +405,15 @@ impl Rule for NoOpenRedirect {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "js/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "js/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: createHash('md5') or createHash('sha1')
@@ -493,9 +429,9 @@ impl Rule for NoWeakCrypto {
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'');
                                     if inner == "md5" || inner == "sha1" {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "createHash('{}') uses a weak hash — use sha256 or stronger",
                                                 inner
@@ -512,6 +448,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -519,24 +456,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "js/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via fs operations with user input"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "js/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via fs operations with user input",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let fs_fns = [
             "readFile",
@@ -569,9 +497,9 @@ impl Rule for NoPathTraversal {
                                 let kind = first_arg.kind();
                                 if kind == "binary_expression" || kind == "template_string" {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic path — validate and sanitize to prevent path traversal",
                                             func_name
@@ -598,9 +526,9 @@ impl Rule for NoPathTraversal {
                                 );
                                 if is_dynamic {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic path — validate and sanitize to prevent path traversal",
                                             func_name
@@ -616,6 +544,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -623,24 +552,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "js/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via dynamic outbound request URL"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoSsrf,
+    id = "js/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via dynamic outbound request URL",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let request_fns = [
             "fetch",
@@ -702,9 +622,9 @@ impl Rule for NoSsrf {
 
             if is_dynamic {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     &format!(
                         "{} called with dynamic URL — validate and allowlist outbound destinations to prevent SSRF",
                         func_text
@@ -716,6 +636,7 @@ impl Rule for NoSsrf {
         });
 
         findings
+
     }
 }
 
@@ -723,24 +644,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPrototypePollution;
 
-impl Rule for NoPrototypePollution {
-    fn id(&self) -> &str {
-        "js/no-prototype-pollution"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1321")
-    }
-    fn description(&self) -> &str {
-        "Potential prototype pollution via dynamic property assignment"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoPrototypePollution,
+    id = "js/no-prototype-pollution",
+    severity = Severity::High,
+    cwe = Some("CWE-1321"),
+    description = "Potential prototype pollution via dynamic property assignment",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: obj[key][subkey] = value where keys are identifiers (not literals)
@@ -754,9 +666,9 @@ impl Rule for NoPrototypePollution {
                                 if let Some(object) = left.child_by_field_name("object") {
                                     if object.kind() == "subscript_expression" {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "Nested dynamic property assignment — risk of prototype pollution",
                                             node,
                                             src,
@@ -770,6 +682,7 @@ impl Rule for NoPrototypePollution {
             }
         });
         findings
+
     }
 }
 
@@ -777,24 +690,15 @@ impl Rule for NoPrototypePollution {
 
 pub struct NoUnsafeRegex;
 
-impl Rule for NoUnsafeRegex {
-    fn id(&self) -> &str {
-        "js/no-unsafe-regex"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1333")
-    }
-    fn description(&self) -> &str {
-        "Potentially catastrophic backtracking regex pattern"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoUnsafeRegex,
+    id = "js/no-unsafe-regex",
+    severity = Severity::Medium,
+    cwe = Some("CWE-1333"),
+    description = "Potentially catastrophic backtracking regex pattern",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         // Patterns known to cause catastrophic backtracking: nested quantifiers
         let dangerous_pattern =
@@ -806,9 +710,9 @@ impl Rule for NoUnsafeRegex {
                 let regex_text = &src[node.byte_range()];
                 if dangerous_pattern.is_match(regex_text) {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Regex with nested quantifiers may cause catastrophic backtracking (ReDoS)",
                         node,
                         src,
@@ -827,9 +731,9 @@ impl Rule for NoUnsafeRegex {
                                     let pattern_text = &src[first_arg.byte_range()];
                                     if dangerous_pattern.is_match(pattern_text) {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "RegExp with nested quantifiers may cause catastrophic backtracking (ReDoS)",
                                             node,
                                             src,
@@ -843,6 +747,7 @@ impl Rule for NoUnsafeRegex {
             }
         });
         findings
+
     }
 }
 
@@ -850,24 +755,15 @@ impl Rule for NoUnsafeRegex {
 
 pub struct ExpressNoHardcodedSessionSecret;
 
-impl Rule for ExpressNoHardcodedSessionSecret {
-    fn id(&self) -> &str {
-        "js/express-no-hardcoded-session-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded session secret in express-session configuration"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressNoHardcodedSessionSecret,
+    id = "js/express-no-hardcoded-session-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded session secret in express-session configuration",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: session({ secret: "literal" }) — look for a pair with key "secret"
@@ -886,9 +782,9 @@ impl Rule for ExpressNoHardcodedSessionSecret {
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Hardcoded session secret — use an environment variable instead",
                                 node,
                                 src,
@@ -899,6 +795,7 @@ impl Rule for ExpressNoHardcodedSessionSecret {
             }
         });
         findings
+
     }
 }
 
@@ -906,24 +803,15 @@ impl Rule for ExpressNoHardcodedSessionSecret {
 
 pub struct ExpressCookieNoSecure;
 
-impl Rule for ExpressCookieNoSecure {
-    fn id(&self) -> &str {
-        "js/express-cookie-no-secure"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-614")
-    }
-    fn description(&self) -> &str {
-        "Cookie configuration missing secure flag"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressCookieNoSecure,
+    id = "js/express-cookie-no-secure",
+    severity = Severity::Medium,
+    cwe = Some("CWE-614"),
+    description = "Cookie configuration missing secure flag",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Look for object literals with a "cookie" key whose value is an object
@@ -942,9 +830,9 @@ impl Rule for ExpressCookieNoSecure {
                             || obj_text.contains("secure:false")
                         {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Cookie configuration missing 'secure: true' — cookies may be sent over HTTP",
                                 node,
                                 src,
@@ -955,6 +843,7 @@ impl Rule for ExpressCookieNoSecure {
             }
         });
         findings
+
     }
 }
 
@@ -962,24 +851,15 @@ impl Rule for ExpressCookieNoSecure {
 
 pub struct ExpressCookieNoHttpOnly;
 
-impl Rule for ExpressCookieNoHttpOnly {
-    fn id(&self) -> &str {
-        "js/express-cookie-no-httponly"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1004")
-    }
-    fn description(&self) -> &str {
-        "Cookie configuration missing httpOnly flag"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressCookieNoHttpOnly,
+    id = "js/express-cookie-no-httponly",
+    severity = Severity::Medium,
+    cwe = Some("CWE-1004"),
+    description = "Cookie configuration missing httpOnly flag",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "pair" {
@@ -996,9 +876,9 @@ impl Rule for ExpressCookieNoHttpOnly {
                             || obj_text.contains("httpOnly:false")
                         {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Cookie configuration missing 'httpOnly: true' — cookies accessible to JavaScript",
                                 node,
                                 src,
@@ -1009,6 +889,7 @@ impl Rule for ExpressCookieNoHttpOnly {
             }
         });
         findings
+
     }
 }
 
@@ -1016,24 +897,15 @@ impl Rule for ExpressCookieNoHttpOnly {
 
 pub struct ExpressCookieNoSameSite;
 
-impl Rule for ExpressCookieNoSameSite {
-    fn id(&self) -> &str {
-        "js/express-cookie-no-samesite"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "Cookie configuration missing sameSite protection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressCookieNoSameSite,
+    id = "js/express-cookie-no-samesite",
+    severity = Severity::Medium,
+    cwe = Some("CWE-352"),
+    description = "Cookie configuration missing sameSite protection",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "pair" {
@@ -1054,9 +926,9 @@ impl Rule for ExpressCookieNoSameSite {
                             || obj_text.contains("sameSite:false");
                         if !has_same_site || none_mode {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Cookie configuration missing a safe sameSite setting — set sameSite to 'lax' or 'strict'",
                                 node,
                                 src,
@@ -1067,6 +939,7 @@ impl Rule for ExpressCookieNoSameSite {
             }
         });
         findings
+
     }
 }
 
@@ -1074,24 +947,15 @@ impl Rule for ExpressCookieNoSameSite {
 
 pub struct ExpressSessionSaveUninitializedTrue;
 
-impl Rule for ExpressSessionSaveUninitializedTrue {
-    fn id(&self) -> &str {
-        "js/express-session-saveuninitialized-true"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-359")
-    }
-    fn description(&self) -> &str {
-        "express-session configured with saveUninitialized: true"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressSessionSaveUninitializedTrue,
+    id = "js/express-session-saveuninitialized-true",
+    severity = Severity::Medium,
+    cwe = Some("CWE-359"),
+    description = "express-session configured with saveUninitialized: true",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() != "pair" {
@@ -1110,9 +974,9 @@ impl Rule for ExpressSessionSaveUninitializedTrue {
             let value_text = &src[value.byte_range()];
             if key_inner == "saveUninitialized" && value_text == "true" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "express-session saveUninitialized: true stores sessions before consent or login state is established",
                     node,
                     src,
@@ -1120,6 +984,7 @@ impl Rule for ExpressSessionSaveUninitializedTrue {
             }
         });
         findings
+
     }
 }
 
@@ -1127,24 +992,15 @@ impl Rule for ExpressSessionSaveUninitializedTrue {
 
 pub struct ExpressSessionResaveTrue;
 
-impl Rule for ExpressSessionResaveTrue {
-    fn id(&self) -> &str {
-        "js/express-session-resave-true"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-384")
-    }
-    fn description(&self) -> &str {
-        "express-session configured with resave: true"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressSessionResaveTrue,
+    id = "js/express-session-resave-true",
+    severity = Severity::Medium,
+    cwe = Some("CWE-384"),
+    description = "express-session configured with resave: true",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() != "pair" {
@@ -1163,9 +1019,9 @@ impl Rule for ExpressSessionResaveTrue {
             let value_text = &src[value.byte_range()];
             if key_inner == "resave" && value_text == "true" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "express-session resave: true can overwrite sessions unnecessarily — prefer resave: false unless your store requires it",
                     node,
                     src,
@@ -1173,6 +1029,7 @@ impl Rule for ExpressSessionResaveTrue {
             }
         });
         findings
+
     }
 }
 
@@ -1180,24 +1037,15 @@ impl Rule for ExpressSessionResaveTrue {
 
 pub struct ExpressDirectResponseWrite;
 
-impl Rule for ExpressDirectResponseWrite {
-    fn id(&self) -> &str {
-        "js/express-direct-response-write"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "XSS via direct response write with user input"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    ExpressDirectResponseWrite,
+    id = "js/express-direct-response-write",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "XSS via direct response write with user input",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         // Match user-controlled input objects
         let user_input_re = Regex::new(r"^req\.(params|query|body|headers)(\b|\[|\.)").unwrap();
@@ -1249,9 +1097,9 @@ impl Rule for ExpressDirectResponseWrite {
                                         let arg_text = &src[arg.byte_range()];
                                         if user_input_re.is_match(arg_text.trim()) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 &format!(
                                                     "res.{}() called with user input — risk of reflected XSS, sanitize before sending",
                                                     prop_text
@@ -1270,6 +1118,7 @@ impl Rule for ExpressDirectResponseWrite {
             }
         });
         findings
+
     }
 }
 
@@ -1277,24 +1126,15 @@ impl Rule for ExpressDirectResponseWrite {
 
 pub struct JwtHardcodedSecret;
 
-impl Rule for JwtHardcodedSecret {
-    fn id(&self) -> &str {
-        "js/jwt-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "JWT signing or verification with a hardcoded secret"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    JwtHardcodedSecret,
+    id = "js/jwt-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "JWT signing or verification with a hardcoded secret",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1331,9 +1171,9 @@ impl Rule for JwtHardcodedSecret {
             }
 
             findings.push(make_finding(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "JWT secret is hardcoded — load signing keys from environment or a secrets manager",
                 node,
                 src,
@@ -1341,6 +1181,7 @@ impl Rule for JwtHardcodedSecret {
         });
 
         findings
+
     }
 }
 
@@ -1348,24 +1189,15 @@ impl Rule for JwtHardcodedSecret {
 
 pub struct JwtNoneAlgorithm;
 
-impl Rule for JwtNoneAlgorithm {
-    fn id(&self) -> &str {
-        "js/jwt-none-algorithm"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-347")
-    }
-    fn description(&self) -> &str {
-        "JWT configured to use the 'none' algorithm"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    JwtNoneAlgorithm,
+    id = "js/jwt-none-algorithm",
+    severity = Severity::High,
+    cwe = Some("CWE-347"),
+    description = "JWT configured to use the 'none' algorithm",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1409,9 +1241,9 @@ impl Rule for JwtNoneAlgorithm {
             }
 
             findings.push(make_finding(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "JWT configured with algorithm 'none' — require a signed algorithm such as HS256 or RS256",
                 node,
                 src,
@@ -1419,6 +1251,7 @@ impl Rule for JwtNoneAlgorithm {
         });
 
         findings
+
     }
 }
 
@@ -1426,24 +1259,15 @@ impl Rule for JwtNoneAlgorithm {
 
 pub struct JwtIgnoreExpiration;
 
-impl Rule for JwtIgnoreExpiration {
-    fn id(&self) -> &str {
-        "js/jwt-ignore-expiration"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-613")
-    }
-    fn description(&self) -> &str {
-        "JWT verification configured to ignore token expiration"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    JwtIgnoreExpiration,
+    id = "js/jwt-ignore-expiration",
+    severity = Severity::High,
+    cwe = Some("CWE-613"),
+    description = "JWT verification configured to ignore token expiration",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1477,9 +1301,9 @@ impl Rule for JwtIgnoreExpiration {
             }
 
             findings.push(make_finding(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "JWT verification ignores expiration — reject expired tokens instead of setting ignoreExpiration: true",
                 node,
                 src,
@@ -1487,6 +1311,7 @@ impl Rule for JwtIgnoreExpiration {
         });
 
         findings
+
     }
 }
 
@@ -1494,24 +1319,15 @@ impl Rule for JwtIgnoreExpiration {
 
 pub struct JwtDecodeWithoutVerify;
 
-impl Rule for JwtDecodeWithoutVerify {
-    fn id(&self) -> &str {
-        "js/jwt-decode-without-verify"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-347")
-    }
-    fn description(&self) -> &str {
-        "JWT decoded without signature verification"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    JwtDecodeWithoutVerify,
+    id = "js/jwt-decode-without-verify",
+    severity = Severity::High,
+    cwe = Some("CWE-347"),
+    description = "JWT decoded without signature verification",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1528,9 +1344,9 @@ impl Rule for JwtDecodeWithoutVerify {
             }
 
             findings.push(make_finding(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "JWT decoded without verification — use jwt.verify() when authenticity matters",
                 node,
                 src,
@@ -1538,6 +1354,7 @@ impl Rule for JwtDecodeWithoutVerify {
         });
 
         findings
+
     }
 }
 
@@ -1545,24 +1362,15 @@ impl Rule for JwtDecodeWithoutVerify {
 
 pub struct JwtVerifyMissingAlgorithms;
 
-impl Rule for JwtVerifyMissingAlgorithms {
-    fn id(&self) -> &str {
-        "js/jwt-verify-missing-algorithms"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-347")
-    }
-    fn description(&self) -> &str {
-        "JWT verification without an explicit algorithms allowlist"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    JwtVerifyMissingAlgorithms,
+    id = "js/jwt-verify-missing-algorithms",
+    severity = Severity::High,
+    cwe = Some("CWE-347"),
+    description = "JWT verification without an explicit algorithms allowlist",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1584,9 +1392,9 @@ impl Rule for JwtVerifyMissingAlgorithms {
 
             let Some(options_arg) = args.named_child(2) else {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "JWT verification does not restrict allowed algorithms — pass an explicit algorithms allowlist",
                     node,
                     src,
@@ -1601,9 +1409,9 @@ impl Rule for JwtVerifyMissingAlgorithms {
             let options_text = &src[options_arg.byte_range()];
             if !options_text.contains("algorithms") {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "JWT verification does not restrict allowed algorithms — pass an explicit algorithms allowlist",
                     node,
                     src,
@@ -1612,6 +1420,7 @@ impl Rule for JwtVerifyMissingAlgorithms {
         });
 
         findings
+
     }
 }
 
@@ -1619,24 +1428,15 @@ impl Rule for JwtVerifyMissingAlgorithms {
 
 pub struct NoCorsStar;
 
-impl Rule for NoCorsStar {
-    fn id(&self) -> &str {
-        "js/no-cors-star"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-942")
-    }
-    fn description(&self) -> &str {
-        "CORS misconfiguration allowing all origins"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoCorsStar,
+    id = "js/no-cors-star",
+    severity = Severity::Medium,
+    cwe = Some("CWE-942"),
+    description = "CORS misconfiguration allowing all origins",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: setHeader("Access-Control-Allow-Origin", "*")
@@ -1663,9 +1463,9 @@ impl Rule for NoCorsStar {
                                             && val_inner == "*"
                                         {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Access-Control-Allow-Origin set to '*' — restrict to specific origins",
                                                 node,
                                                 src,
@@ -1692,9 +1492,9 @@ impl Rule for NoCorsStar {
                         let val_inner = val_text.trim_matches(|c| c == '"' || c == '\'');
                         if val_inner == "*" {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "CORS origin set to '*' — restrict to specific origins",
                                 node,
                                 src,
@@ -1705,6 +1505,7 @@ impl Rule for NoCorsStar {
             }
         });
         findings
+
     }
 }
 
@@ -1712,24 +1513,15 @@ impl Rule for NoCorsStar {
 
 pub struct NoUnsafeFormatString;
 
-impl Rule for NoUnsafeFormatString {
-    fn id(&self) -> &str {
-        "js/no-unsafe-format-string"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-134")
-    }
-    fn description(&self) -> &str {
-        "Template literal with variables in console/logging function may enable log injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoUnsafeFormatString,
+    id = "js/no-unsafe-format-string",
+    severity = Severity::Medium,
+    cwe = Some("CWE-134"),
+    description = "Template literal with variables in console/logging function may enable log injection",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1760,9 +1552,9 @@ impl Rule for NoUnsafeFormatString {
                                     }
                                     if has_interpolation {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "Template literal with variables in logging function — user-controlled values may forge log entries",
                                             node,
                                             src,
@@ -1776,6 +1568,7 @@ impl Rule for NoUnsafeFormatString {
             }
         });
         findings
+
     }
 }
 
@@ -1783,24 +1576,15 @@ impl Rule for NoUnsafeFormatString {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "js/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Unsafe deserialization of untrusted data"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "js/no-unsafe-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Unsafe deserialization of untrusted data",
+    language = Language::JavaScript,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1820,9 +1604,9 @@ impl Rule for NoUnsafeDeserialization {
                 || func_text == "funcster.deepDeserialize"
             {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Avoid deserializing untrusted data with node-serialize. Use JSON.parse() for structured data.",
                     node,
                     src,
@@ -1845,9 +1629,9 @@ impl Rule for NoUnsafeDeserialization {
                     }
                 }
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Avoid deserializing untrusted data with node-serialize. Use JSON.parse() for structured data.",
                     node,
                     src,
@@ -1856,6 +1640,7 @@ impl Rule for NoUnsafeDeserialization {
         });
 
         findings
+
     }
 }
 
@@ -1973,42 +1758,25 @@ impl TaintXssInnerHtml {
     }
 }
 
-impl Rule for TaintXssInnerHtml {
-    fn id(&self) -> &str {
-        "js/taint-xss-innerhtml"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches innerHTML or document.write sink"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintXssInnerHtml,
+    id = "js/taint-xss-innerhtml",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "Untrusted input reaches innerHTML or document.write sink",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use `DOMPurify.sanitize()` or `textContent` instead of `innerHTML`/`document.write`"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can lead to XSS", src, sink)
         })
+
     }
 }
 
@@ -2056,42 +1824,25 @@ impl TaintSqlInjection {
     }
 }
 
-impl Rule for TaintSqlInjection {
-    fn id(&self) -> &str {
-        "js/taint-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a SQL execute sink — possible SQL injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintSqlInjection,
+    id = "js/taint-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Untrusted input reaches a SQL execute sink — possible SQL injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use parameterized queries: `db.query(\"SELECT * FROM users WHERE name = $1\", [name])`"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can inject SQL", src, sink)
         })
+
     }
 }
 
@@ -2122,37 +1873,19 @@ impl TaintEval {
     }
 }
 
-impl Rule for TaintEval {
-    fn id(&self) -> &str {
-        "js/taint-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches eval or Function — arbitrary code execution"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintEval,
+    id = "js/taint-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Untrusted input reaches eval or Function — arbitrary code execution",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Remove `eval()`/`new Function()` and use safe alternatives like `JSON.parse()`",
             ),
@@ -2163,6 +1896,7 @@ impl Rule for TaintEval {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2217,37 +1951,19 @@ impl TaintCommandInjection {
     }
 }
 
-impl Rule for TaintCommandInjection {
-    fn id(&self) -> &str {
-        "js/taint-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a command execution sink — OS command injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintCommandInjection,
+    id = "js/taint-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Untrusted input reaches a command execution sink — OS command injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Pass arguments as an array to `child_process.execFile()` instead of building a shell string"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2256,6 +1972,7 @@ impl Rule for TaintCommandInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2321,37 +2038,19 @@ impl TaintSsrf {
     }
 }
 
-impl Rule for TaintSsrf {
-    fn id(&self) -> &str {
-        "js/taint-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches an HTTP request sink — possible SSRF"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintSsrf,
+    id = "js/taint-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Untrusted input reaches an HTTP request sink — possible SSRF",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate URLs against an allowlist of permitted hosts before making requests",
             ),
@@ -2362,6 +2061,7 @@ impl Rule for TaintSsrf {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2415,37 +2115,19 @@ impl TaintSsti {
     }
 }
 
-impl Rule for TaintSsti {
-    fn id(&self) -> &str {
-        "js/taint-ssti"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1336")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a template rendering sink — possible server-side template injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintSsti,
+    id = "js/taint-ssti",
+    severity = Severity::Critical,
+    cwe = Some("CWE-1336"),
+    description = "Untrusted input reaches a template rendering sink — possible server-side template injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use pre-compiled templates with auto-escaping instead of rendering user input as template strings"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2454,6 +2136,7 @@ impl Rule for TaintSsti {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2491,37 +2174,19 @@ impl TaintXpathInjection {
     }
 }
 
-impl Rule for TaintXpathInjection {
-    fn id(&self) -> &str {
-        "js/taint-xpath-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-643")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches an XPath evaluation sink — possible XPath injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintXpathInjection,
+    id = "js/taint-xpath-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-643"),
+    description = "Untrusted input reaches an XPath evaluation sink — possible XPath injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate and sanitize user input before building XPath expressions",
             ),
@@ -2532,6 +2197,7 @@ impl Rule for TaintXpathInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2577,37 +2243,19 @@ impl TaintLdapInjection {
     }
 }
 
-impl Rule for TaintLdapInjection {
-    fn id(&self) -> &str {
-        "js/taint-ldap-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-90")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches an LDAP operation sink — possible LDAP injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintLdapInjection,
+    id = "js/taint-ldap-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-90"),
+    description = "Untrusted input reaches an LDAP operation sink — possible LDAP injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use ldap-escape or sanitize special LDAP characters before building filter strings"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2616,6 +2264,7 @@ impl Rule for TaintLdapInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2654,37 +2303,19 @@ impl TaintLogInjection {
     }
 }
 
-impl Rule for TaintLogInjection {
-    fn id(&self) -> &str {
-        "js/taint-log-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-117")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a logging sink — possible log injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintLogInjection,
+    id = "js/taint-log-injection",
+    severity = Severity::Medium,
+    cwe = Some("CWE-117"),
+    description = "Untrusted input reaches a logging sink — possible log injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Sanitize user input before logging — strip newlines and control characters",
             ),
@@ -2695,6 +2326,7 @@ impl Rule for TaintLogInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2724,37 +2356,19 @@ impl TaintXxe {
     }
 }
 
-impl Rule for TaintXxe {
-    fn id(&self) -> &str {
-        "js/taint-xxe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-611")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintXxe,
+    id = "js/taint-xxe",
+    severity = Severity::High,
+    cwe = Some("CWE-611"),
+    description = "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Disable external entity resolution in XML parser configuration"),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2763,6 +2377,7 @@ impl Rule for TaintXxe {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2830,37 +2445,19 @@ impl TaintNosqlInjection {
     }
 }
 
-impl Rule for TaintNosqlInjection {
-    fn id(&self) -> &str {
-        "js/taint-nosql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-943")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a MongoDB query sink — possible NoSQL injection"
-    }
-    fn language(&self) -> Language {
-        Language::JavaScript
-    }
+impl_rule! {
+    TaintNosqlInjection,
+    id = "js/taint-nosql-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-943"),
+    description = "Untrusted input reaches a MongoDB query sink — possible NoSQL injection",
+    language = Language::JavaScript,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = JsTaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Validate and sanitize user input before using in MongoDB queries. Use mongo-sanitize to strip $ operators."),
         };
         map_js_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2869,6 +2466,7 @@ impl Rule for TaintNosqlInjection {
                 src, sink
             )
         })
+
     }
 }
 

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1,5 +1,5 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
-use crate::rules::Rule;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 
@@ -137,24 +137,15 @@ fn has_string_concat(node: tree_sitter::Node, src: &str) -> bool {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "kt/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string concatenation in query method"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "kt/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string concatenation in query method",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_methods =
             Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery|rawQuery|execSQL)$")
@@ -167,9 +158,9 @@ impl Rule for NoSqlInjection {
                         if let Some(args) = call_arguments(node) {
                             if has_string_concat(args, src) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "SQL query built with string concatenation — use parameterized queries or prepared statements",
                                     node,
                                     src,
@@ -181,6 +172,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -188,24 +180,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "kt/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via Runtime.exec or ProcessBuilder with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "kt/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via Runtime.exec or ProcessBuilder with dynamic input",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -219,9 +202,9 @@ impl Rule for NoCommandInjection {
                                     if let Some(first) = first_argument(args) {
                                         if !is_string_literal(first) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Runtime.exec() called with dynamic argument — risk of command injection",
                                                 node,
                                                 src,
@@ -241,9 +224,9 @@ impl Rule for NoCommandInjection {
                             if let Some(first) = first_argument(args) {
                                 if !is_string_literal(first) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "ProcessBuilder created with dynamic argument — risk of command injection",
                                         node,
                                         src,
@@ -256,6 +239,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -263,24 +247,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "kt/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Unsafe deserialization can lead to remote code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "kt/no-unsafe-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Unsafe deserialization can lead to remote code execution",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -294,9 +269,9 @@ impl Rule for NoUnsafeDeserialization {
                                 || !receiver.contains('.')
                             {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "readObject() on untrusted data can lead to remote code execution — use allowlist-based deserialization",
                                     node,
                                     src,
@@ -310,9 +285,9 @@ impl Rule for NoUnsafeDeserialization {
                         if let Some(receiver) = call_receiver_text(node, src) {
                             if receiver.contains("Yaml") || receiver.contains("yaml") {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "Yaml.load() deserializes arbitrary objects — use Yaml.safeLoad() or a safe constructor",
                                     node,
                                     src,
@@ -324,6 +299,7 @@ impl Rule for NoUnsafeDeserialization {
             }
         });
         findings
+
     }
 }
 
@@ -331,24 +307,15 @@ impl Rule for NoUnsafeDeserialization {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "kt/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via URL or HTTP client with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoSsrf,
+    id = "kt/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via URL or HTTP client with dynamic input",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -360,9 +327,9 @@ impl Rule for NoSsrf {
                             if let Some(first) = first_argument(args) {
                                 if !is_string_literal(first) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "URL/URI created with dynamic argument — validate and allowlist target hosts to prevent SSRF",
                                         node,
                                         src,
@@ -390,9 +357,9 @@ impl Rule for NoSsrf {
                                     if let Some(first) = first_argument(args) {
                                         if !is_string_literal(first) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "RestTemplate called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                                 node,
                                                 src,
@@ -407,6 +374,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -414,24 +382,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "kt/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via dynamic file path"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "kt/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via dynamic file path",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -443,9 +402,9 @@ impl Rule for NoPathTraversal {
                             if let Some(first) = first_argument(args) {
                                 if !is_string_literal(first) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() with dynamic path — sanitize input to prevent path traversal",
                                             ctor_name
@@ -468,9 +427,9 @@ impl Rule for NoPathTraversal {
                                     if let Some(first) = first_argument(args) {
                                         if !is_string_literal(first) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Paths.get() with dynamic path — sanitize input to prevent path traversal",
                                                 node,
                                                 src,
@@ -485,6 +444,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -492,24 +452,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "kt/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic algorithm"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "kt/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic algorithm",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let weak_algo =
             Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#).unwrap();
@@ -529,9 +480,9 @@ impl Rule for NoWeakCrypto {
                                         let arg_text = &src[first.byte_range()];
                                         if weak_algo.is_match(arg_text) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 &format!(
                                                     "{}.getInstance({}) uses a weak algorithm — use AES-GCM, SHA-256, or stronger",
                                                     receiver, arg_text
@@ -549,6 +500,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -556,24 +508,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "kt/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "kt/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|apiKey|token|auth|credential|private_?key)")
@@ -607,9 +550,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches('"');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                             name
@@ -638,9 +581,9 @@ impl Rule for NoHardcodedSecret {
                                     let inner = val.trim_matches('"');
                                     if inner.len() >= 4 {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "Hardcoded secret in '{}' — use environment variables or a secret manager",
                                                 left_text.trim()
@@ -657,6 +600,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -664,24 +608,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoXxe;
 
-impl Rule for NoXxe {
-    fn id(&self) -> &str {
-        "kt/no-xxe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-611")
-    }
-    fn description(&self) -> &str {
-        "XML parser created without disabling external entities (XXE)"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoXxe,
+    id = "kt/no-xxe",
+    severity = Severity::High,
+    cwe = Some("CWE-611"),
+    description = "XML parser created without disabling external entities (XXE)",
+    language = Language::Kotlin,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let factory_pattern = Regex::new(
             r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
@@ -693,9 +628,9 @@ impl Rule for NoXxe {
         if factory_pattern.is_match(source) && !secure_pattern.is_match(source) {
             for matched in factory_pattern.find_iter(source) {
                 findings.push(make_finding_from_offsets(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "XML parser factory created without disabling external entities — set feature to prevent XXE attacks",
                     source,
                     matched.start(),
@@ -704,6 +639,7 @@ impl Rule for NoXxe {
             }
         }
         findings
+
     }
 }
 
@@ -711,24 +647,15 @@ impl Rule for NoXxe {
 
 pub struct NoCorsStar;
 
-impl Rule for NoCorsStar {
-    fn id(&self) -> &str {
-        "kt/no-cors-star"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-942")
-    }
-    fn description(&self) -> &str {
-        "Permissive CORS configuration allows any origin"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoCorsStar,
+    id = "kt/no-cors-star",
+    severity = Severity::Medium,
+    cwe = Some("CWE-942"),
+    description = "Permissive CORS configuration allows any origin",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         // allowedOrigins("*") / addAllowedOrigin("*")
@@ -736,9 +663,9 @@ impl Rule for NoCorsStar {
             Regex::new(r#"(allowedOrigins|addAllowedOrigin)\s*\(\s*"\*"\s*\)"#).unwrap();
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "Wildcard CORS origin permits any domain — restrict to trusted origins",
                 source,
                 matched.start(),
@@ -759,9 +686,9 @@ impl Rule for NoCorsStar {
                                         let second_text = &src[second.byte_range()];
                                         if second_text.contains('*') {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "Access-Control-Allow-Origin set to wildcard — restrict to trusted origins",
                                                 node,
                                                 src,
@@ -776,6 +703,7 @@ impl Rule for NoCorsStar {
             }
         });
         findings
+
     }
 }
 
@@ -783,24 +711,15 @@ impl Rule for NoCorsStar {
 
 pub struct NoEval;
 
-impl Rule for NoEval {
-    fn id(&self) -> &str {
-        "kt/no-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-94")
-    }
-    fn description(&self) -> &str {
-        "ScriptEngine.eval can execute arbitrary code"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    NoEval,
+    id = "kt/no-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-94"),
+    description = "ScriptEngine.eval can execute arbitrary code",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -811,9 +730,9 @@ impl Rule for NoEval {
                             if let Some(first) = first_argument(args) {
                                 if !is_string_literal(first) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "ScriptEngine.eval() called with dynamic argument — risk of arbitrary code execution",
                                         node,
                                         src,
@@ -826,6 +745,7 @@ impl Rule for NoEval {
             }
         });
         findings
+
     }
 }
 
@@ -1411,28 +1331,19 @@ fn find_ssrf_sinks(
 
 pub struct TaintSqlInjection;
 
-impl Rule for TaintSqlInjection {
-    fn id(&self) -> &str {
-        "kt/taint-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input from Ktor/Spring handler reaches SQL query sink"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    TaintSqlInjection,
+    id = "kt/taint-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Untrusted input from Ktor/Spring handler reaches SQL query sink",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         run_kt_taint(
-            self.id(),
-            self.severity(),
-            self.cwe(),
+            _self.id(),
+            _self.severity(),
+            _self.cwe(),
             source,
             tree,
             &KtTaintSpec {
@@ -1445,6 +1356,7 @@ impl Rule for TaintSqlInjection {
                 )
             },
         )
+
     }
 }
 
@@ -1452,28 +1364,19 @@ impl Rule for TaintSqlInjection {
 
 pub struct TaintCommandInjection;
 
-impl Rule for TaintCommandInjection {
-    fn id(&self) -> &str {
-        "kt/taint-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input from Ktor/Spring handler reaches command execution sink"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    TaintCommandInjection,
+    id = "kt/taint-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Untrusted input from Ktor/Spring handler reaches command execution sink",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         run_kt_taint(
-            self.id(),
-            self.severity(),
-            self.cwe(),
+            _self.id(),
+            _self.severity(),
+            _self.cwe(),
             source,
             tree,
             &KtTaintSpec {
@@ -1486,6 +1389,7 @@ impl Rule for TaintCommandInjection {
                 )
             },
         )
+
     }
 }
 
@@ -1493,28 +1397,19 @@ impl Rule for TaintCommandInjection {
 
 pub struct TaintSsrf;
 
-impl Rule for TaintSsrf {
-    fn id(&self) -> &str {
-        "kt/taint-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input from Ktor/Spring handler reaches HTTP/URL sink"
-    }
-    fn language(&self) -> Language {
-        Language::Kotlin
-    }
+impl_rule! {
+    TaintSsrf,
+    id = "kt/taint-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Untrusted input from Ktor/Spring handler reaches HTTP/URL sink",
+    language = Language::Kotlin,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         run_kt_taint(
-            self.id(),
-            self.severity(),
-            self.cwe(),
+            _self.id(),
+            _self.severity(),
+            _self.cwe(),
             source,
             tree,
             &KtTaintSpec {
@@ -1527,6 +1422,7 @@ impl Rule for TaintSsrf {
                 )
             },
         )
+
     }
 }
 
@@ -1534,6 +1430,7 @@ impl Rule for TaintSsrf {
 mod tests {
     use super::*;
     use crate::engine::parser::parse_file;
+    use crate::rules::Rule;
 
     fn check_rule(rule: &dyn Rule, source: &str) -> Vec<Finding> {
         let tree = parse_file(source, Language::Kotlin).expect("parse failed");

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -20,6 +20,97 @@ pub mod swift;
 use crate::{Finding, Language, Severity};
 use std::path::Path;
 
+/// Macro to reduce boilerplate in `impl Rule for …` blocks.
+///
+/// # Variant 1 — rules that only implement `check`:
+///
+/// ```ignore
+/// impl_rule! {
+///     SomeRule,
+///     id = "py/some-rule",
+///     severity = Severity::High,
+///     cwe = Some("CWE-123"),
+///     description = "Some description",
+///     language = Language::Python,
+///     fn check(&self, source, tree) {
+///         // …body using `self`, `source`, `tree`…
+///     }
+/// }
+/// ```
+///
+/// # Variant 2 — rules that implement `check_with_context` (auto-generates
+///   a delegating `check`):
+///
+/// ```ignore
+/// impl_rule! {
+///     SomeRule,
+///     id = "py/some-rule",
+///     severity = Severity::High,
+///     cwe = Some("CWE-123"),
+///     description = "Some description",
+///     language = Language::Python,
+///     fn check_with_context(&self, source, tree, ctx) {
+///         // …body using `self`, `source`, `tree`, `ctx`…
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! impl_rule {
+    // ── Variant 1: check only ──────────────────────────────────────────────
+    (
+        $struct:ty,
+        id = $id:expr,
+        severity = $sev:expr,
+        cwe = $cwe:expr,
+        description = $desc:expr,
+        language = $lang:expr,
+        fn check($self_:ident, $src:ident, $tree:ident) { $($check_body:tt)* }
+    ) => {
+        impl $crate::rules::Rule for $struct {
+            fn id(&self) -> &str { $id }
+            fn severity(&self) -> $crate::Severity { $sev }
+            fn cwe(&self) -> Option<&str> { $cwe }
+            fn description(&self) -> &str { $desc }
+            fn language(&self) -> $crate::Language { $lang }
+            fn check(&self, $src: &str, $tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
+                let $self_ = self;
+                $($check_body)*
+            }
+        }
+    };
+
+    // ── Variant 2: check_with_context (auto-generates delegating check) ──
+    (
+        $struct:ty,
+        id = $id:expr,
+        severity = $sev:expr,
+        cwe = $cwe:expr,
+        description = $desc:expr,
+        language = $lang:expr,
+        fn check_with_context($self_:ident, $src:ident, $tree:ident, $ctx:ident) { $($check_body:tt)* }
+    ) => {
+        impl $crate::rules::Rule for $struct {
+            fn id(&self) -> &str { $id }
+            fn severity(&self) -> $crate::Severity { $sev }
+            fn cwe(&self) -> Option<&str> { $cwe }
+            fn description(&self) -> &str { $desc }
+            fn language(&self) -> $crate::Language { $lang }
+            fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
+                self.check_with_context(source, tree, &$crate::rules::FileContext::default())
+            }
+            fn check_with_context(
+                &self,
+                $src: &str,
+                $tree: &tree_sitter::Tree,
+                $ctx: &$crate::rules::FileContext<'_>,
+            ) -> Vec<$crate::Finding> {
+                let $self_ = self;
+                $($check_body)*
+            }
+        }
+    };
+}
+
 /// Per-file analysis context shared across all rules running on a single file.
 ///
 /// Computed once after parsing in the scanner and handed to each rule via

--- a/src/rules/php.rs
+++ b/src/rules/php.rs
@@ -1,30 +1,21 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 // ─── Rule 1: no-eval ──────────────────────────────────────────────────────────
 
 pub struct NoEval;
 
-impl Rule for NoEval {
-    fn id(&self) -> &str {
-        "php/no-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Use of eval() allows arbitrary code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoEval,
+    id = "php/no-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Use of eval() allows arbitrary code execution",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -33,9 +24,9 @@ impl Rule for NoEval {
                     let func_text = &src[func.byte_range()];
                     if func_text == "eval" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "eval() allows arbitrary code execution — avoid dynamic code evaluation",
                             node,
                             src,
@@ -45,6 +36,7 @@ impl Rule for NoEval {
             }
         });
         findings
+
     }
 }
 
@@ -52,24 +44,15 @@ impl Rule for NoEval {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "php/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via shell execution function"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "php/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via shell execution function",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -82,9 +65,9 @@ impl Rule for NoCommandInjection {
                         "exec" | "system" | "passthru" | "shell_exec" | "popen" | "proc_open"
                     ) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{}() executes shell commands — risk of command injection",
                                 func_text
@@ -99,9 +82,9 @@ impl Rule for NoCommandInjection {
             // Detect backtick execution
             if node.kind() == "shell_command_expression" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Backtick operator executes shell commands — risk of command injection",
                     node,
                     src,
@@ -109,6 +92,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -116,24 +100,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "php/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string interpolation or concatenation"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "php/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string interpolation or concatenation",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_funcs = ["mysqli_query", "pg_query", "mysql_query"];
 
@@ -147,9 +122,9 @@ impl Rule for NoSqlInjection {
                             let arg_text = &src[args.byte_range()];
                             if Self::has_interpolation_or_concat(args) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     &format!(
                                         "{}() with dynamic query — use parameterized queries",
                                         func_text
@@ -160,9 +135,9 @@ impl Rule for NoSqlInjection {
                             } else if arg_text.contains('$') || arg_text.contains('.') {
                                 // Rough heuristic for interpolated or concatenated strings
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     &format!(
                                         "{}() with dynamic query — use parameterized queries",
                                         func_text
@@ -184,9 +159,9 @@ impl Rule for NoSqlInjection {
                         if let Some(args) = node.child_by_field_name("arguments") {
                             if Self::has_interpolation_or_concat(args) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "->query() with dynamic query — use parameterized queries",
                                     node,
                                     src,
@@ -198,6 +173,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -230,24 +206,15 @@ impl NoSqlInjection {
 
 pub struct NoUnserialize;
 
-impl Rule for NoUnserialize {
-    fn id(&self) -> &str {
-        "php/no-unserialize"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Use of unserialize() on untrusted data can lead to object injection"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoUnserialize,
+    id = "php/no-unserialize",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Use of unserialize() on untrusted data can lead to object injection",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -256,9 +223,9 @@ impl Rule for NoUnserialize {
                     let func_text = &src[func.byte_range()];
                     if func_text == "unserialize" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "unserialize() on untrusted data can lead to object injection — use json_decode instead",
                             node,
                             src,
@@ -268,6 +235,7 @@ impl Rule for NoUnserialize {
             }
         });
         findings
+
     }
 }
 
@@ -275,24 +243,15 @@ impl Rule for NoUnserialize {
 
 pub struct NoFileInclusion;
 
-impl Rule for NoFileInclusion {
-    fn id(&self) -> &str {
-        "php/no-file-inclusion"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-98")
-    }
-    fn description(&self) -> &str {
-        "Dynamic file inclusion with variable argument enables remote/local file inclusion"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoFileInclusion,
+    id = "php/no-file-inclusion",
+    severity = Severity::Critical,
+    cwe = Some("CWE-98"),
+    description = "Dynamic file inclusion with variable argument enables remote/local file inclusion",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -309,9 +268,9 @@ impl Rule for NoFileInclusion {
                 if has_variable || text.contains('$') {
                     let keyword = node.kind().replace("_expression", "").replace('_', " ");
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         &format!(
                             "{} with variable argument — risk of file inclusion attack",
                             keyword
@@ -323,6 +282,7 @@ impl Rule for NoFileInclusion {
             }
         });
         findings
+
     }
 }
 
@@ -348,24 +308,15 @@ impl NoFileInclusion {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "php/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "php/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -375,9 +326,9 @@ impl Rule for NoWeakCrypto {
                     if func_text == "md5" || func_text == "sha1" {
                         let algo = if func_text == "md5" { "MD5" } else { "SHA1" };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{}() is cryptographically weak — use hash('sha256', ...) or stronger",
                                 algo
@@ -390,6 +341,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -397,24 +349,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "php/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "php/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern = Regex::new(r"(?i)(password|secret|api_?key|token)").unwrap();
 
@@ -433,9 +376,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches(|c| c == '"' || c == '\'');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables",
                                             left_text
@@ -451,6 +394,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -458,24 +402,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "php/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via file_get_contents or curl_init with variable URL"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoSsrf,
+    id = "php/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via file_get_contents or curl_init with variable URL",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -488,9 +423,9 @@ impl Rule for NoSsrf {
                                 // Flag if the argument is not a string literal
                                 if first_arg.kind() != "string" {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                             func_text
@@ -506,6 +441,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -513,24 +449,15 @@ impl Rule for NoSsrf {
 
 pub struct NoExtract;
 
-impl Rule for NoExtract {
-    fn id(&self) -> &str {
-        "php/no-extract"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-621")
-    }
-    fn description(&self) -> &str {
-        "Use of extract() can overwrite existing variables"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoExtract,
+    id = "php/no-extract",
+    severity = Severity::High,
+    cwe = Some("CWE-621"),
+    description = "Use of extract() can overwrite existing variables",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -539,9 +466,9 @@ impl Rule for NoExtract {
                     let func_text = &src[func.byte_range()];
                     if func_text == "extract" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "extract() imports variables into the current scope — risk of variable overwrite",
                             node,
                             src,
@@ -551,6 +478,7 @@ impl Rule for NoExtract {
             }
         });
         findings
+
     }
 }
 
@@ -558,24 +486,15 @@ impl Rule for NoExtract {
 
 pub struct NoPregEval;
 
-impl Rule for NoPregEval {
-    fn id(&self) -> &str {
-        "php/no-preg-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "preg_replace with /e modifier allows arbitrary code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Php
-    }
+impl_rule! {
+    NoPregEval,
+    id = "php/no-preg-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "preg_replace with /e modifier allows arbitrary code execution",
+    language = Language::Php,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let e_modifier = Regex::new(r#"['"][^'"]*/.*/[a-z]*e[a-z]*['"]"#).unwrap();
 
@@ -589,9 +508,9 @@ impl Rule for NoPregEval {
                                 let arg_text = &src[first_arg.byte_range()];
                                 if e_modifier.is_match(arg_text) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "preg_replace() with /e modifier executes code — use preg_replace_callback instead",
                                         node,
                                         src,
@@ -604,5 +523,6 @@ impl Rule for NoPregEval {
             }
         });
         findings
+
     }
 }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1,5 +1,6 @@
+use crate::impl_rule;
 use crate::rules::common::{get_source_line, make_finding, walk_tree};
-use crate::rules::{FileContext, Rule};
+use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 use std::borrow::Cow;
@@ -22,33 +23,15 @@ fn resolve_callee<'a>(func_text: &'a str, ctx: &'a FileContext<'_>) -> Cow<'a, s
 
 pub struct NoEval;
 
-impl Rule for NoEval {
-    fn id(&self) -> &str {
-        "py/no-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Use of eval()/exec() allows arbitrary code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoEval,
+    id = "py/no-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Use of eval()/exec() allows arbitrary code execution",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -58,9 +41,9 @@ impl Rule for NoEval {
                     let resolved = resolve_callee(func_text, ctx);
                     if resolved.as_ref() == "eval" || resolved.as_ref() == "exec" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{}() allows arbitrary code execution — avoid using it with untrusted input",
                                 resolved
@@ -73,6 +56,7 @@ impl Rule for NoEval {
             }
         });
         findings
+
     }
 }
 
@@ -80,24 +64,15 @@ impl Rule for NoEval {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "py/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "py/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)")
@@ -120,9 +95,9 @@ impl Rule for NoHardcodedSecret {
                             .trim_matches(|c| c == '"' || c == '\'');
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "Hardcoded secret in '{}' — use environment variables or a secrets manager",
                                     left_text
@@ -136,6 +111,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -143,24 +119,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "py/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string formatting"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "py/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string formatting",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_pattern =
             Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").unwrap();
@@ -175,9 +142,9 @@ impl Rule for NoSqlInjection {
                     && sql_pattern.is_match(text)
                 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "SQL query built with f-string — use parameterized queries",
                         node,
                         src,
@@ -194,9 +161,9 @@ impl Rule for NoSqlInjection {
                                 let text = &src[left.byte_range()];
                                 if sql_pattern.is_match(text) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "SQL query built with % formatting — use parameterized queries",
                                         node,
                                         src,
@@ -219,9 +186,9 @@ impl Rule for NoSqlInjection {
                                         let text = &src[obj.byte_range()];
                                         if sql_pattern.is_match(text) {
                                             findings.push(make_finding(
-                                                self.id(),
-                                                self.severity(),
-                                                self.cwe(),
+                                                _self.id(),
+                                                _self.severity(),
+                                                _self.cwe(),
                                                 "SQL query built with .format() — use parameterized queries",
                                                 node,
                                                 src,
@@ -244,9 +211,9 @@ impl Rule for NoSqlInjection {
                                 let text = &src[left.byte_range()];
                                 if sql_pattern.is_match(text) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "SQL query built with string concatenation — use parameterized queries",
                                         node,
                                         src,
@@ -259,6 +226,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -266,33 +234,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "py/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via os.system/subprocess with user input"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "py/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via os.system/subprocess with user input",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let dangerous_fns = [
             "os.system",
@@ -326,9 +276,9 @@ impl Rule for NoCommandInjection {
                                 };
                                 if is_dynamic {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic argument — risk of command injection",
                                             resolved
@@ -344,6 +294,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -351,33 +302,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "py/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via open() with user input"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "py/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via open() with user input",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -402,9 +335,9 @@ impl Rule for NoPathTraversal {
                                 };
                                 if is_dynamic {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() called with dynamic path — validate and sanitize to prevent path traversal",
                                             resolved
@@ -420,6 +353,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -427,33 +361,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "py/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via dynamic outbound request URL"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoSsrf,
+    id = "py/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via dynamic outbound request URL",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let request_fns = [
             "requests.get",
@@ -511,9 +427,9 @@ impl Rule for NoSsrf {
 
             if is_dynamic {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     &format!(
                         "{} called with dynamic URL — validate and allowlist outbound destinations to prevent SSRF",
                         resolved
@@ -525,6 +441,7 @@ impl Rule for NoSsrf {
         });
 
         findings
+
     }
 }
 
@@ -532,33 +449,15 @@ impl Rule for NoSsrf {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "py/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "py/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -573,9 +472,9 @@ impl Rule for NoWeakCrypto {
                             "SHA1"
                         };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "hashlib.{}() is cryptographically weak — use sha256 or stronger",
                                 algo.to_lowercase()
@@ -594,9 +493,9 @@ impl Rule for NoWeakCrypto {
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'');
                                     if inner == "md5" || inner == "sha1" {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "hashlib.new('{}') is cryptographically weak — use sha256 or stronger",
                                                 inner
@@ -613,6 +512,7 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
@@ -620,33 +520,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoPickle;
 
-impl Rule for NoPickle {
-    fn id(&self) -> &str {
-        "py/no-pickle"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Deserialization of untrusted data via pickle"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoPickle,
+    id = "py/no-pickle",
+    severity = Severity::High,
+    cwe = Some("CWE-502"),
+    description = "Deserialization of untrusted data via pickle",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
         let dangerous_fns = [
             "pickle.loads",
@@ -662,9 +544,9 @@ impl Rule for NoPickle {
                     let resolved = resolve_callee(func_text, ctx);
                     if dangerous_fns.contains(&resolved.as_ref()) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{}() deserializes untrusted data — can execute arbitrary code",
                                 resolved
@@ -677,6 +559,7 @@ impl Rule for NoPickle {
             }
         });
         findings
+
     }
 }
 
@@ -684,33 +567,15 @@ impl Rule for NoPickle {
 
 pub struct NoYamlLoad;
 
-impl Rule for NoYamlLoad {
-    fn id(&self) -> &str {
-        "py/no-yaml-load"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "yaml.load() without SafeLoader can execute arbitrary code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoYamlLoad,
+    id = "py/no-yaml-load",
+    severity = Severity::High,
+    cwe = Some("CWE-502"),
+    description = "yaml.load() without SafeLoader can execute arbitrary code",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -727,9 +592,9 @@ impl Rule for NoYamlLoad {
                                 && !args_text.contains("BaseLoader")
                             {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "yaml.load() without SafeLoader — use yaml.safe_load() or pass Loader=SafeLoader",
                                     node,
                                     src,
@@ -741,6 +606,7 @@ impl Rule for NoYamlLoad {
             }
         });
         findings
+
     }
 }
 
@@ -748,24 +614,15 @@ impl Rule for NoYamlLoad {
 
 pub struct NoDebugTrue;
 
-impl Rule for NoDebugTrue {
-    fn id(&self) -> &str {
-        "py/no-debug-true"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-489")
-    }
-    fn description(&self) -> &str {
-        "DEBUG = True left enabled — disable in production"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoDebugTrue,
+    id = "py/no-debug-true",
+    severity = Severity::Medium,
+    cwe = Some("CWE-489"),
+    description = "DEBUG = True left enabled — disable in production",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -779,9 +636,9 @@ impl Rule for NoDebugTrue {
                     let right_text = &src[right.byte_range()];
                     if left_text == "DEBUG" && right_text == "True" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "DEBUG = True — ensure debug mode is disabled in production (Django CWE-489)",
                             node,
                             src,
@@ -791,6 +648,7 @@ impl Rule for NoDebugTrue {
             }
         });
         findings
+
     }
 }
 
@@ -798,24 +656,15 @@ impl Rule for NoDebugTrue {
 
 pub struct FlaskDebugMode;
 
-impl Rule for FlaskDebugMode {
-    fn id(&self) -> &str {
-        "py/flask-debug-mode"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-489")
-    }
-    fn description(&self) -> &str {
-        "Flask app.run(debug=True) exposes debugger and reloader in production"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    FlaskDebugMode,
+    id = "py/flask-debug-mode",
+    severity = Severity::High,
+    cwe = Some("CWE-489"),
+    description = "Flask app.run(debug=True) exposes debugger and reloader in production",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -831,9 +680,9 @@ impl Rule for FlaskDebugMode {
                                         || args_text.contains("debug = True")
                                     {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "Flask app.run(debug=True) — exposes Werkzeug debugger, disable in production",
                                             node,
                                             src,
@@ -856,9 +705,9 @@ impl Rule for FlaskDebugMode {
                     let right_text = &src[right.byte_range()];
                     if left_text.ends_with(".debug") && right_text == "True" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "app.debug = True — exposes debugger, disable in production",
                             node,
                             src,
@@ -868,6 +717,7 @@ impl Rule for FlaskDebugMode {
             }
         });
         findings
+
     }
 }
 
@@ -875,24 +725,15 @@ impl Rule for FlaskDebugMode {
 
 pub struct DjangoSecretKeyHardcoded;
 
-impl Rule for DjangoSecretKeyHardcoded {
-    fn id(&self) -> &str {
-        "py/django-secret-key-hardcoded"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Django SECRET_KEY hardcoded in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    DjangoSecretKeyHardcoded,
+    id = "py/django-secret-key-hardcoded",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Django SECRET_KEY hardcoded in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -908,9 +749,9 @@ impl Rule for DjangoSecretKeyHardcoded {
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Django SECRET_KEY is hardcoded — use an environment variable or secrets manager",
                                 node,
                                 src,
@@ -921,6 +762,7 @@ impl Rule for DjangoSecretKeyHardcoded {
             }
         });
         findings
+
     }
 }
 
@@ -928,24 +770,15 @@ impl Rule for DjangoSecretKeyHardcoded {
 
 pub struct NoOpenRedirect;
 
-impl Rule for NoOpenRedirect {
-    fn id(&self) -> &str {
-        "py/no-open-redirect"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-601")
-    }
-    fn description(&self) -> &str {
-        "Open redirect via redirect() with user-controlled input"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoOpenRedirect,
+    id = "py/no-open-redirect",
+    severity = Severity::Medium,
+    cwe = Some("CWE-601"),
+    description = "Open redirect via redirect() with user-controlled input",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let redirect_fns = ["redirect", "HttpResponseRedirect"];
 
@@ -969,9 +802,9 @@ impl Rule for NoOpenRedirect {
                                 };
                                 if is_dynamic {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{}() with dynamic URL — validate target to prevent open redirect",
                                             func_name
@@ -987,6 +820,7 @@ impl Rule for NoOpenRedirect {
             }
         });
         findings
+
     }
 }
 
@@ -994,24 +828,15 @@ impl Rule for NoOpenRedirect {
 
 pub struct NoCorsStar;
 
-impl Rule for NoCorsStar {
-    fn id(&self) -> &str {
-        "py/no-cors-star"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-942")
-    }
-    fn description(&self) -> &str {
-        "CORS misconfiguration allowing all origins"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    NoCorsStar,
+    id = "py/no-cors-star",
+    severity = Severity::Medium,
+    cwe = Some("CWE-942"),
+    description = "CORS misconfiguration allowing all origins",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1028,9 +853,9 @@ impl Rule for NoCorsStar {
                         && right_text == "True"
                     {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!("{} = True — restrict CORS to specific origins", left_text),
                             node,
                             src,
@@ -1049,9 +874,9 @@ impl Rule for NoCorsStar {
                             && node_text.contains("*")
                         {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "Access-Control-Allow-Origin set to '*' — restrict to specific origins",
                                 node,
                                 src,
@@ -1072,9 +897,9 @@ impl Rule for NoCorsStar {
                         let value_text = &src[value.byte_range()];
                         if value_text.contains("\"*\"") || value_text.contains("'*'") {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "CORS allow_origins includes '*' — restrict to specific origins",
                                 node,
                                 src,
@@ -1085,6 +910,7 @@ impl Rule for NoCorsStar {
             }
         });
         findings
+
     }
 }
 
@@ -1092,24 +918,15 @@ impl Rule for NoCorsStar {
 
 pub struct FlaskSecretKeyHardcoded;
 
-impl Rule for FlaskSecretKeyHardcoded {
-    fn id(&self) -> &str {
-        "py/flask-secret-key-hardcoded"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Flask SECRET_KEY hardcoded in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    FlaskSecretKeyHardcoded,
+    id = "py/flask-secret-key-hardcoded",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Flask SECRET_KEY hardcoded in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1142,9 +959,9 @@ impl Rule for FlaskSecretKeyHardcoded {
             }
 
             findings.push(make_finding(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "Flask SECRET_KEY is hardcoded — use an environment variable or secrets manager",
                 node,
                 src,
@@ -1152,6 +969,7 @@ impl Rule for FlaskSecretKeyHardcoded {
         });
 
         findings
+
     }
 }
 
@@ -1159,24 +977,15 @@ impl Rule for FlaskSecretKeyHardcoded {
 
 pub struct SessionCookieSecureDisabled;
 
-impl Rule for SessionCookieSecureDisabled {
-    fn id(&self) -> &str {
-        "py/session-cookie-secure-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-614")
-    }
-    fn description(&self) -> &str {
-        "SESSION_COOKIE_SECURE disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    SessionCookieSecureDisabled,
+    id = "py/session-cookie-secure-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-614"),
+    description = "SESSION_COOKIE_SECURE disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1197,9 +1006,9 @@ impl Rule for SessionCookieSecureDisabled {
                 left_text == "SESSION_COOKIE_SECURE" || left_text.contains("SESSION_COOKIE_SECURE");
             if is_session_cookie_secure && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "SESSION_COOKIE_SECURE = False — session cookies may be sent over HTTP",
                     node,
                     src,
@@ -1208,6 +1017,7 @@ impl Rule for SessionCookieSecureDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1215,24 +1025,15 @@ impl Rule for SessionCookieSecureDisabled {
 
 pub struct SessionCookieHttpOnlyDisabled;
 
-impl Rule for SessionCookieHttpOnlyDisabled {
-    fn id(&self) -> &str {
-        "py/session-cookie-httponly-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1004")
-    }
-    fn description(&self) -> &str {
-        "SESSION_COOKIE_HTTPONLY disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    SessionCookieHttpOnlyDisabled,
+    id = "py/session-cookie-httponly-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-1004"),
+    description = "SESSION_COOKIE_HTTPONLY disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1253,9 +1054,9 @@ impl Rule for SessionCookieHttpOnlyDisabled {
                 || left_text.contains("SESSION_COOKIE_HTTPONLY");
             if is_session_cookie_httponly && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "SESSION_COOKIE_HTTPONLY = False — session cookies may be exposed to client-side scripts",
                     node,
                     src,
@@ -1264,6 +1065,7 @@ impl Rule for SessionCookieHttpOnlyDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1271,24 +1073,15 @@ impl Rule for SessionCookieHttpOnlyDisabled {
 
 pub struct SessionCookieSameSiteDisabled;
 
-impl Rule for SessionCookieSameSiteDisabled {
-    fn id(&self) -> &str {
-        "py/session-cookie-samesite-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "SESSION_COOKIE_SAMESITE disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    SessionCookieSameSiteDisabled,
+    id = "py/session-cookie-samesite-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-352"),
+    description = "SESSION_COOKIE_SAMESITE disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1315,9 +1108,9 @@ impl Rule for SessionCookieSameSiteDisabled {
                 || right_text == "False";
             if is_session_cookie_samesite && disabled {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "SESSION_COOKIE_SAMESITE disabled — set it to 'Lax' or 'Strict' to reduce CSRF risk",
                     node,
                     src,
@@ -1326,6 +1119,7 @@ impl Rule for SessionCookieSameSiteDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1333,24 +1127,15 @@ impl Rule for SessionCookieSameSiteDisabled {
 
 pub struct CsrfCookieSecureDisabled;
 
-impl Rule for CsrfCookieSecureDisabled {
-    fn id(&self) -> &str {
-        "py/csrf-cookie-secure-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-614")
-    }
-    fn description(&self) -> &str {
-        "CSRF_COOKIE_SECURE disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    CsrfCookieSecureDisabled,
+    id = "py/csrf-cookie-secure-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-614"),
+    description = "CSRF_COOKIE_SECURE disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1371,9 +1156,9 @@ impl Rule for CsrfCookieSecureDisabled {
                 left_text == "CSRF_COOKIE_SECURE" || left_text.contains("CSRF_COOKIE_SECURE");
             if is_csrf_cookie_secure && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "CSRF_COOKIE_SECURE = False — CSRF cookies may be sent over HTTP",
                     node,
                     src,
@@ -1382,6 +1167,7 @@ impl Rule for CsrfCookieSecureDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1389,24 +1175,15 @@ impl Rule for CsrfCookieSecureDisabled {
 
 pub struct CsrfCookieHttpOnlyDisabled;
 
-impl Rule for CsrfCookieHttpOnlyDisabled {
-    fn id(&self) -> &str {
-        "py/csrf-cookie-httponly-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1004")
-    }
-    fn description(&self) -> &str {
-        "CSRF_COOKIE_HTTPONLY disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    CsrfCookieHttpOnlyDisabled,
+    id = "py/csrf-cookie-httponly-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-1004"),
+    description = "CSRF_COOKIE_HTTPONLY disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1427,9 +1204,9 @@ impl Rule for CsrfCookieHttpOnlyDisabled {
                 left_text == "CSRF_COOKIE_HTTPONLY" || left_text.contains("CSRF_COOKIE_HTTPONLY");
             if is_csrf_cookie_httponly && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "CSRF_COOKIE_HTTPONLY = False — CSRF cookies may be exposed to client-side scripts",
                     node,
                     src,
@@ -1438,6 +1215,7 @@ impl Rule for CsrfCookieHttpOnlyDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1445,24 +1223,15 @@ impl Rule for CsrfCookieHttpOnlyDisabled {
 
 pub struct CsrfCookieSameSiteDisabled;
 
-impl Rule for CsrfCookieSameSiteDisabled {
-    fn id(&self) -> &str {
-        "py/csrf-cookie-samesite-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "CSRF_COOKIE_SAMESITE disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    CsrfCookieSameSiteDisabled,
+    id = "py/csrf-cookie-samesite-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-352"),
+    description = "CSRF_COOKIE_SAMESITE disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1489,9 +1258,9 @@ impl Rule for CsrfCookieSameSiteDisabled {
                 || right_text == "False";
             if is_csrf_cookie_samesite && disabled {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "CSRF_COOKIE_SAMESITE disabled — set it to 'Lax' or 'Strict' to reduce CSRF risk",
                     node,
                     src,
@@ -1500,6 +1269,7 @@ impl Rule for CsrfCookieSameSiteDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1507,33 +1277,24 @@ impl Rule for CsrfCookieSameSiteDisabled {
 
 pub struct CsrfExempt;
 
-impl Rule for CsrfExempt {
-    fn id(&self) -> &str {
-        "py/csrf-exempt"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "View marked csrf_exempt"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    CsrfExempt,
+    id = "py/csrf-exempt",
+    severity = Severity::High,
+    cwe = Some("CWE-352"),
+    description = "View marked csrf_exempt",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             let text = &src[node.byte_range()];
             if node.kind() == "decorator" && text.contains("csrf_exempt") {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "@csrf_exempt disables CSRF protection — prefer scoped exemptions or validated alternative controls",
                     node,
                     src,
@@ -1542,6 +1303,7 @@ impl Rule for CsrfExempt {
         });
 
         findings
+
     }
 }
 
@@ -1549,24 +1311,15 @@ impl Rule for CsrfExempt {
 
 pub struct WtfCsrfDisabled;
 
-impl Rule for WtfCsrfDisabled {
-    fn id(&self) -> &str {
-        "py/wtf-csrf-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "Flask-WTF CSRF protection disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    WtfCsrfDisabled,
+    id = "py/wtf-csrf-disabled",
+    severity = Severity::High,
+    cwe = Some("CWE-352"),
+    description = "Flask-WTF CSRF protection disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1585,9 +1338,9 @@ impl Rule for WtfCsrfDisabled {
             let right_text = &src[right.byte_range()];
             if left_text.contains("WTF_CSRF_ENABLED") && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Flask-WTF CSRF protection disabled — keep WTF_CSRF_ENABLED enabled",
                     node,
                     src,
@@ -1596,6 +1349,7 @@ impl Rule for WtfCsrfDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1603,24 +1357,15 @@ impl Rule for WtfCsrfDisabled {
 
 pub struct WtfCsrfCheckDefaultDisabled;
 
-impl Rule for WtfCsrfCheckDefaultDisabled {
-    fn id(&self) -> &str {
-        "py/wtf-csrf-check-default-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "Flask-WTF default CSRF checks disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    WtfCsrfCheckDefaultDisabled,
+    id = "py/wtf-csrf-check-default-disabled",
+    severity = Severity::High,
+    cwe = Some("CWE-352"),
+    description = "Flask-WTF default CSRF checks disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1639,9 +1384,9 @@ impl Rule for WtfCsrfCheckDefaultDisabled {
             let right_text = &src[right.byte_range()];
             if left_text.contains("WTF_CSRF_CHECK_DEFAULT") && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Flask-WTF default CSRF checks disabled — keep WTF_CSRF_CHECK_DEFAULT enabled",
                     node,
                     src,
@@ -1650,6 +1395,7 @@ impl Rule for WtfCsrfCheckDefaultDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1657,24 +1403,15 @@ impl Rule for WtfCsrfCheckDefaultDisabled {
 
 pub struct DjangoAllowedHostsWildcard;
 
-impl Rule for DjangoAllowedHostsWildcard {
-    fn id(&self) -> &str {
-        "py/django-allowed-hosts-wildcard"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-346")
-    }
-    fn description(&self) -> &str {
-        "Django ALLOWED_HOSTS allows all hosts"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    DjangoAllowedHostsWildcard,
+    id = "py/django-allowed-hosts-wildcard",
+    severity = Severity::Medium,
+    cwe = Some("CWE-346"),
+    description = "Django ALLOWED_HOSTS allows all hosts",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1693,9 +1430,9 @@ impl Rule for DjangoAllowedHostsWildcard {
             let right_text = &src[right.byte_range()];
             if left_text.contains("ALLOWED_HOSTS") && right_text.contains("\"*\"") {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Django ALLOWED_HOSTS contains '*' — restrict hostnames explicitly to reduce host header abuse risk",
                     node,
                     src,
@@ -1704,6 +1441,7 @@ impl Rule for DjangoAllowedHostsWildcard {
         });
 
         findings
+
     }
 }
 
@@ -1711,24 +1449,15 @@ impl Rule for DjangoAllowedHostsWildcard {
 
 pub struct SecureSslRedirectDisabled;
 
-impl Rule for SecureSslRedirectDisabled {
-    fn id(&self) -> &str {
-        "py/secure-ssl-redirect-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-319")
-    }
-    fn description(&self) -> &str {
-        "Django SECURE_SSL_REDIRECT disabled in source code"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    SecureSslRedirectDisabled,
+    id = "py/secure-ssl-redirect-disabled",
+    severity = Severity::Medium,
+    cwe = Some("CWE-319"),
+    description = "Django SECURE_SSL_REDIRECT disabled in source code",
+    language = Language::Python,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1747,9 +1476,9 @@ impl Rule for SecureSslRedirectDisabled {
             let right_text = &src[right.byte_range()];
             if left_text.contains("SECURE_SSL_REDIRECT") && right_text == "False" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "SECURE_SSL_REDIRECT = False — enable HTTPS redirect in production-facing Django deployments",
                     node,
                     src,
@@ -1758,6 +1487,7 @@ impl Rule for SecureSslRedirectDisabled {
         });
 
         findings
+
     }
 }
 
@@ -1765,33 +1495,15 @@ impl Rule for SecureSslRedirectDisabled {
 
 pub struct JwtNoVerify;
 
-impl Rule for JwtNoVerify {
-    fn id(&self) -> &str {
-        "py/jwt-no-verify"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-347")
-    }
-    fn description(&self) -> &str {
-        "JWT decoded without signature verification"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    JwtNoVerify,
+    id = "py/jwt-no-verify",
+    severity = Severity::Critical,
+    cwe = Some("CWE-347"),
+    description = "JWT decoded without signature verification",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1827,9 +1539,9 @@ impl Rule for JwtNoVerify {
 
             if no_verify || none_algo {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "JWT decoded without signature verification — always verify tokens with a trusted key",
                     node,
                     src,
@@ -1838,6 +1550,7 @@ impl Rule for JwtNoVerify {
         });
 
         findings
+
     }
 }
 
@@ -1845,33 +1558,15 @@ impl Rule for JwtNoVerify {
 
 pub struct JwtHardcodedSecret;
 
-impl Rule for JwtHardcodedSecret {
-    fn id(&self) -> &str {
-        "py/jwt-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "JWT signing or verification with a hardcoded secret"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    JwtHardcodedSecret,
+    id = "py/jwt-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "JWT signing or verification with a hardcoded secret",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1904,9 +1599,9 @@ impl Rule for JwtHardcodedSecret {
                 let inner = secret_text.trim_matches(|c| c == '"' || c == '\'');
                 if inner.len() >= 4 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "JWT secret is hardcoded — load signing keys from environment or a secrets manager",
                         node,
                         src,
@@ -1916,6 +1611,7 @@ impl Rule for JwtHardcodedSecret {
         });
 
         findings
+
     }
 }
 
@@ -2019,37 +1715,19 @@ impl TaintPickleDeserialization {
     }
 }
 
-impl Rule for TaintPickleDeserialization {
-    fn id(&self) -> &str {
-        "py/taint-pickle-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches pickle deserialization sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintPickleDeserialization,
+    id = "py/taint-pickle-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Untrusted input reaches pickle deserialization sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use `json` or `msgpack` instead of pickle for untrusted data: `json.loads(data)`",
             ),
@@ -2060,6 +1738,7 @@ impl Rule for TaintPickleDeserialization {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2076,37 +1755,19 @@ impl TaintEvalFromRequest {
     }
 }
 
-impl Rule for TaintEvalFromRequest {
-    fn id(&self) -> &str {
-        "py/taint-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches eval/exec sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintEvalFromRequest,
+    id = "py/taint-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Untrusted input reaches eval/exec sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use `ast.literal_eval()` for safe evaluation, or remove eval/exec entirely",
             ),
@@ -2117,6 +1778,7 @@ impl Rule for TaintEvalFromRequest {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2145,37 +1807,19 @@ impl TaintCommandInjectionFromRequest {
     }
 }
 
-impl Rule for TaintCommandInjectionFromRequest {
-    fn id(&self) -> &str {
-        "py/taint-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches OS command execution sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintCommandInjectionFromRequest,
+    id = "py/taint-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Untrusted input reaches OS command execution sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use `shlex.quote()` to escape arguments, or pass a list to `subprocess.run([...])` instead of a shell string"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2184,6 +1828,7 @@ impl Rule for TaintCommandInjectionFromRequest {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2209,37 +1854,19 @@ impl TaintSsrfFromRequest {
     }
 }
 
-impl Rule for TaintSsrfFromRequest {
-    fn id(&self) -> &str {
-        "py/taint-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches outbound HTTP sink (potential SSRF)"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintSsrfFromRequest,
+    id = "py/taint-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Untrusted input reaches outbound HTTP sink (potential SSRF)",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Validate URLs against an allowlist of permitted hosts before making requests",
             ),
@@ -2250,6 +1877,7 @@ impl Rule for TaintSsrfFromRequest {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2270,37 +1898,19 @@ impl TaintYamlLoadFromRequest {
     }
 }
 
-impl Rule for TaintYamlLoadFromRequest {
-    fn id(&self) -> &str {
-        "py/taint-yaml-load"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches unsafe YAML loader"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintYamlLoadFromRequest,
+    id = "py/taint-yaml-load",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Untrusted input reaches unsafe YAML loader",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use `yaml.safe_load()` instead of `yaml.load()` for untrusted input",
             ),
@@ -2311,6 +1921,7 @@ impl Rule for TaintYamlLoadFromRequest {
                     src, sink
                 )
         })
+
     }
 }
 
@@ -2345,42 +1956,25 @@ impl TaintSqlInjectionFromRequest {
     }
 }
 
-impl Rule for TaintSqlInjectionFromRequest {
-    fn id(&self) -> &str {
-        "py/taint-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches DB execute sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintSqlInjectionFromRequest,
+    id = "py/taint-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Untrusted input reaches DB execute sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Use parameterized queries: `cur.execute(\"SELECT * FROM users WHERE name = ?\", (name,))`"),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
             format!("{} reaches {} — untrusted input can inject SQL", src, sink)
         })
+
     }
 }
 
@@ -2412,37 +2006,19 @@ impl TaintSsti {
     }
 }
 
-impl Rule for TaintSsti {
-    fn id(&self) -> &str {
-        "py/taint-ssti"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-1336")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches template rendering sink (potential SSTI)"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintSsti,
+    id = "py/taint-ssti",
+    severity = Severity::Critical,
+    cwe = Some("CWE-1336"),
+    description = "Untrusted input reaches template rendering sink (potential SSTI)",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use render_template() with separate template files instead of render_template_string() with user input",
             ),
@@ -2453,6 +2029,7 @@ impl Rule for TaintSsti {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2477,37 +2054,19 @@ impl TaintXpathInjection {
     }
 }
 
-impl Rule for TaintXpathInjection {
-    fn id(&self) -> &str {
-        "py/taint-xpath-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-643")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches XPath query sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintXpathInjection,
+    id = "py/taint-xpath-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-643"),
+    description = "Untrusted input reaches XPath query sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use parameterized XPath queries or validate/sanitize input before building XPath expressions",
             ),
@@ -2518,6 +2077,7 @@ impl Rule for TaintXpathInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2548,37 +2108,19 @@ impl TaintLdapInjection {
     }
 }
 
-impl Rule for TaintLdapInjection {
-    fn id(&self) -> &str {
-        "py/taint-ldap-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-90")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches LDAP search sink"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintLdapInjection,
+    id = "py/taint-ldap-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-90"),
+    description = "Untrusted input reaches LDAP search sink",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use ldap.filter.escape_filter_chars() to sanitize user input before building LDAP filters",
             ),
@@ -2589,6 +2131,7 @@ impl Rule for TaintLdapInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2634,37 +2177,19 @@ impl TaintLogInjection {
     }
 }
 
-impl Rule for TaintLogInjection {
-    fn id(&self) -> &str {
-        "py/taint-log-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-117")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a logging sink — possible log injection"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintLogInjection,
+    id = "py/taint-log-injection",
+    severity = Severity::Medium,
+    cwe = Some("CWE-117"),
+    description = "Untrusted input reaches a logging sink — possible log injection",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Sanitize user input before logging — strip newlines and control characters (no standard sanitizer; use str.replace() or a regex to remove \\n, \\r, and ANSI escape sequences)",
             ),
@@ -2675,6 +2200,7 @@ impl Rule for TaintLogInjection {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2709,37 +2235,19 @@ impl TaintXxe {
     }
 }
 
-impl Rule for TaintXxe {
-    fn id(&self) -> &str {
-        "py/taint-xxe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-611")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintXxe,
+    id = "py/taint-xxe",
+    severity = Severity::High,
+    cwe = Some("CWE-611"),
+    description = "Untrusted input reaches an XML parser — possible XML External Entity (XXE) injection",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some(
                 "Use defusedxml instead of xml.etree.ElementTree for untrusted XML input",
             ),
@@ -2750,6 +2258,7 @@ impl Rule for TaintXxe {
                 src, sink
             )
         })
+
     }
 }
 
@@ -2805,37 +2314,19 @@ impl TaintNosqlInjection {
     }
 }
 
-impl Rule for TaintNosqlInjection {
-    fn id(&self) -> &str {
-        "py/taint-nosql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-943")
-    }
-    fn description(&self) -> &str {
-        "Untrusted input reaches a MongoDB query sink — possible NoSQL injection"
-    }
-    fn language(&self) -> Language {
-        Language::Python
-    }
+impl_rule! {
+    TaintNosqlInjection,
+    id = "py/taint-nosql-injection",
+    severity = Severity::High,
+    cwe = Some("CWE-943"),
+    description = "Untrusted input reaches a MongoDB query sink — possible NoSQL injection",
+    language = Language::Python,
+    fn check_with_context(_self, source, tree, ctx) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
-        self.check_with_context(source, tree, &FileContext::default())
-    }
-
-    fn check_with_context(
-        &self,
-        source: &str,
-        tree: &tree_sitter::Tree,
-        ctx: &FileContext<'_>,
-    ) -> Vec<Finding> {
         let meta = TaintRuleMeta {
-            rule_id: self.id(),
-            severity: self.severity(),
-            cwe: self.cwe(),
+            rule_id: _self.id(),
+            severity: _self.severity(),
+            cwe: _self.cwe(),
             fix_suggestion: Some("Validate and sanitize user input before using in MongoDB queries. Avoid passing raw user input as query filters."),
         };
         map_taint_findings(&meta, source, tree, ctx, &Self::spec(), |src, sink| {
@@ -2844,6 +2335,7 @@ impl Rule for TaintNosqlInjection {
                 src, sink
             )
         })
+
     }
 }
 

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -1,6 +1,6 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 /// Returns `true` if a tree-sitter `string` node contains interpolation
@@ -21,24 +21,15 @@ fn has_interpolation(string_node: tree_sitter::Node) -> bool {
 
 pub struct NoEval;
 
-impl Rule for NoEval {
-    fn id(&self) -> &str {
-        "rb/no-eval"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "Use of eval or similar dynamic code execution"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoEval,
+    id = "rb/no-eval",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "Use of eval or similar dynamic code execution",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -57,9 +48,9 @@ impl Rule for NoEval {
                 // standard Ruby metaprogramming patterns used by every framework
                 if name == "eval" || name == "instance_eval" {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         &format!(
                             "{} executes arbitrary code — avoid dynamic evaluation",
                             name
@@ -71,6 +62,7 @@ impl Rule for NoEval {
             }
         });
         findings
+
     }
 }
 
@@ -78,33 +70,24 @@ impl Rule for NoEval {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "rb/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via system/exec/spawn or backtick execution"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "rb/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via system/exec/spawn or backtick execution",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect backtick/subshell execution
             if node.kind() == "subshell" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "Backtick/subshell command execution — risk of command injection",
                     node,
                     src,
@@ -149,9 +132,9 @@ impl Rule for NoCommandInjection {
 
                     if !is_safe_literal {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{} called — risk of command injection with dynamic arguments",
                                 name
@@ -168,9 +151,9 @@ impl Rule for NoCommandInjection {
                 let text = &src[node.byte_range()];
                 if text.starts_with("%x") {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "%x command execution — risk of command injection",
                         node,
                         src,
@@ -179,6 +162,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -186,24 +170,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "rb/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string interpolation in query methods"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "rb/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string interpolation in query methods",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -223,9 +198,9 @@ impl Rule for NoSqlInjection {
                     let node_text = &src[node.byte_range()];
                     if node_text.contains("#{") {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "String interpolation in {} — use parameterized queries to prevent SQL injection",
                                 name
@@ -238,6 +213,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -245,24 +221,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoMassAssignment;
 
-impl Rule for NoMassAssignment {
-    fn id(&self) -> &str {
-        "rb/no-mass-assignment"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-915")
-    }
-    fn description(&self) -> &str {
-        "Mass assignment via permit! allows all parameters"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoMassAssignment,
+    id = "rb/no-mass-assignment",
+    severity = Severity::High,
+    cwe = Some("CWE-915"),
+    description = "Mass assignment via permit! allows all parameters",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -271,9 +238,9 @@ impl Rule for NoMassAssignment {
                     let name = &src[method.byte_range()];
                     if name == "permit!" {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "permit! allows all parameters — use permit(:field1, :field2) to whitelist",
                             node,
                             src,
@@ -283,6 +250,7 @@ impl Rule for NoMassAssignment {
             }
         });
         findings
+
     }
 }
 
@@ -290,24 +258,15 @@ impl Rule for NoMassAssignment {
 
 pub struct NoUnsafeDeserialization;
 
-impl Rule for NoUnsafeDeserialization {
-    fn id(&self) -> &str {
-        "rb/no-unsafe-deserialization"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-502")
-    }
-    fn description(&self) -> &str {
-        "Unsafe deserialization via Marshal.load or YAML.load"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoUnsafeDeserialization,
+    id = "rb/no-unsafe-deserialization",
+    severity = Severity::Critical,
+    cwe = Some("CWE-502"),
+    description = "Unsafe deserialization via Marshal.load or YAML.load",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -323,9 +282,9 @@ impl Rule for NoUnsafeDeserialization {
                         || (recv == "YAML" && (meth == "load" || meth == "unsafe_load"))
                     {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{}.{} can execute arbitrary code — use YAML.safe_load or safer alternatives",
                                 recv, meth
@@ -338,6 +297,7 @@ impl Rule for NoUnsafeDeserialization {
             }
         });
         findings
+
     }
 }
 
@@ -345,24 +305,15 @@ impl Rule for NoUnsafeDeserialization {
 
 pub struct NoOpenRedirect;
 
-impl Rule for NoOpenRedirect {
-    fn id(&self) -> &str {
-        "rb/no-open-redirect"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-601")
-    }
-    fn description(&self) -> &str {
-        "Potential open redirect via redirect_to with dynamic argument"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoOpenRedirect,
+    id = "rb/no-open-redirect",
+    severity = Severity::High,
+    cwe = Some("CWE-601"),
+    description = "Potential open redirect via redirect_to with dynamic argument",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -389,9 +340,9 @@ impl Rule for NoOpenRedirect {
 
                 if !has_literal_only {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "redirect_to with dynamic argument — validate URL to prevent open redirect",
                         node,
                         src,
@@ -400,6 +351,7 @@ impl Rule for NoOpenRedirect {
             }
         });
         findings
+
     }
 }
 
@@ -407,24 +359,15 @@ impl Rule for NoOpenRedirect {
 
 pub struct NoCsrfSkip;
 
-impl Rule for NoCsrfSkip {
-    fn id(&self) -> &str {
-        "rb/no-csrf-skip"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-352")
-    }
-    fn description(&self) -> &str {
-        "CSRF protection disabled via skip_before_action"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoCsrfSkip,
+    id = "rb/no-csrf-skip",
+    severity = Severity::High,
+    cwe = Some("CWE-352"),
+    description = "CSRF protection disabled via skip_before_action",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -443,9 +386,9 @@ impl Rule for NoCsrfSkip {
                     let text = &src[node.byte_range()];
                     if text.contains("verify_authenticity_token") {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "skip_before_action :verify_authenticity_token disables CSRF protection",
                             node,
                             src,
@@ -455,6 +398,7 @@ impl Rule for NoCsrfSkip {
             }
         });
         findings
+
     }
 }
 
@@ -462,24 +406,15 @@ impl Rule for NoCsrfSkip {
 
 pub struct NoHtmlSafe;
 
-impl Rule for NoHtmlSafe {
-    fn id(&self) -> &str {
-        "rb/no-html-safe"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-79")
-    }
-    fn description(&self) -> &str {
-        "Potential XSS via html_safe or raw()"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoHtmlSafe,
+    id = "rb/no-html-safe",
+    severity = Severity::High,
+    cwe = Some("CWE-79"),
+    description = "Potential XSS via html_safe or raw()",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -492,9 +427,9 @@ impl Rule for NoHtmlSafe {
                             // Only flag non-string-literal receivers
                             if receiver.kind() != "string" {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     ".html_safe on dynamic content — risk of XSS",
                                     node,
                                     src,
@@ -520,9 +455,9 @@ impl Rule for NoHtmlSafe {
 
             if is_raw {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "raw() bypasses HTML escaping — risk of XSS",
                     node,
                     src,
@@ -530,6 +465,7 @@ impl Rule for NoHtmlSafe {
             }
         });
         findings
+
     }
 }
 
@@ -537,24 +473,15 @@ impl Rule for NoHtmlSafe {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "rb/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "rb/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)")
@@ -576,9 +503,9 @@ impl Rule for NoHardcodedSecret {
                             .trim_end_matches(['"', '\'']);
                         if inner.len() >= 4 {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "Hardcoded secret in '{}' — use environment variables",
                                     left_text.trim()
@@ -592,6 +519,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -599,24 +527,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "rb/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via dynamic outbound HTTP request URL"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoSsrf,
+    id = "rb/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via dynamic outbound HTTP request URL",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -672,9 +591,9 @@ impl Rule for NoSsrf {
                     if let Some(arg) = first_arg {
                         if arg.kind() != "string" {
                             let mut finding = make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "{} called with dynamic URL — validate against an allowlist to prevent SSRF",
                                     label
@@ -712,9 +631,9 @@ impl Rule for NoSsrf {
 
                     if !is_literal {
                         let mut finding = make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "open called with dynamic URL — validate against an allowlist to prevent SSRF",
                             node,
                             src,
@@ -730,6 +649,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -737,24 +657,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "rb/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via dynamic file path"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "rb/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via dynamic file path",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -814,9 +725,9 @@ impl Rule for NoPathTraversal {
                     if let Some(arg) = first_arg {
                         if arg.kind() != "string" {
                             let mut finding = make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 &format!(
                                     "{} called with dynamic path — validate to prevent path traversal",
                                     label
@@ -853,9 +764,9 @@ impl Rule for NoPathTraversal {
 
                     if !is_literal {
                         let mut finding = make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "send_file called with dynamic path — validate to prevent path traversal",
                             node,
                             src,
@@ -871,6 +782,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -878,24 +790,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "rb/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Ruby
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "rb/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Ruby,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -905,9 +808,9 @@ impl Rule for NoWeakCrypto {
                 if text == "Digest::MD5" || text == "Digest::SHA1" {
                     let algo = if text.contains("MD5") { "MD5" } else { "SHA1" };
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         &format!(
                             "{} is cryptographically weak — use SHA-256 or stronger",
                             algo
@@ -919,12 +822,14 @@ impl Rule for NoWeakCrypto {
             }
         });
         findings
+
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rules::Rule;
     use tree_sitter::Parser;
 
     fn parse_ruby(source: &str) -> tree_sitter::Tree {

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -1,38 +1,29 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 // ─── Rule 1: unsafe-block ─────────────────────────────────────────────────────
 
 pub struct UnsafeBlock;
 
-impl Rule for UnsafeBlock {
-    fn id(&self) -> &str {
-        "rs/unsafe-block"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-676")
-    }
-    fn description(&self) -> &str {
-        "Use of unsafe block bypasses Rust memory safety guarantees"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    UnsafeBlock,
+    id = "rs/unsafe-block",
+    severity = Severity::Medium,
+    cwe = Some("CWE-676"),
+    description = "Use of unsafe block bypasses Rust memory safety guarantees",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "unsafe_block" {
                 findings.push(make_finding(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "unsafe block bypasses Rust memory safety — ensure correctness is manually verified",
                     node,
                     src,
@@ -40,6 +31,7 @@ impl Rule for UnsafeBlock {
             }
         });
         findings
+
     }
 }
 
@@ -47,24 +39,15 @@ impl Rule for UnsafeBlock {
 
 pub struct TransmuteUsage;
 
-impl Rule for TransmuteUsage {
-    fn id(&self) -> &str {
-        "rs/transmute-usage"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-843")
-    }
-    fn description(&self) -> &str {
-        "Use of std::mem::transmute can cause type confusion and undefined behavior"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    TransmuteUsage,
+    id = "rs/transmute-usage",
+    severity = Severity::High,
+    cwe = Some("CWE-843"),
+    description = "Use of std::mem::transmute can cause type confusion and undefined behavior",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -73,9 +56,9 @@ impl Rule for TransmuteUsage {
                     let func_text = &src[func.byte_range()];
                     if func_text.contains("transmute") {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "std::mem::transmute can cause type confusion and undefined behavior — prefer safe casts",
                             node,
                             src,
@@ -85,6 +68,7 @@ impl Rule for TransmuteUsage {
             }
         });
         findings
+
     }
 }
 
@@ -92,24 +76,15 @@ impl Rule for TransmuteUsage {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "rs/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via Command::new with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "rs/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via Command::new with dynamic input",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -128,9 +103,9 @@ impl Rule for NoCommandInjection {
                             }
                             if !has_literal {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     "Command::new called with dynamic argument — risk of command injection",
                                     node,
                                     src,
@@ -142,6 +117,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -149,24 +125,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "rs/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via format! macro in query argument"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "rs/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via format! macro in query argument",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_methods = Regex::new(r"(?i)\b(query|sql_query|execute|raw_sql)\b").unwrap();
 
@@ -183,9 +150,9 @@ impl Rule for NoSqlInjection {
                                     let macro_text = &src[arg.byte_range()];
                                     if macro_text.starts_with("format!") {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             "SQL query built with format! macro — use parameterized queries",
                                             node,
                                             src,
@@ -199,6 +166,7 @@ impl Rule for NoSqlInjection {
             }
         });
         findings
+
     }
 }
 
@@ -206,24 +174,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoWeakHash;
 
-impl Rule for NoWeakHash {
-    fn id(&self) -> &str {
-        "rs/no-weak-hash"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-328")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoWeakHash,
+    id = "rs/no-weak-hash",
+    severity = Severity::Medium,
+    cwe = Some("CWE-328"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let weak_hash = Regex::new(r"\b(md5|sha1|Md5|Sha1|MD5|SHA1)\b").unwrap();
 
@@ -239,9 +198,9 @@ impl Rule for NoWeakHash {
                             "SHA1"
                         };
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         &format!(
                             "Import of weak hash algorithm {} — use SHA-256 or stronger",
                             algo
@@ -266,9 +225,9 @@ impl Rule for NoWeakHash {
                             "SHA1"
                         };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{} is cryptographically weak — use SHA-256 or stronger",
                                 algo
@@ -281,6 +240,7 @@ impl Rule for NoWeakHash {
             }
         });
         findings
+
     }
 }
 
@@ -288,24 +248,15 @@ impl Rule for NoWeakHash {
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "rs/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "rs/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(r"(?i)(password|secret|api_?key|token|auth|credential|private_?key)")
@@ -323,9 +274,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches('"');
                                 if inner.len() >= 4 {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables",
                                             name.trim()
@@ -341,6 +292,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -348,24 +300,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct TlsVerifyDisabled;
 
-impl Rule for TlsVerifyDisabled {
-    fn id(&self) -> &str {
-        "rs/tls-verify-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-295")
-    }
-    fn description(&self) -> &str {
-        "TLS certificate verification disabled with danger_accept_invalid_certs"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    TlsVerifyDisabled,
+    id = "rs/tls-verify-disabled",
+    severity = Severity::High,
+    cwe = Some("CWE-295"),
+    description = "TLS certificate verification disabled with danger_accept_invalid_certs",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -378,9 +321,9 @@ impl Rule for TlsVerifyDisabled {
                                 let arg_text = &src[first_arg.byte_range()];
                                 if arg_text == "true" {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         "danger_accept_invalid_certs(true) disables TLS verification — prefer proper CA validation",
                                         node,
                                         src,
@@ -393,6 +336,7 @@ impl Rule for TlsVerifyDisabled {
             }
         });
         findings
+
     }
 }
 
@@ -400,24 +344,15 @@ impl Rule for TlsVerifyDisabled {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "rs/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via reqwest with dynamic URL"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoSsrf,
+    id = "rs/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via reqwest with dynamic URL",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -435,9 +370,9 @@ impl Rule for NoSsrf {
                                 if let Some(first_arg) = args.named_child(0) {
                                     if first_arg.kind() != "string_literal" {
                                         findings.push(make_finding(
-                                            self.id(),
-                                            self.severity(),
-                                            self.cwe(),
+                                            _self.id(),
+                                            _self.severity(),
+                                            _self.cwe(),
                                             &format!(
                                                 "{} called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                                                 func_text
@@ -454,6 +389,7 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }
 
@@ -461,24 +397,15 @@ impl Rule for NoSsrf {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "rs/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via Path::new or PathBuf::from with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "rs/no-path-traversal",
+    severity = Severity::Medium,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via Path::new or PathBuf::from with dynamic input",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -490,9 +417,9 @@ impl Rule for NoPathTraversal {
                             if let Some(first_arg) = args.named_child(0) {
                                 if first_arg.kind() != "string_literal" {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "{} called with dynamic path — validate input to prevent path traversal",
                                             func_text
@@ -508,6 +435,7 @@ impl Rule for NoPathTraversal {
             }
         });
         findings
+
     }
 }
 
@@ -515,24 +443,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoUnwrapInLib;
 
-impl Rule for NoUnwrapInLib {
-    fn id(&self) -> &str {
-        "rs/no-unwrap-in-lib"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-248")
-    }
-    fn description(&self) -> &str {
-        "Use of .unwrap() or .expect() can cause panics in production"
-    }
-    fn language(&self) -> Language {
-        Language::Rust
-    }
+impl_rule! {
+    NoUnwrapInLib,
+    id = "rs/no-unwrap-in-lib",
+    severity = Severity::Medium,
+    cwe = Some("CWE-248"),
+    description = "Use of .unwrap() or .expect() can cause panics in production",
+    language = Language::Rust,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -546,9 +465,9 @@ impl Rule for NoUnwrapInLib {
                             ".expect()"
                         };
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             &format!(
                                 "{} can panic at runtime — use proper error handling with ? or match",
                                 method
@@ -561,5 +480,6 @@ impl Rule for NoUnwrapInLib {
             }
         });
         findings
+
     }
 }

--- a/src/rules/swift.rs
+++ b/src/rules/swift.rs
@@ -1,30 +1,21 @@
+use crate::impl_rule;
 use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
-use crate::rules::Rule;
-use crate::{Finding, Language, Severity};
+use crate::{Language, Severity};
 use regex::Regex;
 
 // ─── Rule 1: no-hardcoded-secret ────────────────────────────────────────────
 
 pub struct NoHardcodedSecret;
 
-impl Rule for NoHardcodedSecret {
-    fn id(&self) -> &str {
-        "swift/no-hardcoded-secret"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-798")
-    }
-    fn description(&self) -> &str {
-        "Hardcoded secret or credential detected"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoHardcodedSecret,
+    id = "swift/no-hardcoded-secret",
+    severity = Severity::High,
+    cwe = Some("CWE-798"),
+    description = "Hardcoded secret or credential detected",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let mut reported_lines = std::collections::HashSet::new();
         let secret_pattern =
@@ -56,9 +47,9 @@ impl Rule for NoHardcodedSecret {
                             let line = node.start_position().row;
                             if inner.len() >= 4 && reported_lines.insert(line) {
                                 findings.push(make_finding(
-                                    self.id(),
-                                    self.severity(),
-                                    self.cwe(),
+                                    _self.id(),
+                                    _self.severity(),
+                                    _self.cwe(),
                                     &format!(
                                         "Hardcoded secret in '{}' — use environment variables or Keychain",
                                         name
@@ -91,9 +82,9 @@ impl Rule for NoHardcodedSecret {
                                 let inner = val.trim_matches('"');
                                 if inner.len() >= 4 && reported_lines.insert(line) {
                                     findings.push(make_finding(
-                                        self.id(),
-                                        self.severity(),
-                                        self.cwe(),
+                                        _self.id(),
+                                        _self.severity(),
+                                        _self.cwe(),
                                         &format!(
                                             "Hardcoded secret in '{}' — use environment variables or Keychain",
                                             name
@@ -110,6 +101,7 @@ impl Rule for NoHardcodedSecret {
             }
         });
         findings
+
     }
 }
 
@@ -117,24 +109,15 @@ impl Rule for NoHardcodedSecret {
 
 pub struct NoCommandInjection;
 
-impl Rule for NoCommandInjection {
-    fn id(&self) -> &str {
-        "swift/no-command-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-78")
-    }
-    fn description(&self) -> &str {
-        "Potential command injection via Process or NSTask with dynamic arguments"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoCommandInjection,
+    id = "swift/no-command-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-78"),
+    description = "Potential command injection via Process or NSTask with dynamic arguments",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -142,9 +125,9 @@ impl Rule for NoCommandInjection {
                 let text = &src[node.byte_range()];
                 if text.starts_with("Process(") || text.starts_with("NSTask(") {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Process/NSTask created — ensure arguments are not user-controlled to prevent command injection",
                         node,
                         src,
@@ -159,9 +142,9 @@ impl Rule for NoCommandInjection {
                     && !text.contains('"')
                 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Process arguments set with dynamic value — risk of command injection",
                         node,
                         src,
@@ -170,6 +153,7 @@ impl Rule for NoCommandInjection {
             }
         });
         findings
+
     }
 }
 
@@ -177,24 +161,15 @@ impl Rule for NoCommandInjection {
 
 pub struct NoWeakCrypto;
 
-impl Rule for NoWeakCrypto {
-    fn id(&self) -> &str {
-        "swift/no-weak-crypto"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Medium
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-327")
-    }
-    fn description(&self) -> &str {
-        "Use of weak cryptographic hash (MD5/SHA1)"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoWeakCrypto,
+    id = "swift/no-weak-crypto",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Use of weak cryptographic hash (MD5/SHA1)",
+    language = Language::Swift,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let pattern =
             Regex::new(r"\b(CC_MD5|CC_SHA1|\.md5|\.sha1|Insecure\.MD5|Insecure\.SHA1)\b").unwrap();
@@ -206,9 +181,9 @@ impl Rule for NoWeakCrypto {
                 "SHA1"
             };
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 &format!(
                     "{} is cryptographically weak — use SHA-256 or stronger",
                     algo
@@ -219,6 +194,7 @@ impl Rule for NoWeakCrypto {
             ));
         }
         findings
+
     }
 }
 
@@ -226,24 +202,15 @@ impl Rule for NoWeakCrypto {
 
 pub struct NoInsecureTransport;
 
-impl Rule for NoInsecureTransport {
-    fn id(&self) -> &str {
-        "swift/no-insecure-transport"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-319")
-    }
-    fn description(&self) -> &str {
-        "Insecure HTTP URL detected — use HTTPS instead"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoInsecureTransport,
+    id = "swift/no-insecure-transport",
+    severity = Severity::High,
+    cwe = Some("CWE-319"),
+    description = "Insecure HTTP URL detected — use HTTPS instead",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -254,9 +221,9 @@ impl Rule for NoInsecureTransport {
                     && !text.contains("http://127.0.0.1")
                 {
                     findings.push(make_finding(
-                        self.id(),
-                        self.severity(),
-                        self.cwe(),
+                        _self.id(),
+                        _self.severity(),
+                        _self.cwe(),
                         "Insecure HTTP URL — use HTTPS to protect data in transit",
                         node,
                         src,
@@ -265,6 +232,7 @@ impl Rule for NoInsecureTransport {
             }
         });
         findings
+
     }
 }
 
@@ -272,24 +240,15 @@ impl Rule for NoInsecureTransport {
 
 pub struct NoEvalJs;
 
-impl Rule for NoEvalJs {
-    fn id(&self) -> &str {
-        "swift/no-eval-js"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-95")
-    }
-    fn description(&self) -> &str {
-        "WKWebView evaluateJavaScript with dynamic input enables code injection"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoEvalJs,
+    id = "swift/no-eval-js",
+    severity = Severity::Critical,
+    cwe = Some("CWE-95"),
+    description = "WKWebView evaluateJavaScript with dynamic input enables code injection",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -302,9 +261,9 @@ impl Rule for NoEvalJs {
                         !text.contains("evaluateJavaScript(\"") || has_interpolation;
                     if is_variable_arg {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "evaluateJavaScript called with dynamic input — risk of JavaScript injection in WKWebView",
                             node,
                             src,
@@ -314,6 +273,7 @@ impl Rule for NoEvalJs {
             }
         });
         findings
+
     }
 }
 
@@ -321,24 +281,15 @@ impl Rule for NoEvalJs {
 
 pub struct NoSqlInjection;
 
-impl Rule for NoSqlInjection {
-    fn id(&self) -> &str {
-        "swift/no-sql-injection"
-    }
-    fn severity(&self) -> Severity {
-        Severity::Critical
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-89")
-    }
-    fn description(&self) -> &str {
-        "Potential SQL injection via string interpolation in SQLite queries"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoSqlInjection,
+    id = "swift/no-sql-injection",
+    severity = Severity::Critical,
+    cwe = Some("CWE-89"),
+    description = "Potential SQL injection via string interpolation in SQLite queries",
+    language = Language::Swift,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let sql_keywords =
             Regex::new(r"(?i)(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\s").unwrap();
@@ -349,9 +300,9 @@ impl Rule for NoSqlInjection {
             let text = matched.as_str();
             if sql_keywords.is_match(text) {
                 findings.push(make_finding_from_offsets(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     "SQL query with string interpolation — use parameterized queries to prevent SQL injection",
                     source,
                     matched.start(),
@@ -367,9 +318,9 @@ impl Rule for NoSqlInjection {
         .unwrap();
         for matched in sql_concat.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 "SQL query built with string concatenation — use parameterized queries",
                 source,
                 matched.start(),
@@ -378,6 +329,7 @@ impl Rule for NoSqlInjection {
         }
 
         findings
+
     }
 }
 
@@ -385,24 +337,15 @@ impl Rule for NoSqlInjection {
 
 pub struct NoInsecureKeychain;
 
-impl Rule for NoInsecureKeychain {
-    fn id(&self) -> &str {
-        "swift/no-insecure-keychain"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-311")
-    }
-    fn description(&self) -> &str {
-        "Insecure Keychain accessibility level allows access when device is locked"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoInsecureKeychain,
+    id = "swift/no-insecure-keychain",
+    severity = Severity::High,
+    cwe = Some("CWE-311"),
+    description = "Insecure Keychain accessibility level allows access when device is locked",
+    language = Language::Swift,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let pattern =
             Regex::new(r"\b(kSecAttrAccessibleAlways|kSecAttrAccessibleAlwaysThisDeviceOnly)\b")
@@ -410,9 +353,9 @@ impl Rule for NoInsecureKeychain {
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 &format!(
                     "{} allows Keychain access when device is locked — use kSecAttrAccessibleWhenUnlocked",
                     matched.as_str()
@@ -423,6 +366,7 @@ impl Rule for NoInsecureKeychain {
             ));
         }
         findings
+
     }
 }
 
@@ -430,24 +374,15 @@ impl Rule for NoInsecureKeychain {
 
 pub struct NoTlsDisabled;
 
-impl Rule for NoTlsDisabled {
-    fn id(&self) -> &str {
-        "swift/no-tls-disabled"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-295")
-    }
-    fn description(&self) -> &str {
-        "TLS certificate validation disabled or weakened"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoTlsDisabled,
+    id = "swift/no-tls-disabled",
+    severity = Severity::High,
+    cwe = Some("CWE-295"),
+    description = "TLS certificate validation disabled or weakened",
+    language = Language::Swift,
+    fn check(_self, source, _tree) {
 
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
 
         let patterns = [
@@ -468,9 +403,9 @@ impl Rule for NoTlsDisabled {
         for (pattern, msg) in &patterns {
             for matched in pattern.find_iter(source) {
                 findings.push(make_finding_from_offsets(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     msg,
                     source,
                     matched.start(),
@@ -479,6 +414,7 @@ impl Rule for NoTlsDisabled {
             }
         }
         findings
+
     }
 }
 
@@ -486,24 +422,15 @@ impl Rule for NoTlsDisabled {
 
 pub struct NoPathTraversal;
 
-impl Rule for NoPathTraversal {
-    fn id(&self) -> &str {
-        "swift/no-path-traversal"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-22")
-    }
-    fn description(&self) -> &str {
-        "Potential path traversal via FileManager with dynamic path"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoPathTraversal,
+    id = "swift/no-path-traversal",
+    severity = Severity::High,
+    cwe = Some("CWE-22"),
+    description = "Potential path traversal via FileManager with dynamic path",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let mut reported_lines = std::collections::HashSet::new();
 
@@ -531,9 +458,9 @@ impl Rule for NoPathTraversal {
                         let line = node.start_position().row;
                         if reported_lines.insert(line) {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "FileManager operation with dynamic path — validate and sanitize to prevent path traversal",
                                 node,
                                 src,
@@ -545,6 +472,7 @@ impl Rule for NoPathTraversal {
         });
 
         findings
+
     }
 }
 
@@ -552,24 +480,15 @@ impl Rule for NoPathTraversal {
 
 pub struct NoSsrf;
 
-impl Rule for NoSsrf {
-    fn id(&self) -> &str {
-        "swift/no-ssrf"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some("CWE-918")
-    }
-    fn description(&self) -> &str {
-        "Potential SSRF via URLSession or URL with dynamic input"
-    }
-    fn language(&self) -> Language {
-        Language::Swift
-    }
+impl_rule! {
+    NoSsrf,
+    id = "swift/no-ssrf",
+    severity = Severity::High,
+    cwe = Some("CWE-918"),
+    description = "Potential SSRF via URLSession or URL with dynamic input",
+    language = Language::Swift,
+    fn check(_self, source, tree) {
 
-    fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding> {
         let mut findings = Vec::new();
         let mut reported_lines = std::collections::HashSet::new();
 
@@ -586,9 +505,9 @@ impl Rule for NoSsrf {
                         let line = node.start_position().row;
                         if reported_lines.insert(line) {
                             findings.push(make_finding(
-                                self.id(),
-                                self.severity(),
-                                self.cwe(),
+                                _self.id(),
+                                _self.severity(),
+                                _self.cwe(),
                                 "URL(string:) called with dynamic value — validate and allowlist target hosts to prevent SSRF",
                                 node,
                                 src,
@@ -603,9 +522,9 @@ impl Rule for NoSsrf {
                     let line = node.start_position().row;
                     if !text.contains("\"http") && reported_lines.insert(line) {
                         findings.push(make_finding(
-                            self.id(),
-                            self.severity(),
-                            self.cwe(),
+                            _self.id(),
+                            _self.severity(),
+                            _self.cwe(),
                             "URLSession.dataTask called with dynamic URL — validate and allowlist target hosts to prevent SSRF",
                             node,
                             src,
@@ -615,5 +534,6 @@ impl Rule for NoSsrf {
             }
         });
         findings
+
     }
 }


### PR DESCRIPTION
## Summary
- Add an `impl_rule!` macro in `src/rules/mod.rs` with two variants: one for rules implementing `check` and one for rules implementing `check_with_context` (auto-generates the delegating `check` method).
- Replace all 174 manual `impl Rule for` blocks across 10 language rule files (python.rs, javascript.rs, go.rs, kotlin.rs, ruby.rs, java.rs, php.rs, csharp.rs, swift.rs, rust_lang.rs) with macro invocations.
- Net reduction of ~1,665 lines of boilerplate code while preserving identical behavior.

The macro uses `$crate::` qualified paths for hygiene and a `let _self = self;` binding to work around Rust 2021 macro `self` restrictions. Dynamic rules (semgrep_compat, semgrep_taint) are unchanged since their metadata comes from runtime YAML.

## Test plan
- [x] `cargo check` passes with zero warnings
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — formatted

none