### PR TITLE
perf: share Python taint Pass 1 summaries across rules

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -876,6 +876,31 @@ fn scan_files(
                 ));
             }
 
+            // Python taint rules share identical Pass 1 summaries across
+            // all rules in the same sanitizer-group. Same rationale as
+            // the Go block above — see `crate::rules::python::run_py_taint_batched`.
+            let enabled_py_taint_ids: std::collections::HashSet<&str> =
+                if matches!(language, Language::Python) {
+                    rules
+                        .iter()
+                        .filter(|r| {
+                            crate::rules::python::is_py_taint_rule_id(r.id())
+                                && r.applies_to_path(&relative_path)
+                        })
+                        .map(|r| r.id())
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                };
+            if !enabled_py_taint_ids.is_empty() {
+                file_findings.extend(crate::rules::python::run_py_taint_batched(
+                    source,
+                    tree,
+                    &ctx,
+                    &enabled_py_taint_ids,
+                ));
+            }
+
             for rule in rules {
                 if !rule.applies_to_path(&relative_path) {
                     continue;
@@ -883,6 +908,11 @@ fn scan_files(
                 // Skip rules already handled by the batched Go taint
                 // runner above.
                 if enabled_go_taint_ids.contains(rule.id()) {
+                    continue;
+                }
+                // Skip rules already handled by the batched Python taint
+                // runner above.
+                if enabled_py_taint_ids.contains(rule.id()) {
                     continue;
                 }
                 file_findings.extend(rule.check_with_context(source, tree, &ctx));

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1666,7 +1666,7 @@ fn map_taint_findings(
         (Some(summaries), Some(import_paths)) => Some(python_taint::CrossFileInfo {
             import_to_path: import_paths,
             summaries,
-            current_rule_id: meta.rule_id,
+            rule_filter: python_taint::RuleFilter::Single(meta.rule_id),
         }),
         _ => None,
     };
@@ -2373,4 +2373,270 @@ pub fn python_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
         ("py/taint-xxe", TaintXxe::spec()),
         ("py/taint-nosql-injection", TaintNosqlInjection::spec()),
     ]
+}
+
+// ─── Batched Python taint runner ────────────────────────────────────────
+//
+// Mirrors the Go taint batched runner in `rules::go::run_go_taint_batched`.
+// Historically every Python taint rule called
+// `python_taint::analyze_tree_with_cross_file` on its own, which
+// re-walked the file's AST and recomputed Pass 1 summaries once per
+// rule. The shared Pass 1 output depends only on sources and
+// sanitizers (not on sinks) and every built-in rule uses
+// `python_taint_sources()`, so rules with matching sanitizer
+// fingerprints can collapse into a single AST walk whose findings are
+// dispatched back per-rule by `rule_id_hint`.
+
+/// Per-rule metadata used by the batched Python taint runner to shape
+/// findings (severity, CWE, fix hint, description formatter).
+struct PyTaintRuleDispatch {
+    meta: TaintRuleMeta<'static>,
+    format_description: fn(&str, &str) -> String,
+}
+
+fn py_taint_pickle_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can execute arbitrary code via pickle")
+}
+fn py_taint_eval_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can execute arbitrary Python code")
+}
+fn py_taint_command_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject OS commands")
+}
+fn py_taint_ssrf_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can drive server-side request forgery")
+}
+fn py_taint_yaml_load_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can execute arbitrary code via YAML deserialization")
+}
+fn py_taint_sql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject SQL")
+}
+fn py_taint_ssti_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject server-side templates")
+}
+fn py_taint_xpath_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject XPath expressions")
+}
+fn py_taint_ldap_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject LDAP filters")
+}
+fn py_taint_log_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can forge log entries")
+}
+fn py_taint_xxe_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can trigger XML External Entity processing")
+}
+fn py_taint_nosql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject NoSQL operators")
+}
+
+fn py_taint_rule_dispatch_table() -> Vec<PyTaintRuleDispatch> {
+    vec![
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-pickle-deserialization",
+                severity: Severity::Critical,
+                cwe: Some("CWE-502"),
+                fix_suggestion: Some(
+                    "Use `json` or `msgpack` instead of pickle for untrusted data: `json.loads(data)`",
+                ),
+            },
+            format_description: py_taint_pickle_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-eval",
+                severity: Severity::Critical,
+                cwe: Some("CWE-95"),
+                fix_suggestion: Some(
+                    "Use `ast.literal_eval()` for safe evaluation, or remove eval/exec entirely",
+                ),
+            },
+            format_description: py_taint_eval_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-command-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-78"),
+                fix_suggestion: Some("Use `shlex.quote()` to escape arguments, or pass a list to `subprocess.run([...])` instead of a shell string"),
+            },
+            format_description: py_taint_command_injection_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-ssrf",
+                severity: Severity::High,
+                cwe: Some("CWE-918"),
+                fix_suggestion: Some(
+                    "Validate URLs against an allowlist of permitted hosts before making requests",
+                ),
+            },
+            format_description: py_taint_ssrf_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-yaml-load",
+                severity: Severity::Critical,
+                cwe: Some("CWE-502"),
+                fix_suggestion: Some(
+                    "Use `yaml.safe_load()` instead of `yaml.load()` for untrusted input",
+                ),
+            },
+            format_description: py_taint_yaml_load_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-sql-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-89"),
+                fix_suggestion: Some("Use parameterized queries: `cur.execute(\"SELECT * FROM users WHERE name = ?\", (name,))`"),
+            },
+            format_description: py_taint_sql_injection_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-ssti",
+                severity: Severity::Critical,
+                cwe: Some("CWE-1336"),
+                fix_suggestion: Some(
+                    "Use render_template() with separate template files instead of render_template_string() with user input",
+                ),
+            },
+            format_description: py_taint_ssti_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-xpath-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-643"),
+                fix_suggestion: Some(
+                    "Use parameterized XPath queries or validate/sanitize input before building XPath expressions",
+                ),
+            },
+            format_description: py_taint_xpath_injection_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-ldap-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-90"),
+                fix_suggestion: Some(
+                    "Use ldap.filter.escape_filter_chars() to sanitize user input before building LDAP filters",
+                ),
+            },
+            format_description: py_taint_ldap_injection_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-log-injection",
+                severity: Severity::Medium,
+                cwe: Some("CWE-117"),
+                fix_suggestion: Some(
+                    "Sanitize user input before logging — strip newlines and control characters (no standard sanitizer; use str.replace() or a regex to remove \\n, \\r, and ANSI escape sequences)",
+                ),
+            },
+            format_description: py_taint_log_injection_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-xxe",
+                severity: Severity::High,
+                cwe: Some("CWE-611"),
+                fix_suggestion: Some(
+                    "Use defusedxml instead of xml.etree.ElementTree for untrusted XML input",
+                ),
+            },
+            format_description: py_taint_xxe_desc,
+        },
+        PyTaintRuleDispatch {
+            meta: TaintRuleMeta {
+                rule_id: "py/taint-nosql-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-943"),
+                fix_suggestion: Some("Validate and sanitize user input before using in MongoDB queries. Avoid passing raw user input as query filters."),
+            },
+            format_description: py_taint_nosql_injection_desc,
+        },
+    ]
+}
+
+/// Returns `true` if `rule_id` is one of the built-in Python taint
+/// rules handled by [`run_py_taint_batched`]. The scanner uses this to
+/// avoid running those rules individually in the per-rule loop.
+pub fn is_py_taint_rule_id(rule_id: &str) -> bool {
+    rule_id.starts_with("py/taint-")
+}
+
+/// Run every built-in Python taint rule over `tree` in a single
+/// batched pass, returning per-rule [`Finding`]s.
+///
+/// This replaces the historical code path where each Python taint rule
+/// called [`python_taint::analyze_tree_with_cross_file`] individually —
+/// which recomputed rule-agnostic Pass 1 summaries and re-walked every
+/// function body once per rule.
+///
+/// Rules are grouped by their sanitizer profile so rules sharing the
+/// same sanitizers collapse into a single AST walk.
+pub fn run_py_taint_batched(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    ctx: &FileContext<'_>,
+    enabled_rule_ids: &std::collections::HashSet<&str>,
+) -> Vec<Finding> {
+    let dispatch = py_taint_rule_dispatch_table();
+    let rule_specs = python_taint_rule_specs();
+
+    // Only include rules the caller actually registered.
+    let rules: Vec<python_taint::BatchedRule<'_>> = rule_specs
+        .iter()
+        .filter(|(id, _)| enabled_rule_ids.contains(id))
+        .map(|(id, spec)| python_taint::BatchedRule { rule_id: id, spec })
+        .collect();
+
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    let cross_file_info = match (ctx.cross_file_summaries, ctx.python_import_paths) {
+        (Some(summaries), Some(import_paths)) => Some(python_taint::CrossFileInfoBatched {
+            import_to_path: import_paths,
+            summaries,
+        }),
+        _ => None,
+    };
+
+    let raw = python_taint::analyze_tree_batched(
+        tree.root_node(),
+        source,
+        &rules,
+        ctx.python_aliases,
+        cross_file_info.as_ref(),
+    );
+
+    raw.into_iter()
+        .filter_map(|(rule_id, t)| {
+            let d = dispatch.iter().find(|d| d.meta.rule_id == rule_id)?;
+            Some(Finding {
+                rule_id: d.meta.rule_id.to_string(),
+                severity: d.meta.severity,
+                cwe: d.meta.cwe.map(|s| s.to_string()),
+                description: (d.format_description)(&t.source_description, &t.sink_description),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
+                sink_start_byte: Some(t.sink_start_byte),
+                sink_end_byte: Some(t.sink_end_byte),
+            })
+        })
+        .collect()
 }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -46,9 +46,37 @@ pub struct CrossFileInfo<'a> {
     pub import_to_path: &'a HashMap<String, PathBuf>,
     /// Cross-file summaries keyed by canonical file path.
     pub summaries: &'a CrossFileSummaryMap,
