### PR TITLE
perf: share JavaScript taint Pass 1 summaries across rules

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -901,18 +901,43 @@ fn scan_files(
                 ));
             }
 
+            // JavaScript taint rules: same batched approach as Go/Python
+            // above — see `crate::rules::javascript::run_js_taint_batched`.
+            let enabled_js_taint_ids: std::collections::HashSet<&str> =
+                if matches!(language, Language::JavaScript) {
+                    rules
+                        .iter()
+                        .filter(|r| {
+                            crate::rules::javascript::is_js_taint_rule_id(r.id())
+                                && r.applies_to_path(&relative_path)
+                        })
+                        .map(|r| r.id())
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                };
+            if !enabled_js_taint_ids.is_empty() {
+                file_findings.extend(crate::rules::javascript::run_js_taint_batched(
+                    source,
+                    tree,
+                    &ctx,
+                    &enabled_js_taint_ids,
+                ));
+            }
+
             for rule in rules {
                 if !rule.applies_to_path(&relative_path) {
                     continue;
                 }
-                // Skip rules already handled by the batched Go taint
-                // runner above.
+                // Skip rules already handled by the batched taint
+                // runners above.
                 if enabled_go_taint_ids.contains(rule.id()) {
                     continue;
                 }
-                // Skip rules already handled by the batched Python taint
-                // runner above.
                 if enabled_py_taint_ids.contains(rule.id()) {
+                    continue;
+                }
+                if enabled_js_taint_ids.contains(rule.id()) {
                     continue;
                 }
                 file_findings.extend(rule.check_with_context(source, tree, &ctx));

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1676,7 +1676,7 @@ fn map_js_taint_findings(
         (Some(summaries), Some(import_paths)) => Some(javascript_taint::CrossFileInfo {
             import_to_path: import_paths,
             summaries,
-            current_rule_id: meta.rule_id,
+            rule_filter: javascript_taint::RuleFilter::Single(meta.rule_id),
         }),
         _ => None,
     };
@@ -2490,4 +2490,225 @@ pub fn js_taint_rule_specs() -> Vec<(&'static str, JsTaintSpec)> {
         ("js/taint-xxe", TaintXxe::spec()),
         ("js/taint-nosql-injection", TaintNosqlInjection::spec()),
     ]
+}
+
+/// Returns `true` if `rule_id` is one of the built-in JS taint rules
+/// handled by [`run_js_taint_batched`]. The scanner uses this to avoid
+/// running those rules individually in the per-rule loop.
+pub fn is_js_taint_rule_id(rule_id: &str) -> bool {
+    rule_id.starts_with("js/taint-")
+}
+
+/// Per-rule metadata used by the batched JS taint runner to shape
+/// findings (severity, CWE, fix hint, description formatter).
+struct JsTaintRuleDispatch {
+    meta: JsTaintRuleMeta<'static>,
+    format_description: fn(&str, &str) -> String,
+}
+
+fn js_taint_xss_innerhtml_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can lead to XSS")
+}
+fn js_taint_sql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject SQL")
+}
+fn js_taint_eval_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can execute arbitrary code")
+}
+fn js_taint_command_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject OS commands")
+}
+fn js_taint_ssrf_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can cause server-side request forgery")
+}
+fn js_taint_ssti_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject server-side templates")
+}
+fn js_taint_xpath_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject XPath expressions")
+}
+fn js_taint_ldap_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject LDAP filters")
+}
+fn js_taint_log_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can forge log entries")
+}
+fn js_taint_xxe_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can trigger XML External Entity processing")
+}
+fn js_taint_nosql_injection_desc(src: &str, sink: &str) -> String {
+    format!("{src} reaches {sink} — untrusted input can inject NoSQL operators")
+}
+
+fn js_taint_rule_dispatch_table() -> Vec<JsTaintRuleDispatch> {
+    vec![
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-xss-innerhtml",
+                severity: Severity::High,
+                cwe: Some("CWE-79"),
+                fix_suggestion: Some("Use `DOMPurify.sanitize()` or `textContent` instead of `innerHTML`/`document.write`"),
+            },
+            format_description: js_taint_xss_innerhtml_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-sql-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-89"),
+                fix_suggestion: Some("Use parameterized queries: `db.query(\"SELECT * FROM users WHERE name = $1\", [name])`"),
+            },
+            format_description: js_taint_sql_injection_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-eval",
+                severity: Severity::Critical,
+                cwe: Some("CWE-95"),
+                fix_suggestion: Some("Remove `eval()`/`new Function()` and use safe alternatives like `JSON.parse()`"),
+            },
+            format_description: js_taint_eval_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-command-injection",
+                severity: Severity::Critical,
+                cwe: Some("CWE-78"),
+                fix_suggestion: Some("Pass arguments as an array to `child_process.execFile()` instead of building a shell string"),
+            },
+            format_description: js_taint_command_injection_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-ssrf",
+                severity: Severity::High,
+                cwe: Some("CWE-918"),
+                fix_suggestion: Some("Validate URLs against an allowlist of permitted hosts before making requests"),
+            },
+            format_description: js_taint_ssrf_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-ssti",
+                severity: Severity::Critical,
+                cwe: Some("CWE-1336"),
+                fix_suggestion: Some("Use pre-compiled templates with auto-escaping instead of rendering user input as template strings"),
+            },
+            format_description: js_taint_ssti_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-xpath-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-643"),
+                fix_suggestion: Some("Validate and sanitize user input before building XPath expressions"),
+            },
+            format_description: js_taint_xpath_injection_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-ldap-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-90"),
+                fix_suggestion: Some("Use ldap-escape or sanitize special LDAP characters before building filter strings"),
+            },
+            format_description: js_taint_ldap_injection_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-log-injection",
+                severity: Severity::Medium,
+                cwe: Some("CWE-117"),
+                fix_suggestion: Some("Sanitize user input before logging — strip newlines and control characters"),
+            },
+            format_description: js_taint_log_injection_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-xxe",
+                severity: Severity::High,
+                cwe: Some("CWE-611"),
+                fix_suggestion: Some("Disable external entity resolution in XML parser configuration"),
+            },
+            format_description: js_taint_xxe_desc,
+        },
+        JsTaintRuleDispatch {
+            meta: JsTaintRuleMeta {
+                rule_id: "js/taint-nosql-injection",
+                severity: Severity::High,
+                cwe: Some("CWE-943"),
+                fix_suggestion: Some("Validate and sanitize user input before using in MongoDB queries. Use mongo-sanitize to strip $ operators."),
+            },
+            format_description: js_taint_nosql_injection_desc,
+        },
+    ]
+}
+
+/// Run every built-in JS taint rule over `tree` in a single batched
+/// pass, returning per-rule [`Finding`]s.
+///
+/// Rules are grouped by their sanitizer profile so that rules sharing
+/// the same sanitizers collapse into a single AST walk. The default
+/// JS taint ruleset has two groups (no-sanitizer x 8, sanitizer x 3),
+/// which means 2 walks per file instead of 11.
+pub fn run_js_taint_batched(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    ctx: &FileContext<'_>,
+    enabled_rule_ids: &std::collections::HashSet<&str>,
+) -> Vec<Finding> {
+    let dispatch = js_taint_rule_dispatch_table();
+    let rule_specs = js_taint_rule_specs();
+
+    // Only include rules the caller actually registered.
+    let rules: Vec<javascript_taint::BatchedRule<'_>> = rule_specs
+        .iter()
+        .filter(|(id, _)| enabled_rule_ids.contains(id))
+        .map(|(id, spec)| javascript_taint::BatchedRule { rule_id: id, spec })
+        .collect();
+
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    let cross_file_info = match (ctx.cross_file_summaries, ctx.javascript_import_paths) {
+        (Some(summaries), Some(import_paths)) => Some(javascript_taint::CrossFileInfoBatched {
+            import_to_path: import_paths,
+            summaries,
+        }),
+        _ => None,
+    };
+
+    let raw = javascript_taint::analyze_tree_batched(
+        tree.root_node(),
+        source,
+        &rules,
+        ctx.javascript_aliases,
+        cross_file_info.as_ref(),
+    );
+
+    raw.into_iter()
+        .filter_map(|(rule_id, t)| {
+            let d = dispatch.iter().find(|d| d.meta.rule_id == rule_id)?;
+            Some(Finding {
+                rule_id: d.meta.rule_id.to_string(),
+                severity: d.meta.severity,
+                cwe: d.meta.cwe.map(|s| s.to_string()),
+                description: (d.format_description)(&t.source_description, &t.sink_description),
+                file: String::new(),
+                line: t.sink_line,
+                column: t.sink_column,
+                end_line: t.sink_end_line,
+                end_column: t.sink_end_column,
+                snippet: get_source_line(source, t.sink_start_byte),
+                source_line: Some(t.source_line),
+                source_description: Some(t.source_description),
+                sink_line: Some(t.sink_line),
+                sink_description: Some(t.sink_description),
+                fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
+                sink_start_byte: Some(t.sink_start_byte),
+                sink_end_byte: Some(t.sink_end_byte),
+            })
+        })
+        .collect()
 }

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -108,22 +108,52 @@ pub struct TaintFinding {
     pub sink_description: String,
     /// 1-indexed line where the taint source was introduced.
     pub source_line: usize,
+    /// Optional rule id hint set by the batched analyzer so callers can
+    /// dispatch a finding back to the correct rule. `None` for
+    /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
+    pub rule_id_hint: Option<String>,
 }
 
 /// Cross-file context passed to `analyze_tree_with_cross_file` to enable
 /// cross-file taint propagation. When `Some`, the engine resolves calls to
 /// imported functions via the summary map and emits findings when tainted
 /// arguments reach cross-file sinks.
