### PR TITLE
fix(npm): always download version-matched binary, ignore PATH

### DIFF
--- a/packages/npm/bin/foxguard
+++ b/packages/npm/bin/foxguard
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { execFileSync, execSync } = require("child_process");
+const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -46,35 +46,6 @@ function getCacheDir() {
 
 function getBinaryName() {
   return os.platform() === "win32" ? "foxguard.exe" : "foxguard";
-}
-
-// Check if cargo-installed foxguard exists
-function findCargoInstall() {
-  try {
-    const cargoHome = process.env.CARGO_HOME || path.join(os.homedir(), ".cargo");
-    const cargoBin = path.join(cargoHome, "bin", getBinaryName());
-    if (fs.existsSync(cargoBin)) {
-      return cargoBin;
-    }
-  } catch {}
-
-  // Try PATH
-  try {
-    const which = os.platform() === "win32" ? "where" : "which";
-    const result = execSync(`${which} foxguard 2>/dev/null`, {
-      encoding: "utf8",
-    }).trim();
-    if (result && !result.includes("node_modules")) {
-      // Resolve symlinks to avoid finding ourselves (the npm wrapper)
-      const resolved = fs.realpathSync(result);
-      const thisScript = fs.realpathSync(__filename);
-      if (resolved !== thisScript) {
-        return result;
-      }
-    }
-  } catch {}
-
-  return null;
 }
 
 function download(url) {
@@ -151,18 +122,11 @@ async function downloadBinary() {
 }
 
 async function main() {
-  // 1. Check for cargo-installed binary
-  const cargoBin = findCargoInstall();
-  if (cargoBin) {
-    try {
-      execFileSync(cargoBin, process.argv.slice(2), { stdio: "inherit" });
-      return;
-    } catch (e) {
-      process.exit(e.status || 1);
-    }
-  }
-
-  // 2. Download or use cached binary
+  // Always resolve to the binary matching the npm package version. A
+  // previously-installed foxguard on PATH (cargo, Homebrew, etc.) may be
+  // an older version that does not understand newer subcommands, so we
+  // ignore it. Users who want their own foxguard can invoke it directly
+  // instead of via `npx`.
   const bin = await downloadBinary();
   try {
     execFileSync(bin, process.argv.slice(2), { stdio: "inherit" });


### PR DESCRIPTION
## Bug

\`npx foxguard@X.Y.Z <subcmd>\` silently runs whatever \`foxguard\` happens to be on PATH (cargo-installed, Homebrew-installed, earlier Rust checkout) instead of the version the user explicitly pinned.

**Repro:**
\`\`\`sh
cargo install foxguard --version 0.3.2
npx foxguard@latest tui
# Error: path 'tui' does not exist
\`\`\`

v0.3.2 has no \`tui\` subcommand, so it treats \`tui\` as a path argument. The user who pinned \`foxguard@latest\` (v0.7.1) never sees the v0.7.1 binary.

Found while debugging why \`npx foxguard@0.7.1 tui\` wasn't launching the TUI that shipped today. Two systems reproduced the bug, both had old cargo-installed foxguard versions shadowing the pinned npm version.

## Root cause

The wrapper's \`main()\` used to call \`findCargoInstall()\` first, which walks \`\$CARGO_HOME/bin\` and falls back to \`which foxguard\`:

\`\`\`js
const cargoBin = findCargoInstall();
if (cargoBin) {
  execFileSync(cargoBin, process.argv.slice(2), { stdio: "inherit" });
  return;  // ← ignores npm package version entirely
}
\`\`\`

There's no version check — any \`foxguard\` anywhere on the system takes priority over the pinned npm version. This silently breaks version pinning for npm consumers.

## Fix

Remove \`findCargoInstall()\` entirely. The wrapper now always downloads the release binary matching \`package.json\`'s \`version\` and caches it (per-version cache, so subsequent runs are fast).

Users who want to run their own cargo-installed \`foxguard\` should invoke it directly — \`npx\` is the wrong entry point for that use case.

## Tested

\`\`\`sh
# Before: shadowed by cargo binary
$ which foxguard
/Users/peak/.cargo/bin/foxguard  # v0.3.2
$ npx foxguard@latest tui
Error: path 'tui' does not exist

# After fix
$ node packages/npm/bin/foxguard tui --help
foxguard: downloading v0.7.1 for aarch64-apple-darwin...
Explore scan findings in the interactive terminal TUI
Usage: foxguard tui [OPTIONS] [PATH]
\`\`\`

## Release impact

This fix needs a new npm release to reach users — v0.7.1 on npm still has the buggy wrapper. Suggest bundling with a v0.7.2 patch release (can also pick up the \`rand\` LOW Dependabot alert GHSA-cq8v-f236-94qc that surfaced today).

## Test plan
- [x] \`node -c\` syntax check
- [x] Local wrapper invocation — correctly downloads v0.7.1 and dispatches \`tui\`
- [ ] CI green
- [ ] After merge + v0.7.2 release: \`npx foxguard@0.7.2 tui\` works on a machine with stale cargo foxguard