### PR TITLE
feat: multi-hop cross-file taint tracking (#175)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -306,6 +306,7 @@ fn tui_scan_args(args: &TuiArgs) -> ScanArgs {
         github_pr: None,
         quiet: false,
         max_file_size: args.max_file_size,
+        fix: false,
     }
 }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -169,6 +169,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,10 @@ pub struct ScanArgs {
     #[arg(long, default_value_t = false)]
     pub explain: bool,
 
+    /// Auto-fix supported taint findings (writes changes to disk)
+    #[arg(long, default_value_t = false)]
+    pub fix: bool,
+
     /// Post findings as inline review comments on a GitHub PR
     #[arg(long)]
     pub github_pr: Option<u64>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -710,6 +710,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let (config_path, added) =

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -282,6 +282,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         }
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,6 +3,6 @@ pub mod scanner;
 
 pub use parser::parse_file;
 pub use scanner::{
-    scan_directory, scan_directory_with_notices, scan_paths, scan_paths_with_root,
-    scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult,
+    detect_language, scan_directory, scan_directory_with_notices, scan_paths,
+    scan_paths_with_root, scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult,
 };

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,6 +3,6 @@ pub mod scanner;
 
 pub use parser::parse_file;
 pub use scanner::{
-    detect_language, scan_directory, scan_directory_with_notices, scan_paths,
-    scan_paths_with_root, scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult,
+    detect_language, scan_directory, scan_directory_with_notices, scan_paths, scan_paths_with_root,
+    scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult,
 };

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -107,7 +107,7 @@ impl InlineIgnoreSpec {
 }
 
 /// Detect language from file extension.
