### PR TITLE
feat: auto-bump README install refs during release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,27 @@ jobs:
       - run: bash -n benchmarks/run.sh
       - run: bash -n scripts/release.sh
 
+  readme-version-refs:
+    name: README Version Refs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check README install refs match Cargo.toml
+        run: |
+          cargo_v=$(grep '^version' Cargo.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          action_v=$(grep -oE 'PwnKit-Labs/foxguard/action@v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1 | sed -E 's/.*v(.+)/\1/')
+          rev_v=$(grep -oE 'rev:\s+v[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1 | sed -E 's/.*v(.+)/\1/')
+          fail=0
+          if [ "$action_v" != "$cargo_v" ]; then
+            echo "::error::action ref v$action_v != Cargo v$cargo_v"
+            fail=1
+          fi
+          if [ "$rev_v" != "$cargo_v" ]; then
+            echo "::error::pre-commit rev v$rev_v != Cargo v$cargo_v"
+            fail=1
+          fi
+          exit $fail
+
   build:
     name: Build Release
     runs-on: ${{ matrix.os }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,6 +48,11 @@ for pkg in packages/npm/package.json vscode-extension/package.json; do
   "
 done
 
+# Rewrite README install-ref examples so copy-pasteable snippets stay pinned
+# to the version users are about to receive.
+perl -i -pe 's{(PwnKit-Labs/foxguard/action)\@v[0-9]+\.[0-9]+\.[0-9]+}{$1\@v'"${VERSION}"'}g' README.md
+perl -i -pe 's{(\s+rev:\s+)v[0-9]+\.[0-9]+\.[0-9]+}{${1}v'"${VERSION}"'}g' README.md
+
 (
   cd vscode-extension
   npm install --package-lock-only
@@ -73,7 +78,7 @@ cargo test
 )
 
 echo "Committing release metadata..."
-git add Cargo.toml Cargo.lock packages/npm/package.json vscode-extension/package.json vscode-extension/package-lock.json
+git add Cargo.toml Cargo.lock packages/npm/package.json vscode-extension/package.json vscode-extension/package-lock.json README.md
 git commit -m "Prepare ${TAG} release metadata" -m "Bump crate, npm, and VS Code extension versions to ${VERSION} so the
 tag-driven release workflow can publish a coherent release.
 


### PR DESCRIPTION
Closes #191.

## Summary

Extends `scripts/release.sh` to auto-rewrite the two versioned install examples in README.md during the release prep commit:

- `uses: PwnKit-Labs/foxguard/action@vX.Y.Z`
- `rev: vX.Y.Z` (pre-commit)

Previously these drifted — we hit this with v0.7.0 (PR #190) and had to manually bump from v0.6.0 on top of the version-bump PR. This ensures they stay in sync with the shipped version.

### Changes
- `scripts/release.sh`: two new `perl -i -pe` substitutions sibling to the existing `node -e` loop; `README.md` added to the release-metadata `git add` list.
- `.github/workflows/ci.yml`: new `README Version Refs` job that asserts the action/pre-commit refs match `Cargo.toml`'s version — belt-and-suspenders in case the script is ever bypassed.

### Not in scope
- Benchmarks prose mentions `foxguard 0.6.2` in the methodology caption — that's a specific historical benchmark run, not a reference users copy-paste. Left untouched.
- The TUI launch callout (`v0.7.0 adds foxguard tui .`) is also prose tied to a specific release's blog post, not an install ref. Left untouched.

### Test plan
- [x] `bash -n scripts/release.sh`
- [x] Dry-run perl subs on temp copy of README with a fake version (`0.9.9`) — both lines updated exactly once, no drift anywhere else.
- [x] Simulated the new CI check locally against current README — passes (all three values are `0.7.0`).
- [ ] CI green on this PR
- [ ] End-to-end test in next release