### PR TITLE
fix: automate Homebrew release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -28,7 +29,7 @@ jobs:
       - name: Verify release secrets
         run: |
           missing=0
-          for name in NPM_TOKEN CARGO_REGISTRY_TOKEN VSCE_PAT; do
+          for name in NPM_TOKEN CARGO_REGISTRY_TOKEN VSCE_PAT HOMEBREW_TAP_TOKEN; do
             if [ -z "${!name:-}" ]; then
               echo "::error::Missing required release secret: ${name}"
               missing=1
@@ -240,3 +241,54 @@ jobs:
           fi
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  publish-homebrew:
+    name: Publish Homebrew Formula
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Render formula
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          macos_arm_sha=$(sha256sum artifacts/foxguard-macos-aarch64/foxguard-macos-aarch64 | cut -d' ' -f1)
+          macos_x64_sha=$(sha256sum artifacts/foxguard-macos-x86_64/foxguard-macos-x86_64 | cut -d' ' -f1)
+          linux_arm_sha=$(sha256sum artifacts/foxguard-linux-aarch64/foxguard-linux-aarch64 | cut -d' ' -f1)
+          linux_x64_sha=$(sha256sum artifacts/foxguard-linux-x86_64/foxguard-linux-x86_64 | cut -d' ' -f1)
+
+          bash scripts/render-homebrew-formula.sh \
+            "${tag_version}" \
+            "${macos_arm_sha}" \
+            "${macos_x64_sha}" \
+            "${linux_arm_sha}" \
+            "${linux_x64_sha}" \
+            > foxguard.rb
+
+      - name: Checkout tap repository
+        uses: actions/checkout@v6
+        with:
+          repository: peaktwilight/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
+
+      - name: Update formula
+        run: |
+          mv foxguard.rb homebrew-tap/Formula/foxguard.rb
+          if git -C homebrew-tap diff --quiet; then
+            echo "Formula already up to date"
+            exit 0
+          fi
+
+          env \
+            GIT_AUTHOR_NAME="github-actions[bot]" \
+            GIT_AUTHOR_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
+            GIT_COMMITTER_NAME="github-actions[bot]" \
+            GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
+            git -C homebrew-tap commit -am "Update foxguard to ${GITHUB_REF_NAME}"
+
+          git -C homebrew-tap push origin main

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -93,4 +93,4 @@ git push origin "${TAG}"
 
 echo ""
 echo "=== ${TAG} queued ==="
-echo "GitHub Actions release workflow will build binaries and publish GitHub, crates.io, npm, and VS Code if the required secrets are configured."
+echo "GitHub Actions release workflow will build binaries and publish GitHub, crates.io, npm, VS Code, and the Homebrew tap if the required secrets are configured."

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:?Usage: $0 <version> <macos-arm-sha> <macos-x64-sha> <linux-arm-sha> <linux-x64-sha>}"
+MACOS_ARM_SHA="${2:?Missing macOS arm64 SHA}"
+MACOS_X64_SHA="${3:?Missing macOS x86_64 SHA}"
+LINUX_ARM_SHA="${4:?Missing Linux arm64 SHA}"
+LINUX_X64_SHA="${5:?Missing Linux x86_64 SHA}"
+
+cat <<EOF
+class Foxguard < Formula
+  desc "Security scanner as fast as a linter. 174 built-in rules, 10 languages, taint tracking."
+  homepage "https://foxguard.dev"
+  version "${VERSION}"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/PwnKit-Labs/foxguard/releases/download/v${VERSION}/foxguard-macos-aarch64"
+      sha256 "${MACOS_ARM_SHA}"
+    else
+      url "https://github.com/PwnKit-Labs/foxguard/releases/download/v${VERSION}/foxguard-macos-x86_64"
+      sha256 "${MACOS_X64_SHA}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/PwnKit-Labs/foxguard/releases/download/v${VERSION}/foxguard-linux-aarch64"
+      sha256 "${LINUX_ARM_SHA}"
+    else
+      url "https://github.com/PwnKit-Labs/foxguard/releases/download/v${VERSION}/foxguard-linux-x86_64"
+      sha256 "${LINUX_X64_SHA}"
+    end
+  end
+
+  def install
+    bin.install Dir["foxguard*"].first => "foxguard"
+  end
+
+  test do
+    assert_match "foxguard", shell_output("#{bin}/foxguard --version")
+  end
+end
+EOF


### PR DESCRIPTION
## Summary
- add release automation that renders and pushes the Homebrew tap formula from the tag-triggered workflow
- require a `HOMEBREW_TAP_TOKEN` release secret so the published install path stays in sync with shipped binaries
- add a small formula renderer script and update the release script messaging to include the Homebrew publish step

## Verification
- bash -n scripts/render-homebrew-formula.sh
- bash -n scripts/release.sh
- bash scripts/render-homebrew-formula.sh 0.6.3 <sample-shas>

## Notes
- the cross-repo formula push depends on the `HOMEBREW_TAP_TOKEN` secret in GitHub Actions and cannot be fully exercised locally