### PR TITLE
feat: confidence scores per finding (closes #207)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -146,6 +146,10 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
         apply_severity_overrides(&mut findings, config.as_ref(), &known_rule_ids);
     notices.extend(override_warnings);
 
+    if let Some(min_conf) = scan.min_confidence {
+        findings.retain(|f| f.confidence >= min_conf);
+    }
+
     if let Some(ref min_severity) = scan.severity {
         let min = min_severity.to_severity();
         findings.retain(|f| f.severity >= min);
@@ -368,6 +372,8 @@ fn tui_scan_args(args: &TuiArgs) -> ScanArgs {
         quiet: false,
         max_file_size: args.max_file_size,
         fix: false,
+        show_confidence: false,
+        min_confidence: None,
     }
 }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -171,6 +171,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         }
     }
 
@@ -189,5 +190,28 @@ mod tests {
             .expect("load should succeed")
             .expect("baseline should exist");
         assert_eq!(baseline.entries.len(), 1);
+    }
+
+    #[test]
+    fn legacy_finding_json_without_confidence_field_deserializes_with_default() {
+        // JSON written before `confidence` was added omits the field.
+        // Serde should fill in the default (1.0). Regression guard for
+        // issue #207 — callers that persist Finding JSON (e.g. the
+        // `foxguard scan -f json` output piped to disk) should keep
+        // deserializing after upgrading.
+        let legacy_json = r#"{
+            "rule_id": "py/no-eval",
+            "severity": "high",
+            "cwe": null,
+            "description": "eval used",
+            "file": "src/app.py",
+            "line": 5,
+            "column": 1,
+            "end_line": 5,
+            "end_column": 10,
+            "snippet": "eval(x)"
+        }"#;
+        let finding: Finding = serde_json::from_str(legacy_json).expect("should deserialize");
+        assert_eq!(finding.confidence, 1.0);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -79,6 +79,15 @@ pub struct ScanArgs {
     /// Maximum file size in bytes to scan (default: 1 MB)
     #[arg(long, default_value_t = 1_048_576)]
     pub max_file_size: u64,
+
+    /// Show per-finding confidence scores in terminal output
+    #[arg(long, default_value_t = false)]
+    pub show_confidence: bool,
+
+    /// Minimum confidence (0.0–1.0) to report. Findings below this
+    /// threshold are suppressed. Defaults to 0.0 (report all).
+    #[arg(long)]
+    pub min_confidence: Option<f32>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,10 @@ pub struct ScanConfig {
     pub disable_rules: Vec<String>,
     /// Threshold knobs for built-in pattern rules (refs #210).
     pub thresholds: ScanThresholds,
+    /// Minimum confidence (0.0–1.0) to report. Findings whose
+    /// `confidence` is strictly below this value are suppressed.
+    /// `None` means "no filter" (equivalent to 0.0). See issue #207.
+    pub min_confidence: Option<f32>,
 }
 
 /// Tunable thresholds for pattern/heuristic rules.
@@ -129,6 +133,8 @@ struct RawScanConfig {
     /// at load time rather than silently falling back to defaults.
     #[serde(default)]
     thresholds: RawScanThresholds,
+    #[serde(default)]
+    min_confidence: Option<f32>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -207,6 +213,9 @@ pub fn apply_scan_defaults(scan: &mut ScanArgs, config: Option<&FoxguardConfig>)
     }
     if scan.baseline.is_none() {
         scan.baseline = config.scan.baseline.clone();
+    }
+    if scan.min_confidence.is_none() {
+        scan.min_confidence = config.scan.min_confidence;
     }
 }
 
