### PR TITLE
perf: share Go taint Pass 1 summaries across rules

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -847,8 +847,42 @@ fn scan_files(
             };
 
             let mut file_findings = Vec::new();
+
+            // Go taint rules share identical Pass 1 summaries across all
+            // rules in the same sanitizer-group. Instead of walking the
+            // AST once per rule, run them all through a single batched
+            // call that computes summaries once and emits per-rule
+            // findings in a single walk per sanitizer-group. See
+            // `crate::rules::go::run_go_taint_batched` for details.
+            let enabled_go_taint_ids: std::collections::HashSet<&str> =
+                if matches!(language, Language::Go) {
+                    rules
+                        .iter()
+                        .filter(|r| {
+                            crate::rules::go::is_go_taint_rule_id(r.id())
+                                && r.applies_to_path(&relative_path)
+                        })
+                        .map(|r| r.id())
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                };
+            if !enabled_go_taint_ids.is_empty() {
+                file_findings.extend(crate::rules::go::run_go_taint_batched(
+                    source,
+                    tree,
+                    &ctx,
+                    &enabled_go_taint_ids,
+                ));
+            }
+
             for rule in rules {
                 if !rule.applies_to_path(&relative_path) {
+                    continue;
+                }
+                // Skip rules already handled by the batched Go taint
+                // runner above.
+                if enabled_go_taint_ids.contains(rule.id()) {
                     continue;
                 }
                 file_findings.extend(rule.check_with_context(source, tree, &ctx));

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -738,7 +738,7 @@ fn map_go_taint_findings(
         (Some(summaries), Some(paths)) => Some(go_taint::CrossFileInfo {
             same_package_paths: paths,
             summaries,
-            current_rule_id: meta.rule_id,
+            rule_filter: go_taint::RuleFilter::Single(meta.rule_id),
         }),
         _ => None,
     };
@@ -1282,4 +1282,214 @@ pub fn go_taint_rule_specs() -> Vec<(&'static str, GoTaintSpec)> {
         ("go/taint-nosql-injection", TaintNosqlInjection::spec()),
         ("go/taint-path-traversal", TaintPathTraversal::spec()),
     ]
+}
+
+/// Per-rule metadata used by the batched Go taint runner to shape
+/// findings (severity, CWE, fix hint, description formatter).
+struct GoTaintRuleDispatch {
+    meta: GoTaintRuleMeta<'static>,
+    format_description: fn(&str, &str) -> String,
+}
+
+fn go_taint_command_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject OS commands")
+}
+fn go_taint_sql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject SQL")
+}
+fn go_taint_ssti_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject server-side templates")
+}
+fn go_taint_xpath_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject XPath queries")
+}
+fn go_taint_ldap_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject LDAP queries")
+}
+fn go_taint_ssrf_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can drive server-side request forgery")
+}
+fn go_taint_log_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can forge log entries")
+}
+fn go_taint_nosql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject NoSQL operators")
+}
+fn go_taint_path_traversal_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can traverse the filesystem")
+}
+
+fn go_taint_rule_dispatch_table() -> Vec<GoTaintRuleDispatch> {
+    vec![
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-command-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-78"),
+                fix_suggestion: Some("Go has no standard shell-escape function. Pass arguments as separate elements to `exec.Command(name, arg1, arg2)` instead of building a shell string — this avoids shell interpretation entirely"),
+            },
+            format_description: go_taint_command_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-sql-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-89"),
+                fix_suggestion: Some("Use parameterized queries: `db.Query(\"SELECT * FROM users WHERE name = $1\", name)`"),
+            },
+            format_description: go_taint_sql_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-ssti",
+                severity: Severity::Critical,
+                cwe: Some("CWE-1336"),
+                fix_suggestion: Some("Use pre-defined template files with template.ParseFiles() instead of parsing user-controlled template strings"),
+            },
+            format_description: go_taint_ssti_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-xpath-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-643"),
+                fix_suggestion: Some("Validate and sanitize user input before building XPath expressions"),
+            },
+            format_description: go_taint_xpath_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-ldap-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-90"),
+                fix_suggestion: Some("Use ldap.EscapeFilter() to sanitize user input before building LDAP filter strings"),
+            },
+            format_description: go_taint_ldap_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-ssrf",
+                severity: Severity::High,
+                cwe: Some("CWE-918"),
+                fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
+            },
+            format_description: go_taint_ssrf_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-log-injection",
+                severity: Severity::Medium,
+                cwe: Some("CWE-117"),
+                fix_suggestion: Some("Sanitize user input before logging — strip newlines and control characters"),
+            },
+            format_description: go_taint_log_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-nosql-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-943"),
+                fix_suggestion: Some("Validate and sanitize user input before building MongoDB queries."),
+            },
+            format_description: go_taint_nosql_injection_desc,
+        },
+        GoTaintRuleDispatch {
+            meta: GoTaintRuleMeta {
+                rule_id: "go/taint-path-traversal",
+                severity: Severity::High,
+                cwe: Some("CWE-22"),
+                fix_suggestion: Some("Validate file paths with filepath.Clean() and ensure they don't escape the intended directory"),
+            },
+            format_description: go_taint_path_traversal_desc,
+        },
+    ]
+}
+
+/// Returns `true` if `rule_id` is one of the built-in Go taint rules
+/// handled by [`run_go_taint_batched`]. The scanner uses this to avoid
+/// running those rules individually in the per-rule loop.
+pub fn is_go_taint_rule_id(rule_id: &str) -> bool {
+    rule_id.starts_with("go/taint-")
+}
+
+/// Run every built-in Go taint rule over `tree` in a single batched
+/// pass, returning per-rule [`Finding`]s.
+///
+/// This replaces the historical code path where each of the nine Go
+/// taint rules called [`go_taint::analyze_tree_with_cross_file`]
+/// individually — which recomputed rule-agnostic Pass 1 summaries and
+/// re-walked every function body once per rule.
+///
+/// Rules are grouped by their sanitizer profile so that rules sharing
+/// the same sanitizers collapse into a single AST walk. The default
+/// ruleset has two groups (no-sanitizer × 8 rules, path-traversal × 1
+/// rule), which means 2 walks per file instead of 9.
+pub fn run_go_taint_batched(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    ctx: &FileContext<'_>,
+    enabled_rule_ids: &std::collections::HashSet<&str>,
+) -> Vec<Finding> {
+    // Resolve aliases (prefer the one from FileContext).
+    let local_aliases: Option<AliasTable> = if ctx.go_aliases.is_none() {
+        Some(go_aliases_from_tree(source, tree))
+    } else {
+        None
+    };
+    let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
+
+    let dispatch = go_taint_rule_dispatch_table();
+    let rule_specs = go_taint_rule_specs();
+
+    // Only include rules the caller actually registered.
+    let rules: Vec<go_taint::BatchedRule<'_>> = rule_specs
+        .iter()
+        .filter(|(id, _)| enabled_rule_ids.contains(id))
+        .map(|(id, spec)| go_taint::BatchedRule { rule_id: id, spec })
+        .collect();
+
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    let cross_file_info = match (ctx.cross_file_summaries, ctx.go_same_package_paths.as_ref()) {
+        (Some(summaries), Some(paths)) => Some(go_taint::CrossFileInfoBatched {
+            same_package_paths: paths,
+            summaries,
+        }),
+        _ => None,
+    };
+
+    let raw = go_taint::analyze_tree_batched(
+        tree.root_node(),
+        source,
+        &rules,
+        aliases,
+        cross_file_info.as_ref(),
+    );
+
+    raw.into_iter()
+        .filter_map(|(rule_id, t)| {
+            let d = dispatch.iter().find(|d| d.meta.rule_id == rule_id)?;
+            Some(Finding {
+                rule_id: d.meta.rule_id.to_string(),
+                severity: d.meta.severity,
+                cwe: d.meta.cwe.map(|s| s.to_string()),
+                description: (d.format_description)(&t.source_description, &t.sink_description),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
+                sink_start_byte: Some(t.sink_start_byte),
+                sink_end_byte: Some(t.sink_end_byte),
+            })
+        })
+        .collect()
 }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -113,9 +113,36 @@ pub struct CrossFileInfo<'a> {
     pub same_package_paths: &'a [PathBuf],
     /// Cross-file summaries keyed by canonical file path.
     pub summaries: &'a CrossFileSummaryMap,
