### PR TITLE
fix: add --quiet flag, warn on unsupported files, fix summary format (refs #156, #157, #158)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,10 @@ pub struct ScanArgs {
     #[arg(long, default_value_t = false)]
     pub explain: bool,
 
+    /// Suppress terminal output (exit code still reflects findings)
+    #[arg(short, long)]
+    pub quiet: bool,
+
     /// Maximum file size in bytes to scan (default: 1 MB)
     #[arg(long, default_value_t = 1_048_576)]
     pub max_file_size: u64,

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,14 +161,22 @@ fn run_scan(scan: &ScanArgs) -> i32 {
 
     findings = suppress_with_baseline(findings, baseline.as_ref());
 
+    if files_scanned == 0 {
+        eprintln!(
+            "Warning: no files with supported extensions found. Supported: .js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
+        );
+    }
+
     match scan.format {
         OutputFormat::Terminal => {
-            foxguard::report::terminal::print_findings_with_options(
-                &findings,
-                files_scanned,
-                duration,
-                scan.explain,
-            );
+            if !scan.quiet {
+                foxguard::report::terminal::print_findings_with_options(
+                    &findings,
+                    files_scanned,
+                    duration,
+                    scan.explain,
+                );
+            }
         }
         OutputFormat::Json => foxguard::report::json::print_json(&findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&findings),
@@ -372,6 +380,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 baseline: None,
                 write_baseline: None,
                 explain: false,
+                quiet: false,
                 max_file_size: 1_048_576,
             },
             output: repo_root.join(&args.baseline).display().to_string(),

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -14,7 +14,7 @@ pub fn print_findings_with_options(
     if findings.is_empty() {
         if files_scanned > 0 {
             println!(
-                "{}  Scanned {} files in {:.2}s",
+                "{} Scanned {} files in {:.2}s.",
                 "No security issues found.".green().bold(),
                 files_scanned.to_string().bold(),
                 duration.as_secs_f64(),


### PR DESCRIPTION
## Summary
- **#156**: Add `--quiet` / `-q` flag to `ScanArgs` that suppresses terminal report output while preserving correct exit codes (1 for findings, 0 for clean) and JSON/SARIF output
- **#157**: Print a warning to stderr when `files_scanned == 0`, listing all supported extensions so users know why nothing was scanned
- **#158**: Fix double space in the clean summary line (`"No security issues found."` followed by two spaces) and add a trailing period for consistency

## Test plan
- [ ] Run `foxguard --quiet` on a repo with findings -- verify no terminal output, exit code 1
- [ ] Run `foxguard --quiet` on a clean repo -- verify no terminal output, exit code 0
- [ ] Run `foxguard --quiet --format json` -- verify JSON still prints to stdout
- [ ] Run `foxguard` on a directory with only `.txt` files -- verify the unsupported-files warning appears on stderr
- [ ] Run `foxguard` on a clean repo -- verify the summary reads `No security issues found. Scanned N files in Xs.` (single space, trailing period)
- [ ] `cargo test`, `cargo fmt --check`, `cargo clippy` all pass

none