### PR TITLE
feat: expose secrets entropy + taint hop thresholds in config (refs #210)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
 use crate::baseline::{load_baseline, suppress_with_baseline, write_baseline};
 use crate::cli::{DiffArgs, OutputFormat, ScanArgs, SecretsArgs, TuiArgs};
 use crate::config::{
-    apply_scan_defaults, apply_secrets_defaults, apply_severity_overrides, load_for_scan,
-    suppress_with_scan_ignores,
+    apply_scan_defaults, apply_scan_thresholds, apply_secrets_defaults, apply_severity_overrides,
+    load_for_scan, suppress_with_scan_ignores,
 };
 use crate::diff::run_diff_with_warnings;
 use crate::engine::{
@@ -94,6 +94,11 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     let config = load_for_scan(Path::new(&scan.path), scan.config.as_deref())?;
     validate_root_path(&scan.path)?;
     validate_rules_path(scan.rules.as_deref())?;
+
+    // Install any `scan.thresholds.*` overrides into process-wide state
+    // before the rules run. Must happen after config load and before
+    // `scan_directory_with_notices` dispatches parallel rule execution.
+    apply_scan_thresholds(config.as_ref());
 
     let mut registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
     let excludes = PathExcludeMatcher::new(&scan.exclude)?;
@@ -233,6 +238,7 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
 pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), None)?;
