### PR TITLE
fix: pass 1 max-file-size check, disable symlink following, encode SARIF URIs (refs #152, #153, #154)

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -67,6 +67,7 @@ pub fn scan_directory(root: &str, registry: &RuleRegistry, max_file_size: u64) -
         }
     } else {
         WalkBuilder::new(root)
+            .follow_links(false) // never follow symlinks
             .hidden(true) // skip hidden files
             .git_ignore(true) // respect .gitignore
             .build()
@@ -370,6 +371,9 @@ fn scan_files(
         python_files
             .par_iter()
             .filter_map(|(path, _)| {
+                if std::fs::metadata(path).ok()?.len() > max_file_size {
+                    return None;
+                }
                 let source = std::fs::read_to_string(path).ok()?;
                 if is_minified(&source) {
                     return None;
@@ -401,6 +405,9 @@ fn scan_files(
         let js_summaries: CrossFileSummaryMap = js_files
             .par_iter()
             .filter_map(|(path, _)| {
+                if std::fs::metadata(path).ok()?.len() > max_file_size {
+                    return None;
+                }
                 let source = std::fs::read_to_string(path).ok()?;
                 if is_minified(&source) {
                     return None;
@@ -430,6 +437,9 @@ fn scan_files(
         let go_summaries: CrossFileSummaryMap = go_files
             .par_iter()
             .filter_map(|(path, _)| {
+                if std::fs::metadata(path).ok()?.len() > max_file_size {
+                    return None;
+                }
                 let source = std::fs::read_to_string(path).ok()?;
                 if is_minified(&source) {
                     return None;

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -1,6 +1,27 @@
 use crate::Finding;
 use serde_json::json;
 
+/// Encode a file path as a URI suitable for SARIF `artifactLocation.uri`.
+/// Normalizes backslashes to forward slashes and percent-encodes characters
+/// that are not valid in URI path segments.
+fn path_to_uri(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let encoded = normalized
+        .split('/')
+        .map(|segment| {
+            segment
+                .replace('%', "%25")
+                .replace(' ', "%20")
+                .replace('#', "%23")
+                .replace('?', "%3F")
+                .replace('[', "%5B")
+                .replace(']', "%5D")
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("file://{encoded}")
+}
+
 pub fn print_sarif(findings: &[Finding]) {
     let results: Vec<_> = findings
         .iter()
@@ -23,7 +44,7 @@ pub fn print_sarif(findings: &[Finding]) {
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": {
-                            "uri": f.file
+                            "uri": path_to_uri(&f.file)
                         },
                         "region": {
                             "startLine": f.line,


### PR DESCRIPTION
## Summary

- **#152** – Add `metadata().len()` size guard before `read_to_string` in pass 1 cross-file summary extraction for Python, JS, and Go, so `--max-file-size` is respected during cross-file analysis (previously only enforced in pass 2)
- **#153** – Set `follow_links(false)` on the `WalkBuilder` to prevent symlinks from causing scans outside the project directory
- **#154** – Percent-encode file paths in SARIF `artifactLocation.uri` (spaces, `#`, `?`, `[`, `]`) so output contains valid URIs

## Test plan

- [x] `cargo test` passes (all 180 tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied

none