### PR TITLE
feat: add scan exclude path patterns

### DIFF
--- a/src/bin/foxguard_mcp.rs
+++ b/src/bin/foxguard_mcp.rs
@@ -161,7 +161,7 @@ fn handle_tools_call(request: &Value, registry: &RuleRegistry) -> Result<Value, 
             if !p.is_file() {
                 return Err(format!("Path is not a file: {}", path));
             }
-            let result = scan_directory(path, registry, 1_048_576);
+            let result = scan_directory(path, registry, 1_048_576, None);
             Ok(format_scan_result(result))
         }
         "scan_directory" => {
@@ -172,7 +172,7 @@ fn handle_tools_call(request: &Value, registry: &RuleRegistry) -> Result<Value, 
             if !p.is_dir() {
                 return Err(format!("Path is not a directory: {}", path));
             }
-            let result = scan_directory(path, registry, 1_048_576);
+            let result = scan_directory(path, registry, 1_048_576, None);
             Ok(format_scan_result(result))
         }
         _ => Err(format!("Unknown tool: {}", tool_name)),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,6 +48,10 @@ pub struct ScanArgs {
     #[arg(long, default_value_t = false)]
     pub changed: bool,
 
+    /// Exclude scan-relative paths by glob or prefix (repeatable)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
     /// Apply a baseline file to suppress known findings
     #[arg(long)]
     pub baseline: Option<String>,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -117,6 +117,7 @@ fn scan_target_branch_files(
         &temp_paths,
         registry,
         max_file_size,
+        None,
     ))
 }
 