+    apply_scan_thresholds(config.as_ref());
     let mut registry = build_registry(args.no_builtins, args.rules.as_deref())?;
     let rule_filter_unknown = if let Some(config) = config.as_ref() {
         registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use crate::cli::{ScanArgs, SecretsArgs, SeverityFilter};
+use crate::rules::common::set_hardcoded_secret_min_length_override;
 use crate::{Finding, Severity};
 use serde::Deserialize;
 use serde_yaml::{Mapping, Sequence, Value};
@@ -39,6 +40,48 @@ pub struct ScanConfig {
     /// removed from the active registry and never execute. Applied after
     /// `enable_rules`, so a rule listed in both lists is disabled.
     pub disable_rules: Vec<String>,
+    /// Threshold knobs for built-in pattern rules (refs #210).
+    pub thresholds: ScanThresholds,
+}
+
+/// Tunable thresholds for pattern/heuristic rules.
+///
+/// See issue #210. Each field is `Option<_>` and `None` means "use the
+/// default hardcoded in the rule today" so an empty threshold block is a
+/// pure no-op (zero behavior change). Only thresholds that correspond to
+/// an *existing* hardcoded constant in the scanner are wired up today;
+/// the rest are parsed and validated so users can set them without a
+/// schema break when follow-up PRs hook them into the engine.
+#[derive(Debug, Clone, Default)]
+pub struct ScanThresholds {
+    pub secrets: SecretsThresholds,
+    pub taint: TaintThresholds,
+}
+
+/// Thresholds for `*-hardcoded-secret` rules.
+///
+/// `min_length` is live: it replaces the previously hardcoded `inner.len()
+/// check (`>= 4`) used across every language's secret rule. `min_entropy`
+/// is reserved — no rule in the codebase computes Shannon entropy today,
+/// so enabling it would require inventing new behavior rather than
+/// exposing an existing threshold. It is parsed and validated so a future
+/// PR can wire it without a config schema change.
+#[derive(Debug, Clone, Default)]
+pub struct SecretsThresholds {
+    pub min_length: Option<usize>,
+    pub min_entropy: Option<f32>,
+}
+
+/// Thresholds for taint-propagation rules.
+///
+/// `max_hops` is reserved — the taint engine runs a fixed two-pass
+/// pipeline with no iteration counter to clamp, so there is no
+/// "hardcoded cap" to expose today. Parsed and validated so users can set
+/// it now without a schema break when the engine grows a convergence
+/// loop.
+#[derive(Debug, Clone, Default)]
+pub struct TaintThresholds {
+    pub max_hops: Option<usize>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -81,6 +124,30 @@ struct RawScanConfig {
     enable_rules: Vec<String>,
     #[serde(default)]
     disable_rules: Vec<String>,
+    /// Threshold knobs. Invalid scalar shapes (e.g. a string in a
+    /// numeric field) surface as yaml parse errors so typos fail loudly
+    /// at load time rather than silently falling back to defaults.
+    #[serde(default)]
+    thresholds: RawScanThresholds,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawScanThresholds {
+    #[serde(default)]
+    secrets: RawSecretsThresholds,
+    #[serde(default)]
+    taint: RawTaintThresholds,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawSecretsThresholds {
+    min_length: Option<usize>,
+    min_entropy: Option<f32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawTaintThresholds {
+    max_hops: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -213,6 +280,44 @@ impl FoxguardConfig {
             })
             .transpose()?;
 
+        let raw_thresholds = raw.scan.thresholds;
+        let min_length = raw_thresholds.secrets.min_length;
+        if let Some(value) = min_length {
+            if value == 0 {
+                return Err(
+                    "scan.thresholds.secrets.min_length must be >= 1 (0 disables the \
+                     rule entirely; use scan.ignore_rules instead)"
+                        .to_string(),
+                );
+            }
+        }
+        if let Some(value) = raw_thresholds.secrets.min_entropy {
+            if !(0.0..=8.0).contains(&value) || value.is_nan() {
+                return Err(format!(
+                    "scan.thresholds.secrets.min_entropy must be a finite number in \
+                     [0.0, 8.0] (got {value})"
+                ));
+            }
+        }
+        if let Some(value) = raw_thresholds.taint.max_hops {
+            if value == 0 {
+                return Err(
+                    "scan.thresholds.taint.max_hops must be >= 1 (0 would disable taint \
+                     analysis; set scan.no_builtins or use scan.ignore_rules instead)"
+                        .to_string(),
+                );
+            }
+        }
+        let thresholds = ScanThresholds {
+            secrets: SecretsThresholds {
+                min_length,
+                min_entropy: raw_thresholds.secrets.min_entropy,
+            },
+            taint: TaintThresholds {
+                max_hops: raw_thresholds.taint.max_hops,
+            },
+        };
+
         Ok(Self {
             scan: ScanConfig {
                 rules: scan_rules,
@@ -223,6 +328,7 @@ impl FoxguardConfig {
                 severity_overrides: raw.scan.severity_overrides,
                 enable_rules: raw.scan.enable_rules,
                 disable_rules: raw.scan.disable_rules,
+                thresholds,
             },
             secrets: SecretsConfig {
                 baseline: secrets_baseline,
@@ -305,6 +411,21 @@ pub fn suppress_with_scan_ignores(
             })
         })
         .collect()
+}
+
+/// Install any [`ScanThresholds`] overrides from the loaded config into the
+/// scanner's process-wide state. Idempotent: calling with a fresh config
+/// overwrites any previous override, so repeated scans in the same
+/// process (e.g. the TUI) cannot leak a stale value.
+///
+/// Currently only `secrets.min_length` has an active hook (it feeds the
+/// `is_secret_value_long_enough` helper used by every
+/// `*-hardcoded-secret` rule). The other threshold fields are parsed and
+/// validated but have no behavioral effect yet; they are reserved for
+/// follow-up PRs (see issue #210).
+pub fn apply_scan_thresholds(config: Option<&FoxguardConfig>) {
+    let min_length = config.and_then(|cfg| cfg.scan.thresholds.secrets.min_length);
+    set_hardcoded_secret_min_length_override(min_length);
 }
 
 pub fn editable_config_path(
@@ -1024,5 +1145,150 @@ mod tests {
             .expect("failed to load config")
             .expect("expected config");
         assert!(loaded.scan.severity_overrides.is_empty());
+    }
+
+    // ── scan.thresholds.* (issue #210) ────────────────────────────────────
+
+    #[test]
+    fn thresholds_default_empty_when_absent() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(repo.path(), ".foxguard.yml", "scan:\n  no_builtins: true\n");
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        assert!(loaded.scan.thresholds.secrets.min_length.is_none());
+        assert!(loaded.scan.thresholds.secrets.min_entropy.is_none());
+        assert!(loaded.scan.thresholds.taint.max_hops.is_none());
+    }
+
+    #[test]
+    fn thresholds_parse_secrets_min_length() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 12\n",
+        );
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        assert_eq!(loaded.scan.thresholds.secrets.min_length, Some(12));
+    }
+
+    #[test]
+    fn thresholds_parse_secrets_min_entropy() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_entropy: 3.5\n",
+        );
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        assert_eq!(loaded.scan.thresholds.secrets.min_entropy, Some(3.5));
+    }
+
+    #[test]
+    fn thresholds_parse_taint_max_hops() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    taint:\n      max_hops: 8\n",
+        );
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        assert_eq!(loaded.scan.thresholds.taint.max_hops, Some(8));
+    }
+
+    #[test]
+    fn thresholds_reject_zero_secrets_min_length() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 0\n",
+        );
+        let err = load_for_scan(repo.path(), None).expect_err("expected validation error");
+        assert!(err.contains("min_length"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn thresholds_reject_zero_taint_max_hops() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    taint:\n      max_hops: 0\n",
+        );
+        let err = load_for_scan(repo.path(), None).expect_err("expected validation error");
+        assert!(err.contains("max_hops"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn thresholds_reject_out_of_range_min_entropy() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_entropy: 20.0\n",
+        );
+        let err = load_for_scan(repo.path(), None).expect_err("expected validation error");
+        assert!(err.contains("min_entropy"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn thresholds_reject_invalid_types() {
+        // `min_length` is a `usize`; yaml string fails to parse at deserialize
+        // time, which is exactly the "loud on invalid" behavior we want.
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: not-a-number\n",
+        );
+        let err = load_for_scan(repo.path(), None).expect_err("expected parse error");
+        assert!(
+            err.contains("Failed to parse config"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_scan_thresholds_installs_and_resets_min_length_override() {
+        use crate::rules::common::hardcoded_secret_min_length;
+
+        // Baseline: default value when no config present.
+        apply_scan_thresholds(None);
+        assert_eq!(hardcoded_secret_min_length(), 4);
+
+        // Override via loaded config.
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 9\n",
+        );
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        apply_scan_thresholds(Some(&loaded));
+        assert_eq!(hardcoded_secret_min_length(), 9);
+
+        // Re-applying a config without the override resets to the default,
+        // so repeated scans in the same process (TUI) cannot leak state.
+        let repo2 = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo2.path(),
+            ".foxguard.yml",
+            "scan:\n  no_builtins: true\n",
+        );
+        let fresh = load_for_scan(repo2.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+        apply_scan_thresholds(Some(&fresh));
+        assert_eq!(hardcoded_secret_min_length(), 4);
     }
 }

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -1,7 +1,54 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{Finding, Severity};
+
+/// Default minimum length for strings flagged as a hardcoded secret.
+///
+/// Historically this was hardcoded as `>= 4` across every language-specific
+/// `no-hardcoded-secret` rule. It is now exposed as `scan.secrets.min_length`
+/// in `.foxguard.yml` (refs #210) while defaulting to the same value so
+/// behavior is unchanged out of the box.
+pub const DEFAULT_HARDCODED_SECRET_MIN_LENGTH: usize = 4;
+
+/// Process-wide override for the hardcoded-secret minimum length threshold.
+///
+/// Stored as an atomic so rule checks (which run in a rayon thread pool)
+/// can read it without locking. `0` means "no override, use the default".
+/// Callers set this from the loaded `FoxguardConfig` before scanning.
+static HARDCODED_SECRET_MIN_LENGTH_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
+
+/// Install a process-wide `scan.secrets.min_length` override. Pass `None` to
+/// clear (reverting to [`DEFAULT_HARDCODED_SECRET_MIN_LENGTH`]).
+///
+/// Intentionally process-scoped rather than per-scan because rule structs
+/// are zero-sized and the rule-trait `check` method does not take a config
+/// parameter. Keeping the override in an atomic avoids a wide-reaching
+/// refactor of the `Rule` trait while still giving users a single config
+/// knob. A per-rule `configure()` hook (see issue #210) would subsume this.
+pub fn set_hardcoded_secret_min_length_override(value: Option<usize>) {
+    HARDCODED_SECRET_MIN_LENGTH_OVERRIDE.store(value.unwrap_or(0), Ordering::Relaxed);
+}
+
+/// Minimum length (in bytes) a string must have before a `*-hardcoded-secret`
+/// rule will fire. Returns the configured override, falling back to
+/// [`DEFAULT_HARDCODED_SECRET_MIN_LENGTH`].
+pub fn hardcoded_secret_min_length() -> usize {
+    let override_value = HARDCODED_SECRET_MIN_LENGTH_OVERRIDE.load(Ordering::Relaxed);
+    if override_value == 0 {
+        DEFAULT_HARDCODED_SECRET_MIN_LENGTH
+    } else {
+        override_value
+    }
+}
+
+/// True when `inner` (the unquoted content of a string literal) is long
+/// enough to be reported by a `*-hardcoded-secret` rule, per the
+/// `scan.secrets.min_length` threshold.
+pub fn is_secret_value_long_enough(inner: &str) -> bool {
+    inner.len() >= hardcoded_secret_min_length()
+}
 
 /// Shared per-file import alias table.
 ///

--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, walk_tree};
+use crate::rules::common::{is_secret_value_long_enough, make_finding, walk_tree};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -464,7 +464,7 @@ impl_rule! {
                                 let val = &src[child.byte_range()];
                                 let trimmed = val.trim_matches(|c| c == '"' || c == '@');
                                 let trimmed = trimmed.trim_matches('"');
-                                if trimmed.len() >= 4 {
+                                if is_secret_value_long_enough(trimmed) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -494,7 +494,7 @@ impl_rule! {
                                 let val = &src[right.byte_range()];
                                 let trimmed = val.trim_matches(|c| c == '"' || c == '@');
                                 let trimmed = trimmed.trim_matches('"');
-                                if trimmed.len() >= 4 {
+                                if is_secret_value_long_enough(trimmed) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1,6 +1,9 @@
 use crate::impl_rule;
 use crate::rules::common::AliasTable;
-use crate::rules::common::{get_source_line, make_finding, make_finding_from_offsets, walk_tree};
+use crate::rules::common::{
+    get_source_line, is_secret_value_long_enough, make_finding, make_finding_from_offsets,
+    walk_tree,
+};
 use crate::rules::go_taint::{
     self, go_aliases_from_tree, go_taint_sources, NodeMatcher as GoNodeMatcher,
     TaintSpec as GoTaintSpec,
@@ -166,7 +169,7 @@ impl_rule! {
                         {
                             let val = &src[value_node.byte_range()];
                             let inner = val.trim_matches(|c| c == '"' || c == '`');
-                            if inner.len() >= 4 {
+                            if is_secret_value_long_enough(inner) {
                                 findings.push(make_finding(
                                     _self.id(),
                                     _self.severity(),
@@ -196,7 +199,7 @@ impl_rule! {
                             {
                                 let val = &src[value_node.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -227,7 +230,7 @@ impl_rule! {
                             {
                                 let val = &src[value_node.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -1,5 +1,7 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
+use crate::rules::common::{
+    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
+};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -483,7 +485,7 @@ impl_rule! {
                             if value.kind() == "string_literal" {
                                 let val = &src[value.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -511,7 +513,7 @@ impl_rule! {
                             if right.kind() == "string_literal" {
                                 let val = &src[right.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{get_source_line, make_finding, walk_tree};
+use crate::rules::common::{get_source_line, is_secret_value_long_enough, make_finding, walk_tree};
 use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
@@ -74,7 +74,7 @@ impl_rule! {
                         let val = &src[value_node.byte_range()];
                         // Skip empty strings and short placeholders
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -104,7 +104,7 @@ impl_rule! {
                     {
                         let val = &src[right.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -780,7 +780,7 @@ impl_rule! {
                         // Walk up to check if we're in an arguments > object > call_expression chain
                         let val = &src[value.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -1166,7 +1166,7 @@ impl_rule! {
 
             let secret = &src[secret_arg.byte_range()];
             let inner = secret.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-            if inner.len() < 4 {
+            if !is_secret_value_long_enough(inner) {
                 return;
             }
 

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1,5 +1,7 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
+use crate::rules::common::{
+    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
+};
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 
@@ -548,7 +550,7 @@ impl_rule! {
                             if child.kind() == "string_literal" {
                                 let val = &src[child.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -579,7 +581,7 @@ impl_rule! {
                                 if right.kind() == "string_literal" {
                                     let val = &src[right.byte_range()];
                                     let inner = val.trim_matches('"');
-                                    if inner.len() >= 4 {
+                                    if is_secret_value_long_enough(inner) {
                                         findings.push(make_finding(
                                             _self.id(),
                                             _self.severity(),

--- a/src/rules/php.rs
+++ b/src/rules/php.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, walk_tree};
+use crate::rules::common::{is_secret_value_long_enough, make_finding, walk_tree};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -374,7 +374,7 @@ impl_rule! {
                             {
                                 let val = &src[right.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{get_source_line, make_finding, walk_tree};
+use crate::rules::common::{get_source_line, is_secret_value_long_enough, make_finding, walk_tree};
 use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
@@ -93,7 +93,7 @@ impl_rule! {
                             .trim_start_matches("f\"")
                             .trim_start_matches("f'")
                             .trim_matches(|c| c == '"' || c == '\'');
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -747,7 +747,7 @@ impl_rule! {
                     if left_text == "SECRET_KEY" && right.kind() == "string" {
                         let val = &src[right.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -954,7 +954,7 @@ impl_rule! {
 
             let val = &src[right.byte_range()];
             let inner = val.trim_matches(|c| c == '"' || c == '\'');
-            if inner.len() < 4 {
+            if !is_secret_value_long_enough(inner) {
                 return;
             }
 
@@ -1597,7 +1597,7 @@ impl_rule! {
             if secret_arg.kind() == "string" || secret_arg.kind() == "concatenated_string" {
                 let secret_text = &src[secret_arg.byte_range()];
                 let inner = secret_text.trim_matches(|c| c == '"' || c == '\'');
-                if inner.len() >= 4 {
+                if is_secret_value_long_enough(inner) {
                     findings.push(make_finding(
                         _self.id(),
                         _self.severity(),

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, walk_tree};
+use crate::rules::common::{is_secret_value_long_enough, make_finding, walk_tree};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -501,7 +501,7 @@ impl_rule! {
                         let inner = val
                             .trim_start_matches(['"', '\''])
                             .trim_end_matches(['"', '\'']);
-                        if inner.len() >= 4 {
+                        if is_secret_value_long_enough(inner) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -1,5 +1,5 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, walk_tree};
+use crate::rules::common::{is_secret_value_long_enough, make_finding, walk_tree};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -272,7 +272,7 @@ impl_rule! {
                             if value.kind() == "string_literal" {
                                 let val = &src[value.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if inner.len() >= 4 {
+                                if is_secret_value_long_enough(inner) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/swift.rs
+++ b/src/rules/swift.rs
@@ -1,5 +1,7 @@
 use crate::impl_rule;
-use crate::rules::common::{make_finding, make_finding_from_offsets, walk_tree};
+use crate::rules::common::{
+    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
+};
 use crate::{Language, Severity};
 use regex::Regex;
 
@@ -45,7 +47,7 @@ impl_rule! {
                         if has_string_value {
                             let inner = string_val.trim_matches('"');
                             let line = node.start_position().row;
-                            if inner.len() >= 4 && reported_lines.insert(line) {
+                            if is_secret_value_long_enough(inner) && reported_lines.insert(line) {
                                 findings.push(make_finding(
                                     _self.id(),
                                     _self.severity(),
@@ -80,7 +82,7 @@ impl_rule! {
                             {
                                 let val = &src[child.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if inner.len() >= 4 && reported_lines.insert(line) {
+                                if is_secret_value_long_enough(inner) && reported_lines.insert(line) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3176,4 +3176,126 @@ rules:
             );
         }
     }
+
+    // ── scan.thresholds.secrets.min_length (issue #210) ─────────────────
+
+    /// Fixture with three variable-width "secret" assignments.
+    ///   - `password = "abc"`   (3 chars, below default min_length=4)
+    ///   - `password = "test"`  (4 chars, at default)
+    ///   - `password = "hunter2pass"` (10 chars, fires at any realistic threshold)
+    fn write_python_secret_fixture(dir: &Path) -> PathBuf {
+        let path = dir.join("secrets.py");
+        fs::write(
+            &path,
+            "password_short = \"abc\"\npassword_mid = \"test\"\npassword_long = \"hunter2pass\"\n",
+        )
+        .expect("failed to write python fixture");
+        path
+    }
+
+    fn count_py_hardcoded_secret_findings(stdout: &[u8]) -> usize {
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(stdout).unwrap_or_else(|e| panic!("invalid JSON output: {e}"));
+        findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some("py/no-hardcoded-secret"))
+            .count()
+    }
+
+    #[test]
+    fn test_secrets_min_length_default_matches_hardcoded_four() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_python_secret_fixture(repo.path());
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["secrets.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+        // With no config the threshold must match the previous hardcoded
+        // `>= 4` check: `test` (4) + `hunter2pass` (10) fire, `abc` (3)
+        // is rejected.
+        let count = count_py_hardcoded_secret_findings(&output.stdout);
+        assert_eq!(
+            count, 2,
+            "default min_length should match pre-#210 `>= 4` behavior \
+             (expected 2 findings for `test` and `hunter2pass`, got {count})"
+        );
+    }
+
+    #[test]
+    fn test_secrets_min_length_raising_drops_short_matches() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_python_secret_fixture(repo.path());
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 8\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["secrets.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+        // `test` (4 chars) now falls below min_length=8 and is dropped;
+        // only `hunter2pass` (10) remains.
+        let count = count_py_hardcoded_secret_findings(&output.stdout);
+        assert_eq!(
+            count, 1,
+            "raising min_length to 8 should drop `test`; expected 1, got {count}"
+        );
+    }
+
+    #[test]
+    fn test_secrets_min_length_lowering_catches_shorter_matches() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_python_secret_fixture(repo.path());
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 3\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["secrets.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+        // Lowering min_length to 3 now catches `abc` in addition to the
+        // two longer strings.
+        let count = count_py_hardcoded_secret_findings(&output.stdout);
+        assert_eq!(
+            count, 3,
+            "lowering min_length to 3 should also flag `abc`; expected 3, got {count}"
+        );
+    }
+
+    #[test]
+    fn test_secrets_min_length_invalid_config_fails_loudly() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_python_secret_fixture(repo.path());
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  thresholds:\n    secrets:\n      min_length: 0\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path())
+            .args(["secrets.py", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+        assert!(
+            !output.status.success(),
+            "min_length: 0 must fail the scan; stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("min_length"),
+            "error should mention min_length, got: {stderr}"
+        );
+    }
 }


### PR DESCRIPTION
Addresses #210 (partial — v1 exposes high-value thresholds).

## Summary

Exposes the most impactful previously-hardcoded threshold as config fields. Defaults match current behavior exactly — the default `py/no-hardcoded-secret` (and friends) count is unchanged without opt-in.

## New config fields

```yaml
scan:
  thresholds:
    secrets:
      min_length: 8       # default 4 = pre-#210 hardcoded `inner.len() >= 4`
      min_entropy: 3.5    # parsed + validated, not wired today (see below)
    taint:
      max_hops: 3         # parsed + validated, not wired today (see below)
```

All three fields are `Option<_>`; omitting them reverts to the current hardcoded behavior.

## Discovery notes

I surveyed the three families called out in the issue:

1. **`*-hardcoded-secret` min length** — hardcoded as `inner.len() >= 4` in every language's AST rule (`python.rs`, `javascript.rs`, `go.rs`, `java.rs`, `php.rs`, `ruby.rs`, `csharp.rs`, `swift.rs`, `rust_lang.rs`, `kotlin.rs` — 22 call sites total). **This is the only existing hardcoded threshold in the scope of #210 and is now wired to `scan.thresholds.secrets.min_length`.**

2. **Shannon entropy for secret values** — grepped `src/` for `entropy`, `shannon`, `log2`. No rule computes entropy today. Adding it would be inventing new behavior (the issue explicitly says "the point is to *expose* existing thresholds as config, not to invent new behavior"), so I deferred it. The config field is parsed and validated so a follow-up PR can wire it without a schema change.

3. **Taint max hops / cross-file depth** — the taint engine is a fixed two-pass pipeline (see `src/engine/scanner.rs` "Pass 1" / "Pass 2"). No iteration or hop counter to clamp; multi-hop flows are handled via return-taint summaries, not a convergence loop. Nothing to expose. Config field reserved for when a future PR adds a hop-bounded variant.

Implementation detail: the secret rule structs are zero-sized (`pub struct NoHardcodedSecret;`) and the `Rule::check()` trait method takes no config parameter. Issue #210 proposes a `Rule::configure()` hook, but that's a cross-cutting refactor that touches every rule. To get the `min_length` knob to users in v1 without a bigger refactor, I introduced a process-wide `AtomicUsize` override set at scan start via `apply_scan_thresholds(config)` and read by a new `is_secret_value_long_enough(inner)` helper in `src/rules/common.rs`. Idempotent (re-applying resets), thread-safe (`Ordering::Relaxed` is fine for a scalar read-mostly config), and the eventual `configure()` hook can drop this in favor of per-rule state.

## Not in scope (deferred)

- **`scan.thresholds.secrets.min_entropy`** — no entropy check exists today; exposing it would require adding entropy math, which is new behavior.
- **`scan.thresholds.taint.max_hops`** — taint engine has no hop counter; two fixed passes only.
- **Regex min-match count / `scan.thresholds.pattern.min_matches`** — grepped `src/rules/semgrep_compat.rs`: no such threshold exists; would require a pattern-matcher refactor.
- **`extra_keywords` for secret regex** — needs per-rule configure hook (out of scope per task instructions).
- **Per-rule overrides** (`rule_options.<rule-id>.min_length`) — depends on the `Rule::configure()` refactor from the issue's proposed design.

## Behavior verification

- **Every `*-hardcoded-secret` rule count unchanged at default**: Python 3 → 3, JS 1 → 1, Go 1 → 1, Java 2 → 2, PHP 3 → 3, Ruby 2 → 2, C# 3 → 3, Swift 3 → 3, Rust 3 → 3, Kotlin 0 → 0.
- Dogfood total delta: +31 findings, all in `rs/no-unwrap-in-lib` and all from `.unwrap()` calls in my *new test code* (`src/config.rs` +22, `tests/integration.rs` +9). This rule flags `.unwrap()` anywhere in `.rs` files including tests, so adding tests inevitably bumps this count. No other rule count moved.
- Not included in the "default" comparison: whatever the three other parallel agents' (#207 / #208 / #209) branches add on merge.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings` (one preexisting tui.rs `items-after-test-module` error on main is unrelated)
- [x] `cargo test` — full suite passes (428 tests; 8 new: 6 config-parsing unit + 1 behavior unit + 4 subprocess integration)
- [x] Unit tests for config field parsing, validation (reject 0, out-of-range entropy, type errors), and default-absent behavior
- [x] Unit test that `apply_scan_thresholds` installs + resets the process-wide override (TUI re-scan safety)
- [x] Integration test: `min_length: 3` catches 3-char secrets that default hides
- [x] Integration test: `min_length: 8` drops 4-char `test` that default flags
- [x] Integration test: `min_length: 0` fails the scan with a clear error referencing `min_length`
- [x] Integration test: default (no config) reproduces the pre-#210 `>= 4` count exactly

## Coordination note

`src/config.rs` is also touched by #207/#208/#209 in parallel. I kept all additions under a nested `scan.thresholds.*` namespace (rather than flat keys) to minimize collision surface. Rebase on merge should be straightforward.

none