### PR TITLE
perf: hoist TaintSpec construction out of per-param loop

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -646,20 +646,18 @@ fn scan_files(
 
     let has_cross_file = !cross_file_summaries.is_empty();
 
-    let canonical_path_lookup: HashMap<PathBuf, PathBuf> = prepared_files
-        .iter()
-        .flat_map(|(path, prepared)| {
-            let canonical = prepared.canonical_path.clone();
-            let mut entries = vec![
-                (path.clone(), canonical.clone()),
-                (canonical.clone(), canonical),
-            ];
+    let canonical_path_lookup: HashMap<PathBuf, PathBuf> = {
+        let mut lookup = HashMap::with_capacity(prepared_files.len() * 3);
+        for (path, prepared) in &prepared_files {
+            let canonical = &prepared.canonical_path;
+            lookup.insert(path.clone(), canonical.clone());
+            lookup.insert(canonical.clone(), canonical.clone());
             if path.is_relative() {
-                entries.push((scan_root.join(path), prepared.canonical_path.clone()));
+                lookup.insert(scan_root.join(path), canonical.clone());
             }
-            entries
-        })
-        .collect();
+        }
+        lookup
+    };
 
     // Build a directory→files index for Go same-package resolution.
     // All .go files in the same directory share the same package.

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -375,6 +375,33 @@ pub fn extract_cross_file_summaries(
 
         let empty_summary = ReturnSummary::new();
 
+        // Pre-build reusable specs outside the per-param loop. Only the
+        // `sources` field changes per parameter; sinks and sanitizers are
+        // constant. This avoids cloning the entire sink/sanitizer vecs on
+        // every iteration.
+        let placeholder_source = NodeMatcher::ParamName {
+            names: vec![],
+            description: String::new(),
+        };
+        let mut return_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: vec![],
+            sanitizers: vec![],
+        };
+        let mut batched_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: batched_sinks,
+            sanitizers: vec![],
+        };
+        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
+            .iter()
+            .map(|(_, rule_spec)| TaintSpec {
+                sources: vec![placeholder_source.clone()],
+                sinks: rule_spec.sinks.clone(),
+                sanitizers: rule_spec.sanitizers.clone(),
+            })
+            .collect();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -382,11 +409,7 @@ pub fn extract_cross_file_summaries(
             };
 
             // Check return-taint: does this parameter flow to a return value?