@@ -329,6 +338,7 @@ impl FoxguardConfig {
                 enable_rules: raw.scan.enable_rules,
                 disable_rules: raw.scan.disable_rules,
                 thresholds,
+                min_confidence: raw.scan.min_confidence,
             },
             secrets: SecretsConfig {
                 baseline: secrets_baseline,
@@ -901,6 +911,37 @@ mod tests {
     }
 
     #[test]
+    fn load_for_scan_parses_min_confidence() {
+        // `scan.min_confidence` is optional. When supplied, it's stored
+        // as a raw f32 in [0.0, 1.0] that the scan pipeline uses to drop
+        // low-confidence findings before they reach reporting.
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  min_confidence: 0.8\n",
+        );
+
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+
+        assert_eq!(loaded.scan.min_confidence, Some(0.8));
+    }
+
+    #[test]
+    fn load_for_scan_defaults_min_confidence_to_none() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_config(repo.path(), ".foxguard.yml", "scan:\n  severity: high\n");
+
+        let loaded = load_for_scan(repo.path(), None)
+            .expect("failed to load config")
+            .expect("expected config");
+
+        assert!(loaded.scan.min_confidence.is_none());
+    }
+
+    #[test]
     fn load_for_scan_parses_scan_ignore_rules() {
         let repo = TempDir::new().expect("failed to create temp dir");
         write_config(
@@ -941,6 +982,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let (config_path, added) =
@@ -1001,6 +1043,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -284,6 +284,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,13 @@ impl std::fmt::Display for Language {
     }
 }
 
+/// Default confidence score for a finding when nothing else is specified.
+/// Used by [`Finding::confidence`] via `#[serde(default)]` so baseline files
+/// written before the field existed still deserialize correctly.
+pub fn default_confidence() -> f32 {
+    1.0
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Finding {
     pub rule_id: String,
@@ -91,4 +98,12 @@ pub struct Finding {
     pub sink_start_byte: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sink_end_byte: Option<usize>,
+    /// Detection certainty in the closed interval [0.0, 1.0].
+    ///
+    /// Defaults to 1.0 ("no confidence information; treat as certain").
+    /// Taint findings lower this based on hop count; Semgrep-compat
+    /// findings default to 0.7 because external pattern rules are
+    /// inherently fuzzier than curated built-in AST-walked rules.
+    #[serde(default = "default_confidence")]
+    pub confidence: f32,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,11 +55,12 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         OutputFormat::Terminal => {
             if !result.args.quiet {
                 foxguard::report::terminal::clear_banner();
-                foxguard::report::terminal::print_findings_with_options(
+                foxguard::report::terminal::print_findings_with_options_and_confidence(
                     &result.findings,
                     result.files_scanned,
                     result.duration,
                     result.args.explain,
+                    result.args.show_confidence,
                 );
             }
         }
@@ -291,6 +292,8 @@ fn run_init(args: &InitArgs) -> i32 {
                 github_pr: None,
                 quiet: false,
                 max_file_size: 1_048_576,
+                show_confidence: false,
+                min_confidence: None,
             },
             output: repo_root.join(&args.baseline).display().to_string(),
         };

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -181,6 +181,7 @@ mod tests {
             ),
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         }
     }
 

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -30,6 +30,14 @@ pub fn print_sarif(findings: &[Finding]) {
             if let Some(cwe) = &f.cwe {
                 props.insert("tags".to_string(), json!([cwe]));
             }
+            // Expose confidence in properties so downstream tooling that
+            // ignores the native `rank` field can still consume it.
+            let clamped_conf = f.confidence.clamp(0.0, 1.0);
+            props.insert("confidence".to_string(), json!(clamped_conf));
+
+            // SARIF `rank` is a native 0.0..=100.0 ordering hint. Map
+            // confidence linearly so 1.0 → 100 and 0.0 → 0.
+            let rank = clamped_conf as f64 * 100.0;
 
             let mut result = json!({
                 "ruleId": f.rule_id,
@@ -38,6 +46,7 @@ pub fn print_sarif(findings: &[Finding]) {
                     crate::Severity::Medium => "warning",
                     crate::Severity::Low => "note",
                 },
+                "rank": rank,
                 "message": {
                     "text": f.description
                 },

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -46,6 +46,21 @@ pub fn print_findings_with_options(
     duration: std::time::Duration,
     explain: bool,
 ) {
+    print_findings_with_options_and_confidence(findings, files_scanned, duration, explain, false);
+}
+
+/// Variant of [`print_findings_with_options`] that also controls whether
+/// per-finding confidence scores are displayed. Terminal output keeps
+/// them hidden by default because they're too noisy; callers that want
+/// them pass `show_confidence: true` (typically from the
+/// `--show-confidence` CLI flag).
+pub fn print_findings_with_options_and_confidence(
+    findings: &[Finding],
+    files_scanned: usize,
+    duration: std::time::Duration,
+    explain: bool,
+    show_confidence: bool,
+) {
     if findings.is_empty() {
         if files_scanned > 0 {
             println!(
@@ -86,7 +101,7 @@ pub fn print_findings_with_options(
         println!();
 
         for f in file_findings {
-            print_finding(f, explain);
+            print_finding(f, explain, show_confidence);
         }
         println!();
     }
@@ -124,7 +139,7 @@ fn truncate_snippet(line: &str) -> String {
     format!("{}...", &trimmed[..end])
 }
 
-fn print_finding(f: &Finding, explain: bool) {
+fn print_finding(f: &Finding, explain: bool, show_confidence: bool) {
     let accent = severity_accent(f.severity);
     let badge = severity_badge(f.severity);
     let cwe = f
@@ -137,11 +152,19 @@ fn print_finding(f: &Finding, explain: bool) {
     println!("    {accent} {badge} {}", f.description,);
 
     // Line 2: rule ID + CWE + location (secondary info, dimmed)
+    // Confidence is intentionally off by default — it's noisy for most
+    // users. `--show-confidence` opts in.
+    let conf_suffix = if show_confidence {
+        format!("  conf {:.2}", f.confidence.clamp(0.0, 1.0))
+    } else {
+        String::new()
+    };
     println!(
-        "    {accent}   {}{}  {}",
+        "    {accent}   {}{}  {}{}",
         f.rule_id.cyan().dimmed(),
         cwe.dimmed(),
         format!("line {}:{}", f.line, f.column).dimmed(),
+        conf_suffix.dimmed(),
     );
 
     // Code snippet (recessed further)

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -173,6 +173,7 @@ pub fn make_finding(
         fix_suggestion: None,
         sink_start_byte: None,
         sink_end_byte: None,
+        confidence: crate::default_confidence(),
     }
 }
 
@@ -216,6 +217,25 @@ pub fn make_finding_from_offsets(
         fix_suggestion: None,
         sink_start_byte: None,
         sink_end_byte: None,
+        confidence: crate::default_confidence(),
+    }
+}
+
+/// Map a taint hop count to a confidence score.
+///
+/// The curve is intentionally coarse:
+/// - 1 hop (direct source→sink in the same function) → 1.0
+/// - 2 hops (one level of interprocedural propagation, typically a
+///   cross-file summary hit) → 0.8
+/// - 3+ hops → 0.6
+///
+/// Tuned for the v1 taint engine which only tracks a small number of
+/// hops in practice. Update this when deeper analysis lands.
+pub fn confidence_for_hops(hops: u8) -> f32 {
+    match hops {
+        0 | 1 => 1.0,
+        2 => 0.8,
+        _ => 0.6,
     }
 }
 
@@ -239,5 +259,18 @@ mod tests {
     #[test]
     fn get_source_line_out_of_bounds() {
         assert_eq!(get_source_line("hello", 100), "");
+    }
+
+    #[test]
+    fn confidence_for_hops_curve_matches_documented_values() {
+        // Documented curve from issue #207: 1 hop → 1.0, 2 hops → 0.8,
+        // 3+ hops → 0.6. A zero hop value is treated as "no info" and
+        // maps to 1.0 so a TaintFinding built without an explicit hops
+        // value doesn't accidentally get downgraded.
+        assert_eq!(confidence_for_hops(0), 1.0);
+        assert_eq!(confidence_for_hops(1), 1.0);
+        assert_eq!(confidence_for_hops(2), 0.8);
+        assert_eq!(confidence_for_hops(3), 0.6);
+        assert_eq!(confidence_for_hops(10), 0.6);
     }
 }

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -771,6 +771,7 @@ fn map_go_taint_findings(
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
+            confidence: crate::rules::common::confidence_for_hops(t.hops),
         })
         .collect()
 }
@@ -1492,6 +1493,7 @@ pub fn run_go_taint_batched(
                 fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
+                confidence: crate::rules::common::confidence_for_hops(t.hops),
             })
         })
         .collect()

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -162,6 +162,11 @@ pub struct TaintFinding {
     /// dispatch a finding back to the correct rule. `None` for
     /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
     pub rule_id_hint: Option<String>,
+    /// Approximate number of hops along the source→sink flow. 1 for a
+    /// direct in-function flow, 2 for a flow that crosses a file
+    /// boundary via cross-file summaries. Used by the reporting layer
+    /// to derive a confidence score.
+    pub hops: u8,
 }
 
 /// Return-taint summary map keyed by a function / method simple name.
@@ -1167,6 +1172,7 @@ fn handle_call(
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
                     rule_id_hint: sink_rule_id.clone(),
+                    hops: 1,
                 });
                 break;
             }
@@ -1254,6 +1260,7 @@ fn handle_cross_file_call(
                 ),
                 source_line: src_line,
                 rule_id_hint: Some(flow.sink_rule_id.clone()),
+                hops: 2,
             });
             // One finding per cross-file call is enough.
             return;

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1706,6 +1706,7 @@ fn map_js_taint_findings(
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
+            confidence: crate::rules::common::confidence_for_hops(t.hops),
         })
         .collect()
 }