-#[derive(Clone)]
 pub struct CrossFileInfo<'a> {
     /// Map from local import name (e.g. `"./services"` module specifier or
     /// local binding) to the resolved file path.
     pub import_to_path: &'a HashMap<String, PathBuf>,
     /// Cross-file summaries keyed by canonical file path.
     pub summaries: &'a CrossFileSummaryMap,
-    /// The rule ID currently being analyzed. Cross-file findings are only
-    /// emitted when the summary's `sink_rule_id` matches this value.
-    pub current_rule_id: &'a str,
+    /// The rule filter used to emit cross-file findings. Cross-file
+    /// findings are only emitted when the summary's `sink_rule_id`
+    /// passes this filter.
+    ///
+    /// - [`RuleFilter::Single`] in single-rule mode (the historical
+    ///   behaviour).
+    /// - [`RuleFilter::Any`] with a set of allowed rule ids in batched
+    ///   mode, so a single walk can attribute findings to any of the
+    ///   batched rules.
+    pub rule_filter: RuleFilter<'a>,
+}
+
+/// How cross-file findings should be attributed to rules.
+pub enum RuleFilter<'a> {
+    /// Only emit cross-file findings whose `sink_rule_id` equals the
+    /// given value; the finding is attributed to that rule.
+    Single(&'a str),
+    /// Emit cross-file findings whose `sink_rule_id` appears in the
+    /// given set; each finding is attributed to the matching rule via
+    /// `rule_id_hint`.
+    Any(&'a HashSet<String>),
+}
+
+impl<'a> RuleFilter<'a> {
+    fn allows(&self, rule_id: &str) -> bool {
+        match self {
+            RuleFilter::Single(id) => *id == rule_id,
+            RuleFilter::Any(set) => set.contains(rule_id),
+        }
+    }
 }
 
 /// Return-taint summary map keyed by a function's simple name. Mirrors
@@ -144,6 +174,10 @@ struct AnalysisContext<'a> {
     summaries: &'a ReturnSummary,
     /// Cross-file info for resolving imported function calls.
     cross_file: Option<&'a CrossFileInfo<'a>>,
+    /// When the batched analyzer merges sinks from multiple rules into a
+    /// single `TaintSpec`, this map attributes each matched sink back to
+    /// its owning rule id. `None` in single-rule mode.
+    sink_to_rule: Option<&'a HashMap<String, String>>,
 }
 
 /// Run the taint engine over every function/method body inside `root` and
