### PR TITLE
feat: add TUI showcase section and bump terminal demo version

### DIFF
--- a/www/src/components/sections/TriageShowcase.astro
+++ b/www/src/components/sections/TriageShowcase.astro
@@ -1,0 +1,43 @@
+---
+---
+
+<section class="py-24" id="tui">
+  <div class="max-w-5xl mx-auto px-6">
+
+    <h2 class="font-heading text-noir-50 text-3xl sm:text-4xl mb-4">Triage without leaving the terminal</h2>
+    <p class="text-noir-500 text-base mb-2">
+      <code class="text-noir-400">foxguard tui .</code> opens an interactive view over scan, diff, and secrets modes.
+    </p>
+    <p class="text-noir-500 text-base mb-12">
+      Browse findings, read full dataflow traces, and mark false positives or fixes in place &mdash; no context switching.
+    </p>
+
+    <!-- Screenshot -->
+    <div class="rounded-xl overflow-hidden border border-noir-800 bg-noir-950 mb-8">
+      <img
+        src="/tui/findings.png"
+        alt="foxguard TUI showing the findings list on the left and the full dataflow detail for a selected SQL injection on the right"
+        class="block w-full h-auto"
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
+
+    <!-- Copy command -->
+    <div class="flex items-center gap-3">
+      <code class="flex-1 bg-noir-950 border border-noir-800 rounded-lg px-4 py-3 font-mono text-sm text-noir-300">
+        <span class="text-noir-600">$</span> npx foxguard tui .
+      </code>
+      <button
+        type="button"
+        class="copy-btn rounded-lg border border-noir-700 px-4 py-3 text-sm text-noir-300 hover:border-noir-600 hover:text-noir-100 transition-colors"
+        data-copy="npx foxguard tui ."
+        aria-label="Copy command"
+      >
+        <span class="copy-icon">copy</span>
+        <span class="check-icon hidden">copied!</span>
+      </button>
+    </div>
+
+  </div>
+</section>

--- a/www/src/components/ui/TerminalDemo.astro
+++ b/www/src/components/ui/TerminalDemo.astro
@@ -15,7 +15,7 @@
   <div class="p-4 sm:p-5 font-mono text-[11px] sm:text-[12px] leading-[1.72] text-left">
     <div class="mb-4">
       <span class="text-fox-light font-bold">foxguard</span>
-      <span class="text-noir-600"> v0.6.3</span>
+      <span class="text-noir-600"> v0.7.0</span>
     </div>
 
     <div class="mb-1">

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -5,6 +5,7 @@ import InstallTabs from '../components/ui/InstallTabs.astro';
 import Hero from '../components/sections/Hero.astro';
 import WhatItCatches from '../components/sections/WhatItCatches.astro';
 import Speed from '../components/sections/Speed.astro';
+import TriageShowcase from '../components/sections/TriageShowcase.astro';
 import Coverage from '../components/sections/Coverage.astro';
 import Rules from '../components/sections/Rules.astro';
 import Footer from '../components/sections/Footer.astro';
@@ -24,6 +25,8 @@ import Footer from '../components/sections/Footer.astro';
   <WhatItCatches />
   <div class="h-px bg-noir-800"></div>
   <Speed />
+  <div class="h-px bg-noir-800"></div>
+  <TriageShowcase />
   <div class="h-px bg-noir-800"></div>
   <Coverage />
   <div class="h-px bg-noir-800"></div>


### PR DESCRIPTION
## Summary

Adds a landing-page section featuring the v0.7.0 TUI, placed between the Speed and Coverage sections. Also bumps the hardcoded version label in `TerminalDemo.astro` from `v0.6.3` to `v0.7.0`.

### Changes
- New `TriageShowcase.astro` section with the findings+detail TUI screenshot, short copy, and `npx foxguard tui .` CTA
- Wired into `index.astro` between `<Speed />` and `<Coverage />`
- `TerminalDemo.astro` version label: `v0.6.3` → `v0.7.0`

### Why here, not the Hero
The Hero's "as fast as a linter" framing is still the primary pitch and converts curiosity. A dedicated section for the TUI reads as a natural "here's what you do with the findings" follow-on without disrupting the top-of-funnel message.

### Test plan
- [x] `cd www && npm run build` succeeds
- [ ] Local preview: `cd www && npm run dev`, visit landing page — TUI screenshot renders, section dividers consistent with neighbors
- [ ] Screenshot alt text meaningful for a11y