### PR TITLE
feat: per-rule enable/disable in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,15 @@ scan:
   baseline: .foxguard/baseline.json
   rules: ./semgrep-rules
 
+  # Optional allowlist: when non-empty, ONLY these rule IDs run.
+  # enable_rules:
+  #   - py/no-sql-injection
+  #   - py/no-xss
+  # Denylist: these rule IDs never run (applied after enable_rules).
+  # disable_rules:
+  #   - py/no-eval
+  #   - js/no-function-constructor
+
 secrets:
   baseline: .foxguard/secrets-baseline.json
   exclude_paths:
@@ -240,6 +249,21 @@ secrets:
   ignore_rules:
     - secret/github-token
 ```
+
+### Per-rule enable / disable
+
+`scan.enable_rules` and `scan.disable_rules` filter the active rule set globally.
+
+- If `enable_rules` is present, only those rule IDs run (allowlist).
+- `disable_rules` always applies — listed IDs are removed.
+- If both are present, `enable_rules` is applied first (intersection with
+  the registry), then `disable_rules` subtracts any IDs you want
+  explicitly off. So a rule listed in both lists is disabled.
+- Unknown rule IDs are reported on stderr once at scan start and the scan
+  continues.
+
+For path-scoped suppression of a specific rule on a specific file, use
+`scan.ignore_rules` instead.
 
 ## Suppressing Deliberate Findings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,9 +95,15 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     validate_root_path(&scan.path)?;
     validate_rules_path(scan.rules.as_deref())?;
 
-    let registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
+    let mut registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
     let excludes = PathExcludeMatcher::new(&scan.exclude)?;
     let targets = collect_changed_targets(&scan.path, scan.changed)?;
+
+    let rule_filter_unknown = if let Some(config) = config.as_ref() {
+        registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)
+    } else {
+        Vec::new()
+    };
 
     let (result, mut notices) = if let Some(files) = targets {
         scan_paths_with_root_with_notices(
@@ -110,6 +116,21 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     } else {
         scan_directory_with_notices(&scan.path, &registry, scan.max_file_size, Some(&excludes))
     };
+
+    if !rule_filter_unknown.is_empty() {
+        notices.insert(
+            0,
+            format!(
+                "Warning: unknown rule id{} in config (enable_rules/disable_rules): {}",
+                if rule_filter_unknown.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                rule_filter_unknown.join(", ")
+            ),
+        );
+    }
 
     let files_scanned = result.files_scanned;
     let duration = result.duration;
@@ -212,9 +233,29 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
 pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), None)?;
-    let registry = build_registry(args.no_builtins, args.rules.as_deref())?;
+    let mut registry = build_registry(args.no_builtins, args.rules.as_deref())?;
+    let rule_filter_unknown = if let Some(config) = config.as_ref() {
+        registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)
+    } else {
+        Vec::new()
+    };
     let ((scan_result, mut diff_result), mut notices) =
         run_diff_with_warnings(&args.path, &args.target, &registry, args.max_file_size)?;
+
+    if !rule_filter_unknown.is_empty() {
+        notices.insert(
+            0,
+            format!(
+                "Warning: unknown rule id{} in config (enable_rules/disable_rules): {}",
+                if rule_filter_unknown.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                },
+                rule_filter_unknown.join(", ")
+            ),
+        );
+    }
 
     let known_rule_ids = collect_rule_ids(&registry);
     let override_warnings = apply_severity_overrides(

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,13 @@ pub struct ScanConfig {
     /// `severity` min-filter, so demoting a rule to Low with a
     /// `severity: medium` filter will suppress the finding.
     pub severity_overrides: HashMap<String, Severity>,
+    /// Optional allowlist of rule IDs. When non-empty, only rules whose
+    /// `id()` appears in the list are kept in the active registry.
+    pub enable_rules: Vec<String>,
+    /// Denylist of rule IDs. Rules whose `id()` appears in this list are
+    /// removed from the active registry and never execute. Applied after
+    /// `enable_rules`, so a rule listed in both lists is disabled.
+    pub disable_rules: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -70,6 +77,10 @@ struct RawScanConfig {
     /// validation.
     #[serde(default)]
     severity_overrides: HashMap<String, Severity>,
+    #[serde(default)]
+    enable_rules: Vec<String>,
+    #[serde(default)]
+    disable_rules: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -210,6 +221,8 @@ impl FoxguardConfig {
                 baseline: scan_baseline,
                 ignore_rules: scan_ignore_rules,
                 severity_overrides: raw.scan.severity_overrides,
+                enable_rules: raw.scan.enable_rules,
+                disable_rules: raw.scan.disable_rules,
             },
             secrets: SecretsConfig {
                 baseline: secrets_baseline,
@@ -731,6 +744,39 @@ mod tests {
             loaded.secrets.exclude_paths,
             vec![expected.display().to_string()]
         );
+    }
+
+    #[test]
+    fn load_for_scan_parses_enable_and_disable_rules() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  enable_rules:\n    - py/no-eval\n    - js/no-xss\n  disable_rules:\n    - go/no-ssrf\n",
+        );
+
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+
+        assert_eq!(
+            loaded.scan.enable_rules,
+            vec!["py/no-eval".to_string(), "js/no-xss".to_string()]
+        );
+        assert_eq!(loaded.scan.disable_rules, vec!["go/no-ssrf".to_string()]);
+    }
+
+    #[test]
+    fn load_for_scan_defaults_enable_and_disable_rules_to_empty() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(repo.path(), ".foxguard.yml", "scan:\n  severity: high\n");
+
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+
+        assert!(loaded.scan.enable_rules.is_empty());
+        assert!(loaded.scan.disable_rules.is_empty());
     }
 
     #[test]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -396,4 +396,130 @@ impl RuleRegistry {
     pub fn all_rules(&self) -> &[Box<dyn Rule>] {
         &self.rules
     }
+
+    /// Apply `scan.enable_rules` (allowlist) and `scan.disable_rules`
+    /// (denylist) from the loaded config to the active rule set.
+    ///
+    /// Semantics:
+    /// - If `enable` is non-empty, only rules whose id is in `enable` are
+    ///   retained (intersection with the full registry).
+    /// - If `disable` is non-empty, rules whose id is in `disable` are
+    ///   removed. Applied after `enable`, so IDs appearing in both lists
+    ///   are disabled.
+    /// - Both empty → no change.
+    ///
+    /// Returns the set of IDs from `enable` or `disable` that do not
+    /// correspond to any registered rule. Callers should surface these
+    /// as a single warning so users catch typos without failing the scan.
+    pub fn apply_rule_filter(&mut self, enable: &[String], disable: &[String]) -> Vec<String> {
+        if enable.is_empty() && disable.is_empty() {
+            return Vec::new();
+        }
+
+        let known: std::collections::HashSet<&str> = self.rules.iter().map(|r| r.id()).collect();
+
+        let mut unknown: Vec<String> = Vec::new();
+        let mut seen_unknown: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for id in enable.iter().chain(disable.iter()) {
+            if !known.contains(id.as_str()) && seen_unknown.insert(id.as_str()) {
+                unknown.push(id.clone());
+            }
+        }
+
+        if !enable.is_empty() {
+            let enable_set: std::collections::HashSet<&str> =
+                enable.iter().map(|s| s.as_str()).collect();
+            self.rules.retain(|r| enable_set.contains(r.id()));
+        }
+
+        if !disable.is_empty() {
+            let disable_set: std::collections::HashSet<&str> =
+                disable.iter().map(|s| s.as_str()).collect();
+            self.rules.retain(|r| !disable_set.contains(r.id()));
+        }
+
+        unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule_ids(registry: &RuleRegistry) -> Vec<String> {
+        registry.rules.iter().map(|r| r.id().to_string()).collect()
+    }
+
+    fn has_rule(registry: &RuleRegistry, id: &str) -> bool {
+        registry.rules.iter().any(|r| r.id() == id)
+    }
+
+    #[test]
+    fn apply_rule_filter_no_op_when_both_lists_empty() {
+        let mut registry = RuleRegistry::new();
+        let before = rule_ids(&registry);
+        let unknown = registry.apply_rule_filter(&[], &[]);
+        assert!(unknown.is_empty());
+        assert_eq!(rule_ids(&registry), before);
+    }
+
+    #[test]
+    fn apply_rule_filter_allowlist_keeps_only_listed_ids() {
+        let mut registry = RuleRegistry::new();
+        let unknown =
+            registry.apply_rule_filter(&["py/no-eval".to_string(), "js/no-eval".to_string()], &[]);
+        assert!(unknown.is_empty());
+        assert_eq!(registry.rules.len(), 2);
+        assert!(has_rule(&registry, "py/no-eval"));
+        assert!(has_rule(&registry, "js/no-eval"));
+    }
+
+    #[test]
+    fn apply_rule_filter_denylist_removes_listed_ids() {
+        let mut registry = RuleRegistry::new();
+        let before_count = registry.rules.len();
+        let unknown = registry.apply_rule_filter(&[], &["py/no-eval".to_string()]);
+        assert!(unknown.is_empty());
+        assert_eq!(registry.rules.len(), before_count - 1);
+        assert!(!has_rule(&registry, "py/no-eval"));
+    }
+
+    #[test]
+    fn apply_rule_filter_both_intersects_then_subtracts() {
+        // enable = {py/no-eval, py/no-sql-injection}; disable = {py/no-eval}
+        // Expected: only py/no-sql-injection remains.
+        let mut registry = RuleRegistry::new();
+        let unknown = registry.apply_rule_filter(
+            &["py/no-eval".to_string(), "py/no-sql-injection".to_string()],
+            &["py/no-eval".to_string()],
+        );
+        assert!(unknown.is_empty());
+        assert_eq!(registry.rules.len(), 1);
+        assert!(has_rule(&registry, "py/no-sql-injection"));
+        assert!(!has_rule(&registry, "py/no-eval"));
+    }
+
+    #[test]
+    fn apply_rule_filter_reports_unknown_rule_ids() {
+        let mut registry = RuleRegistry::new();
+        let unknown = registry.apply_rule_filter(
+            &["py/no-eval".to_string(), "py/does-not-exist".to_string()],
+            &["another/typo".to_string()],
+        );
+        assert_eq!(unknown.len(), 2);
+        assert!(unknown.contains(&"py/does-not-exist".to_string()));
+        assert!(unknown.contains(&"another/typo".to_string()));
+        // Real rule still applies (allowlist kept py/no-eval, denylist had no matches).
+        assert!(has_rule(&registry, "py/no-eval"));
+    }
+
+    #[test]
+    fn apply_rule_filter_deduplicates_unknown_ids() {
+        let mut registry = RuleRegistry::new();
+        let unknown = registry.apply_rule_filter(
+            &["py/typo".to_string(), "py/typo".to_string()],
+            &["py/typo".to_string()],
+        );
+        assert_eq!(unknown, vec!["py/typo".to_string()]);
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1985,6 +1985,167 @@ rules:
     }
 
     #[test]
+    fn test_enable_rules_allowlist_runs_only_listed_ids() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        copy_fixture_to(repo.path(), "vulnerable.py", "vulnerable.py");
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  enable_rules:\n    - py/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["vulnerable.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            !findings.is_empty(),
+            "expected at least one py/no-eval finding"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f["rule_id"].as_str() == Some("py/no-eval")),
+            "expected only py/no-eval findings when allowlisted, got: {:?}",
+            findings
+                .iter()
+                .map(|f| f["rule_id"].as_str().unwrap_or("?"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_disable_rules_denylist_removes_listed_ids() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        copy_fixture_to(repo.path(), "vulnerable.py", "vulnerable.py");
+
+        // First scan without disable_rules to confirm py/no-eval fires.
+        let baseline = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["vulnerable.py", "-f", "json"])
+            .output()
+            .expect("failed to execute baseline foxguard scan");
+        let baseline_findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&baseline.stdout).expect("invalid JSON");
+        assert!(
+            baseline_findings
+                .iter()
+                .any(|f| f["rule_id"].as_str() == Some("py/no-eval")),
+            "baseline scan should include py/no-eval"
+        );
+
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  disable_rules:\n    - py/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["vulnerable.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            !findings.is_empty(),
+            "other rules should still fire when only py/no-eval is disabled"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f["rule_id"].as_str() != Some("py/no-eval")),
+            "expected py/no-eval to be suppressed by disable_rules"
+        );
+    }
+
+    #[test]
+    fn test_enable_and_disable_rules_intersection_then_subtraction() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        copy_fixture_to(repo.path(), "vulnerable.py", "vulnerable.py");
+        // Allowlist two rules, then disable one of them. Only the other
+        // should remain.
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  enable_rules:\n    - py/no-eval\n    - py/no-hardcoded-secret\n  disable_rules:\n    - py/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["vulnerable.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            findings
+                .iter()
+                .any(|f| f["rule_id"].as_str() == Some("py/no-hardcoded-secret")),
+            "expected py/no-hardcoded-secret to remain after intersection"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f["rule_id"].as_str() != Some("py/no-eval")),
+            "py/no-eval should be removed by disable_rules even when allowlisted"
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| matches!(f["rule_id"].as_str(), Some("py/no-hardcoded-secret"))),
+            "only intersection(enable) minus disable should fire"
+        );
+    }
+
+    #[test]
+    fn test_unknown_rule_ids_warn_on_stderr_and_continue() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        copy_fixture_to(repo.path(), "vulnerable.py", "vulnerable.py");
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  disable_rules:\n    - py/does-not-exist\n    - py/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["vulnerable.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        // Unknown IDs should never fail the scan.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("py/does-not-exist"),
+            "expected unknown rule id in stderr warning, got: {}",
+            stderr
+        );
+        assert!(
+            stderr.contains("unknown rule"),
+            "expected 'unknown rule' phrase in warning, got: {}",
+            stderr
+        );
+
+        // Scan should still proceed and the known disable (py/no-eval)
+        // should apply.
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            findings
+                .iter()
+                .all(|f| f["rule_id"].as_str() != Some("py/no-eval")),
+            "known disable should still apply even with unknown ids present"
+        );
+    }
+
+    #[test]
     fn test_scan_rejects_config_path_traversal() {
         let repo = TempDir::new().expect("failed to create temp dir");
         let outside = TempDir::new().expect("failed to create outside temp dir");


### PR DESCRIPTION
Closes #208.

## Summary
Adds `scan.enable_rules` (allowlist) and `scan.disable_rules` (denylist) to `.foxguard.yml`.

## Semantics
- `enable_rules` present → only listed rule IDs run (allowlist: intersection with the registry).
- `disable_rules` present → listed rule IDs are removed from the active set.
- **Both present** → `enable_rules` runs first (filter to allowlist), then `disable_rules` removes any explicitly disabled IDs. A rule listed in both is disabled. This keeps the mental model simple: "only these rules, except these."
- Neither present → all rules run (current behaviour, no regression).
- Unknown rule IDs in either list → single stderr warning at scan start, scan continues. Never fails the scan so typos are easy to catch.
- Wildcards are intentionally out of scope for v1.

Orthogonal to `scan.ignore_rules` (per-file suppression) and `scan.no_builtins` (nuclear option).

## Changes
- `src/config.rs`: added `enable_rules: Vec<String>` and `disable_rules: Vec<String>` to `ScanConfig`, plus matching fields on `RawScanConfig`. Both default to empty when the keys are absent.
- `src/rules/mod.rs`: new `RuleRegistry::apply_rule_filter(&mut self, enable, disable) -> Vec<String>` that applies the two-stage filter in place and returns the deduplicated list of unknown IDs for the caller to surface.
- `src/app.rs`: `execute_scan` and `execute_diff` now call `apply_rule_filter` right after `build_registry` and prepend the unknown-ID warning to the notices list (which `main.rs` prints to stderr).
- `src/rules/{python,go,javascript}.rs`: **untouched.** The batched taint runners already take `enabled_rule_ids` built from the filtered registry (via `rules_by_lang` in the scanner), so registry filtering propagates automatically. No dispatch-table plumbing needed.
- `README.md`: documented the new keys in the Configuration section.

## Test plan
- [x] `cargo test` — 308 lib tests + 82 integration tests + all suites pass
  - New unit tests: `rules::tests::apply_rule_filter_*` (6 tests: no-op, allowlist only, denylist only, both, unknown IDs reported, unknown ID dedup)
  - New unit tests: `config::tests::load_for_scan_parses_enable_and_disable_rules`, `..._defaults_enable_and_disable_rules_to_empty`
  - New integration tests: `features::test_enable_rules_allowlist_runs_only_listed_ids`, `test_disable_rules_denylist_removes_listed_ids`, `test_enable_and_disable_rules_intersection_then_subtraction`, `test_unknown_rule_ids_warn_on_stderr_and_continue`
- [x] `cargo clippy --lib -- -D warnings` — clean (a pre-existing `src/tui.rs:1999` `items-after-test-module` warning is unrelated to this PR)
- [x] `cargo fmt --check` — clean
- [x] Dogfood unchanged by default: `./target/release/foxguard tests/fixtures -f json` returned 539 findings both before and after the branch (identical set), confirming no behaviour change when neither key is set.
- [x] Manual: scan with `enable_rules: [py/no-eval]` on a file with eval/hardcoded-secret/os.system → only `py/no-eval` fires.
- [x] Manual: scan with `disable_rules: [py/no-eval]` on the same file → `py/no-hardcoded-secret` and `py/no-command-injection` still fire, `py/no-eval` does not.
- [x] Manual: `disable_rules: [py/does-not-exist, py/no-eval]` → stderr prints `Warning: unknown rule id in config (enable_rules/disable_rules): py/does-not-exist` and the scan continues with the known disable applied.