-    /// The rule ID currently being analyzed. Cross-file findings are only
-    /// emitted when the summary's `sink_rule_id` matches this value.
-    pub current_rule_id: &'a str,
+    /// The rule filter used to emit cross-file findings. Cross-file
+    /// findings are only emitted when the summary's `sink_rule_id`
+    /// passes this filter.
+    ///
+    /// - [`RuleFilter::Single`] in single-rule mode (the historical
+    ///   behaviour).
+    /// - [`RuleFilter::Any`] with a set of allowed rule ids in batched
+    ///   mode, so a single walk can attribute findings to any of the
+    ///   batched rules.
+    pub rule_filter: RuleFilter<'a>,
+}
+
+/// How cross-file findings should be attributed to rules.
+pub enum RuleFilter<'a> {
+    /// Only emit cross-file findings whose `sink_rule_id` equals the
+    /// given value; the finding is attributed to that rule.
+    Single(&'a str),
+    /// Emit cross-file findings whose `sink_rule_id` appears in the
+    /// given set; each finding is attributed to the matching rule via
+    /// `rule_id_hint`.
+    Any(&'a HashSet<String>),
+}
+
+impl<'a> RuleFilter<'a> {
+    fn allows(&self, rule_id: &str) -> bool {
+        match self {
+            RuleFilter::Single(id) => *id == rule_id,
+            RuleFilter::Any(set) => set.contains(rule_id),
+        }
+    }
 }
 
 /// A single source→sink flow reported by the engine.
@@ -131,6 +158,10 @@ pub struct TaintFinding {
     pub sink_description: String,
     /// 1-indexed line where the taint source was introduced.
     pub source_line: usize,
+    /// Optional rule id hint set by the batched analyzer so callers can
+    /// dispatch a finding back to the correct rule. `None` for
+    /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
+    pub rule_id_hint: Option<String>,
 }
 
 /// Return-taint summary map keyed by a function / method simple name.
@@ -151,6 +182,10 @@ struct AnalysisContext<'a> {
     summaries: &'a ReturnSummary,
     /// Cross-file info for resolving same-package function calls.
     cross_file: Option<&'a CrossFileInfo<'a>>,
+    /// When the batched analyzer merges sinks from multiple rules into a
+    /// single `TaintSpec`, this map attributes each matched sink back to
+    /// its owning rule id. `None` in single-rule mode.
+    sink_to_rule: Option<&'a HashMap<String, String>>,
 }
 
 /// Run the taint engine over every function/method body inside `root`