@@ -184,6 +218,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
+        sink_to_rule: None,
     };
     collect_summary_targets(root, source, &mut |name, func_node| {
         let ret = summarize_function(func_node, &pass1_ctx);
@@ -196,12 +231,190 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
+        sink_to_rule: None,
     };
     let mut findings = Vec::new();
     collect_function_scopes(root, &mut |func_node| {
         analyze_function(func_node, &ctx, &mut findings);
     });
     findings
+}
+
+/// Inputs to [`analyze_tree_batched`]: a set of rules that should share
+/// Pass 1/Pass 2 walks when their sanitizer profile matches.
+pub struct BatchedRule<'a> {
+    pub rule_id: &'a str,
+    pub spec: &'a TaintSpec,
+}
+
+/// Cross-file info used by the batched analyzer.
+///
+/// Unlike [`CrossFileInfo`] — which takes a single rule filter — the
+/// batched variant only needs the summary map and the import paths.
+/// The allowed rule ids are derived per sanitizer-group from the input
+/// [`BatchedRule`] slice.
+pub struct CrossFileInfoBatched<'a> {
+    pub import_to_path: &'a HashMap<String, PathBuf>,
+    pub summaries: &'a CrossFileSummaryMap,
+}
+
+/// Batched JS taint analysis.
+///
+/// Runs the taint engine once per sanitizer-group instead of once per
+/// rule. Rules with different sanitizer sets land in different groups
+/// because sanitizers affect both the return-taint summary and the
+/// intra-file taint state.
+///
+/// Returns `(rule_id, finding)` pairs.
+pub fn analyze_tree_batched<'a>(
+    root: Node<'_>,
+    source: &'a str,
+    rules: &[BatchedRule<'a>],
+    aliases: Option<&'a AliasTable>,
+    cross_file: Option<&'a CrossFileInfoBatched<'a>>,
+) -> Vec<(String, TaintFinding)> {
+    if rules.is_empty() {
+        return Vec::new();
+    }
+
+    // Group rules that share the same sanitizer matchers.
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for (i, r) in rules.iter().enumerate() {
+        let mut placed = false;
+        for g in groups.iter_mut() {
+            let rep = rules[g[0]].spec;
+            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
+                g.push(i);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            groups.push(vec![i]);
+        }
+    }
+
+    let mut out: Vec<(String, TaintFinding)> = Vec::new();
+    for group in &groups {
+        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
+        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut seen_source_descs: HashSet<String> = HashSet::new();
+        let mut seen_sink_descs: HashSet<String> = HashSet::new();
+        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
+        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
+
+        for &idx in group {
+            let r = &rules[idx];
+            allowed_rule_ids.insert(r.rule_id.to_string());
+            for src in &r.spec.sources {
+                if seen_source_descs.insert(src.description().to_string()) {
+                    merged_sources.push(src.clone());
+                }
+            }
+            for sink in &r.spec.sinks {
+                sink_to_rule
+                    .entry(sink.description().to_string())
+                    .or_insert_with(|| r.rule_id.to_string());
+                if seen_sink_descs.insert(sink.description().to_string()) {
+                    merged_sinks.push(sink.clone());
+                }
+            }
+        }
+
+        let sanitizers = rules[group[0]].spec.sanitizers.clone();
+        let merged_spec = TaintSpec {
+            sources: merged_sources,
+            sinks: merged_sinks,
+            sanitizers,
+        };
+
+        // Pass 1: compute summaries once for the entire group.
+        let empty_summary = ReturnSummary::new();
+        let pass1_ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rule: None,
+        };
+        let mut summaries = ReturnSummary::new();
+        collect_summary_targets(root, source, &mut |name, func_node| {
+            let ret = summarize_function(func_node, &pass1_ctx);
+            summaries.insert(name, ret);
+        });
+
+        // Pass 2: one walk emits findings for every rule in the group.
+        let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
+            import_to_path: cf.import_to_path,
+            summaries: cf.summaries,
+            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+        });
+        let ctx = AnalysisContext {
+            source,
+            spec: &merged_spec,
+            aliases,
+            summaries: &summaries,
+            cross_file: cross_file_for_group.as_ref(),
+            sink_to_rule: Some(&sink_to_rule),
+        };
+        let mut group_findings: Vec<TaintFinding> = Vec::new();
+        collect_function_scopes(root, &mut |func_node| {
+            analyze_function(func_node, &ctx, &mut group_findings);
+        });
+
+        // Attribute each finding back to the rule id.
+        for mut f in group_findings {
+            let rule_id = f
+                .rule_id_hint
+                .clone()
+                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
+            if let Some(rid) = rule_id {
+                f.rule_id_hint = Some(rid.clone());
+                out.push((rid, f));
+            }
+        }
+    }
+
+    out
+}
+
+fn sanitizer_fingerprints_eq(a: &[NodeMatcher], b: &[NodeMatcher]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let fingerprint = |matchers: &[NodeMatcher]| -> Vec<String> {
+        let mut v: Vec<String> = matchers.iter().map(matcher_fingerprint).collect();
+        v.sort();
+        v
+    };
+    fingerprint(a) == fingerprint(b)
+}
+
+fn matcher_fingerprint(m: &NodeMatcher) -> String {
+    match m {
+        NodeMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => format!("A|{root}|{field}|{description}"),
+        NodeMatcher::Call {
+            canonical,
+            description,
+        } => format!("C|{canonical}|{description}"),
+        NodeMatcher::ParamName { names, description } => {
+            format!("P|{}|{description}", names.join(","))
+        }
+        NodeMatcher::MethodName {
+            method,
+            description,
+        } => {
+            format!("M|{method}|{description}")
+        }
+        NodeMatcher::MemberAssign { field, description } => {
+            format!("MA|{field}|{description}")
+        }
+    }
 }
 
 /// Walk `root` and invoke `visit(name, body_node)` for every function