-    /// The rule ID currently being analyzed. Cross-file findings are only
-    /// emitted when the summary's `sink_rule_id` matches this value.
-    pub current_rule_id: &'a str,
+    /// The rule filter used to emit cross-file findings. Cross-file
+    /// findings are only emitted when the summary's `sink_rule_id`
+    /// passes this filter.
+    ///
+    /// - [`RuleFilter::Single`] in single-rule mode (the historical
+    ///   behaviour).
+    /// - [`RuleFilter::Any`] with a set of allowed rule ids in batched
+    ///   mode, so a single walk can attribute findings to any of the
+    ///   batched rules.
+    pub rule_filter: RuleFilter<'a>,
+}
+
+/// How cross-file findings should be attributed to rules.
+#[derive(Clone)]
+pub enum RuleFilter<'a> {
+    /// Only emit cross-file findings whose `sink_rule_id` equals the
+    /// given value; the finding is attributed to that rule.
+    Single(&'a str),
+    /// Emit cross-file findings whose `sink_rule_id` appears in the
+    /// given set; each finding is attributed to the matching rule via
+    /// `rule_id_hint`.
+    Any(&'a HashSet<String>),
+}
+
+impl<'a> RuleFilter<'a> {
+    fn allows(&self, rule_id: &str) -> bool {
+        match self {
+            RuleFilter::Single(id) => *id == rule_id,
+            RuleFilter::Any(set) => set.contains(rule_id),
+        }
+    }
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────
@@ -147,6 +175,10 @@ pub struct TaintFinding {
     pub sink_description: String,
     /// 1-indexed line where the taint source was introduced.
     pub source_line: usize,
+    /// Optional rule id hint set by the batched analyzer so callers can
+    /// dispatch a finding back to the correct rule. `None` for
+    /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
+    pub rule_id_hint: Option<String>,
 }
 
 /// Return-taint summary for a single function. Keyed by the function's
@@ -168,6 +200,10 @@ struct AnalysisContext<'a> {
     summaries: &'a ReturnSummary,
     /// Cross-file info for resolving imported function calls.
     cross_file: Option<&'a CrossFileInfo<'a>>,
+    /// When the batched analyzer merges sinks from multiple rules into a
+    /// single `TaintSpec`, this map attributes each matched sink back to
+    /// its owning rule id. `None` in single-rule mode.
+    sink_to_rule: Option<&'a HashMap<String, String>>,
 }
 
 /// Run the taint engine over every function definition inside `root` and
@@ -226,6 +262,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
+        sink_to_rule: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -242,12 +279,213 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
+        sink_to_rule: None,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
         analyze_function(func_node, &ctx, &mut findings);
     });
     findings
