### PR TITLE
feat: add `foxguard diff` subcommand to show new findings vs target branch (refs #165)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ regex = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
 globset = "0.4"
+tempfile = "3"
 
 [[bin]]
 name = "foxguard-mcp"
 path = "src/bin/foxguard_mcp.rs"
 
 [dev-dependencies]
-tempfile = "3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,6 +153,37 @@ pub struct SecretsArgs {
     pub max_file_size: u64,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct DiffArgs {
+    /// Target branch to compare against (e.g., "main", "origin/main")
+    #[arg()]
+    pub target: String,
+
+    /// Path to scan
+    #[arg(default_value = ".")]
+    pub path: String,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value = "terminal")]
+    pub format: OutputFormat,
+
+    /// Minimum severity to report
+    #[arg(short, long, value_enum)]
+    pub severity: Option<SeverityFilter>,
+
+    /// Path to Semgrep YAML rule file or directory
+    #[arg(short, long)]
+    pub rules: Option<String>,
+
+    /// Disable built-in rules and run only external rules loaded via --rules
+    #[arg(long, default_value_t = false)]
+    pub no_builtins: bool,
+
+    /// Maximum file size in bytes to scan (default: 1 MB)
+    #[arg(long, default_value_t = 1_048_576)]
+    pub max_file_size: u64,
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum Command {
     /// Install a pre-commit hook for local foxguard runs
@@ -161,6 +192,8 @@ pub enum Command {
     Baseline(BaselineArgs),
     /// Scan repositories and changed files for common secrets
     Secrets(SecretsArgs),
+    /// Show only new findings compared to a target branch
+    Diff(DiffArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,304 @@
+use crate::engine::{scan_directory, scan_paths_with_root, ScanResult};
+use crate::rules::RuleRegistry;
+use crate::Finding;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Result of a diff scan: new findings plus summary counts.
+pub struct DiffResult {
+    pub new_findings: Vec<Finding>,
+    pub total_current: usize,
+    pub existing_count: usize,
+}
+
+/// Run git in a specific repo directory.
+fn run_git(repo_root: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(args)
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Get the repo root for the given path.
+fn repo_root(path: &Path) -> Result<PathBuf, String> {
+    let dir = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(Path::new("."))
+    };
+    let root = run_git(dir, &["rev-parse", "--show-toplevel"])?;
+    Ok(PathBuf::from(root.trim()))
+}
+
+/// Get files changed between the target branch and HEAD.
+fn changed_files_vs_target(repo_root: &Path, target: &str) -> Result<Vec<PathBuf>, String> {
+    // Get the merge base to find only truly changed files
+    let merge_base =
+        run_git(repo_root, &["merge-base", target, "HEAD"]).unwrap_or_else(|_| target.to_string());
+    let merge_base = merge_base.trim();
+
+    let stdout = run_git(
+        repo_root,
+        &["diff", "--name-only", "--diff-filter=ACMR", merge_base],
+    )?;
+
+    let mut files = Vec::new();
+    for line in stdout.lines().map(str::trim).filter(|l| !l.is_empty()) {
+        let path = repo_root.join(line);
+        if path.exists() {
+            files.push(path);
+        }
+    }
+
+    Ok(files)
+}
+
+/// Read a file's contents from a specific git ref.
+fn read_file_at_ref(repo_root: &Path, git_ref: &str, rel_path: &str) -> Result<String, String> {
+    let spec = format!("{}:{}", git_ref, rel_path);
+    run_git(repo_root, &["show", &spec])
+}
+
+/// Scan the target branch's version of specific files by writing them to temp files.
+fn scan_target_branch_files(
+    repo_root: &Path,
+    target: &str,
+    changed_files: &[PathBuf],
+    registry: &RuleRegistry,
+    max_file_size: u64,
+) -> Result<ScanResult, String> {
+    let temp_dir =
+        tempfile::tempdir().map_err(|e| format!("Failed to create temp directory: {}", e))?;
+
+    let mut temp_paths = Vec::new();
+
+    for file in changed_files {
+        let rel_path = file
+            .strip_prefix(repo_root)
+            .map_err(|e| format!("Failed to get relative path: {}", e))?;
+        let rel_str = rel_path.to_string_lossy().to_string();
+
+        // Try to read from the target branch; skip files that don't exist there (new files)
+        let content = match read_file_at_ref(repo_root, target, &rel_str) {
+            Ok(c) => c,
+            Err(_) => continue, // file doesn't exist on target branch
+        };
+
+        let temp_path = temp_dir.path().join(rel_path);
+        if let Some(parent) = temp_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create temp dir: {}", e))?;
+        }
+        std::fs::write(&temp_path, &content)
+            .map_err(|e| format!("Failed to write temp file: {}", e))?;
+
+        temp_paths.push(temp_path);
+    }
+
+    if temp_paths.is_empty() {
+        return Ok(ScanResult {
+            findings: Vec::new(),
+            files_scanned: 0,
+            duration: std::time::Duration::ZERO,
+        });
+    }
+
+    Ok(scan_paths_with_root(
+        temp_dir.path(),
+        &temp_paths,
+        registry,
+        max_file_size,
+    ))
+}
+
+/// Two findings are "the same" if they share the same rule_id and snippet content.
+/// We deliberately ignore line numbers since they shift with edits.
+fn finding_key(finding: &Finding) -> (String, String, String) {
+    (
+        finding.rule_id.clone(),
+        finding.file.clone(),
+        finding.snippet.trim().to_string(),
+    )
+}
+
+/// Compute new findings: those in current but not in base.
+/// Matching is by (rule_id, relative_file_path, snippet_content).
+pub fn diff_findings(current: Vec<Finding>, base: Vec<Finding>) -> DiffResult {
+    let total_current = current.len();
+
+    let base_keys: HashSet<(String, String, String)> = base.iter().map(finding_key).collect();
+
+    let new_findings: Vec<Finding> = current
+        .into_iter()
+        .filter(|f| !base_keys.contains(&finding_key(f)))
+        .collect();
+
+    let existing_count = total_current - new_findings.len();
+
+    DiffResult {
+        new_findings,
+        total_current,
+        existing_count,
+    }
+}
+
+/// Run a full diff scan: scan current tree, scan target branch files, return new findings.
+pub fn run_diff(
+    scan_path: &str,
+    target: &str,
+    registry: &RuleRegistry,
+    max_file_size: u64,
+) -> Result<(ScanResult, DiffResult), String> {
+    let scan_root = Path::new(scan_path);
+    let repo = repo_root(scan_root)?;
+
+    // Verify the target ref exists
+    run_git(&repo, &["rev-parse", "--verify", target])
+        .map_err(|_| format!("Target ref '{}' does not exist", target))?;
+
+    // Scan current working tree
+    let current_result = scan_directory(scan_path, registry, max_file_size);
+
+    // Get changed files between target and HEAD
+    let changed = changed_files_vs_target(&repo, target)?;
+
+    if changed.is_empty() {
+        // No changed files — everything is existing
+        let total = current_result.findings.len();
+        return Ok((
+            ScanResult {
+                findings: Vec::new(),
+                files_scanned: current_result.files_scanned,
+                duration: current_result.duration,
+            },
+            DiffResult {
+                new_findings: Vec::new(),
+                total_current: total,
+                existing_count: total,
+            },
+        ));
+    }
+
+    // Scan the target branch versions of changed files
+    let base_result = scan_target_branch_files(&repo, target, &changed, registry, max_file_size)?;
+
+    // Only diff findings from changed files (current side)
+    let changed_rel: HashSet<String> = changed
+        .iter()
+        .filter_map(|p| {
+            p.strip_prefix(&repo)
+                .ok()
+                .map(|r| r.to_string_lossy().to_string())
+        })
+        .collect();
+
+    let (changed_findings, unchanged_findings): (Vec<Finding>, Vec<Finding>) =
+        current_result.findings.into_iter().partition(|f| {
+            // The file field in findings is relative to scan root
+            changed_rel
+                .iter()
+                .any(|rel| f.file.ends_with(rel) || rel.ends_with(&f.file))
+        });
+
+    let diff = diff_findings(changed_findings, base_result.findings);
+    let total_current = diff.total_current + unchanged_findings.len();
+    let existing_count = diff.existing_count + unchanged_findings.len();
+
+    Ok((
+        ScanResult {
+            findings: Vec::new(), // not used; diff_result has everything
+            files_scanned: current_result.files_scanned,
+            duration: current_result.duration,
+        },
+        DiffResult {
+            new_findings: diff.new_findings,
+            total_current,
+            existing_count,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Severity;
+
+    fn make_finding(rule_id: &str, file: &str, line: usize, snippet: &str) -> Finding {
+        Finding {
+            rule_id: rule_id.to_string(),
+            severity: Severity::High,
+            cwe: None,
+            description: "test".to_string(),
+            file: file.to_string(),
+            line,
+            column: 1,
+            end_line: line,
+            end_column: 10,
+            snippet: snippet.to_string(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+        }
+    }
+
+    #[test]
+    fn test_diff_findings_new_only() {
+        let current = vec![
+            make_finding("rule-1", "app.js", 10, "eval(input)"),
+            make_finding("rule-2", "app.js", 20, "exec(cmd)"),
+        ];
+        let base = vec![
+            make_finding("rule-1", "app.js", 8, "eval(input)"), // same rule+snippet, different line
+        ];
+
+        let result = diff_findings(current, base);
+        assert_eq!(result.new_findings.len(), 1);
+        assert_eq!(result.new_findings[0].rule_id, "rule-2");
+        assert_eq!(result.total_current, 2);
+        assert_eq!(result.existing_count, 1);
+    }
+
+    #[test]
+    fn test_diff_findings_all_new() {
+        let current = vec![make_finding("rule-1", "app.js", 10, "eval(input)")];
+        let base = vec![];
+
+        let result = diff_findings(current, base);
+        assert_eq!(result.new_findings.len(), 1);
+        assert_eq!(result.existing_count, 0);
+    }
+
+    #[test]
+    fn test_diff_findings_none_new() {
+        let current = vec![make_finding("rule-1", "app.js", 10, "eval(input)")];
+        let base = vec![make_finding("rule-1", "app.js", 10, "eval(input)")];
+
+        let result = diff_findings(current, base);
+        assert_eq!(result.new_findings.len(), 0);
+        assert_eq!(result.existing_count, 1);
+    }
+
+    #[test]
+    fn test_diff_findings_snippet_whitespace_tolerance() {
+        let current = vec![make_finding("rule-1", "app.js", 10, "  eval(input)  ")];
+        let base = vec![make_finding("rule-1", "app.js", 5, "eval(input)")];
+
+        let result = diff_findings(current, base);
+        assert_eq!(
+            result.new_findings.len(),
+            0,
+            "whitespace-trimmed snippets should match"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod baseline;
 pub mod cli;
 pub mod config;
+pub mod diff;
 pub mod engine;
 pub mod git;
 pub mod report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use foxguard::baseline::{load_baseline, suppress_with_baseline, write_baseline};
-use foxguard::cli::{BaselineArgs, Cli, Command, InitArgs, OutputFormat, ScanArgs, SecretsArgs};
+use foxguard::cli::{
+    BaselineArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat, ScanArgs, SecretsArgs,
+};
 use foxguard::config::{apply_scan_defaults, apply_secrets_defaults, load_for_scan};
 use foxguard::engine::{scan_directory, scan_paths_with_root, ScanResult};
 use foxguard::git::changed_files;
@@ -23,6 +25,7 @@ fn main() {
         Some(Command::Init(args)) => run_init(&args),
         Some(Command::Baseline(args)) => run_baseline(&args),
         Some(Command::Secrets(args)) => run_secrets(&args),
+        Some(Command::Diff(args)) => run_diff_cmd(&args),
         None => run_scan(&cli.scan),
     };
 
@@ -287,6 +290,84 @@ fn run_secrets(args: &SecretsArgs) -> i32 {
     }
 
     if !findings.is_empty() {
+        return 1;
+    }
+
+    0
+}
+
+fn run_diff_cmd(args: &DiffArgs) -> i32 {
+    let scan_path = Path::new(&args.path);
+    if !scan_path.exists() {
+        eprintln!("Error: path '{}' does not exist", args.path);
+        return 2;
+    }
+
+    let mut registry = if args.no_builtins {
+        RuleRegistry::empty()
+    } else {
+        RuleRegistry::new()
+    };
+
+    if let Some(ref rules_path) = args.rules {
+        let path = Path::new(rules_path);
+        if !path.exists() {
+            eprintln!("Error: rules path '{}' does not exist", rules_path);
+            return 2;
+        }
+        let semgrep_rules = load_semgrep_rules(path);
+        let count = semgrep_rules.len();
+        for rule in semgrep_rules {
+            registry.register(rule);
+        }
+        if count > 0 {
+            eprintln!("Loaded {} Semgrep rule(s) from {}", count, rules_path);
+        }
+    }
+
+    let (scan_result, mut diff_result) =
+        match foxguard::diff::run_diff(&args.path, &args.target, &registry, args.max_file_size) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                return 2;
+            }
+        };
+
+    // Filter by severity if specified
+    if let Some(ref min_severity) = args.severity {
+        let min = min_severity.to_severity();
+        diff_result.new_findings.retain(|f| f.severity >= min);
+    }
+
+    let new_count = diff_result.new_findings.len();
+    let total = diff_result.total_current;
+    let existing = diff_result.existing_count;
+
+    match args.format {
+        OutputFormat::Terminal => {
+            use colored::Colorize;
+            eprintln!(
+                "\n  {} {} {} {} new issue{} ({} total, {} existing)\n",
+                "foxguard diff".truecolor(245, 158, 11).bold(),
+                "vs".dimmed(),
+                args.target.bold(),
+                "\u{00b7}".dimmed(),
+                if new_count == 1 { "" } else { "s" },
+                total,
+                existing,
+            );
+            foxguard::report::terminal::print_findings(
+                &diff_result.new_findings,
+                scan_result.files_scanned,
+                scan_result.duration,
+            );
+        }
+        OutputFormat::Json => foxguard::report::json::print_json(&diff_result.new_findings),
+        OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&diff_result.new_findings),
+    }
+
+    if new_count > 0 {
         return 1;
     }
 

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -134,10 +134,7 @@ fn print_finding(f: &Finding, explain: bool) {
         .unwrap_or_default();
 
     // Line 1: badge + description (the main thing you read)
-    println!(
-        "    {accent} {badge} {}",
-        f.description,
-    );
+    println!("    {accent} {badge} {}", f.description,);
 
     // Line 2: rule ID + CWE + location (secondary info, dimmed)
     println!(
@@ -189,23 +186,50 @@ fn print_finding(f: &Finding, explain: bool) {
 }
 
 fn print_summary(findings: &[Finding], files_scanned: usize, duration: std::time::Duration) {
-    let critical = findings.iter().filter(|f| f.severity == Severity::Critical).count();
-    let high = findings.iter().filter(|f| f.severity == Severity::High).count();
-    let medium = findings.iter().filter(|f| f.severity == Severity::Medium).count();
-    let low = findings.iter().filter(|f| f.severity == Severity::Low).count();
+    let critical = findings
+        .iter()
+        .filter(|f| f.severity == Severity::Critical)
+        .count();
+    let high = findings
+        .iter()
+        .filter(|f| f.severity == Severity::High)
+        .count();
+    let medium = findings
+        .iter()
+        .filter(|f| f.severity == Severity::Medium)
+        .count();
+    let low = findings
+        .iter()
+        .filter(|f| f.severity == Severity::Low)
+        .count();
 
     let mut badges = Vec::new();
     if critical > 0 {
-        badges.push(format!("{}", format!(" {critical} critical ").on_truecolor(130, 50, 180).white().bold()));
+        badges.push(format!(
+            "{}",
+            format!(" {critical} critical ")
+                .on_truecolor(130, 50, 180)
+                .white()
+                .bold()
+        ));
     }
     if high > 0 {
-        badges.push(format!("{}", format!(" {high} high ").on_red().white().bold()));
+        badges.push(format!(
+            "{}",
+            format!(" {high} high ").on_red().white().bold()
+        ));
     }
     if medium > 0 {
-        badges.push(format!("{}", format!(" {medium} medium ").on_yellow().black().bold()));
+        badges.push(format!(
+            "{}",
+            format!(" {medium} medium ").on_yellow().black().bold()
+        ));
     }
     if low > 0 {
-        badges.push(format!("{}", format!(" {low} low ").on_blue().white().bold()));
+        badges.push(format!(
+            "{}",
+            format!(" {low} low ").on_blue().white().bold()
+        ));
     }
 
     let total = findings.len();


### PR DESCRIPTION
## Summary
- Adds `foxguard diff <target>` subcommand that scans the current working tree and compares findings against a target branch (e.g., `main`, `origin/main`), reporting only NEW issues
- Uses `git show <ref>:<file>` to read target branch file contents into temp directories — no checkout or stash needed, so the repo is never left in a dirty state
- Matches findings by `(rule_id, file, snippet)` with whitespace-trimmed snippet comparison, deliberately ignoring line numbers since they shift with edits
- Supports `--format` (terminal/json/sarif), `--severity`, `--rules`, `--no-builtins`, and `--max-file-size` flags
- Terminal output includes a summary header: `foxguard diff vs main · 3 new issues (42 total, 39 existing)`

## Test plan
- [x] Unit tests for `diff_findings` matching logic (new only, all new, none new, whitespace tolerance)
- [x] All 349 existing tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [ ] Manual test: run `foxguard diff main` on a branch with known new vulnerabilities
- [ ] Manual test: verify JSON/SARIF output modes work correctly
- [ ] Manual test: verify `--severity` filtering applies to diff results

none