@@ -414,6 +627,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
+                sink_to_rule: None,
             };
             let ret_taint = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -431,6 +645,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -456,6 +671,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
+                    sink_to_rule: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -1393,6 +1609,10 @@ fn handle_assignment(
                 if let Some((src_desc, src_line)) = expression_taint(right, ctx, state) {
                     let start = node.start_position();
                     let end = node.end_position();
+                    let rule_id_hint = ctx
+                        .sink_to_rule
+                        .and_then(|m| m.get(sink_desc.as_str()))
+                        .map(|s| s.to_string());
                     findings.push(TaintFinding {
                         sink_start_byte: node.start_byte(),
                         sink_end_byte: node.end_byte(),
@@ -1403,6 +1623,7 @@ fn handle_assignment(
                         source_description: src_desc,
                         sink_description: sink_desc,
                         source_line: src_line,
+                        rule_id_hint,
                     });
                 }
             }
@@ -1463,8 +1684,18 @@ fn handle_call(
         } if method == final_segment => Some(description.clone()),
         _ => None,
     });
+    // When the engine is running in batched mode, map the matched sink
+    // description back to the rule it came from so the caller can
+    // dispatch the finding correctly. `None` in single-rule mode.
+    let sink_desc = sink_desc.map(|d| {
+        let rule = ctx
+            .sink_to_rule
+            .and_then(|m| m.get(d.as_str()))
+            .map(|s| s.to_string());
+        (d, rule)
+    });
 
