### PR TITLE
chore: unify tagline to 'A security scanner as fast as a linter, written in Rust'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "foxguard"
 version = "0.7.0"
 edition = "2021"
-description = "Security scanner as fast as a linter. 170+ built-in rules, 10 languages, sub-second scans."
+description = "A security scanner as fast as a linter, written in Rust. 170+ built-in rules across 10 languages."
 license = "MIT"
 repository = "https://github.com/PwnKit-Labs/foxguard"
 homepage = "https://foxguard.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">foxguard</h1>
 
 <p align="center">
-  <strong>Sub-second local security scanning for real codebases.</strong>
+  <strong>A security scanner as fast as a linter, written in Rust.</strong>
   <br/>
   170+ built-in rules &middot; 10 languages &middot; cross-file taint tracking for Python, JavaScript, Go, Kotlin &middot; single Rust binary &middot; Semgrep-compatible YAML bridge
   <br/><br/>

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,6 +1,6 @@
 # foxguard
 
-Sub-second local security scanning for real codebases.
+A security scanner as fast as a linter, written in Rust.
 
 ```sh
 npx foxguard .

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foxguard",
   "version": "0.7.0",
-  "description": "Security scanner as fast as a linter. 170+ built-in rules, 10 languages, sub-second scans.",
+  "description": "A security scanner as fast as a linter, written in Rust. 170+ built-in rules across 10 languages.",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,6 +1,6 @@
 # foxguard for VS Code
 
-Security scanner as fast as a linter. Scans your code on every save and shows findings as underlines.
+A security scanner as fast as a linter, written in Rust. Scans your code on every save and shows findings as underlines.
 
 ## Features
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foxguard",
   "displayName": "foxguard",
-  "description": "Security scanner as fast as a linter",
+  "description": "A security scanner as fast as a linter, written in Rust.",
   "version": "0.7.0",
   "publisher": "peaktwilight",
   "license": "MIT",

--- a/www/src/content/blog/cross-file-taint-in-003-seconds.md
+++ b/www/src/content/blog/cross-file-taint-in-003-seconds.md
@@ -98,4 +98,4 @@ Both are on the roadmap. Neither changes the architecture — the two-pass desig
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, cross-file taint tracking for Python, JavaScript, and Go. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, cross-file taint tracking for Python, JavaScript, and Go. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/content/blog/fast-is-not-enough-how-we-keep-local-scans-useful.md
+++ b/www/src/content/blog/fast-is-not-enough-how-we-keep-local-scans-useful.md
@@ -169,4 +169,4 @@ That is the bar.
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/content/blog/how-to-roll-out-foxguard-without-blowing-up-ci.md
+++ b/www/src/content/blog/how-to-roll-out-foxguard-without-blowing-up-ci.md
@@ -163,4 +163,4 @@ That is why the rollout matters as much as the engine.
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/content/blog/scanning-top-frameworks.md
+++ b/www/src/content/blog/scanning-top-frameworks.md
@@ -98,4 +98,4 @@ Any application using `ginS` trusts all proxies by default, allowing IP spoofing
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, sub-second scans. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, sub-second scans. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/content/blog/semgrep-in-ci-foxguard-on-save.md
+++ b/www/src/content/blog/semgrep-in-ci-foxguard-on-save.md
@@ -124,4 +124,4 @@ That is the whole bet behind foxguard.
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, sub-second local scans, and a focused Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/content/blog/taint-tracking-without-the-yaml.md
+++ b/www/src/content/blog/taint-tracking-without-the-yaml.md
@@ -159,4 +159,4 @@ The YAML is optional. That is how it should be.
 
 ---
 
-*foxguard is an open-source security scanner written in Rust. 174 built-in rules, 10 languages, cross-file taint tracking for Python, JavaScript, Go, and Kotlin. Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*
+*foxguard is an open-source security scanner written in Rust. 170+ built-in rules, 10 languages, cross-file taint tracking for Python, JavaScript, Go, and Kotlin. Semgrep/OpenGrep-compatible YAML bridge. [Try it](https://github.com/PwnKit-Labs/foxguard): `npx foxguard .`*

--- a/www/src/layouts/Base.astro
+++ b/www/src/layouts/Base.astro
@@ -4,7 +4,7 @@ interface Props {
   description?: string;
 }
 
-const { title, description = 'Security scanner as fast as a linter. 174 built-in rules, 10 languages, cross-file taint tracking. Single Rust binary, sub-second scans.' } = Astro.props;
+const { title, description = 'A security scanner as fast as a linter, written in Rust. 170+ built-in rules, 10 languages, cross-file taint tracking. Sub-second scans.' } = Astro.props;
 ---
 
 <!doctype html>

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -13,7 +13,7 @@ import Footer from '../components/sections/Footer.astro';
 
 <Base
   title="foxguard — Security scanner as fast as a linter"
-  description="174 built-in rules across 10 languages, cross-file taint tracking, sub-second scans. Single Rust binary."
+  description="170+ built-in rules across 10 languages, cross-file taint tracking, sub-second scans. Single Rust binary."
 >
   <div class="sticky top-0 z-40 bg-noir-950 border-b border-noir-800">
     <div class="max-w-5xl mx-auto px-6">


### PR DESCRIPTION
## Summary

Tagline drift cleanup. We had two competing top-line taglines and mismatched rule counts across the repo. This PR standardizes both.

### Chosen tagline
> **A security scanner as fast as a linter, written in Rust.**

Why:
- **HN-validated.** This is close to the exact title of the [HN post](https://news.ycombinator.com/item?id=XXX) that reached the front page last week — the framing that earned engagement.
- **Astral-pattern compatible.** Matches the skeleton Astral uses across uv, ruff, and ty:  \"An extremely fast [X], written in Rust.\" — borrowing an established Rust-tooling template reads as credibility, not vanity.
- **Honest.** \"as fast as a linter\" is a concrete reference class (developers know linter latency viscerally); \"extremely fast\" is vague marketing. The HN thread itself confirmed the tool is effectively a fast linter — that's a feature, not a flaw.
- **Drops \"local\" from the top line.** \"Local\" earns its place in supporting copy, not the hook. Front-loading it diluted the speed-first framing.

### Rule-count unification
Drift: README/Cargo/npm used \`170+\`, Base.astro meta and all 6 blog footers used \`174\`. Standardized on **\`170+\`** — drift-proof floor with 6+ months of runway before it needs a bump. The website Hero keeps its dynamic \`{totalRules}\` binding (unchanged).

### Files changed
| File | Change |
|---|---|
| README.md | H1 sub → new tagline |
| Cargo.toml | description |
| packages/npm/package.json | description |
| packages/npm/README.md | intro line |
| vscode-extension/package.json | description |
| vscode-extension/README.md | intro line |
| www/src/layouts/Base.astro | default OG/meta description, \`174 → 170+\` |
| www/src/pages/index.astro | meta description, \`174 → 170+\` |
| www/src/content/blog/*.md (×6) | footer, \`174 → 170+\` |

### Also done outside this PR
- GitHub repo **About** updated via \`gh repo edit\`: \"A extremely fast local code security scanning tool, written in rust.\" → \"A security scanner as fast as a linter, written in Rust.\"

### Untouched (intentionally)
- Website Hero H1 (\`Security scanner<br/>as fast as a linter\`) — works standalone and the H1 pattern is different. Subtitle supplies the rest.
- \`foxguard-0-7-0-tui-launch.md\` blog footer — didn't use the shared footer template.

### Test plan
- [x] \`cd www && npm run build\` succeeds (9 pages built, no errors)
- [x] No remaining \`174 built-in rules\` references
- [x] No remaining \`Sub-second local security scanning for real codebases\` references
- [ ] CI green