+}
+
+/// Inputs to [`analyze_tree_batched`]: a set of rules that should share
+/// Pass 1/Pass 2 walks when their sanitizer profile matches.
+pub struct BatchedRule<'a> {
+    pub rule_id: &'a str,
+    pub spec: &'a TaintSpec,
+}
+
+/// Cross-file info used by the batched analyzer.
+///
+/// Unlike [`CrossFileInfo`] — which takes a single `current_rule_id` —
+/// the batched variant only needs the summary map and the import map.
+/// The allowed rule ids are derived per sanitizer-group from the input
+/// [`BatchedRule`] slice.
+pub struct CrossFileInfoBatched<'a> {
+    pub import_to_path: &'a HashMap<String, PathBuf>,
+    pub summaries: &'a CrossFileSummaryMap,
+}
+
+/// Batched Python taint analysis.
+///
+/// Runs the taint engine once per sanitizer-group instead of once per
+/// rule. The rule-agnostic Pass 1 summaries are shared across all rules
+/// in a sanitizer group (summaries are source-driven and foxguard's
+/// built-in Python taint rules share `python_taint_sources()`). Rules
+/// with different sanitizer sets land in different groups because
+/// sanitizers affect both the return-taint summary and the intra-file
+/// taint state.
+///
+/// Returns `(rule_id, finding)` pairs. Each finding carries its
+/// `rule_id_hint` set to the attributed rule so the caller can dispatch
+/// to per-rule metadata (severity, CWE, fix hints).
+pub fn analyze_tree_batched<'a>(
+    root: Node<'_>,
+    source: &'a str,
+    rules: &[BatchedRule<'a>],
+    aliases: Option<&'a AliasTable>,
+    cross_file: Option<&'a CrossFileInfoBatched<'a>>,
+) -> Vec<(String, TaintFinding)> {
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    // Group rules that share the same sanitizer matchers. Sanitizers
+    // change taint-state semantics (they clear taint) so rules with
+    // different sanitizer profiles must NOT be merged into the same
+    // spec. Sinks and sources, by contrast, don't affect state during
+    // a walk — only findings — so we can safely union them within a
+    // group.
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for (i, r) in rules.iter().enumerate() {
+        let mut placed = false;
+        for g in groups.iter_mut() {
+            // First rule in each group is representative.
+            let rep = rules[g[0]].spec;
+            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
+                g.push(i);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            groups.push(vec![i]);
+        }
+    }
+
+    let mut out: Vec<(String, TaintFinding)> = Vec::new();
+    for group in &groups {
+        // Union all sources and sinks from every rule in the group.
+        // Using dedup-by-description keeps the matcher list tight
+        // without sacrificing correctness (duplicate descriptions would
+        // only cause duplicate findings).
+        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
+        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut seen_source_descs: HashSet<String> = HashSet::new();
+        let mut seen_sink_descs: HashSet<String> = HashSet::new();
+        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
+        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
+
+        for &idx in group {
+            let r = &rules[idx];
+            allowed_rule_ids.insert(r.rule_id.to_string());
+            for src in &r.spec.sources {
+                if seen_source_descs.insert(src.description().to_string()) {
+                    merged_sources.push(src.clone());
+                }
+            }
+            for sink in &r.spec.sinks {
+                // If two rules declare the same sink description, keep
+                // the first rule's attribution. In the default ruleset
+                // sink descriptions are unique per rule.
+                sink_to_rule
+                    .entry(sink.description().to_string())
+                    .or_insert_with(|| r.rule_id.to_string());
+                if seen_sink_descs.insert(sink.description().to_string()) {
+                    merged_sinks.push(sink.clone());
+                }
+            }
+        }
+
+        let sanitizers = rules[group[0]].spec.sanitizers.clone();
+        let merged_spec = TaintSpec {
+            sources: merged_sources,
+            sinks: merged_sinks,
+            sanitizers,
+        };
+
+        // Pass 1: compute summaries once for the entire group.
+        let empty_summary = ReturnSummary::new();
+        let pass1_ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rule: None,
+        };
+        let mut summaries = ReturnSummary::new();
+        collect_function_defs(root, &mut |func_node| {
+            let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+            if let Some(name) = name {
+                summaries.insert(name, ret_taint);
+            }
+        });
+
+        // Pass 2: one walk emits findings for every rule in the group.
+        // Cross-file dispatch uses `RuleFilter::Any` so the single walk
+        // can attribute findings across every rule in this group.
+        let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
+            import_to_path: cf.import_to_path,
+            summaries: cf.summaries,
+            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+        });
+        let ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &summaries,
+            cross_file: cross_file_for_group.as_ref(),
+            sink_to_rule: Some(&sink_to_rule),
+        };
+        let mut group_findings: Vec<TaintFinding> = Vec::new();
+        collect_function_defs(root, &mut |func_node| {
+            analyze_function(func_node, &ctx, &mut group_findings);
+        });
+
+        // Attribute each finding back to the rule id. Intra-file
+        // findings carry a `rule_id_hint` set by `handle_call`.
+        // Cross-file findings carry one set by `handle_cross_file_call`.
+        // For safety, fall back to the sink-description lookup when the
+        // hint is missing.
+        for mut f in group_findings {
+            let rule_id = f
+                .rule_id_hint
+                .clone()
+                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
+            if let Some(rid) = rule_id {
+                f.rule_id_hint = Some(rid.clone());
+                out.push((rid, f));
+            }
+        }
+    }
+
+    out
+}
+
+fn sanitizer_fingerprints_eq(a: &[NodeMatcher], b: &[NodeMatcher]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let fingerprint = |matchers: &[NodeMatcher]| -> Vec<String> {
+        let mut v: Vec<String> = matchers.iter().map(matcher_fingerprint).collect();
+        v.sort();
+        v
+    };
+    fingerprint(a) == fingerprint(b)
+}
+
+fn matcher_fingerprint(m: &NodeMatcher) -> String {
+    match m {
+        NodeMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => format!("A|{root}|{field}|{description}"),
+        NodeMatcher::Call {
+            canonical,
+            description,
+        } => format!("C|{canonical}|{description}"),
+        NodeMatcher::ParamName { names, description } => {
+            format!("P|{}|{description}", names.join(","))
+        }
+        NodeMatcher::MethodName {
+            method,
+            description,
+        } => {
+            format!("M|{method}|{description}")
+        }
+    }
 }
 
 /// Extract cross-file function taint summaries for all top-level functions