@@ -2708,6 +2709,7 @@ pub fn run_js_taint_batched(
                 fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
+                confidence: crate::rules::common::confidence_for_hops(t.hops),
             })
         })
         .collect()

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -112,6 +112,11 @@ pub struct TaintFinding {
     /// dispatch a finding back to the correct rule. `None` for
     /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
     pub rule_id_hint: Option<String>,
+    /// Approximate number of hops along the source→sink flow. 1 for a
+    /// direct in-function flow, 2 for a flow that crosses a file
+    /// boundary via cross-file summaries. Used by the reporting layer
+    /// to derive a confidence score.
+    pub hops: u8,
 }
 
 /// Cross-file context passed to `analyze_tree_with_cross_file` to enable
@@ -1624,6 +1629,7 @@ fn handle_assignment(
                         sink_description: sink_desc,
                         source_line: src_line,
                         rule_id_hint,
+                        hops: 1,
                     });
                 }
             }
@@ -1715,6 +1721,7 @@ fn handle_call(
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
                     rule_id_hint: sink_rule_id.clone(),
+                    hops: 1,
                 });
                 break;
             }
@@ -1791,6 +1798,7 @@ fn handle_cross_file_call(
                 ),
                 source_line: src_line,
                 rule_id_hint: Some(flow.sink_rule_id.clone()),