@@ -189,6 +224,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
+        sink_to_rule: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -204,12 +240,216 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
+        sink_to_rule: None,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
         analyze_function(func_node, &ctx, &mut findings);
     });
     findings
+}
+
+/// Inputs to [`analyze_tree_batched`]: a set of rules that should share
+/// Pass 1/Pass 2 walks when their sanitizer profile matches.
+pub struct BatchedRule<'a> {
+    pub rule_id: &'a str,
+    pub spec: &'a TaintSpec,
+}
+
+/// Cross-file info used by the batched analyzer.
+///
+/// Unlike [`CrossFileInfo`] — which takes a single `current_rule_id` —
+/// the batched variant only needs the summary map and the same-package
+/// paths. The allowed rule ids are derived per sanitizer-group from the
+/// input [`BatchedRule`] slice.
+pub struct CrossFileInfoBatched<'a> {
+    pub same_package_paths: &'a [PathBuf],
+    pub summaries: &'a CrossFileSummaryMap,
+}
+
+/// Batched Go taint analysis.
+///
+/// Runs the taint engine once per sanitizer-group instead of once per
+/// rule. In foxguard's default Go taint ruleset (9 rules) this collapses
+/// 9 full AST walks to 2 — one for the 8 no-sanitizer rules and one for
+/// the path-traversal rule (the only rule with sanitizers).
+///
+/// The rule-agnostic Pass 1 summaries are shared across all rules in a
+/// sanitizer group (they are source-driven, and the 9 built-in rules
+/// share `go_taint_sources()`). Rules with different sanitizer sets land
+/// in different groups because sanitizers affect both the return-taint
+/// summary and the intra-file taint state.
+///
+/// Returns `(rule_id, finding)` pairs. Each finding carries its
+/// `rule_id_hint` set to the attributed rule so the caller can dispatch
+/// to per-rule metadata (severity, CWE, fix hints).
+pub fn analyze_tree_batched<'a>(
+    root: Node<'_>,
+    source: &'a str,
+    rules: &[BatchedRule<'a>],
+    aliases: Option<&'a AliasTable>,
+    cross_file: Option<&'a CrossFileInfoBatched<'a>>,
+) -> Vec<(String, TaintFinding)> {
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    // Group rules that share the same sanitizer matchers. Sanitizers
+    // change taint-state semantics (they clear taint) so rules with
+    // different sanitizer profiles must NOT be merged into the same
+    // spec. Sinks and sources, by contrast, don't affect state during
+    // a walk — only findings — so we can safely union them within a
+    // group.
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for (i, r) in rules.iter().enumerate() {
+        let mut placed = false;
+        for g in groups.iter_mut() {
+            // First rule in each group is representative.
+            let rep = rules[g[0]].spec;
+            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
+                g.push(i);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            groups.push(vec![i]);
+        }
+    }
+
+    let mut out: Vec<(String, TaintFinding)> = Vec::new();
+    for group in &groups {
+        // Union all sources and sinks from every rule in the group.
+        // Using dedup-by-description keeps the matcher list tight
+        // without sacrificing correctness (duplicate descriptions would
+        // only cause duplicate findings).
+        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
+        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut seen_source_descs: HashSet<String> = HashSet::new();
+        let mut seen_sink_descs: HashSet<String> = HashSet::new();
+        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
+        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
+
+        for &idx in group {
+            let r = &rules[idx];
+            allowed_rule_ids.insert(r.rule_id.to_string());
+            for src in &r.spec.sources {
+                if seen_source_descs.insert(src.description().to_string()) {
+                    merged_sources.push(src.clone());
+                }
+            }
+            for sink in &r.spec.sinks {
+                // If two rules declare the same sink description, keep
+                // the first rule's attribution. In the default ruleset
+                // sink descriptions are unique per rule.
+                sink_to_rule
+                    .entry(sink.description().to_string())
+                    .or_insert_with(|| r.rule_id.to_string());
+                if seen_sink_descs.insert(sink.description().to_string()) {
+                    merged_sinks.push(sink.clone());
+                }
+            }
+        }
+
+        let sanitizers = rules[group[0]].spec.sanitizers.clone();
+        let merged_spec = TaintSpec {
+            sources: merged_sources,
+            sinks: merged_sinks,
+            sanitizers,
+        };
+
+        // Pass 1: compute summaries once for the entire group.
+        let empty_summary = ReturnSummary::new();
+        let pass1_ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rule: None,
+        };
+        let mut summaries = ReturnSummary::new();
+        collect_function_defs(root, &mut |func_node| {
+            let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+            if let Some(name) = name {
+                summaries.insert(name, ret_taint);
+            }
+        });
+
+        // Pass 2: one walk emits findings for every rule in the group.
+        // Cross-file dispatch uses `RuleFilter::Any` so the single walk
+        // can attribute findings across every rule in this group.
+        let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
+            same_package_paths: cf.same_package_paths,
+            summaries: cf.summaries,
+            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+        });
+        let ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &summaries,
+            cross_file: cross_file_for_group.as_ref(),
+            sink_to_rule: Some(&sink_to_rule),
+        };
+        let mut group_findings: Vec<TaintFinding> = Vec::new();
+        collect_function_defs(root, &mut |func_node| {
+            analyze_function(func_node, &ctx, &mut group_findings);
+        });
+
+        // Attribute each finding back to the rule id. Intra-file
+        // findings carry a `rule_id_hint` set by `handle_call`.
+        // Cross-file findings carry one set by `handle_cross_file_call`.
+        // For safety, fall back to the sink-description lookup when the
+        // hint is missing.
+        for mut f in group_findings {
+            let rule_id = f
+                .rule_id_hint
+                .clone()
+                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
+            if let Some(rid) = rule_id {
+                f.rule_id_hint = Some(rid.clone());
+                out.push((rid, f));
+            }
+        }
+    }
+
+    out
+}
+
+fn sanitizer_fingerprints_eq(a: &[NodeMatcher], b: &[NodeMatcher]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let fingerprint = |matchers: &[NodeMatcher]| -> Vec<String> {
+        let mut v: Vec<String> = matchers.iter().map(matcher_fingerprint).collect();
+        v.sort();
+        v
+    };
+    fingerprint(a) == fingerprint(b)
+}
+
+fn matcher_fingerprint(m: &NodeMatcher) -> String {
+    match m {
+        NodeMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => format!("A|{root}|{field}|{description}"),
+        NodeMatcher::Call {
+            canonical,
+            description,
+        } => format!("C|{canonical}|{description}"),
+        NodeMatcher::ParamName { names, description } => {
+            format!("P|{}|{description}", names.join(","))
+        }
+        NodeMatcher::MethodName {
+            method,
+            description,
+        } => {
+            format!("M|{method}|{description}")
+        }
+    }
 }
 
 // ─── Per-file import alias table ──────────────────────────────────────────