@@ -343,6 +581,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
+                sink_to_rule: None,
             };
             let (_, ret_taint) = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -360,6 +599,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -385,6 +625,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -872,8 +1113,18 @@ fn handle_call(
         } if method == final_segment => Some(description.clone()),
         _ => None,
     });
+    // When the engine is running in batched mode, map the matched sink
+    // description back to the rule it came from so the caller can
+    // dispatch the finding correctly. `None` in single-rule mode.
+    let sink_desc = sink_desc.map(|d| {
+        let rule = ctx
+            .sink_to_rule
+            .and_then(|m| m.get(d.as_str()))
+            .map(|s| s.to_string());
+        (d, rule)
+    });
 
-    if let Some(sink_desc) = sink_desc {
+    if let Some((sink_desc, sink_rule_id)) = sink_desc {
         // Check each argument for taint.
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
@@ -893,6 +1144,7 @@ fn handle_call(
                     source_description: source_desc,
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
+                    rule_id_hint: sink_rule_id.clone(),
                 });
                 // One finding per sink call is enough — don't double-report
                 // when multiple args are tainted.
@@ -949,9 +1201,9 @@ fn handle_cross_file_call(
     let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
 
     // For each tainted argument, check if the corresponding parameter
-    // has a ParamSinkFlow whose rule ID matches the current rule.
+    // has a ParamSinkFlow whose rule ID matches the current filter.
     for flow in &summary.params_to_sink {
-        if flow.sink_rule_id != cross_file.current_rule_id {
+        if !cross_file.rule_filter.allows(&flow.sink_rule_id) {
             continue;
         }
         if flow.param_index >= arg_nodes.len() {
@@ -974,6 +1226,7 @@ fn handle_cross_file_call(
                     flow.sink_description, func_name
                 ),
                 source_line: src_line,
+                rule_id_hint: Some(flow.sink_rule_id.clone()),
             });
             // One finding per cross-file call is enough.
             return;


### PR DESCRIPTION
Closes #200.

## Summary

Mirrors #199's Go taint optimization for Python. Python taint was re-walking each file's AST once per rule; this PR batches rules by sanitizer fingerprint and shares Pass 1 summaries across them.

For the default twelve-rule Python taint ruleset this collapses Pass 1 + Pass 2 from 12 walks per file to a handful of walks (one per distinct sanitizer fingerprint).

## Benchmark (main vs this PR)

10 iterations, 3 warmup runs on the same machine:

| Repo | main (avg) | this PR (avg) | Δ |
|------|------------|---------------|---|
| express | 196.33 ms | 205.65 ms | +4.7% (noise, no Python) |
| flask | 278.67 ms | 177.62 ms | -36.3% |
| gin | 183.05 ms | 179.62 ms | -1.9% (noise, no Python) |

(Earlier run with 2 warmup showed flask 441->175 / -60%; variance between cold and warm runs is significant but the direction is consistent on flask.)

## Reuses #199 machinery
- `rule_id_hint` on `TaintFinding`
- `RuleFilter::Any` variant on `CrossFileInfo`
- Same batched-walk pattern as `go_taint::analyze_tree_batched`

## Correctness
- [x] `cargo test` passing (all 300+ unit + integration tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Dogfood unchanged (1082 findings, 229/262/591 before and after)
- [x] Flask findings byte-identical (JSON diff empty after sorting)

## Test plan
- [x] `cargo test --release`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `./target/release/foxguard --format json benchmarks/repos/flask` diff vs main: zero diff
- [x] `./target/release/foxguard .` dogfood counts unchanged