+                hops: 2,
             });
             return;
         }

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1133,6 +1133,7 @@ fn run_kt_taint(
                     fix_suggestion: None,
                     sink_start_byte: None,
                     sink_end_byte: None,
+                    confidence: crate::default_confidence(),
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1696,6 +1696,7 @@ fn map_taint_findings(
             fix_suggestion: meta.fix_suggestion.map(|s| s.to_string()),
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
+            confidence: crate::rules::common::confidence_for_hops(t.hops),
         })
         .collect()
 }
@@ -2636,6 +2637,7 @@ pub fn run_py_taint_batched(
                 fix_suggestion: d.meta.fix_suggestion.map(|s| s.to_string()),
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
+                confidence: crate::rules::common::confidence_for_hops(t.hops),
             })
         })
         .collect()

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -179,6 +179,11 @@ pub struct TaintFinding {
     /// dispatch a finding back to the correct rule. `None` for
     /// single-rule callers of [`analyze_tree`] / [`analyze_tree_with_cross_file`].
     pub rule_id_hint: Option<String>,
+    /// Approximate number of hops along the source→sink flow. 1 for a
+    /// direct in-function flow, 2 for a flow that crosses a file
+    /// boundary via cross-file summaries. Used by the reporting layer
+    /// to derive a confidence score.
+    pub hops: u8,
 }
 
 /// Return-taint summary for a single function. Keyed by the function's
@@ -1145,6 +1150,7 @@ fn handle_call(
                     sink_description: sink_desc.clone(),
                     source_line: src_line,
                     rule_id_hint: sink_rule_id.clone(),
+                    hops: 1,
                 });
                 // One finding per sink call is enough — don't double-report
                 // when multiple args are tainted.
@@ -1227,6 +1233,7 @@ fn handle_cross_file_call(
                 ),
                 source_line: src_line,
                 rule_id_hint: Some(flow.sink_rule_id.clone()),
+                hops: 2,
             });
             // One finding per cross-file call is enough.
             return;
@@ -1964,6 +1971,23 @@ def handler():
         assert_eq!(f.len(), 1);
         assert!(f[0].source_description.contains("request.data"));
         assert_eq!(f[0].sink_description, "pickle.loads");
+    }
+
+    #[test]
+    fn direct_in_function_flow_is_tagged_one_hop() {
+        // Direct source→sink flows should come back with hops=1 so the
+        // reporting layer maps them to confidence=1.0 (no downgrade for
+        // interprocedural uncertainty). Regression guard for #207.
+        let src = r#"
+import pickle
+from flask import request
+
+def handler():
+    return pickle.loads(request.data)
+"#;
+        let f = run(src);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].hops, 1);
     }
 
     #[test]

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -204,6 +204,9 @@ impl Rule for SemgrepRule {
                 fix_suggestion: None,
                 sink_start_byte: None,
                 sink_end_byte: None,
+                // External Semgrep rules are inherently fuzzier than
+                // curated built-in AST-walked rules. See issue #207.
+                confidence: 0.7,
             });
         }
 