-    if let Some(sink_desc) = sink_desc {
+    if let Some((sink_desc, sink_rule_id)) = sink_desc {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
@@ -1483,6 +1714,7 @@ fn handle_call(
                     source_description: source_desc,
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
+                    rule_id_hint: sink_rule_id.clone(),
                 });
                 break;
             }
@@ -1535,7 +1767,7 @@ fn handle_cross_file_call(
     let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
 
     for flow in &summary.params_to_sink {
-        if flow.sink_rule_id != cross_file.current_rule_id {
+        if !cross_file.rule_filter.allows(&flow.sink_rule_id) {
             continue;
         }
         if flow.param_index >= arg_nodes.len() {
@@ -1558,6 +1790,7 @@ fn handle_cross_file_call(
                     flow.sink_description, func_name
                 ),
                 source_line: src_line,
+                rule_id_hint: Some(flow.sink_rule_id.clone()),
             });
             return;
         }
@@ -2922,7 +3155,7 @@ function route(req) {
         let cross_file = CrossFileInfo {
             import_to_path: &import_to_path,
             summaries: &summary_map,
-            current_rule_id: "js/taint-sql-injection",
+            rule_filter: RuleFilter::Single("js/taint-sql-injection"),
         };
 
         let spec = rule_specs


### PR DESCRIPTION
Addresses #174. Completes the trilogy — Go (#199), Python (#202), now JavaScript.

## Summary
- Same batched-AST-walk optimization: 11 JS taint rules collapse from 22 walks per file to ~4 (8 no-sanitizer rules share one walk, 3 with sanitizers get individual walks)
- Adds `analyze_tree_batched`, `BatchedRule`, `CrossFileInfoBatched`, `RuleFilter` to `javascript_taint.rs`
- Adds `run_js_taint_batched`, `is_js_taint_rule_id`, dispatch table to `javascript.rs`
- Scanner hook in `scanner.rs` mirrors the Go/Python blocks

## Benchmark (warm cache, 5 runs)

| Repo | v0.4.0 | before | after |
|------|--------|--------|-------|
| express | 53ms | ~94ms | **~82ms** |
| flask | 79ms | ~121ms | ~121ms |
| gin | 68ms | ~120ms | ~120ms |

## Test plan
- [x] All 415 tests pass
- [x] No clippy warnings, cargo fmt clean
- [x] Findings output unchanged
