### PR TITLE
Optimize taint extraction and improve code formatting

### DIFF
--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -83,10 +83,16 @@ pub fn walk_tree(
     let mut stack: Vec<tree_sitter::Node> = vec![node];
     while let Some(current) = stack.pop() {
         callback(current, source);
+        let start = stack.len();
         let mut cursor = current.walk();
-        let children: Vec<_> = current.children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            stack.push(child);
+        if cursor.goto_first_child() {
+            loop {
+                stack.push(cursor.node());
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+            stack[start..].reverse();
         }
     }
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -596,7 +596,6 @@ fn walk_body_for_summary(
                     break;
                 }
             }
-        }
         _ => {}
     }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -37,7 +37,7 @@
 use super::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
@@ -356,6 +356,25 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -368,7 +387,6 @@ pub fn extract_cross_file_summaries(
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -381,8 +399,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -397,17 +446,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -596,6 +596,7 @@ fn walk_body_for_summary(
                     break;
                 }
             }
+        }
         _ => {}
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -318,6 +318,7 @@ fn walk_body_for_summary(
                     break;
                 }
             }
+        }
         _ => {}
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -318,7 +318,6 @@ fn walk_body_for_summary(
                     break;
                 }
             }
-        }
         _ => {}
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -27,7 +27,7 @@
 use super::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
@@ -354,6 +354,25 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -366,7 +385,6 @@ pub fn extract_cross_file_summaries(
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -379,8 +397,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -395,17 +444,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -32,7 +32,7 @@
 
 use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::Node;
 
@@ -283,8 +283,27 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         // For each parameter, create a synthetic spec that treats ONLY
-        // that parameter as a taint source, then run each rule's sinks.
+        // that parameter as a taint source, then check all sinks.
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -292,13 +311,11 @@ pub fn extract_cross_file_summaries(
             };
 
             // Check return-taint: does this parameter flow to a return value?
-            // Use a minimal spec with no sinks just to check return flow.
             let return_spec = TaintSpec {
                 sources: vec![synthetic_source.clone()],
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -311,8 +328,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -327,18 +375,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    // Deduplicate: only record one flow per (param, rule) pair.
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces major optimizations and refactoring to the cross-file taint summary extraction logic for Go, Python, and JavaScript, as well as improvements to tree traversal and sanitizer detection. The main focus is on batching taint analysis for rules without sanitizers, which reduces redundant computation and improves performance, while ensuring correctness for rules with sanitizers. Additional minor refactors and bugfixes are included.

#### Taint Analysis Optimization and Refactoring

* Refactored `extract_cross_file_summaries` in `go_taint.rs`, `python_taint.rs`, and `javascript_taint.rs` to batch all taint analysis rules without sanitizers into a single analysis per parameter, instead of running each rule separately. Rules with sanitizers are still analyzed individually to avoid incorrect taint clearing. This significantly improves performance and deduplication. [[1]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefR359-R377) [[2]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL384-R434) [[3]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL400-R449) [[4]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL413) [[5]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6R357-R375) [[6]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L384-R432) [[7]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L400-R447) [[8]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L413) [[9]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95R286-L301) [[10]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95L314-R363) [[11]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95L330-R378) [[12]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95L344)
* Added a `HashSet` to track and deduplicate (parameter, rule) pairs for sink findings, ensuring that each flow is only recorded once. [[1]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL384-R434) [[2]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L384-R432) [[3]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95L314-R363)
* Updated imports to include `HashSet` where needed. [[1]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL40-R40) [[2]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L30-R30) [[3]](diffhunk://#diff-380014fbee798fc3162bcc1aa1cf804f564644497413a796d3bb5a63ceb7eb95L35-R35)

#### Tree Traversal and Analysis

* Optimized the `walk_tree` function in `common.rs` to use a more efficient stack-based traversal, reducing memory allocations and improving performance.
* Minor refactor in `walk_body_for_summary` for Go and JavaScript to use pattern matching for `return_statement` only when `return_taint` is `None`, improving clarity and correctness. [[1]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL536-R580) [[2]](diffhunk://#diff-1c067b78caa7afd914fc1f352473858619ca3743b1ae42c44dff2c0973dedeefL557) [[3]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L313-R313) [[4]](diffhunk://#diff-c5bf8a1c0ad855d8f8a8543f15ee0002269d15d947db0f1a644031909e39f8d6L323)

#### Other Improvements

* Simplified multi-assign semantics in Go taint analysis by removing an unnecessary `into_iter`.
* Improved sanitizer call detection in JavaScript taint analysis by using Rust pattern matching guards for clarity.## Summary

<!-- What does this PR do? -->

## Checklist

- [x] Code compiles without warnings (`cargo clippy`)
- [x] Tests pass (`cargo test`)
- [x] Code is formatted (`cargo fmt`)
- [x] Security rules have test coverage in `tests/fixtures/`
- [x] Breaking changes are documented