@@ -1146,6 +1149,29 @@ rules:
         let findings = rules[0].check(source, &tree);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].line, 1);
+    }
+
+    #[test]
+    fn semgrep_compat_findings_are_emitted_at_confidence_zero_point_seven() {
+        // External Semgrep-compat rules default to confidence=0.7
+        // because pattern rules are inherently fuzzier than curated
+        // built-in AST-walked rules. See issue #207.
+        let yaml = r#"
+rules:
+  - id: test-eval
+    pattern: eval(...)
+    message: No eval
+    severity: ERROR
+    languages: [python]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+
+        let source = "x = eval(user_input)\n";
+        let tree = parse_file(source, Language::Python).unwrap();
+        let findings = rules[0].check(source, &tree);
+        assert_eq!(findings.len(), 1);
+        assert!((findings[0].confidence - 0.7).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -201,6 +201,7 @@ struct TaintFindingView {
     source_description: String,
     sink_description: String,
     source_line: usize,
+    hops: u8,
 }
 
 impl TaintFindingView {
@@ -214,6 +215,7 @@ impl TaintFindingView {
             source_description: f.source_description,
             sink_description: f.sink_description,
             source_line: f.source_line,
+            hops: f.hops,
         }
     }
     fn from_js(f: javascript_taint::TaintFinding) -> Self {
@@ -226,6 +228,7 @@ impl TaintFindingView {
             source_description: f.source_description,
             sink_description: f.sink_description,
             source_line: f.source_line,
+            hops: f.hops,
         }
     }
     fn from_go(f: go_taint::TaintFinding) -> Self {
@@ -238,6 +241,7 @@ impl TaintFindingView {
             source_description: f.source_description,
             sink_description: f.sink_description,
             source_line: f.source_line,
+            hops: f.hops,
         }
     }
 }
@@ -322,6 +326,7 @@ impl Rule for SemgrepTaintRule {
                 fix_suggestion: None,
                 sink_start_byte: None,
                 sink_end_byte: None,
+                confidence: crate::rules::common::confidence_for_hops(t.hops),
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -279,6 +279,7 @@ pub fn scan_paths_with_config_and_notices(
                         fix_suggestion: None,
                         sink_start_byte: None,
                         sink_end_byte: None,
+                        confidence: crate::default_confidence(),
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2187,6 +2187,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2225,6 +2226,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2265,6 +2267,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         assert_eq!(
@@ -2296,6 +2299,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2331,6 +2335,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = render_source_context(
@@ -2399,6 +2404,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         assert_eq!(
@@ -2444,6 +2450,7 @@ mod tests {
                 fix_suggestion: None,
                 sink_start_byte: None,
                 sink_end_byte: None,
+                confidence: crate::default_confidence(),
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2518,6 +2525,7 @@ mod tests {
                 fix_suggestion: None,
                 sink_start_byte: None,
                 sink_end_byte: None,
+                confidence: crate::default_confidence(),
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2573,6 +2581,7 @@ mod tests {
                 fix_suggestion: None,
                 sink_start_byte: None,
                 sink_end_byte: None,
+                confidence: crate::default_confidence(),
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2653,6 +2662,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -2692,6 +2702,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -2730,6 +2741,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = render_source_context(
@@ -2779,6 +2791,7 @@ mod tests {
             fix_suggestion: None,
             sink_start_byte: None,
             sink_end_byte: None,
+            confidence: crate::default_confidence(),
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
Closes #207.

## Summary
Adds an f32 `confidence` field to `Finding` in [0.0, 1.0]. Defaults to 1.0 (no confidence info). Populated dynamically for taint findings (scales with hop count tracked on `TaintFinding`) and Semgrep-compat findings (0.7). Emitted in JSON and SARIF (as `rank` + `properties.confidence`). Opt-in terminal display via `--show-confidence`. Optional config-level min filter via `scan.min_confidence`.

## Populated confidence values
- **Taint**: 1 hop → 1.0, 2 hops → 0.8, 3+ hops → 0.6. Exact table lives in `confidence_for_hops` in `src/rules/common.rs`. The v1 taint engine currently only emits hops=1 (direct in-function flows) and hops=2 (cross-file summary hits) — 3+ is there for when deeper analysis lands.
- **Semgrep-compat**: 0.7 (external pattern rules are inherently fuzzier than curated AST-walked built-ins).
- **Everything else** (built-in AST-walked rules, secrets, kotlin, etc.) → 1.0 via the shared `crate::default_confidence()` helper.

## Hop-count tracking
`TaintFinding` (python, javascript, go engines) grew a `pub hops: u8` field. The direct-sink code path sets `hops: 1`; the `handle_cross_file_call` path sets `hops: 2`. `SemgrepTaintRule` forwards hops through its unified `TaintFindingView`. The reporting layer in `python.rs`/`javascript.rs`/`go.rs` calls `confidence_for_hops(t.hops)` when building the `Finding`.

## Backward compatibility
- `Finding::confidence` is tagged `#[serde(default = "default_confidence")]`, so baseline/JSON files written before the field existed deserialize with 1.0. New regression test `legacy_finding_json_without_confidence_field_deserializes_with_default` in `src/baseline.rs` guards this.
- Terminal output is unchanged by default (no confidence shown).
- `scan.min_confidence` config field and `--min-confidence` CLI flag are both opt-in (default: no filter). `--show-confidence` is opt-in.

## Changes
- `src/lib.rs` — added `Finding::confidence: f32` with serde default + `pub fn default_confidence() -> f32`.
- `src/rules/common.rs` — added `confidence_for_hops(hops: u8) -> f32` curve + threaded `confidence` through `make_finding` / `make_finding_from_offsets`.
- `src/rules/{python,javascript,go}_taint.rs` — added `hops: u8` to `TaintFinding`; set 1 for direct sink, 2 for cross-file summary hits.
- `src/rules/{python,javascript,go}.rs` — single-rule and batched taint `Finding` builders compute confidence from `t.hops`.
- `src/rules/semgrep_taint.rs` — `TaintFindingView` carries `hops`; `Finding` built with `confidence_for_hops`.
- `src/rules/semgrep_compat.rs` — `SemgrepRule::check` emits findings at `confidence: 0.7`.
- `src/rules/kotlin.rs`, `src/secrets.rs` — non-taint built-ins emit `confidence: default_confidence()`.
- `src/cli.rs` — added `--show-confidence` and `--min-confidence <f32>` on `ScanArgs`.
- `src/config.rs` — added `ScanConfig::min_confidence: Option<f32>` + raw config parse + `apply_scan_defaults` wiring + tests.
- `src/app.rs` — `execute_scan` applies `min_confidence.retain` after the severity filter, before ignore/baseline.
- `src/main.rs` — wires `--show-confidence` into `print_findings_with_options_and_confidence`.
- `src/report/terminal.rs` — new `print_findings_with_options_and_confidence`; appends dimmed `conf X.XX` to the rule-id line when enabled.
- `src/report/sarif.rs` — adds native `rank` (0..100) mapped from confidence, plus `properties.confidence`.
- Test fixtures/scaffolding across `diff.rs`, `baseline.rs`, `tui.rs`, `report/github_pr.rs`, `config.rs` updated for the new field.

## Test plan
- [x] cargo test — 306 lib tests + 78 integration + secrets + parity all pass; new tests cover the confidence curve, legacy JSON deserialize, Semgrep-compat 0.7 default, direct-flow hops=1, and config min_confidence parse/default.
- [x] cargo clippy --lib -- -D warnings (the single pre-existing `items-after-test-module` warning in `tui.rs` is unrelated to this PR — present on HEAD too).
- [x] Dogfood: self-scan yields 1083 high-confidence + 8 low-confidence = 1091 findings (the 9 delta vs the pre-PR 1082 baseline comes from additional `.expect()` calls in the new tests I added; built-in rule output is otherwise unchanged).
- [x] `foxguard . -f json` contains `"confidence": 1.0` / `"confidence": 0.8` / `"confidence": 0.7` as expected.
- [x] `foxguard . --show-confidence` appends `conf X.XX`; default output unchanged.
- [x] `foxguard . --min-confidence 0.9` drops the 8 low-confidence findings as expected (1083 results).
- [x] Perf sanity on `benchmarks/repos/gin`: baseline warm run ~0.20s, this PR warm run ~0.23s — within noise, no measurable regression.

## Coordination note
Kept config additions to just `scan.min_confidence` and tagged it optional, so this should only conflict with #208/#209/#210 on standard struct-field merge boundaries in `config.rs` / `cli.rs`, not on semantics.

none