@@ -179,7 +180,7 @@ pub fn run_diff(
         .map_err(|_| format!("Target ref '{}' does not exist", target))?;
 
     // Scan current working tree
-    let current_result = scan_directory(scan_path, registry, max_file_size);
+    let current_result = scan_directory(scan_path, registry, max_file_size, None);
 
     // Get changed files between target and HEAD
     let changed = changed_files_vs_target(&repo, target)?;

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,4 +2,6 @@ pub mod parser;
 pub mod scanner;
 
 pub use parser::parse_file;
-pub use scanner::{scan_directory, scan_paths, scan_paths_with_root, ScanResult};
+pub use scanner::{
+    scan_directory, scan_paths, scan_paths_with_root, PathExcludeMatcher, ScanResult,
+};

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -5,6 +5,7 @@ use crate::rules::python_aliases::{from_tree as py_aliases_from_tree, resolve_im
 use crate::rules::python_taint;
 use crate::rules::{FileContext, RuleRegistry};
 use crate::{Finding, Language};
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use regex::Regex;
@@ -19,6 +20,66 @@ pub struct ScanResult {
     pub findings: Vec<Finding>,
     pub files_scanned: usize,
     pub duration: std::time::Duration,
+}
+
+#[derive(Default)]
+pub struct PathExcludeMatcher {
+    prefixes: Vec<String>,
+    globset: Option<GlobSet>,
+}
+
+impl PathExcludeMatcher {
+    pub fn new(patterns: &[String]) -> Result<Self, String> {
+        if patterns.is_empty() {
+            return Ok(Self::default());
+        }
+
+        let mut prefixes = Vec::new();
+        let mut builder = GlobSetBuilder::new();
+        let mut has_globs = false;
+
+        for pattern in patterns {
+            let normalized = normalize_match_path(Path::new(pattern));
+            if normalized.is_empty() {
+                continue;
+            }
+
+            if has_glob_metacharacters(pattern) {
+                let glob = Glob::new(&normalized)
+                    .map_err(|e| format!("Invalid exclude glob '{}': {}", pattern, e))?;
+                builder.add(glob);
+                has_globs = true;
+            } else {
+                prefixes.push(normalized.trim_end_matches('/').to_string());
+            }
+        }
+
+        let globset = if has_globs {
+            Some(
+                builder
+                    .build()
+                    .map_err(|e| format!("Failed to build exclude patterns: {}", e))?,
+            )
+        } else {
+            None
+        };
+
+        Ok(Self { prefixes, globset })
+    }
+
+    fn is_excluded(&self, path: &Path) -> bool {
+        let normalized = normalize_match_path(path);
+
+        self.prefixes.iter().any(|prefix| {
+            normalized == *prefix
+                || normalized
+                    .strip_prefix(prefix)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        }) || self
+            .globset
+            .as_ref()
+            .is_some_and(|globset| globset.is_match(&normalized))
+    }
 }
 
 #[derive(Default)]
@@ -56,12 +117,24 @@ fn detect_language(path: &Path) -> Option<Language> {
 }
 
 /// Scan a directory (or single file) and return findings with metadata.
-pub fn scan_directory(root: &str, registry: &RuleRegistry, max_file_size: u64) -> ScanResult {
+pub fn scan_directory(
+    root: &str,
+    registry: &RuleRegistry,
+    max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
+) -> ScanResult {
     let root_path = Path::new(root);
+    let scan_root = scan_root(root_path);
 
     let files: Vec<_> = if root_path.is_file() {
         if let Some(lang) = detect_language(root_path) {
-            vec![(root_path.to_path_buf(), lang)]
+            if excludes.is_some_and(|matcher| {
+                matcher.is_excluded(&relative_scan_path(scan_root, root_path))
+            }) {
+                vec![]
+            } else {
+                vec![(root_path.to_path_buf(), lang)]
+            }
         } else {
             vec![]
         }
@@ -75,17 +148,27 @@ pub fn scan_directory(root: &str, registry: &RuleRegistry, max_file_size: u64) -
             .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
             .filter_map(|entry| {
                 let path = entry.into_path();
+                if excludes.is_some_and(|matcher| {
+                    matcher.is_excluded(&relative_scan_path(scan_root, &path))
+                }) {
+                    return None;
+                }
                 detect_language(&path).map(|lang| (path, lang))
             })
             .collect()
     };
 
-    scan_files(scan_root(root_path), files, registry, max_file_size)
+    scan_files(scan_root, files, registry, max_file_size)
 }
 
 /// Scan an explicit list of paths.
-pub fn scan_paths(paths: &[PathBuf], registry: &RuleRegistry, max_file_size: u64) -> ScanResult {
-    scan_paths_with_root(Path::new("."), paths, registry, max_file_size)
+pub fn scan_paths(
+    paths: &[PathBuf],
+    registry: &RuleRegistry,
+    max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
+) -> ScanResult {
+    scan_paths_with_root(Path::new("."), paths, registry, max_file_size, excludes)
 }
 
 /// Scan an explicit list of paths relative to a scan root.
@@ -94,12 +177,18 @@ pub fn scan_paths_with_root(
     paths: &[PathBuf],
     registry: &RuleRegistry,
     max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
 ) -> ScanResult {
+    let scan_root = scan_root(root);
     let files = paths
         .iter()
+        .filter(|path| {
+            !excludes
+                .is_some_and(|matcher| matcher.is_excluded(&relative_scan_path(scan_root, path)))
+        })
         .filter_map(|path| detect_language(path).map(|lang| (path.clone(), lang)))
         .collect();
-    scan_files(scan_root(root), files, registry, max_file_size)
+    scan_files(scan_root, files, registry, max_file_size)
 }
 
 /// Check if a file path is in a directory that typically contains
@@ -655,6 +744,17 @@ fn relative_scan_path(scan_root: &Path, path: &Path) -> PathBuf {
     path.strip_prefix(scan_root).unwrap_or(path).to_path_buf()
 }
 
+fn has_glob_metacharacters(pattern: &str) -> bool {
+    pattern.contains('*') || pattern.contains('?') || pattern.contains('[') || pattern.contains('{')
+}
+
+fn normalize_match_path(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -700,5 +800,24 @@ mod tests {
         let (_, spec) = result.unwrap();
         assert!(!spec.all_rules);
         assert!(spec.rule_ids.contains("js/no-eval"));
+    }
+
+    #[test]
+    fn path_exclude_matcher_matches_prefixes_recursively() {
+        let matcher =
+            PathExcludeMatcher::new(&["vendor".to_string()]).expect("failed to build matcher");
+
+        assert!(matcher.is_excluded(Path::new("vendor/file.js")));
+        assert!(matcher.is_excluded(Path::new("vendor/nested/file.js")));
+        assert!(!matcher.is_excluded(Path::new("src/vendor/file.js")));
+    }
+
+    #[test]
+    fn path_exclude_matcher_matches_globs() {
+        let matcher = PathExcludeMatcher::new(&["generated/**/*.js".to_string()])
+            .expect("failed to build matcher");
+
+        assert!(matcher.is_excluded(Path::new("generated/foo/bar.js")));
+        assert!(!matcher.is_excluded(Path::new("generated/foo/bar.ts")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use foxguard::cli::{
     BaselineArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat, ScanArgs, SecretsArgs,
 };
 use foxguard::config::{apply_scan_defaults, apply_secrets_defaults, load_for_scan};
-use foxguard::engine::{scan_directory, scan_paths_with_root, ScanResult};
+use foxguard::engine::{scan_directory, scan_paths_with_root, PathExcludeMatcher, ScanResult};
 use foxguard::git::changed_files;
 use foxguard::rules::semgrep_compat::load_semgrep_rules;
 use foxguard::rules::RuleRegistry;
@@ -116,12 +116,25 @@ fn scan_findings(scan: &ScanArgs) -> Result<ScanResult, i32> {
     validate_scan_inputs(scan)?;
 
     let registry = build_registry(scan);
+    let excludes = match PathExcludeMatcher::new(&scan.exclude) {
+        Ok(excludes) => excludes,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return Err(2);
+        }
+    };
     let targets = collect_changed_targets(&scan.path, scan.changed)?;
 
     let mut result = if let Some(files) = targets {
-        scan_paths_with_root(Path::new(&scan.path), &files, &registry, scan.max_file_size)
+        scan_paths_with_root(
+            Path::new(&scan.path),
+            &files,
+            &registry,
+            scan.max_file_size,
+            Some(&excludes),
+        )
     } else {
-        scan_directory(&scan.path, &registry, scan.max_file_size)
+        scan_directory(&scan.path, &registry, scan.max_file_size, Some(&excludes))
     };
 
     // Filter by severity if specified
@@ -474,6 +487,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 rules: None,
                 no_builtins: false,
                 changed: false,
+                exclude: Vec::new(),
                 baseline: None,
                 write_baseline: None,
                 explain: false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2020,6 +2020,96 @@ rules:
         );
     }
 
+    #[test]
+    fn test_scan_exclude_skips_directory_prefixes() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        fs::create_dir_all(repo.path().join("src")).expect("failed to create src dir");
+        fs::create_dir_all(repo.path().join("vendor/nested")).expect("failed to create vendor dir");
+        fs::write(repo.path().join("src/included.js"), "eval(userInput);\n")
+            .expect("failed to write included fixture");
+        fs::write(
+            repo.path().join("vendor/nested/ignored.js"),
+            "eval(userInput);\n",
+        )
+        .expect("failed to write ignored fixture");
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args([".", "-f", "json", "--exclude", "vendor"])
+            .output()
+            .expect("failed to execute foxguard with excludes");
+
+        assert!(
+            !output.status.success(),
+            "non-excluded vulnerable files should still produce findings"
+        );
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            !findings.is_empty(),
+            "expected included file to still produce findings"
+        );
+        assert!(
+            findings.iter().all(|finding| finding["file"]
+                .as_str()
+                .is_some_and(|file| file.ends_with("src/included.js"))),
+            "expected excluded vendor files to be skipped"
+        );
+    }
+
+    #[test]
+    fn test_scan_exclude_glob_applies_to_changed_mode() {
+        let repo = setup_git_repo(&[]);
+        fs::create_dir_all(repo.path().join("src")).expect("failed to create src dir");
+        fs::create_dir_all(repo.path().join("generated/nested"))
+            .expect("failed to create generated dir");
+        fs::write(repo.path().join("src/included.js"), "eval(userInput);\n")
+            .expect("failed to write included fixture");
+        fs::write(
+            repo.path().join("generated/nested/ignored.js"),
+            "eval(userInput);\n",
+        )
+        .expect("failed to write ignored fixture");
+
+        Command::new("git")
+            .args(["add", "src/included.js", "generated/nested/ignored.js"])
+            .current_dir(repo.path())
+            .output()
+            .expect("failed to stage fixtures");
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args([
+                "--changed",
+                ".",
+                "-f",
+                "json",
+                "--exclude",
+                "generated/**/*.js",
+            ])
+            .output()
+            .expect("failed to execute foxguard changed scan with excludes");
+
+        assert!(
+            !output.status.success(),
+            "non-excluded changed files should still produce findings"
+        );
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            !findings.is_empty(),
+            "expected included changed file to still produce findings"
+        );
+        assert!(
+            findings.iter().all(|finding| finding["file"]
+                .as_str()
+                .is_some_and(|file| file.ends_with("src/included.js"))),
+            "expected excluded changed files to be skipped"
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_secrets_rejects_config_symlink_escape() {


### PR DESCRIPTION
## Summary
- add repeatable \'--exclude\' support for code scans using scan-relative prefix or glob matching
- apply excludes before parsing and cross-file analysis in both normal and --changed scans
- add unit and CLI integration coverage for directory-prefix and glob-based exclusions

## Verification
- cargo fmt --check
- cargo test
- cargo build --release