@@ -416,6 +656,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
+                sink_to_rule: None,
             };
             let (_, ret_taint) = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -433,6 +674,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -458,6 +700,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -893,8 +1136,18 @@ fn handle_call(
         } if method == final_segment => Some(description.clone()),
         _ => None,
     });
+    // When the engine is running in batched mode, map the matched sink
+    // description back to the rule it came from so the caller can
+    // dispatch the finding correctly. `None` in single-rule mode.
+    let sink_desc = sink_desc.map(|d| {
+        let rule = ctx
+            .sink_to_rule
+            .and_then(|m| m.get(d.as_str()))
+            .map(|s| s.to_string());
+        (d, rule)
+    });
 
-    if let Some(sink_desc) = sink_desc {
+    if let Some((sink_desc, sink_rule_id)) = sink_desc {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
@@ -913,6 +1166,7 @@ fn handle_call(
                     source_description: source_desc,
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
+                    rule_id_hint: sink_rule_id.clone(),
                 });
                 break;
             }
@@ -974,9 +1228,9 @@ fn handle_cross_file_call(
     let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
 
     // For each tainted argument, check if the corresponding parameter
-    // has a ParamSinkFlow whose rule ID matches the current rule.
+    // has a ParamSinkFlow whose rule ID matches the current filter.
     for flow in &summary.params_to_sink {
-        if flow.sink_rule_id != cross_file.current_rule_id {
+        if !cross_file.rule_filter.allows(&flow.sink_rule_id) {
             continue;
         }
         if flow.param_index >= arg_nodes.len() {
@@ -999,6 +1253,7 @@ fn handle_cross_file_call(
                     flow.sink_description, func_name
                 ),
                 source_line: src_line,
+                rule_id_hint: Some(flow.sink_rule_id.clone()),
             });
             // One finding per cross-file call is enough.
             return;


### PR DESCRIPTION
Addresses #174.

## Summary

Go taint was re-walking each file's AST once per registered rule (9× in v0.7.0). Pass 1 summaries (`params_to_return` and the shared return-taint map) are rule-spec-agnostic apart from sanitizers — they were being recomputed redundantly. This PR shares Pass 1 across all Go taint rules with the same sanitizer profile so each file's AST is walked twice instead of nine times (eight no-sanitizer rules collapse into one walk; `go/taint-path-traversal` still runs alone because of its sanitizers).

## Benchmark (main vs this PR)

```
python3 benchmarks/compare_versions.py --refs "main,HEAD" --iterations 15 --warmup 3
```

| Repo | main | this PR | Δ |
|------|------|---------|---|
| express | 191.96 ms | 187.99 ms | -2% (noise) |
| flask | 264.77 ms | 258.44 ms | -2% (noise) |
| gin | 384.72 ms | 171.67 ms | **-55%** |

Gin drops from ~385 ms to ~172 ms — more than a 2× speedup on the Go-dominant target, bringing Go taint's per-file cost back in line with the Python/JS engines. Express and flask are within run-to-run noise, as expected — this PR only touches the Go taint path.

## How

1. **`go_taint::analyze_tree_batched`** (new) — takes a slice of `BatchedRule { rule_id, spec }`, groups rules by sanitizer fingerprint, unions sources and sinks inside each group, and runs Pass 1 + Pass 2 once per group. Mirrors the batched-spec approach that `extract_cross_file_summaries` already uses for the cross-file path.
2. **`TaintFinding::rule_id_hint`** (new field) — populated by `handle_call` via a sink-description → rule-id map on `AnalysisContext`, and by `handle_cross_file_call` via a new `RuleFilter::Any` variant on `CrossFileInfo`. Lets the batched dispatcher attribute each finding back to the correct rule id.
3. **`rules::go::run_go_taint_batched`** (new) — a scanner-side dispatcher that resolves Go aliases + cross-file info, feeds the nine built-in rule specs through the batched engine, and emits per-rule `Finding`s with the right severity / CWE / fix hint / description formatter.
4. **Scanner hook** — `engine::scanner` detects Go files, runs the batched dispatcher once, and skips the individual `go/taint-*` rules in the per-rule loop.

The single-rule entry points (`analyze_tree`, `analyze_tree_with_cross_file`) are preserved, so `map_go_taint_findings`, `semgrep_taint.rs`, and any downstream caller that constructs a single `CrossFileInfo` keep working unchanged. The only behavioural change on those paths is that `CrossFileInfo` now carries a `rule_filter: RuleFilter::Single(...)` instead of `current_rule_id: &str` — the `go.rs` call sites were updated accordingly.

## Correctness

- [x] `cargo test` — 415 tests pass (release build), including `test_vulnerable_go_taint_catches_every_flow` and `test_safe_go_taint_has_no_taint_findings`
- [x] `cargo clippy` (lib target) — clean. The `all-targets` target still errors on a pre-existing `items-after-test-module` warning in `src/tui.rs` that exists on `main` — unrelated to this PR.
- [x] `cargo fmt --check` — clean
- [x] Dogfood (foxguard scans itself) — 1082 findings before & after, same severity breakdown (229 critical / 262 high / 591 medium)
- [x] Gin findings verified identical byte-for-byte: 27 findings on `benchmarks/repos/gin`, same `(rule_id, file, line)` triples before and after
- [x] Per-rule finding attribution preserved — each finding cites the correct `rule_id`, `cwe`, severity, and fix hint via the dispatch table in `run_go_taint_batched`.

## Not in scope

- Python and JavaScript taint engines have the same structural pattern and likely benefit from an analogous refactor. Deliberately left for a follow-up PR to keep this one focused on the hottest engine and easier to review.