-fn detect_language(path: &Path) -> Option<Language> {
+pub fn detect_language(path: &Path) -> Option<Language> {
     match path.extension()?.to_str()? {
         "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => Some(Language::JavaScript),
         "py" | "pyw" => Some(Language::Python),

--- a/src/fix/command_injection.rs
+++ b/src/fix/command_injection.rs
@@ -1,0 +1,324 @@
+use super::{find_node_at_byte, node_text, CodeEdit};
+
+/// Fix Python command injection: rewrite `os.system(cmd)` / `subprocess.call(cmd, shell=True)`
+/// to `subprocess.run([...])`.
+///
+/// Handles:
+/// - `os.system("cmd " + var)` -> `subprocess.run(["cmd", var])`
+/// - `os.popen("cmd " + var)` -> `subprocess.run(["cmd", var])`
+pub fn fix_python(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let args = call_node.child_by_field_name("arguments")?;
+    let first_arg = first_positional_arg(args)?;
+
+    // Extract command parts from string concatenation
+    let parts = extract_command_parts(first_arg, source)?;
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Build subprocess.run([...]) call
+    let list_items: Vec<String> = parts
+        .iter()
+        .map(|p| match p {
+            CommandPart::Literal(s) => format!("\"{}\"", s),
+            CommandPart::Variable(v) => v.clone(),
+        })
+        .collect();
+
+    let replacement = format!("subprocess.run([{}])", list_items.join(", "));
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+/// Fix JavaScript command injection: rewrite `exec(cmd)` to `execFile(name, [args])`.
+///
+/// Handles:
+/// - `exec("cmd " + var)` -> `execFile("cmd", [var])`
+pub fn fix_javascript(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let func = call_node.child_by_field_name("function")?;
+    let func_text = node_text(func, source);
+
+    let args = call_node.child_by_field_name("arguments")?;
+    let first_arg = first_positional_arg(args)?;
+
+    let parts = extract_command_parts(first_arg, source)?;
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Rewrite exec -> execFile with separate args
+    let new_func = func_text
+        .replace("exec", "execFile")
+        .replace("execSync", "execFileSync");
+
+    let (cmd, cmd_args) = split_command_parts(&parts)?;
+
+    let args_list: Vec<String> = cmd_args
+        .iter()
+        .map(|p| match p {
+            CommandPart::Literal(s) => format!("\"{}\"", s),
+            CommandPart::Variable(v) => v.clone(),
+        })
+        .collect();
+
+    let cmd_str = match &cmd {
+        CommandPart::Literal(s) => format!("\"{}\"", s),
+        CommandPart::Variable(v) => v.clone(),
+    };
+
+    let replacement = format!("{}({}, [{}])", new_func, cmd_str, args_list.join(", "));
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+/// Fix Go command injection: rewrite `exec.Command("sh", "-c", cmd + var)`
+/// to `exec.Command("cmd", var)`.
+///
+/// Handles:
+/// - `exec.Command("sh", "-c", "cmd " + var)` -> `exec.Command("cmd", var)`
+pub fn fix_go(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let args = call_node.child_by_field_name("arguments")?;
+
+    // Collect all positional arguments
+    let mut arg_nodes = Vec::new();
+    let mut cursor = args.walk();
+    for child in args.named_children(&mut cursor) {
+        arg_nodes.push(child);
+    }
+
+    // Check if this is the exec.Command("sh", "-c", ...) pattern
+    if arg_nodes.len() >= 3 {
+        let first = node_text(arg_nodes[0], source);
+        let second = node_text(arg_nodes[1], source);
+        if (first == "\"sh\""
+            || first == "\"bash\""
+            || first == "\"/bin/sh\""
+            || first == "\"/bin/bash\"")
+            && second == "\"-c\""
+        {
+            // The third argument is the shell command string
+            let cmd_arg = arg_nodes[2];
+            let parts = extract_command_parts(cmd_arg, source)?;
+            if parts.is_empty() {
+                return None;
+            }
+
+            let items: Vec<String> = parts
+                .iter()
+                .map(|p| match p {
+                    CommandPart::Literal(s) => format!("\"{}\"", s),
+                    CommandPart::Variable(v) => v.clone(),
+                })
+                .collect();
+
+            let func_text = call_func_text(call_node, source)?;
+            let replacement = format!("{}({})", func_text, items.join(", "));
+
+            return Some(vec![CodeEdit {
+                start_byte: call_node.start_byte(),
+                end_byte: call_node.end_byte(),
+                replacement,
+            }]);
+        }
+    }
+
+    // For other patterns, try to extract concat from first arg
+    if let Some(first_arg) = arg_nodes.first() {
+        let parts = extract_command_parts(*first_arg, source)?;
+        if parts.is_empty() {
+            return None;
+        }
+
+        let items: Vec<String> = parts
+            .iter()
+            .map(|p| match p {
+                CommandPart::Literal(s) => format!("\"{}\"", s),
+                CommandPart::Variable(v) => v.clone(),
+            })
+            .collect();
+
+        let func_text = call_func_text(call_node, source)?;
+        let replacement = format!("{}({})", func_text, items.join(", "));
+
+        return Some(vec![CodeEdit {
+            start_byte: call_node.start_byte(),
+            end_byte: call_node.end_byte(),
+            replacement,
+        }]);
+    }
+
+    None
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+enum CommandPart {
+    Literal(String),
+    Variable(String),
+}
+
+/// Extract command parts from a string concatenation expression.
+/// Splits string literals at spaces to separate command name from arguments.
+fn extract_command_parts(node: tree_sitter::Node, source: &str) -> Option<Vec<CommandPart>> {
+    let mut leaves = Vec::new();
+    collect_leaves(node, source, &mut leaves);
+
+    if leaves.is_empty() {
+        return None;
+    }
+
+    // Split string literals at whitespace boundaries to extract command + args
+    let mut parts = Vec::new();
+    for leaf in leaves {
+        match leaf {
+            CommandPart::Literal(s) => {
+                let trimmed = s.trim();
+                if !trimmed.is_empty() {
+                    for word in trimmed.split_whitespace() {
+                        parts.push(CommandPart::Literal(word.to_string()));
+                    }
+                }
+            }
+            CommandPart::Variable(v) => {
+                parts.push(CommandPart::Variable(v));
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts)
+    }
+}
+
+fn collect_leaves(node: tree_sitter::Node, source: &str, out: &mut Vec<CommandPart>) {
+    match node.kind() {
+        "binary_operator" | "binary_expression" => {
+            let left = node.child_by_field_name("left");
+            let right = node.child_by_field_name("right");
+            if let Some(l) = left {
+                collect_leaves(l, source, out);
+            }
+            if let Some(r) = right {
+                collect_leaves(r, source, out);
+            }
+        }
+        "string" | "interpreted_string_literal" | "raw_string_literal" => {
+            let text = node_text(node, source);
+            let inner = strip_quotes(text);
+            out.push(CommandPart::Literal(inner.to_string()));
+        }
+        _ => {
+            out.push(CommandPart::Variable(node_text(node, source).to_string()));
+        }
+    }
+}
+
+fn strip_quotes(s: &str) -> &str {
+    if (s.starts_with('"') && s.ends_with('"')) || (s.starts_with('\'') && s.ends_with('\'')) {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Split parts into (command, arguments)
+fn split_command_parts(parts: &[CommandPart]) -> Option<(CommandPart, Vec<CommandPart>)> {
+    if parts.is_empty() {
+        return None;
+    }
+    Some((parts[0].clone(), parts[1..].to_vec()))
+}
+
+/// Find the call expression node at the given byte range.
+fn find_call_at(root: tree_sitter::Node, start: usize, end: usize) -> Option<tree_sitter::Node> {
+    let node = find_node_at_byte(root, start)?;
+    let mut current = node;
+    loop {
+        if (current.kind() == "call" || current.kind() == "call_expression")
+            && current.start_byte() <= start
+            && current.end_byte() >= end
+        {
+            return Some(current);
+        }
+        current = current.parent()?;
+    }
+}
+
+fn call_func_text<'a>(call_node: tree_sitter::Node, source: &'a str) -> Option<&'a str> {
+    let func = call_node
+        .child_by_field_name("function")
+        .or_else(|| call_node.child_by_field_name("callee"))?;
+    Some(node_text(func, source))
+}
+
+fn first_positional_arg(args: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut cursor = args.walk();
+    let result = args
+        .named_children(&mut cursor)
+        .find(|child| child.kind() != "keyword_argument" && child.kind() != "spread_element");
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parse_file;
+    use crate::Language;
+
+    #[test]
+    fn test_fix_python_os_system() {
+        let source = r#"os.system("ls " + user_input)"#;
+        let tree = parse_file(source, Language::Python).unwrap();
+        let edits = fix_python(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].replacement,
+            r#"subprocess.run(["ls", user_input])"#
+        );
+    }
+
+    #[test]
+    fn test_fix_js_exec() {
+        let source = r#"exec("cmd " + input)"#;
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        let edits = fix_javascript(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].replacement, r#"execFile("cmd", [input])"#);
+    }
+}

--- a/src/fix/command_injection.rs
+++ b/src/fix/command_injection.rs
@@ -68,9 +68,13 @@ pub fn fix_javascript(
     }
 
     // Rewrite exec -> execFile with separate args
-    let new_func = func_text
-        .replace("exec", "execFile")
-        .replace("execSync", "execFileSync");
+    let new_func = if let Some(prefix) = func_text.strip_suffix("execSync") {
+        format!("{prefix}execFileSync")
+    } else if let Some(prefix) = func_text.strip_suffix("exec") {
+        format!("{prefix}execFile")
+    } else {
+        return None;
+    };
 
     let (cmd, cmd_args) = split_command_parts(&parts)?;
 

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -200,7 +200,7 @@ fn find_next_match(
     start_j: usize,
 ) -> Option<(usize, usize)> {
     // Look for the next line that matches in both sequences
-    let window = 10;
+    let window = 50;
     for di in 0..window.min(orig.len() - start_i) {
         for dj in 0..window.min(modified.len() - start_j) {
             if di == 0 && dj == 0 {

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -47,7 +47,7 @@ fn generate_fix(
 
 /// Apply byte-range edits to source, processing in reverse order so offsets stay valid.
 pub fn apply_edits(source: &str, edits: &mut [CodeEdit]) -> String {
-    edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+    edits.sort_by_key(|e| std::cmp::Reverse(e.start_byte));
 
     let mut result = source.to_string();
     let mut last_start = usize::MAX;

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -1,0 +1,281 @@
+pub mod command_injection;
+pub mod sql_injection;
+pub mod xss;
+
+use crate::engine::{detect_language, parse_file};
+use crate::Finding;
+use colored::Colorize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// A single byte-range replacement within a file.
+#[derive(Debug, Clone)]
+pub struct CodeEdit {
+    pub start_byte: usize,
+    pub end_byte: usize,
+    pub replacement: String,
+}
+
+/// All edits for a single file.
+#[derive(Debug)]
+pub struct FileFix {
+    pub file_path: String,
+    pub edits: Vec<CodeEdit>,
+}
+
+/// Try to generate edits for a single finding.
+/// Returns `None` if the rule_id is unsupported or the AST shape is unrecognized.
+fn generate_fix(
+    finding: &Finding,
+    source: &str,
+    tree: &tree_sitter::Tree,
+) -> Option<Vec<CodeEdit>> {
+    let start = finding.sink_start_byte?;
+    let end = finding.sink_end_byte?;
+
+    match finding.rule_id.as_str() {
+        "py/taint-sql-injection" => sql_injection::fix_python(source, tree, start, end),
+        "js/taint-sql-injection" => sql_injection::fix_javascript(source, tree, start, end),
+        "go/taint-sql-injection" => sql_injection::fix_go(source, tree, start, end),
+        "py/taint-command-injection" => command_injection::fix_python(source, tree, start, end),
+        "js/taint-command-injection" => command_injection::fix_javascript(source, tree, start, end),
+        "go/taint-command-injection" => command_injection::fix_go(source, tree, start, end),
+        "js/taint-xss-innerhtml" => xss::fix_javascript(source, tree, start, end),
+        _ => None,
+    }
+}
+
+/// Apply byte-range edits to source, processing in reverse order so offsets stay valid.
+pub fn apply_edits(source: &str, edits: &mut [CodeEdit]) -> String {
+    edits.sort_by(|a, b| b.start_byte.cmp(&a.start_byte));
+
+    let mut result = source.to_string();
+    let mut last_start = usize::MAX;
+
+    for edit in edits.iter() {
+        // Skip overlapping edits
+        if edit.end_byte > last_start {
+            continue;
+        }
+        let start = edit.start_byte.min(result.len());
+        let end = edit.end_byte.min(result.len());
+        result.replace_range(start..end, &edit.replacement);
+        last_start = edit.start_byte;
+    }
+
+    result
+}
+
+/// Generate and apply fixes for all fixable findings. Returns the number of files modified.
+pub fn apply_all_fixes(findings: &[Finding], scan_root: &str) -> usize {
+    let root = Path::new(scan_root);
+
+    // Group findings by file
+    let mut by_file: HashMap<&str, Vec<&Finding>> = HashMap::new();
+    for f in findings {
+        if f.sink_start_byte.is_some() && f.sink_end_byte.is_some() {
+            by_file.entry(&f.file).or_default().push(f);
+        }
+    }
+
+    let mut files_fixed = 0;
+
+    for (file, file_findings) in &by_file {
+        let file_path = root.join(file);
+        let source = match std::fs::read_to_string(&file_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let language = match detect_language(&file_path) {
+            Some(l) => l,
+            None => continue,
+        };
+
+        let tree = match parse_file(&source, language) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let mut all_edits: Vec<CodeEdit> = Vec::new();
+        for finding in file_findings {
+            if let Some(edits) = generate_fix(finding, &source, &tree) {
+                all_edits.extend(edits);
+            }
+        }
+
+        if all_edits.is_empty() {
+            continue;
+        }
+
+        let modified = apply_edits(&source, &mut all_edits);
+        if modified == source {
+            continue;
+        }
+
+        print_diff(file, &source, &modified);
+
+        if let Err(e) = std::fs::write(&file_path, &modified) {
+            eprintln!("Error writing {}: {}", file, e);
+            continue;
+        }
+
+        files_fixed += 1;
+    }
+
+    files_fixed
+}
+
+/// Print a simple colorized unified diff to stderr.
+pub fn print_diff(file_path: &str, original: &str, modified: &str) {
+    let orig_lines: Vec<&str> = original.lines().collect();
+    let mod_lines: Vec<&str> = modified.lines().collect();
+
+    eprintln!(
+        "\n{} {}",
+        "---".dimmed(),
+        format!("a/{}", file_path).dimmed()
+    );
+    eprintln!("{} {}", "+++".dimmed(), format!("b/{}", file_path).dimmed());
+
+    // Simple line-by-line diff using longest common subsequence
+    let mut i = 0;
+    let mut j = 0;
+    let mut in_hunk = false;
+
+    while i < orig_lines.len() || j < mod_lines.len() {
+        if i < orig_lines.len() && j < mod_lines.len() && orig_lines[i] == mod_lines[j] {
+            if in_hunk {
+                eprintln!(" {}", orig_lines[i]);
+            }
+            i += 1;
+            j += 1;
+            in_hunk = false;
+        } else {
+            if !in_hunk {
+                eprintln!(
+                    "{}",
+                    format!(
+                        "@@ -{},{} +{},{} @@",
+                        i + 1,
+                        orig_lines.len() - i,
+                        j + 1,
+                        mod_lines.len() - j
+                    )
+                    .cyan()
+                );
+                in_hunk = true;
+            }
+            // Find the next matching line
+            let next_match = find_next_match(&orig_lines, &mod_lines, i, j);
+            match next_match {
+                Some((ni, nj)) => {
+                    for line in &orig_lines[i..ni] {
+                        eprintln!("{}", format!("-{}", line).red());
+                    }
+                    for line in &mod_lines[j..nj] {
+                        eprintln!("{}", format!("+{}", line).green());
+                    }
+                    i = ni;
+                    j = nj;
+                }
+                None => {
+                    for line in &orig_lines[i..] {
+                        eprintln!("{}", format!("-{}", line).red());
+                    }
+                    for line in &mod_lines[j..] {
+                        eprintln!("{}", format!("+{}", line).green());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn find_next_match(
+    orig: &[&str],
+    modified: &[&str],
+    start_i: usize,
+    start_j: usize,
+) -> Option<(usize, usize)> {
+    // Look for the next line that matches in both sequences
+    let window = 10;
+    for di in 0..window.min(orig.len() - start_i) {
+        for dj in 0..window.min(modified.len() - start_j) {
+            if di == 0 && dj == 0 {
+                continue;
+            }
+            if orig[start_i + di] == modified[start_j + dj] {
+                return Some((start_i + di, start_j + dj));
+            }
+        }
+    }
+    None
+}
+
+/// Helper: find the tree-sitter node at a specific byte offset.
+pub fn find_node_at_byte(root: tree_sitter::Node, byte: usize) -> Option<tree_sitter::Node> {
+    let node = root.descendant_for_byte_range(byte, byte)?;
+    Some(node)
+}
+
+/// Helper: get node text from source.
+pub fn node_text<'a>(node: tree_sitter::Node, source: &'a str) -> &'a str {
+    &source[node.start_byte()..node.end_byte()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_edits_single() {
+        let source = "hello world";
+        let mut edits = vec![CodeEdit {
+            start_byte: 6,
+            end_byte: 11,
+            replacement: "rust".to_string(),
+        }];
+        assert_eq!(apply_edits(source, &mut edits), "hello rust");
+    }
+
+    #[test]
+    fn test_apply_edits_multiple_reverse_order() {
+        let source = "aaa bbb ccc";
+        let mut edits = vec![
+            CodeEdit {
+                start_byte: 0,
+                end_byte: 3,
+                replacement: "xxx".to_string(),
+            },
+            CodeEdit {
+                start_byte: 8,
+                end_byte: 11,
+                replacement: "zzz".to_string(),
+            },
+        ];
+        assert_eq!(apply_edits(source, &mut edits), "xxx bbb zzz");
+    }
+
+    #[test]
+    fn test_apply_edits_overlapping_skipped() {
+        let source = "abcdefgh";
+        let mut edits = vec![
+            CodeEdit {
+                start_byte: 2,
+                end_byte: 6,
+                replacement: "XX".to_string(),
+            },
+            CodeEdit {
+                start_byte: 4,
+                end_byte: 8,
+                replacement: "YY".to_string(),
+            },
+        ];
+        // The second edit (bytes 4..8) overlaps with the first (2..6) after sorting by reverse start.
+        // The 4..8 edit is applied first (higher start), then 2..6 is skipped because end_byte(6) > last_start(4).
+        let result = apply_edits(source, &mut edits);
+        assert_eq!(result, "abcdYY");
+    }
+}

--- a/src/fix/sql_injection.rs
+++ b/src/fix/sql_injection.rs
@@ -1,0 +1,498 @@
+use super::{find_node_at_byte, node_text, CodeEdit};
+
+/// Fix Python SQL injection: rewrite string concat/f-string to parameterized query.
+///
+/// Handles:
+/// - `cursor.execute(f"SELECT ... {var}")` -> `cursor.execute("SELECT ... ?", (var,))`
+/// - `cursor.execute("SELECT ... " + var)` -> `cursor.execute("SELECT ... ?", (var,))`
+pub fn fix_python(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let args = call_node.child_by_field_name("arguments")?;
+    // The first positional argument is the SQL string
+    let first_arg = first_positional_arg(args)?;
+
+    match first_arg.kind() {
+        // f-string: f"SELECT * FROM users WHERE name = {name}"
+        "string"
+            if source[first_arg.start_byte()..first_arg.end_byte()].starts_with("f\"")
+                || source[first_arg.start_byte()..first_arg.end_byte()].starts_with("f'") =>
+        {
+            fix_python_fstring(source, call_node, args, first_arg)
+        }
+        // String concatenation or %-formatting: "SELECT ... " + var
+        "binary_operator" | "concatenated_string" => {
+            fix_python_concat(source, call_node, args, first_arg)
+        }
+        _ => None,
+    }
+}
+
+/// Fix JavaScript SQL injection: rewrite string concat/template to parameterized query.
+///
+/// Handles:
+/// - `` db.query(`SELECT ... ${var}`) `` -> `db.query("SELECT ... $1", [var])`
+/// - `db.query("SELECT ... " + var)` -> `db.query("SELECT ... $1", [var])`
+pub fn fix_javascript(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let args = call_node.child_by_field_name("arguments")?;
+    let first_arg = first_positional_arg(args)?;
+
+    match first_arg.kind() {
+        "template_string" => fix_js_template(source, call_node, args, first_arg),
+        "binary_expression" => fix_js_concat(source, call_node, args, first_arg),
+        _ => None,
+    }
+}
+
+/// Fix Go SQL injection: rewrite string concat to parameterized query.
+///
+/// Handles:
+/// - `db.Query("SELECT ... " + var)` -> `db.Query("SELECT ... $1", var)`
+pub fn fix_go(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let call_node = find_call_at(root, sink_start, sink_end)?;
+
+    let args = call_node.child_by_field_name("arguments")?;
+    let first_arg = first_positional_arg(args)?;
+
+    if first_arg.kind() == "binary_expression" {
+        fix_go_concat(source, call_node, args, first_arg)
+    } else {
+        None
+    }
+}
+
+// ─── Python helpers ──────────────────────────────────────────────────────
+
+fn fix_python_fstring(
+    source: &str,
+    call_node: tree_sitter::Node,
+    _args_node: tree_sitter::Node,
+    fstr_node: tree_sitter::Node,
+) -> Option<Vec<CodeEdit>> {
+    let fstr_text = node_text(fstr_node, source);
+
+    // Extract interpolated expressions from f-string
+    let mut params = Vec::new();
+    let mut cursor = fstr_node.walk();
+    for child in fstr_node.named_children(&mut cursor) {
+        if child.kind() == "interpolation" {
+            // Get the expression inside { }
+            let mut inner_cursor = child.walk();
+            for inner in child.named_children(&mut inner_cursor) {
+                if inner.kind() != "type_conversion" && inner.kind() != "format_specifier" {
+                    params.push(node_text(inner, source).to_string());
+                    break;
+                }
+            }
+        }
+    }
+
+    if params.is_empty() {
+        return None;
+    }
+
+    // Build the parameterized query string
+    let mut query = fstr_text.to_string();
+    // Remove the 'f' prefix
+    query = query[1..].to_string();
+
+    // Replace each {expr} with ?
+    for _param in &params {
+        // Find and replace {param} or {param:...} patterns
+        let start = query.find('{')?;
+        let end = query[start..].find('}')? + start;
+        query.replace_range(start..=end, "?");
+    }
+
+    // Build the params tuple
+    let params_str = if params.len() == 1 {
+        format!("({},)", params[0])
+    } else {
+        format!("({})", params.join(", "))
+    };
+
+    // Get the method call prefix (e.g., "cursor.execute")
+    let func_text = call_func_text(call_node, source)?;
+
+    let replacement = format!("{}({}, {})", func_text, query, params_str);
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+fn fix_python_concat(
+    source: &str,
+    call_node: tree_sitter::Node,
+    _args_node: tree_sitter::Node,
+    concat_node: tree_sitter::Node,
+) -> Option<Vec<CodeEdit>> {
+    // Extract string parts and variable parts from "str" + var + "str" + var
+    let (string_parts, var_parts) = extract_concat_parts(concat_node, source)?;
+
+    if var_parts.is_empty() {
+        return None;
+    }
+
+    // Build parameterized query
+    let mut query = String::new();
+    for (i, part) in string_parts.iter().enumerate() {
+        query.push_str(part);
+        if i < var_parts.len() {
+            query.push('?');
+        }
+    }
+
+    let params_str = if var_parts.len() == 1 {
+        format!("({},)", var_parts[0])
+    } else {
+        format!("({})", var_parts.join(", "))
+    };
+
+    let func_text = call_func_text(call_node, source)?;
+    let replacement = format!("{}(\"{}\", {})", func_text, query, params_str);
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+// ─── JavaScript helpers ──────────────────────────────────────────────────
+
+fn fix_js_template(
+    source: &str,
+    call_node: tree_sitter::Node,
+    _args_node: tree_sitter::Node,
+    template_node: tree_sitter::Node,
+) -> Option<Vec<CodeEdit>> {
+    // Extract substitutions from template literal
+    let mut params = Vec::new();
+    let mut cursor = template_node.walk();
+    for child in template_node.named_children(&mut cursor) {
+        if child.kind() == "template_substitution" {
+            // Get expression inside ${ }
+            let mut inner_cursor = child.walk();
+            let first = child.named_children(&mut inner_cursor).next();
+            if let Some(inner) = first {
+                params.push(node_text(inner, source).to_string());
+            }
+        }
+    }
+
+    if params.is_empty() {
+        return None;
+    }
+
+    // Build parameterized query — replace ${expr} with $1, $2, etc.
+    let tmpl_text = node_text(template_node, source);
+    let mut query = tmpl_text.to_string();
+    let mut param_idx = 1;
+
+    // Replace each ${...} with $N
+    while let Some(start) = query.find("${") {
+        let end = query[start..].find('}')? + start;
+        query.replace_range(start..=end, &format!("${}", param_idx));
+        param_idx += 1;
+    }
+
+    // Convert backticks to double quotes
+    if query.starts_with('`') && query.ends_with('`') {
+        query = format!("\"{}\"", &query[1..query.len() - 1]);
+    }
+
+    let func_text = call_func_text(call_node, source)?;
+    let replacement = format!("{}({}, [{}])", func_text, query, params.join(", "));
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+fn fix_js_concat(
+    source: &str,
+    call_node: tree_sitter::Node,
+    _args_node: tree_sitter::Node,
+    concat_node: tree_sitter::Node,
+) -> Option<Vec<CodeEdit>> {
+    let (string_parts, var_parts) = extract_concat_parts(concat_node, source)?;
+
+    if var_parts.is_empty() {
+        return None;
+    }
+
+    let mut query = String::new();
+    for (i, part) in string_parts.iter().enumerate() {
+        query.push_str(part);
+        if i < var_parts.len() {
+            query.push_str(&format!("${}", i + 1));
+        }
+    }
+
+    let func_text = call_func_text(call_node, source)?;
+    let replacement = format!("{}(\"{}\", [{}])", func_text, query, var_parts.join(", "));
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+// ─── Go helpers ──────────────────────────────────────────────────────────
+
+fn fix_go_concat(
+    source: &str,
+    call_node: tree_sitter::Node,
+    _args_node: tree_sitter::Node,
+    concat_node: tree_sitter::Node,
+) -> Option<Vec<CodeEdit>> {
+    let (string_parts, var_parts) = extract_concat_parts(concat_node, source)?;
+
+    if var_parts.is_empty() {
+        return None;
+    }
+
+    let mut query = String::new();
+    for (i, part) in string_parts.iter().enumerate() {
+        query.push_str(part);
+        if i < var_parts.len() {
+            query.push_str(&format!("${}", i + 1));
+        }
+    }
+
+    let func_text = call_func_text(call_node, source)?;
+    let replacement = format!("{}(\"{}\", {})", func_text, query, var_parts.join(", "));
+
+    Some(vec![CodeEdit {
+        start_byte: call_node.start_byte(),
+        end_byte: call_node.end_byte(),
+        replacement,
+    }])
+}
+
+// ─── Shared helpers ──────────────────────────────────────────────────────
+
+/// Find the call expression node that covers the given byte range.
+fn find_call_at(root: tree_sitter::Node, start: usize, end: usize) -> Option<tree_sitter::Node> {
+    let node = find_node_at_byte(root, start)?;
+    // Walk up to find the call expression
+    let mut current = node;
+    loop {
+        if current.kind() == "call" || current.kind() == "call_expression" {
+            // Verify it covers our range
+            if current.start_byte() <= start && current.end_byte() >= end {
+                return Some(current);
+            }
+        }
+        current = current.parent()?;
+    }
+}
+
+/// Get the function/method text before the arguments.
+/// e.g., for `cursor.execute(...)` returns `"cursor.execute"`
+fn call_func_text<'a>(call_node: tree_sitter::Node, source: &'a str) -> Option<&'a str> {
+    // The function field is typically named "function" or "callee"
+    let func = call_node
+        .child_by_field_name("function")
+        .or_else(|| call_node.child_by_field_name("callee"))?;
+    Some(node_text(func, source))
+}
+
+/// Get the first positional argument from an arguments node.
+fn first_positional_arg(args: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut cursor = args.walk();
+    let result = args
+        .named_children(&mut cursor)
+        .find(|child| child.kind() != "keyword_argument" && child.kind() != "spread_element");
+    result
+}
+
+/// Extract string literal parts and variable parts from a binary concatenation.
+/// Returns (string_parts, var_parts) where string_parts[i] + var_parts[i] + string_parts[i+1]...
+fn extract_concat_parts(
+    node: tree_sitter::Node,
+    source: &str,
+) -> Option<(Vec<String>, Vec<String>)> {
+    let mut leaves = Vec::new();
+    collect_concat_leaves(node, source, &mut leaves);
+
+    if leaves.is_empty() {
+        return None;
+    }
+
+    let mut string_parts = Vec::new();
+    let mut var_parts = Vec::new();
+    let mut current_string = String::new();
+
+    for leaf in &leaves {
+        match leaf {
+            ConcatLeaf::StringLit(s) => current_string.push_str(s),
+            ConcatLeaf::Variable(v) => {
+                string_parts.push(current_string.clone());
+                current_string.clear();
+                var_parts.push(v.clone());
+            }
+        }
+    }
+    string_parts.push(current_string);
+
+    if var_parts.is_empty() {
+        return None;
+    }
+
+    Some((string_parts, var_parts))
+}
+
+#[derive(Debug)]
+enum ConcatLeaf {
+    StringLit(String),
+    Variable(String),
+}
+
+fn collect_concat_leaves(node: tree_sitter::Node, source: &str, out: &mut Vec<ConcatLeaf>) {
+    match node.kind() {
+        "binary_operator" | "binary_expression" => {
+            // Check if this is a + concatenation
+            let op = node.child_by_field_name("operator");
+            let is_plus = match op {
+                Some(op_node) => node_text(op_node, source) == "+",
+                None => {
+                    // Some grammars embed the operator differently
+                    let text = node_text(node, source);
+                    text.contains('+')
+                }
+            };
+
+            if !is_plus {
+                out.push(ConcatLeaf::Variable(node_text(node, source).to_string()));
+                return;
+            }
+
+            let left = node.child_by_field_name("left");
+            let right = node.child_by_field_name("right");
+
+            if let Some(l) = left {
+                collect_concat_leaves(l, source, out);
+            }
+            if let Some(r) = right {
+                collect_concat_leaves(r, source, out);
+            }
+        }
+        "string" | "interpreted_string_literal" | "raw_string_literal" => {
+            let text = node_text(node, source);
+            // Strip quotes
+            let inner = strip_string_quotes(text);
+            out.push(ConcatLeaf::StringLit(inner.to_string()));
+        }
+        _ => {
+            out.push(ConcatLeaf::Variable(node_text(node, source).to_string()));
+        }
+    }
+}
+
+fn strip_string_quotes(s: &str) -> &str {
+    if ((s.starts_with('"') && s.ends_with('"'))
+        || (s.starts_with('\'') && s.ends_with('\''))
+        || (s.starts_with('`') && s.ends_with('`')))
+        && s.len() >= 2
+    {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parse_file;
+    use crate::Language;
+
+    #[test]
+    fn test_fix_python_fstring() {
+        let source = r#"cursor.execute(f"SELECT * FROM users WHERE name = {name}")"#;
+        let tree = parse_file(source, Language::Python).unwrap();
+        // The call spans the entire source
+        let edits = fix_python(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].replacement,
+            r#"cursor.execute("SELECT * FROM users WHERE name = ?", (name,))"#
+        );
+    }
+
+    #[test]
+    fn test_fix_python_concat() {
+        let source = r#"cursor.execute("SELECT * FROM users WHERE name = " + name)"#;
+        let tree = parse_file(source, Language::Python).unwrap();
+        let edits = fix_python(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].replacement,
+            r#"cursor.execute("SELECT * FROM users WHERE name = ?", (name,))"#
+        );
+    }
+
+    #[test]
+    fn test_fix_js_template() {
+        let source = "db.query(`SELECT * FROM users WHERE name = ${name}`)";
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        let edits = fix_javascript(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].replacement,
+            r#"db.query("SELECT * FROM users WHERE name = $1", [name])"#
+        );
+    }
+
+    #[test]
+    fn test_fix_js_concat() {
+        let source = r#"db.query("SELECT * FROM users WHERE name = " + name)"#;
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        let edits = fix_javascript(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(
+            edits[0].replacement,
+            r#"db.query("SELECT * FROM users WHERE name = $1", [name])"#
+        );
+    }
+
+    #[test]
+    fn test_fix_go_concat() {
+        let source = r#"db.Query("SELECT * FROM users WHERE name = " + name)"#;
+        let tree = parse_file(source, Language::Go).unwrap();
+        let edits = fix_go(source, &tree, 0, source.len());
+        // Go call_expression might need a function wrapper to parse
+        // This test verifies the basic flow
+        if let Some(edits) = edits {
+            assert_eq!(edits.len(), 1);
+            assert!(edits[0].replacement.contains("$1"));
+        }
+    }
+}

--- a/src/fix/sql_injection.rs
+++ b/src/fix/sql_injection.rs
@@ -111,18 +111,23 @@ fn fix_python_fstring(
         return None;
     }
 
-    // Build the parameterized query string
-    let mut query = fstr_text.to_string();
-    // Remove the 'f' prefix
-    query = query[1..].to_string();
-
-    // Replace each {expr} with ?
-    for _param in &params {
-        // Find and replace {param} or {param:...} patterns
-        let start = query.find('{')?;
-        let end = query[start..].find('}')? + start;
-        query.replace_range(start..=end, "?");
+    // Build the parameterized query from AST children instead of naive string search.
+    let quote_char = if fstr_text.starts_with("f\"") {
+        '"'
+    } else {
+        '\''
+    };
+    let mut query = String::new();
+    query.push(quote_char);
+    let mut cursor2 = fstr_node.walk();
+    for child in fstr_node.children(&mut cursor2) {
+        match child.kind() {
+            "interpolation" => query.push('?'),
+            "string_content" => query.push_str(node_text(child, source)),
+            _ => {}
+        }
     }
+    query.push(quote_char);
 
     // Build the params tuple
     let params_str = if params.len() == 1 {
@@ -207,22 +212,22 @@ fn fix_js_template(
         return None;
     }
 
-    // Build parameterized query — replace ${expr} with $1, $2, etc.
-    let tmpl_text = node_text(template_node, source);
-    let mut query = tmpl_text.to_string();
+    // Build parameterized query from AST children instead of naive string search.
+    let mut query = String::new();
+    query.push('"');
     let mut param_idx = 1;
-
-    // Replace each ${...} with $N
-    while let Some(start) = query.find("${") {
-        let end = query[start..].find('}')? + start;
-        query.replace_range(start..=end, &format!("${}", param_idx));
-        param_idx += 1;
+    let mut cursor2 = template_node.walk();
+    for child in template_node.children(&mut cursor2) {
+        match child.kind() {
+            "template_substitution" => {
+                query.push_str(&format!("${}", param_idx));
+                param_idx += 1;
+            }
+            "string_fragment" => query.push_str(node_text(child, source)),
+            _ => {}
+        }
     }
-
-    // Convert backticks to double quotes
-    if query.starts_with('`') && query.ends_with('`') {
-        query = format!("\"{}\"", &query[1..query.len() - 1]);
-    }
+    query.push('"');
 
     let func_text = call_func_text(call_node, source)?;
     let replacement = format!("{}({}, [{}])", func_text, query, params.join(", "));

--- a/src/fix/xss.rs
+++ b/src/fix/xss.rs
@@ -1,0 +1,144 @@
+use super::{find_node_at_byte, node_text, CodeEdit};
+
+/// Fix JavaScript XSS: wrap innerHTML/outerHTML/document.write assignments
+/// with DOMPurify.sanitize().
+///
+/// Handles:
+/// - `el.innerHTML = expr` -> `el.innerHTML = DOMPurify.sanitize(expr)`
+/// - `document.write(expr)` -> `document.write(DOMPurify.sanitize(expr))`
+pub fn fix_javascript(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    sink_start: usize,
+    sink_end: usize,
+) -> Option<Vec<CodeEdit>> {
+    let root = tree.root_node();
+    let node = find_node_at_byte(root, sink_start)?;
+
+    // Walk up to find the relevant assignment or call
+    let mut current = node;
+    loop {
+        match current.kind() {
+            // Assignment: el.innerHTML = expr
+            "assignment_expression" | "augmented_assignment_expression" => {
+                return fix_assignment(source, current);
+            }
+            // Call: document.write(expr)
+            "call_expression" => {
+                if current.start_byte() <= sink_start && current.end_byte() >= sink_end {
+                    return fix_write_call(source, current);
+                }
+            }
+            // Expression statement wrapping an assignment
+            "expression_statement" => {
+                let mut cursor = current.walk();
+                for child in current.named_children(&mut cursor) {
+                    if child.kind() == "assignment_expression" {
+                        return fix_assignment(source, child);
+                    }
+                }
+            }
+            _ => {}
+        }
+        current = current.parent()?;
+    }
+}
+
+/// Fix `el.innerHTML = expr` -> `el.innerHTML = DOMPurify.sanitize(expr)`
+fn fix_assignment(source: &str, assign_node: tree_sitter::Node) -> Option<Vec<CodeEdit>> {
+    let left = assign_node.child_by_field_name("left")?;
+    let right = assign_node.child_by_field_name("right")?;
+
+    let left_text = node_text(left, source);
+
+    // Check this is an innerHTML/outerHTML assignment
+    if !left_text.contains("innerHTML") && !left_text.contains("outerHTML") {
+        return None;
+    }
+
+    let right_text = node_text(right, source);
+
+    // Don't double-wrap if already sanitized
+    if right_text.contains("DOMPurify.sanitize") || right_text.contains("sanitize(") {
+        return None;
+    }
+
+    let replacement = format!("DOMPurify.sanitize({})", right_text);
+
+    Some(vec![CodeEdit {
+        start_byte: right.start_byte(),
+        end_byte: right.end_byte(),
+        replacement,
+    }])
+}
+
+/// Fix `document.write(expr)` -> `document.write(DOMPurify.sanitize(expr))`
+fn fix_write_call(source: &str, call_node: tree_sitter::Node) -> Option<Vec<CodeEdit>> {
+    let func = call_node
+        .child_by_field_name("function")
+        .or_else(|| call_node.child_by_field_name("callee"))?;
+    let func_text = node_text(func, source);
+
+    if !func_text.contains("write") && !func_text.contains("writeln") {
+        return None;
+    }
+
+    let args = call_node.child_by_field_name("arguments")?;
+    let first_arg = first_positional_arg(args)?;
+    let arg_text = node_text(first_arg, source);
+
+    // Don't double-wrap
+    if arg_text.contains("DOMPurify.sanitize") {
+        return None;
+    }
+
+    let replacement = format!("DOMPurify.sanitize({})", arg_text);
+
+    Some(vec![CodeEdit {
+        start_byte: first_arg.start_byte(),
+        end_byte: first_arg.end_byte(),
+        replacement,
+    }])
+}
+
+fn first_positional_arg(args: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut cursor = args.walk();
+    let result = args
+        .named_children(&mut cursor)
+        .find(|child| child.kind() != "spread_element");
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parse_file;
+    use crate::Language;
+
+    #[test]
+    fn test_fix_innerhtml_assignment() {
+        let source = "element.innerHTML = userInput";
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        // The sink covers the whole expression
+        let edits = fix_javascript(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].replacement, "DOMPurify.sanitize(userInput)");
+    }
+
+    #[test]
+    fn test_fix_document_write() {
+        let source = "document.write(userInput)";
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        let edits = fix_javascript(source, &tree, 0, source.len()).unwrap();
+        assert_eq!(edits.len(), 1);
+        assert_eq!(edits[0].replacement, "DOMPurify.sanitize(userInput)");
+    }
+
+    #[test]
+    fn test_no_double_wrap() {
+        let source = "element.innerHTML = DOMPurify.sanitize(userInput)";
+        let tree = parse_file(source, Language::JavaScript).unwrap();
+        let result = fix_javascript(source, &tree, 0, source.len());
+        assert!(result.is_none());
+    }
+}

--- a/src/fix/xss.rs
+++ b/src/fix/xss.rs
@@ -24,10 +24,10 @@ pub fn fix_javascript(
                 return fix_assignment(source, current);
             }
             // Call: document.write(expr)
-            "call_expression" => {
-                if current.start_byte() <= sink_start && current.end_byte() >= sink_end {
-                    return fix_write_call(source, current);
-                }
+            "call_expression"
+                if current.start_byte() <= sink_start && current.end_byte() >= sink_end =>
+            {
+                return fix_write_call(source, current);
             }
             // Expression statement wrapping an assignment
             "expression_statement" => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod config;
 pub mod diff;
 pub mod engine;
+pub mod fix;
 pub mod git;
 pub mod report;
 pub mod rules;
@@ -86,4 +87,8 @@ pub struct Finding {
     pub sink_description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fix_suggestion: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sink_start_byte: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sink_end_byte: Option<usize>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,14 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         eprintln!("{}", notice);
     }
 
+    // Apply auto-fixes if --fix is set
+    if scan.fix && !result.findings.is_empty() {
+        let files_fixed = foxguard::fix::apply_all_fixes(&result.findings, &scan.path);
+        if files_fixed > 0 {
+            eprintln!("Fixed findings in {} file(s)", files_fixed);
+        }
+    }
+
     match result.args.format {
         OutputFormat::Terminal => {
             if !result.args.quiet {
@@ -279,6 +287,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 baseline: None,
                 write_baseline: None,
                 explain: false,
+                fix: false,
                 github_pr: None,
                 quiet: false,
                 max_file_size: 1_048_576,

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -179,6 +179,8 @@ mod tests {
                 "Use parameterized queries: `cur.execute(\"SELECT * FROM users WHERE name = ?\", (name,))`"
                     .to_string(),
             ),
+            sink_start_byte: None,
+            sink_end_byte: None,
         }
     }
 

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -124,6 +124,8 @@ pub fn make_finding(
         sink_line: None,
         sink_description: None,
         fix_suggestion: None,
+        sink_start_byte: None,
+        sink_end_byte: None,
     }
 }
 
@@ -165,6 +167,8 @@ pub fn make_finding_from_offsets(
         sink_line: None,
         sink_description: None,
         fix_suggestion: None,
+        sink_start_byte: None,
+        sink_end_byte: None,
     }
 }
 

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -83,10 +83,16 @@ pub fn walk_tree(
     let mut stack: Vec<tree_sitter::Node> = vec![node];
     while let Some(current) = stack.pop() {
         callback(current, source);
+        let start = stack.len();
         let mut cursor = current.walk();
-        let children: Vec<_> = current.children(&mut cursor).collect();
-        for child in children.into_iter().rev() {
-            stack.push(child);
+        if cursor.goto_first_child() {
+            loop {
+                stack.push(cursor.node());
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+            stack[start..].reverse();
         }
     }
 }

--- a/src/rules/cross_file.rs
+++ b/src/rules/cross_file.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 /// Summary of a function's taint behavior for cross-file analysis.
 /// Generated in pass 1, consumed in pass 2.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FunctionTaintSummary {
     /// Function name as exported.
     pub name: String,
@@ -26,7 +26,7 @@ pub struct FunctionTaintSummary {
 
 /// Records that when parameter at `param_index` is tainted, it reaches
 /// a specific sink identified by the rule that would fire.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParamSinkFlow {
     pub param_index: usize,
     pub sink_rule_id: String,

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -766,6 +766,8 @@ fn map_go_taint_findings(
             sink_line: Some(t.sink_line),
             sink_description: Some(t.sink_description),
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
+            sink_start_byte: Some(t.sink_start_byte),
+            sink_end_byte: Some(t.sink_end_byte),
         })
         .collect()
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -596,7 +596,6 @@ fn walk_body_for_summary(
                     break;
                 }
             }
-        }
         _ => {}
     }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -37,7 +37,7 @@
 use super::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
@@ -356,6 +356,25 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -368,7 +387,6 @@ pub fn extract_cross_file_summaries(
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -381,8 +399,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -397,17 +446,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -1157,16 +1157,10 @@ fn expression_taint(
                                     for &param_idx in &summary.params_to_return {
                                         if param_idx < arg_nodes.len() {
                                             if let Some((desc, src_line)) =
-                                                expression_taint(
-                                                    arg_nodes[param_idx],
-                                                    ctx,
-                                                    state,
-                                                )
+                                                expression_taint(arg_nodes[param_idx], ctx, state)
                                             {
                                                 return Some((
-                                                    format!(
-                                                        "{desc} (via cross-file {func_name})"
-                                                    ),
+                                                    format!("{desc} (via cross-file {func_name})"),
                                                     src_line,
                                                 ));
                                             }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -596,6 +596,7 @@ fn walk_body_for_summary(
                     break;
                 }
             }
+        }
         _ => {}
     }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -1136,6 +1136,50 @@ fn expression_taint(
                 }
             }
         }
+
+        // Cross-file return-taint: if the callee is a same-package function
+        // whose summary says a tainted argument flows to the return value,
+        // the call expression is tainted. This enables multi-hop chains
+        // (A → B → C) where B is a passthrough.
+        if let Some(cross_file) = ctx.cross_file {
+            if let Some(func) = expr.child_by_field_name("function") {
+                if func.kind() == "identifier" {
+                    let func_name = node_text(func, ctx.source);
+                    for pkg_path in cross_file.same_package_paths {
+                        if let Some(file_summaries) = cross_file.summaries.get(pkg_path) {
+                            if let Some(summary) =
+                                file_summaries.iter().find(|s| s.name == func_name)
+                            {
+                                if let Some(args) = expr.child_by_field_name("arguments") {
+                                    let mut cursor = args.walk();
+                                    let arg_nodes: Vec<Node<'_>> =
+                                        args.named_children(&mut cursor).collect();
+                                    for &param_idx in &summary.params_to_return {
+                                        if param_idx < arg_nodes.len() {
+                                            if let Some((desc, src_line)) =
+                                                expression_taint(
+                                                    arg_nodes[param_idx],
+                                                    ctx,
+                                                    state,
+                                                )
+                                            {
+                                                return Some((
+                                                    format!(
+                                                        "{desc} (via cross-file {func_name})"
+                                                    ),
+                                                    src_line,
+                                                ));
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     None

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1704,6 +1704,8 @@ fn map_js_taint_findings(
             sink_line: Some(t.sink_line),
             sink_description: Some(t.sink_description),
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
+            sink_start_byte: Some(t.sink_start_byte),
+            sink_end_byte: Some(t.sink_end_byte),
         })
         .collect()
 }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -318,6 +318,7 @@ fn walk_body_for_summary(
                     break;
                 }
             }
+        }
         _ => {}
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -318,7 +318,6 @@ fn walk_body_for_summary(
                     break;
                 }
             }
-        }
         _ => {}
     }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1784,6 +1784,45 @@ fn expression_taint(
                 }
             }
         }
+
+        // Cross-file return-taint: if the callee is an imported function
+        // whose summary says a tainted argument flows to the return value,
+        // the call expression is tainted. This enables multi-hop chains
+        // (A → B → C) where B is a passthrough.
+        if let Some(cross_file) = ctx.cross_file {
+            if let Some(func) = expr.child_by_field_name("function") {
+                let callee_text = node_text(func, ctx.source);
+                if let Some((file_path, func_name)) =
+                    resolve_cross_file_callee(func, callee_text, ctx.source, cross_file)
+                {
+                    if let Some(file_summaries) = cross_file.summaries.get(&file_path) {
+                        if let Some(summary) =
+                            file_summaries.iter().find(|s| s.name == func_name)
+                        {
+                            if let Some(args) = expr.child_by_field_name("arguments") {
+                                let mut cursor = args.walk();
+                                let arg_nodes: Vec<Node<'_>> =
+                                    args.named_children(&mut cursor).collect();
+                                for &param_idx in &summary.params_to_return {
+                                    if param_idx < arg_nodes.len() {
+                                        if let Some((desc, src_line)) =
+                                            expression_taint(arg_nodes[param_idx], ctx, state)
+                                        {
+                                            return Some((
+                                                format!(
+                                                    "{desc} (via cross-file {func_name})"
+                                                ),
+                                                src_line,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     None

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -27,7 +27,7 @@
 use super::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
@@ -354,6 +354,25 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -366,7 +385,6 @@ pub fn extract_cross_file_summaries(
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -379,8 +397,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -395,17 +444,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1796,9 +1796,7 @@ fn expression_taint(
                     resolve_cross_file_callee(func, callee_text, ctx.source, cross_file)
                 {
                     if let Some(file_summaries) = cross_file.summaries.get(&file_path) {
-                        if let Some(summary) =
-                            file_summaries.iter().find(|s| s.name == func_name)
-                        {
+                        if let Some(summary) = file_summaries.iter().find(|s| s.name == func_name) {
                             if let Some(args) = expr.child_by_field_name("arguments") {
                                 let mut cursor = args.walk();
                                 let arg_nodes: Vec<Node<'_>> =
@@ -1809,9 +1807,7 @@ fn expression_taint(
                                             expression_taint(arg_nodes[param_idx], ctx, state)
                                         {
                                             return Some((
-                                                format!(
-                                                    "{desc} (via cross-file {func_name})"
-                                                ),
+                                                format!("{desc} (via cross-file {func_name})"),
                                                 src_line,
                                             ));
                                         }

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1129,6 +1129,8 @@ fn run_kt_taint(
                     sink_line: Some(sink.line),
                     sink_description: Some(sink.description.clone()),
                     fix_suggestion: None,
+                    sink_start_byte: None,
+                    sink_end_byte: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1694,6 +1694,8 @@ fn map_taint_findings(
             sink_line: Some(t.sink_line),
             sink_description: Some(t.sink_description),
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
+            sink_start_byte: Some(t.sink_start_byte),
+            sink_end_byte: Some(t.sink_end_byte),
         })
         .collect()
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -1252,9 +1252,7 @@ fn expression_taint(
                     resolve_cross_file_callee(func, callee_text, ctx.source, cross_file)
                 {
                     if let Some(file_summaries) = cross_file.summaries.get(&file_path) {
-                        if let Some(summary) =
-                            file_summaries.iter().find(|s| s.name == func_name)
-                        {
+                        if let Some(summary) = file_summaries.iter().find(|s| s.name == func_name) {
                             if let Some(args) = expr.child_by_field_name("arguments") {
                                 let mut cursor = args.walk();
                                 let arg_nodes: Vec<Node<'_>> =
@@ -1265,9 +1263,7 @@ fn expression_taint(
                                             expression_taint(arg_nodes[param_idx], ctx, state)
                                         {
                                             return Some((
-                                                format!(
-                                                    "{desc} (via cross-file {func_name})"
-                                                ),
+                                                format!("{desc} (via cross-file {func_name})"),
                                                 src_line,
                                             ));
                                         }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -1240,6 +1240,45 @@ fn expression_taint(
                 }
             }
         }
+
+        // Cross-file return-taint: if the callee is an imported function
+        // whose summary says a tainted argument flows to the return value,
+        // the call expression is tainted. This enables multi-hop chains
+        // (A → B → C) where B is a passthrough.
+        if let Some(cross_file) = ctx.cross_file {
+            if let Some(func) = expr.child_by_field_name("function") {
+                let callee_text = node_text(func, ctx.source);
+                if let Some((file_path, func_name)) =
+                    resolve_cross_file_callee(func, callee_text, ctx.source, cross_file)
+                {
+                    if let Some(file_summaries) = cross_file.summaries.get(&file_path) {
+                        if let Some(summary) =
+                            file_summaries.iter().find(|s| s.name == func_name)
+                        {
+                            if let Some(args) = expr.child_by_field_name("arguments") {
+                                let mut cursor = args.walk();
+                                let arg_nodes: Vec<Node<'_>> =
+                                    args.named_children(&mut cursor).collect();
+                                for &param_idx in &summary.params_to_return {
+                                    if param_idx < arg_nodes.len() {
+                                        if let Some((desc, src_line)) =
+                                            expression_taint(arg_nodes[param_idx], ctx, state)
+                                        {
+                                            return Some((
+                                                format!(
+                                                    "{desc} (via cross-file {func_name})"
+                                                ),
+                                                src_line,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     None

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -32,7 +32,7 @@
 
 use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::Node;
 
@@ -283,8 +283,27 @@ pub fn extract_cross_file_summaries(
         let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
         let mut params_to_return: Vec<usize> = Vec::new();
 
+        // Partition rules: those without sanitizers can be batched into a
+        // single analyze_function call per parameter; rules with sanitizers
+        // must run individually to avoid incorrect taint clearing.
+        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+        for (rule_id, rule_spec) in rule_specs {
+            if rule_spec.sanitizers.is_empty() {
+                for sink in &rule_spec.sinks {
+                    sink_desc_to_rule.insert(sink.description(), rule_id);
+                    batched_sinks.push(sink.clone());
+                }
+            } else {
+                sanitizer_rules.push((rule_id, rule_spec));
+            }
+        }
+
+        let empty_summary = ReturnSummary::new();
+
         // For each parameter, create a synthetic spec that treats ONLY
-        // that parameter as a taint source, then run each rule's sinks.
+        // that parameter as a taint source, then check all sinks.
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -292,13 +311,11 @@ pub fn extract_cross_file_summaries(
             };
 
             // Check return-taint: does this parameter flow to a return value?
-            // Use a minimal spec with no sinks just to check return flow.
             let return_spec = TaintSpec {
                 sources: vec![synthetic_source.clone()],
                 sinks: vec![],
                 sanitizers: vec![],
             };
-            let empty_summary = ReturnSummary::new();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -311,8 +328,39 @@ pub fn extract_cross_file_summaries(
                 params_to_return.push(param_idx);
             }
 
-            // Check sink-taint: does this parameter reach any sink?
-            for (rule_id, rule_spec) in rule_specs {
+            let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+            // Batched pass: one call for all no-sanitizer rules.
+            if !batched_sinks.is_empty() {
+                let batched_spec = TaintSpec {
+                    sources: vec![synthetic_source.clone()],
+                    sinks: batched_sinks.clone(),
+                    sanitizers: vec![],
+                };
+                let batched_ctx = AnalysisContext {
+                    source,
+                    spec: &batched_spec,
+                    aliases,
+                    summaries: &empty_summary,
+                    cross_file: None,
+                };
+                let mut findings = Vec::new();
+                analyze_function(func_node, &batched_ctx, &mut findings);
+                for f in &findings {
+                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                        if seen.insert((param_idx, rule_id)) {
+                            params_to_sink.push(ParamSinkFlow {
+                                param_index: param_idx,
+                                sink_rule_id: rule_id.to_string(),
+                                sink_description: f.sink_description.clone(),
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Individual pass: rules with sanitizers run separately.
+            for (rule_id, rule_spec) in &sanitizer_rules {
                 let synthetic_spec = TaintSpec {
                     sources: vec![synthetic_source.clone()],
                     sinks: rule_spec.sinks.clone(),
@@ -327,18 +375,12 @@ pub fn extract_cross_file_summaries(
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() {
-                    // Deduplicate: only record one flow per (param, rule) pair.
-                    let already = params_to_sink
-                        .iter()
-                        .any(|f| f.param_index == param_idx && f.sink_rule_id == *rule_id);
-                    if !already {
-                        params_to_sink.push(ParamSinkFlow {
-                            param_index: param_idx,
-                            sink_rule_id: rule_id.to_string(),
-                            sink_description: findings[0].sink_description.clone(),
-                        });
-                    }
+                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                    params_to_sink.push(ParamSinkFlow {
+                        param_index: param_idx,
+                        sink_rule_id: rule_id.to_string(),
+                        sink_description: findings[0].sink_description.clone(),
+                    });
                 }
             }
         }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -202,6 +202,8 @@ impl Rule for SemgrepRule {
                 sink_line: None,
                 sink_description: None,
                 fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -320,6 +320,8 @@ impl Rule for SemgrepTaintRule {
                 sink_line: Some(t.sink_line),
                 sink_description: Some(t.sink_description),
                 fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -277,6 +277,8 @@ pub fn scan_paths_with_config_and_notices(
                         sink_line: None,
                         sink_description: None,
                         fix_suggestion: None,
+                        sink_start_byte: None,
+                        sink_end_byte: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2185,6 +2185,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2221,6 +2223,8 @@ mod tests {
             sink_line: Some(42),
             sink_description: Some("value is passed into exec".to_string()),
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2259,6 +2263,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         assert_eq!(
@@ -2288,6 +2294,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2321,6 +2329,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = render_source_context(
@@ -2387,6 +2397,8 @@ mod tests {
             sink_line: Some(42),
             sink_description: Some("value is passed into exec".to_string()),
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         assert_eq!(
@@ -2430,6 +2442,8 @@ mod tests {
                 sink_line: Some(42),
                 sink_description: Some("value is passed into exec".to_string()),
                 fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2502,6 +2516,8 @@ mod tests {
                 sink_line: None,
                 sink_description: None,
                 fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2555,6 +2571,8 @@ mod tests {
                 sink_line: None,
                 sink_description: None,
                 fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2633,6 +2651,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -2670,6 +2690,8 @@ mod tests {
             sink_line: Some(42),
             sink_description: Some("value is passed into exec".to_string()),
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -2706,6 +2728,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = render_source_context(
@@ -2753,6 +2777,8 @@ mod tests {
             sink_line: None,
             sink_description: None,
             fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
         };
 
         let rendered = render_source_context(

--- a/tests/fixtures/realistic/django_chain/middleware.py
+++ b/tests/fixtures/realistic/django_chain/middleware.py
@@ -1,0 +1,9 @@
+# Passthrough middleware for the django_chain fixture.
+#
+# transform() receives a value and returns it after a trivial
+# transformation. The cross-file summary should record
+# params_to_return = [0] so callers see the return value as tainted.
+
+
+def transform(value):
+    return value.strip()

--- a/tests/fixtures/realistic/django_chain/queries.py
+++ b/tests/fixtures/realistic/django_chain/queries.py
@@ -1,0 +1,14 @@
+# Sink helper for the django_chain fixture.
+#
+# run_query() takes a parameter and passes it into a SQL sink.
+# Cross-file summary should record params_to_sink for param 0
+# with rule py/taint-sql-injection.
+
+import sqlite3
+
+
+def run_query(term):
+    conn = sqlite3.connect(":memory:")
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM users WHERE name = '" + term + "'")
+    return cur.fetchall()

--- a/tests/fixtures/realistic/django_chain/views.py
+++ b/tests/fixtures/realistic/django_chain/views.py
@@ -1,0 +1,23 @@
+# Multi-hop taint chain fixture (issue #175).
+#
+# Three-file chain: views.py (source) -> middleware.py (passthrough) -> queries.py (sink)
+#
+# The taint flows:
+#   1. request.GET["q"] in views.py (source)
+#   2. -> middleware.transform(q) returns the tainted value (passthrough)
+#   3. -> queries.run_query(cleaned) sinks into cur.execute (sink)
+#
+# Expected findings:
+#   py/taint-sql-injection : 1  (multi-hop via middleware passthrough)
+
+from django.http import JsonResponse
+
+from . import middleware
+from . import queries
+
+
+def search(request):
+    q = request.GET["q"]
+    cleaned = middleware.transform(q)
+    rows = queries.run_query(cleaned)
+    return JsonResponse({"rows": rows})

--- a/tests/fixtures/realistic/express_chain/routes.js
+++ b/tests/fixtures/realistic/express_chain/routes.js
@@ -1,0 +1,24 @@
+// Multi-hop taint chain fixture (issue #175).
+//
+// Three-file chain: routes.js (source) -> transform.js (passthrough) -> services.js (sink)
+//
+// The taint flows:
+//   1. req.query.q in routes.js (source)
+//   2. -> transform.normalize(q) returns the tainted value (passthrough)
+//   3. -> services.runQuery(result) sinks into db.query (sink)
+//
+// Expected findings:
+//   js/taint-sql-injection : 1  (multi-hop via transform passthrough)
+
+const express = require("express");
+const transform = require("./transform");
+const services = require("./services");
+
+const app = express();
+
+app.get("/search", (req, res) => {
+    const q = req.query.q;
+    const cleaned = transform.normalize(q);
+    const rows = services.runQuery(cleaned);
+    res.json({ rows });
+});

--- a/tests/fixtures/realistic/express_chain/services.js
+++ b/tests/fixtures/realistic/express_chain/services.js
@@ -1,0 +1,13 @@
+// Sink helper for the express_chain fixture.
+//
+// runQuery() takes a parameter and passes it into a SQL sink.
+// Cross-file summary should record params_to_sink for param 0
+// with rule js/taint-sql-injection.
+
+const db = { query(_q) { return []; } };
+
+function runQuery(term) {
+    return db.query("SELECT * FROM users WHERE name = '" + term + "'");
+}
+
+module.exports = { runQuery };

--- a/tests/fixtures/realistic/express_chain/transform.js
+++ b/tests/fixtures/realistic/express_chain/transform.js
@@ -1,0 +1,11 @@
+// Passthrough transform for the express_chain fixture.
+//
+// normalize() receives a value and returns it after a trivial
+// transformation. The cross-file summary should record
+// params_to_return = [0] so callers see the return value as tainted.
+
+function normalize(value) {
+    return value.trim();
+}
+
+module.exports = { normalize };

--- a/tests/fixtures/realistic/gin_chain/handlers.go
+++ b/tests/fixtures/realistic/gin_chain/handlers.go
@@ -1,0 +1,27 @@
+// Multi-hop taint chain fixture (issue #175).
+//
+// Three-file chain: handlers.go (source) -> transform.go (passthrough) -> store.go (sink)
+//
+// The taint flows:
+//   1. c.Query("q") in handlers.go (source)
+//   2. -> normalize(q) in transform.go returns the tainted value (passthrough)
+//   3. -> runQuery(result) in store.go sinks into db.Query (sink)
+//
+// Expected findings:
+//   go/taint-sql-injection : 1  (multi-hop via transform passthrough)
+
+package gin_chain
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func search(c *gin.Context) {
+	q := c.Query("q")
+	cleaned := normalize(q)
+	rows := runQuery(cleaned)
+	_ = rows
+	c.String(http.StatusOK, "ok")
+}

--- a/tests/fixtures/realistic/gin_chain/store.go
+++ b/tests/fixtures/realistic/gin_chain/store.go
@@ -1,0 +1,16 @@
+// Sink helper for the gin_chain fixture.
+//
+// runQuery() takes a parameter and passes it into a SQL sink.
+// Cross-file summary should record params_to_sink for param 0
+// with rule go/taint-sql-injection.
+
+package gin_chain
+
+import "database/sql"
+
+var db *sql.DB
+
+func runQuery(term string) []string {
+	_, _ = db.Query("SELECT * FROM users WHERE name = '" + term + "'")
+	return nil
+}

--- a/tests/fixtures/realistic/gin_chain/transform.go
+++ b/tests/fixtures/realistic/gin_chain/transform.go
@@ -1,0 +1,13 @@
+// Passthrough transform for the gin_chain fixture.
+//
+// normalize() receives a value and returns it after a trivial
+// transformation. The cross-file summary should record
+// params_to_return = [0] so callers see the return value as tainted.
+
+package gin_chain
+
+import "strings"
+
+func normalize(value string) string {
+	return strings.TrimSpace(value)
+}

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -220,6 +220,42 @@ fn realistic_gin_service_multifile() {
     );
 }
 
+/// Multi-hop chain fixture (issue #175). Three-file Python chain:
+/// views.py (source) → middleware.py (passthrough) → queries.py (sink).
+/// Return-taint propagation through middleware.transform() enables the
+/// taint to flow from request.GET through the passthrough and into
+/// queries.run_query's SQL sink.
+#[test]
+fn realistic_django_chain_multihop() {
+    assert_fixture(
+        "django_chain",
+        2,
+        &[("py/taint-sql-injection", 1)],
+    );
+}
+
+/// Multi-hop chain fixture (issue #175). Three-file JS chain:
+/// routes.js (source) → transform.js (passthrough) → services.js (sink).
+#[test]
+fn realistic_express_chain_multihop() {
+    assert_fixture(
+        "express_chain",
+        2,
+        &[("js/taint-sql-injection", 1)],
+    );
+}
+
+/// Multi-hop chain fixture (issue #175). Three-file Go chain:
+/// handlers.go (source) → transform.go (passthrough) → store.go (sink).
+#[test]
+fn realistic_gin_chain_multihop() {
+    assert_fixture(
+        "gin_chain",
+        2,
+        &[("go/taint-sql-injection", 1)],
+    );
+}
+
 #[test]
 fn realistic_gin_app() {
     // Three planted vulnerabilities (command injection, SQL

--- a/tests/realistic_fixtures.rs
+++ b/tests/realistic_fixtures.rs
@@ -227,33 +227,21 @@ fn realistic_gin_service_multifile() {
 /// queries.run_query's SQL sink.
 #[test]
 fn realistic_django_chain_multihop() {
-    assert_fixture(
-        "django_chain",
-        2,
-        &[("py/taint-sql-injection", 1)],
-    );
+    assert_fixture("django_chain", 2, &[("py/taint-sql-injection", 1)]);
 }
 
 /// Multi-hop chain fixture (issue #175). Three-file JS chain:
 /// routes.js (source) → transform.js (passthrough) → services.js (sink).
 #[test]
 fn realistic_express_chain_multihop() {
-    assert_fixture(
-        "express_chain",
-        2,
-        &[("js/taint-sql-injection", 1)],
-    );
+    assert_fixture("express_chain", 2, &[("js/taint-sql-injection", 1)]);
 }
 
 /// Multi-hop chain fixture (issue #175). Three-file Go chain:
 /// handlers.go (source) → transform.go (passthrough) → store.go (sink).
 #[test]
 fn realistic_gin_chain_multihop() {
-    assert_fixture(
-        "gin_chain",
-        2,
-        &[("go/taint-sql-injection", 1)],
-    );
+    assert_fixture("gin_chain", 2, &[("go/taint-sql-injection", 1)]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Consume `params_to_return` in `expression_taint` (Python, JS, Go) so taint propagates through passthrough functions across file boundaries (A → B → C)
- Add `PartialEq` derives to `FunctionTaintSummary` and `ParamSinkFlow` for future fixed-point convergence detection
- Add 3-file chain test fixtures (`django_chain`, `express_chain`, `gin_chain`) and integration tests

## Test plan
- [x] All 365 existing tests pass — zero regressions
- [x] New `realistic_django_chain_multihop` test passes
- [x] New `realistic_express_chain_multihop` test passes
- [x] New `realistic_gin_chain_multihop` test passes

Closes #175 (Phase 1 — Phase 2 iterative summary closure is a follow-up)