-            let return_spec = TaintSpec {
-                sources: vec![synthetic_source.clone()],
-                sinks: vec![],
-                sanitizers: vec![],
-            };
+            return_spec.sources[0] = synthetic_source.clone();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -402,12 +425,8 @@ pub fn extract_cross_file_summaries(
             let mut seen: HashSet<(usize, &str)> = HashSet::new();
 
             // Batched pass: one call for all no-sanitizer rules.
-            if !batched_sinks.is_empty() {
-                let batched_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: batched_sinks.clone(),
-                    sanitizers: vec![],
-                };
+            if !batched_spec.sinks.is_empty() {
+                batched_spec.sources[0] = synthetic_source.clone();
                 let batched_ctx = AnalysisContext {
                     source,
                     spec: &batched_spec,
@@ -431,15 +450,11 @@ pub fn extract_cross_file_summaries(
             }
 
             // Individual pass: rules with sanitizers run separately.
-            for (rule_id, rule_spec) in &sanitizer_rules {
-                let synthetic_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: rule_spec.sinks.clone(),
-                    sanitizers: rule_spec.sanitizers.clone(),
-                };
+            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
+                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
                 let sink_ctx = AnalysisContext {
                     source,
-                    spec: &synthetic_spec,
+                    spec: &sanitizer_specs[idx],
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -373,6 +373,33 @@ pub fn extract_cross_file_summaries(
 
         let empty_summary = ReturnSummary::new();
 
+        // Pre-build reusable specs outside the per-param loop. Only the
+        // `sources` field changes per parameter; sinks and sanitizers are
+        // constant. This avoids cloning the entire sink/sanitizer vecs on
+        // every iteration.
+        let placeholder_source = NodeMatcher::ParamName {
+            names: vec![],
+            description: String::new(),
+        };
+        let mut return_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: vec![],
+            sanitizers: vec![],
+        };
+        let mut batched_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: batched_sinks,
+            sanitizers: vec![],
+        };
+        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
+            .iter()
+            .map(|(_, rule_spec)| TaintSpec {
+                sources: vec![placeholder_source.clone()],
+                sinks: rule_spec.sinks.clone(),
+                sanitizers: rule_spec.sanitizers.clone(),
+            })
+            .collect();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -380,11 +407,7 @@ pub fn extract_cross_file_summaries(
             };
 
             // Check return-taint: does this parameter flow to a return value?
-            let return_spec = TaintSpec {
-                sources: vec![synthetic_source.clone()],
-                sinks: vec![],
-                sanitizers: vec![],
-            };
+            return_spec.sources[0] = synthetic_source.clone();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -400,12 +423,8 @@ pub fn extract_cross_file_summaries(
             let mut seen: HashSet<(usize, &str)> = HashSet::new();
 
             // Batched pass: one call for all no-sanitizer rules.
-            if !batched_sinks.is_empty() {
-                let batched_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: batched_sinks.clone(),
-                    sanitizers: vec![],
-                };
+            if !batched_spec.sinks.is_empty() {
+                batched_spec.sources[0] = synthetic_source.clone();
                 let batched_ctx = AnalysisContext {
                     source,
                     spec: &batched_spec,
@@ -429,15 +448,11 @@ pub fn extract_cross_file_summaries(
             }
 
             // Individual pass: rules with sanitizers run separately.
-            for (rule_id, rule_spec) in &sanitizer_rules {
-                let synthetic_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: rule_spec.sinks.clone(),
-                    sanitizers: rule_spec.sanitizers.clone(),
-                };
+            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
+                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
                 let sink_ctx = AnalysisContext {
                     source,
-                    spec: &synthetic_spec,
+                    spec: &sanitizer_specs[idx],
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -302,8 +302,33 @@ pub fn extract_cross_file_summaries(
 
         let empty_summary = ReturnSummary::new();
 
-        // For each parameter, create a synthetic spec that treats ONLY
-        // that parameter as a taint source, then check all sinks.
+        // Pre-build reusable specs outside the per-param loop. Only the
+        // `sources` field changes per parameter; sinks and sanitizers are
+        // constant. This avoids cloning the entire sink/sanitizer vecs on
+        // every iteration.
+        let placeholder_source = NodeMatcher::ParamName {
+            names: vec![],
+            description: String::new(),
+        };
+        let mut return_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: vec![],
+            sanitizers: vec![],
+        };
+        let mut batched_spec = TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: batched_sinks,
+            sanitizers: vec![],
+        };
+        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
+            .iter()
+            .map(|(_, rule_spec)| TaintSpec {
+                sources: vec![placeholder_source.clone()],
+                sinks: rule_spec.sinks.clone(),
+                sanitizers: rule_spec.sanitizers.clone(),
+            })
+            .collect();
+
         for (param_idx, param_name) in param_names.iter().enumerate() {
             let synthetic_source = NodeMatcher::ParamName {
                 names: vec![param_name.clone()],
@@ -311,11 +336,7 @@ pub fn extract_cross_file_summaries(
             };
 
             // Check return-taint: does this parameter flow to a return value?
-            let return_spec = TaintSpec {
-                sources: vec![synthetic_source.clone()],
-                sinks: vec![],
-                sanitizers: vec![],
-            };
+            return_spec.sources[0] = synthetic_source.clone();
             let return_ctx = AnalysisContext {
                 source,
                 spec: &return_spec,
@@ -331,12 +352,8 @@ pub fn extract_cross_file_summaries(
             let mut seen: HashSet<(usize, &str)> = HashSet::new();
 
             // Batched pass: one call for all no-sanitizer rules.
-            if !batched_sinks.is_empty() {
-                let batched_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: batched_sinks.clone(),
-                    sanitizers: vec![],
-                };
+            if !batched_spec.sinks.is_empty() {
+                batched_spec.sources[0] = synthetic_source.clone();
                 let batched_ctx = AnalysisContext {
                     source,
                     spec: &batched_spec,
@@ -360,15 +377,11 @@ pub fn extract_cross_file_summaries(
             }
 
             // Individual pass: rules with sanitizers run separately.
-            for (rule_id, rule_spec) in &sanitizer_rules {
-                let synthetic_spec = TaintSpec {
-                    sources: vec![synthetic_source.clone()],
-                    sinks: rule_spec.sinks.clone(),
-                    sanitizers: rule_spec.sanitizers.clone(),
-                };
+            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
+                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
                 let sink_ctx = AnalysisContext {
                     source,
-                    spec: &synthetic_spec,
+                    spec: &sanitizer_specs[idx],
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,


### PR DESCRIPTION
## Summary
- Pre-build batched and sanitizer `TaintSpec` structs once per function instead of cloning sinks/sanitizers for every parameter in `extract_cross_file_summaries`
- Only swap the `sources[0]` field per iteration, avoiding `O(params × sinks)` allocations
- Simplify `canonical_path_lookup` construction to avoid redundant intermediate `Vec` and extra clones
- Applied consistently across all three taint engines (JS, Python, Go)

Addresses #174.

## Test plan
- [x] `cargo test` — all unit + integration tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt` — clean