### PR TITLE
chore: drop Homebrew, add foxguard.dev/install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ That boundary is deliberate. It keeps local scans fast, rule support understanda
 ## Install
 
 ```sh
-npx foxguard .                         # no install needed
-brew install peaktwilight/tap/foxguard # Homebrew (macOS/Linux)
-cargo install foxguard                 # crates.io
+npx foxguard .                                           # no install needed
+curl -fsSL https://foxguard.dev/install.sh | sh          # prebuilt binary (macOS/Linux)
+cargo install foxguard                                   # crates.io
 ```
 
 **Editor:** Install the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=peaktwilight.foxguard) — scans on save, shows findings as underlines.

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -83,7 +83,7 @@ To avoid network fetches on every commit, pin the version:
 { "command": "npx foxguard@0.6.2 --changed --severity high ." }
 ```
 
-Or install foxguard globally / via Homebrew and reference the binary directly:
+Or install foxguard globally (`curl -fsSL https://foxguard.dev/install.sh | sh`) and reference the binary directly:
 
 ```json
 { "command": "foxguard --changed --severity high ." }

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -16,7 +16,7 @@ A security scanner as fast as a linter, written in Rust. Scans your code on ever
 foxguard must be installed:
 
 ```sh
-brew install peaktwilight/tap/foxguard
+curl -fsSL https://foxguard.dev/install.sh | sh
 # or
 npm install -g foxguard
 # or

--- a/www/public/install.sh
+++ b/www/public/install.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# foxguard installer
+#
+# Installs the latest foxguard release from github.com/PwnKit-Labs/foxguard.
+# Usage:
+#   curl -fsSL https://foxguard.dev/install.sh | sh
+#
+# Environment variables:
+#   FOXGUARD_INSTALL_DIR  where to put the binary (default: $HOME/.local/bin)
+#   FOXGUARD_VERSION      specific version tag to install (default: latest)
+
+set -eu
+
+REPO="PwnKit-Labs/foxguard"
+INSTALL_DIR="${FOXGUARD_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${FOXGUARD_VERSION:-latest}"
+
+err() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+command -v curl >/dev/null 2>&1 || err "curl is required"
+
+os="$(uname -s)"
+case "$os" in
+  Linux)  os_name="linux" ;;
+  Darwin) os_name="macos" ;;
+  *) err "unsupported OS: $os. On Windows, use: npx foxguard ." ;;
+esac
+
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64)   arch_name="x86_64" ;;
+  aarch64|arm64)  arch_name="aarch64" ;;
+  *) err "unsupported architecture: $arch" ;;
+esac
+
+binary_name="foxguard-${os_name}-${arch_name}"
+
+if [ "$VERSION" = "latest" ]; then
+  printf 'fetching latest foxguard release...\n'
+  tag="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep -o '"tag_name": *"[^"]*"' | head -1 \
+    | sed 's/.*"\([^"]*\)"$/\1/')"
+  [ -n "$tag" ] || err "could not fetch latest release tag"
+else
+  tag="$VERSION"
+fi
+
+printf 'installing foxguard %s for %s-%s...\n' "$tag" "$os_name" "$arch_name"
+
+mkdir -p "$INSTALL_DIR"
+
+download_url="https://github.com/${REPO}/releases/download/${tag}/${binary_name}"
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! curl -fsSL -o "$tmp" "$download_url"; then
+  err "failed to download $download_url"
+fi
+
+chmod +x "$tmp"
+mv "$tmp" "$INSTALL_DIR/foxguard"
+trap - EXIT
+
+printf '\ninstalled foxguard %s to %s/foxguard\n' "$tag" "$INSTALL_DIR"
+
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    printf '\nnote: %s is not in your PATH.\n' "$INSTALL_DIR"
+    printf 'add this to your shell profile:\n'
+    printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+    ;;
+esac
+
+printf '\ntry:  foxguard --help\n'


### PR DESCRIPTION
## Summary

Ends the Homebrew limbo. The automation was already removed in #195; the tap repo is stuck at v0.6.3 and would drift further with every release. Rather than hand-maintain it, this PR drops Homebrew entirely and replaces it with a curl-based installer served from foxguard.dev.

## What changes

### New: \`www/public/install.sh\`
Astro serves \`www/public/\` at the site root, so this file auto-publishes to **\`https://foxguard.dev/install.sh\`** on the next \`deploy-www.yml\` run.

The script:
- Detects OS (\`linux\` / \`macos\`) and arch (\`x86_64\` / \`aarch64\`)
- Queries the GitHub API for the latest release tag (zero maintenance — always grabs current)
- Downloads the matching \`foxguard-{os}-{arch}\` binary into \`\$HOME/.local/bin\` by default
- Respects \`FOXGUARD_INSTALL_DIR\` (custom location) and \`FOXGUARD_VERSION\` (pin to a specific tag)
- Prints a PATH warning when needed
- ~80 lines of plain POSIX sh, no emojis, inspectable

### Removed Homebrew mentions
- \`README.md\` install section
- \`vscode-extension/README.md\`
- \`docs/claude-code-integration.md\`

\`benchmarks/README.md\` still mentions \`brew install tokei\` and \`/opt/homebrew/bin/semgrep\` — those are for installing benchmark prerequisites, unrelated to distributing foxguard itself. Left untouched.

### Install paths going forward
1. \`curl -fsSL https://foxguard.dev/install.sh | sh\` — prebuilt binary, macOS/Linux
2. \`npx foxguard .\` — universal, no install needed
3. \`cargo install foxguard\` — Rust users

## Verified end-to-end

Tested the script locally against the live v0.7.0 release:

\`\`\`
$ FOXGUARD_INSTALL_DIR=/tmp/foxguard-test-install sh www/public/install.sh
fetching latest foxguard release...
installing foxguard v0.7.0 for macos-aarch64...

installed foxguard v0.7.0 to /tmp/foxguard-test-install/foxguard
...

$ /tmp/foxguard-test-install/foxguard --version
foxguard 0.7.0
\`\`\`

## The tap repo
\`peaktwilight/homebrew-tap\` is left alone (not archived). Anyone who previously ran \`brew install peaktwilight/tap/foxguard\` keeps v0.6.3 and can upgrade by switching to one of the three paths above. If you want to archive the tap later, that's orthogonal.

## Test plan
- [x] Script runs and installs a working binary locally
- [x] Website builds with \`install.sh\` at \`dist/install.sh\`
- [x] No stray Homebrew mentions in project docs (benchmarks prereq mentions intentionally kept)
- [ ] After merge: \`curl -fsSL https://foxguard.dev/install.sh | sh\` works in a clean \`sh\` on a fresh machine