### PR TITLE
Add TLS/config file PQ scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-c-sharp",
  "tree-sitter-go",
  "tree-sitter-java",
@@ -1690,6 +1691,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329a4d48623ac337d42b1df84e81a1c9dbb2946907c102ca72db158c1964a52e"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tree-sitter-rust = "0.24"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-sg = "0.4"
+tree-sitter-bash = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 colored = "2"

--- a/src/bin/gen_rules_ts.rs
+++ b/src/bin/gen_rules_ts.rs
@@ -25,6 +25,10 @@ const LANGUAGE_ORDER: &[Language] = &[
     Language::CSharp,
     Language::Swift,
     Language::Kotlin,
+    Language::NginxConf,
+    Language::ApacheConf,
+    Language::HAProxyConf,
+    Language::Dockerfile,
 ];
 
 fn language_slug(language: Language) -> &'static str {
@@ -39,6 +43,10 @@ fn language_slug(language: Language) -> &'static str {
         Language::CSharp => "cs",
         Language::Swift => "swift",
         Language::Kotlin => "kt",
+        Language::NginxConf => "nginxconf",
+        Language::ApacheConf => "apacheconf",
+        Language::HAProxyConf => "haproxyconf",
+        Language::Dockerfile => "dockerfile",
     }
 }
 
@@ -54,6 +62,10 @@ fn language_display_name(language: Language) -> &'static str {
         Language::CSharp => "C#",
         Language::Swift => "Swift",
         Language::Kotlin => "Kotlin",
+        Language::NginxConf => "Nginx",
+        Language::ApacheConf => "Apache",
+        Language::HAProxyConf => "HAProxy",
+        Language::Dockerfile => "Dockerfile",
     }
 }
 
@@ -69,6 +81,10 @@ fn language_array_name(language: Language) -> &'static str {
         Language::CSharp => "csharpRules",
         Language::Swift => "swiftRules",
         Language::Kotlin => "kotlinRules",
+        Language::NginxConf => "nginxconfRules",
+        Language::ApacheConf => "apacheconfRules",
+        Language::HAProxyConf => "haproxyconfRules",
+        Language::Dockerfile => "dockerfileRules",
     }
 }
 

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -15,6 +15,10 @@ pub fn parse_file(source: &str, language: Language) -> Option<tree_sitter::Tree>
         Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
         Language::Swift => tree_sitter_swift::LANGUAGE.into(),
         Language::Kotlin => tree_sitter_kotlin_sg::LANGUAGE.into(),
+        Language::NginxConf
+        | Language::ApacheConf
+        | Language::HAProxyConf
+        | Language::Dockerfile => tree_sitter_bash::LANGUAGE.into(),
     };
 
     parser.set_language(&ts_language).ok()?;

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -106,20 +106,56 @@ impl InlineIgnoreSpec {
     }
 }
 
+/// Detect config file language from filename and parent directory heuristics.
+fn detect_config_language(path: &Path) -> Option<Language> {
+    let filename = path.file_name().and_then(|f| f.to_str())?;
+    let filename_lower = filename.to_ascii_lowercase();
+
+    // Exact filename matches
+    match filename {
+        "nginx.conf" => return Some(Language::NginxConf),
+        "httpd.conf" | "apache2.conf" => return Some(Language::ApacheConf),
+        "haproxy.cfg" => return Some(Language::HAProxyConf),
+        _ => {}
+    }
+
+    // Dockerfile variants: Dockerfile, Dockerfile.prod, dockerfile, etc.
+    if filename_lower == "dockerfile" || filename_lower.starts_with("dockerfile.") {
+        return Some(Language::Dockerfile);
+    }
+
+    // .conf files under nginx-related or Apache-related directories
+    if filename_lower.ends_with(".conf") {
+        let path_str = path.to_string_lossy();
+        let path_lower = path_str.to_ascii_lowercase();
+        if path_lower.contains("nginx") || path_lower.contains("conf.d/") {
+            return Some(Language::NginxConf);
+        }
+        if path_lower.contains("apache")
+            || path_lower.contains("httpd")
+            || path_lower.contains("sites-available/")
+            || path_lower.contains("sites-enabled/")
+            || path_lower.contains("mods-enabled/")
+        {
+            return Some(Language::ApacheConf);
+        }
+    }
+
+    // .cfg files under haproxy directories
+    if filename_lower.ends_with(".cfg") {
+        let path_str = path.to_string_lossy();
+        if path_str.to_ascii_lowercase().contains("haproxy") {
+            return Some(Language::HAProxyConf);
+        }
+    }
+
+    None
+}
+
 /// Detect language from filename or file extension.
 pub fn detect_language(path: &Path) -> Option<Language> {
-    // Check full filename first for config files
-    if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
-        match filename {
-            "nginx.conf" => return Some(Language::NginxConf),
-            "httpd.conf" | "apache2.conf" => return Some(Language::ApacheConf),
-            "haproxy.cfg" => return Some(Language::HAProxyConf),
-            "Dockerfile" => return Some(Language::Dockerfile),
-            _ => {}
-        }
-        if filename.starts_with("Dockerfile.") {
-            return Some(Language::Dockerfile);
-        }
+    if let Some(lang) = detect_config_language(path) {
+        return Some(lang);
     }
 
     match path.extension()?.to_str()? {

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -106,8 +106,22 @@ impl InlineIgnoreSpec {
     }
 }
 
-/// Detect language from file extension.
+/// Detect language from filename or file extension.
 pub fn detect_language(path: &Path) -> Option<Language> {
+    // Check full filename first for config files
+    if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+        match filename {
+            "nginx.conf" => return Some(Language::NginxConf),
+            "httpd.conf" | "apache2.conf" => return Some(Language::ApacheConf),
+            "haproxy.cfg" => return Some(Language::HAProxyConf),
+            "Dockerfile" => return Some(Language::Dockerfile),
+            _ => {}
+        }
+        if filename.starts_with("Dockerfile.") {
+            return Some(Language::Dockerfile);
+        }
+    }
+
     match path.extension()?.to_str()? {
         "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => Some(Language::JavaScript),
         "py" | "pyw" => Some(Language::Python),
@@ -439,6 +453,10 @@ fn comment_markers(language: Language) -> &'static [&'static str] {
         | Language::CSharp
         | Language::Swift
         | Language::Kotlin => &["//"],
+        Language::NginxConf
+        | Language::ApacheConf
+        | Language::HAProxyConf
+        | Language::Dockerfile => &["#"],
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,10 @@ pub enum Language {
     CSharp,
     Swift,
     Kotlin,
+    NginxConf,
+    ApacheConf,
+    HAProxyConf,
+    Dockerfile,
 }
 
 impl std::fmt::Display for Language {
@@ -61,6 +65,10 @@ impl std::fmt::Display for Language {
             Language::CSharp => write!(f, "csharp"),
             Language::Swift => write!(f, "swift"),
             Language::Kotlin => write!(f, "kotlin"),
+            Language::NginxConf => write!(f, "nginxconf"),
+            Language::ApacheConf => write!(f, "apacheconf"),
+            Language::HAProxyConf => write!(f, "haproxyconf"),
+            Language::Dockerfile => write!(f, "dockerfile"),
         }
     }
 }

--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -70,6 +70,15 @@ fn dockerfile_insecure_env_re() -> &'static Regex {
     })
 }
 
+fn dockerfile_run_insecure_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?im)^RUN\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|curl\s+.*--insecure|curl\s+.*-k[\s|&;]|wget\s+.*--no-check-certificate)"#
+        ).unwrap()
+    })
+}
+
 // ─── Rule 1: nginx PQ-vulnerable TLS ─────────────────────────────────────────
 
 pub struct NginxPqVulnerableTls;
@@ -255,18 +264,32 @@ impl_rule! {
     id = "config/dockerfile-insecure-tls-env",
     severity = Severity::High,
     cwe = Some("CWE-295"),
-    description = "Dockerfile disables TLS certificate verification via environment variable",
+    description = "Dockerfile disables TLS certificate verification via environment variable or insecure command",
     language = Language::Dockerfile,
     fn check(_self, source, _tree) {
         let mut findings = Vec::new();
         let cleaned = strip_comments(source);
 
+        // ENV/ARG lines that disable TLS verification
         for m in dockerfile_insecure_env_re().find_iter(&cleaned) {
             findings.push(make_finding_from_offsets(
                 _self.id(),
                 _self.severity(),
                 _self.cwe(),
                 "Dockerfile disables TLS verification — containers will accept any certificate, enabling MITM attacks",
+                source,
+                m.start(),
+                m.end(),
+            ));
+        }
+
+        // RUN lines that disable TLS verification
+        for m in dockerfile_run_insecure_re().find_iter(&cleaned) {
+            findings.push(make_finding_from_offsets(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "Dockerfile RUN command disables TLS verification — containers will accept any certificate, enabling MITM attacks",
                 source,
                 m.start(),
                 m.end(),

--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -1,0 +1,197 @@
+use regex::Regex;
+
+use crate::impl_rule;
+use crate::rules::common::make_finding_from_offsets;
+use crate::{Language, Severity};
+
+// ─── Rule 1: nginx PQ-vulnerable TLS ─────────────────────────────────────────
+
+pub struct NginxPqVulnerableTls;
+
+impl_rule! {
+    NginxPqVulnerableTls,
+    id = "config/nginx-pq-vulnerable-tls",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Nginx TLS configuration uses quantum-vulnerable protocols or ciphers",
+    language = Language::NginxConf,
+    fn check(_self, source, _tree) {
+        let mut findings = Vec::new();
+
+        // Detect ssl_protocols without TLSv1.3
+        let protocols_re = Regex::new(r"(?i)ssl_protocols\s+[^;]+;").unwrap();
+        for m in protocols_re.find_iter(source) {
+            let directive = m.as_str();
+            if !directive.contains("TLSv1.3") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "ssl_protocols lacks TLSv1.3 — required for post-quantum key exchange (X25519MLKEM768)",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        // Detect ssl_ciphers without PQ-safe suites
+        let ciphers_re = Regex::new(r"(?i)ssl_ciphers\s+[^;]+;").unwrap();
+        for m in ciphers_re.find_iter(source) {
+            let directive = m.as_str().to_uppercase();
+            if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "ssl_ciphers uses only classical key exchange — consider enabling PQ-safe cipher suites via oqs-provider",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        findings
+    }
+}
+
+// ─── Rule 2: Apache PQ-vulnerable TLS ────────────────────────────────────────
+
+pub struct ApachePqVulnerableTls;
+
+impl_rule! {
+    ApachePqVulnerableTls,
+    id = "config/apache-pq-vulnerable-tls",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "Apache TLS configuration uses quantum-vulnerable protocols or ciphers",
+    language = Language::ApacheConf,
+    fn check(_self, source, _tree) {
+        let mut findings = Vec::new();
+
+        // Detect SSLProtocol without TLSv1.3
+        let protocol_re = Regex::new(r"(?i)SSLProtocol\s+.+").unwrap();
+        for m in protocol_re.find_iter(source) {
+            let directive = m.as_str();
+            if !directive.contains("TLSv1.3") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "SSLProtocol lacks TLSv1.3 — required for post-quantum key exchange",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        // Detect SSLCipherSuite without PQ-safe suites
+        let cipher_re = Regex::new(r"(?i)SSLCipherSuite\s+.+").unwrap();
+        for m in cipher_re.find_iter(source) {
+            let directive = m.as_str().to_uppercase();
+            if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "SSLCipherSuite uses only classical key exchange — consider enabling PQ-safe cipher suites",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        findings
+    }
+}
+
+// ─── Rule 3: HAProxy PQ-vulnerable TLS ───────────────────────────────────────
+
+pub struct HAProxyPqVulnerableTls;
+
+impl_rule! {
+    HAProxyPqVulnerableTls,
+    id = "config/haproxy-pq-vulnerable-tls",
+    severity = Severity::Medium,
+    cwe = Some("CWE-327"),
+    description = "HAProxy TLS configuration uses quantum-vulnerable protocols or ciphers",
+    language = Language::HAProxyConf,
+    fn check(_self, source, _tree) {
+        let mut findings = Vec::new();
+
+        // Detect ssl-default-bind-options without TLSv1.3
+        let options_re = Regex::new(r"(?i)ssl-default-bind-options\s+.+").unwrap();
+        for m in options_re.find_iter(source) {
+            let directive = m.as_str();
+            if !directive.contains("ssl-min-ver TLSv1.3")
+                && !directive.contains("min-ver TLSv1.3")
+            {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "ssl-default-bind-options does not enforce TLSv1.3 minimum — required for post-quantum key exchange",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        // Detect ssl-default-bind-ciphers without PQ suites
+        let ciphers_re = Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+").unwrap();
+        for m in ciphers_re.find_iter(source) {
+            let directive = m.as_str().to_uppercase();
+            if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "ssl-default-bind-ciphers uses only classical key exchange — consider enabling PQ-safe cipher suites",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        findings
+    }
+}
+
+// ─── Rule 4: Dockerfile insecure TLS environment ─────────────────────────────
+
+pub struct DockerfileInsecureTlsEnv;
+
+impl_rule! {
+    DockerfileInsecureTlsEnv,
+    id = "config/dockerfile-insecure-tls-env",
+    severity = Severity::High,
+    cwe = Some("CWE-295"),
+    description = "Dockerfile disables TLS certificate verification via environment variable",
+    language = Language::Dockerfile,
+    fn check(_self, source, _tree) {
+        let mut findings = Vec::new();
+
+        let insecure_env_re = Regex::new(
+            r#"(?im)^(?:ENV|ARG)\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|CURL_CA_BUNDLE\s*=\s*(?:''|""|$)|REQUESTS_CA_BUNDLE\s*=\s*(?:''|""|$)|SSL_CERT_FILE\s*=\s*/dev/null)"#
+        ).unwrap();
+
+        for m in insecure_env_re.find_iter(source) {
+            findings.push(make_finding_from_offsets(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "Dockerfile disables TLS verification — containers will accept any certificate, enabling MITM attacks",
+                source,
+                m.start(),
+                m.end(),
+            ));
+        }
+
+        findings
+    }
+}

--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -1,8 +1,69 @@
+use std::sync::OnceLock;
+
 use regex::Regex;
 
 use crate::impl_rule;
 use crate::rules::common::make_finding_from_offsets;
 use crate::{Language, Severity};
+
+/// Strip `#`-comment lines from config source, preserving byte offsets by
+/// replacing comment content with spaces. This lets regex matches still
+/// report correct positions.
+fn strip_comments(source: &str) -> String {
+    let mut out: Vec<u8> = source.as_bytes().to_vec();
+    for line in source.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            let offset = line.as_ptr() as usize - source.as_ptr() as usize;
+            for b in &mut out[offset..offset + line.len()] {
+                *b = b' ';
+            }
+        }
+    }
+    // SAFETY: we only replaced ASCII bytes with ASCII spaces.
+    String::from_utf8(out).expect("strip_comments produced invalid UTF-8")
+}
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn nginx_protocols_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)ssl_protocols\s+[^;]+;").unwrap())
+}
+
+fn nginx_ciphers_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)ssl_ciphers\s+[^;]+;").unwrap())
+}
+
+fn apache_protocol_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)SSLProtocol\s+.+").unwrap())
+}
+
+fn apache_cipher_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)SSLCipherSuite\s+.+").unwrap())
+}
+
+fn haproxy_options_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-options\s+.+").unwrap())
+}
+
+fn haproxy_ciphers_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+").unwrap())
+}
+
+fn dockerfile_insecure_env_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?im)^(?:ENV|ARG)\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|CURL_CA_BUNDLE\s*=\s*(?:''|""|$)|REQUESTS_CA_BUNDLE\s*=\s*(?:''|""|$)|SSL_CERT_FILE\s*=\s*/dev/null)"#
+        ).unwrap()
+    })
+}
 
 // ─── Rule 1: nginx PQ-vulnerable TLS ─────────────────────────────────────────
 
@@ -17,10 +78,10 @@ impl_rule! {
     language = Language::NginxConf,
     fn check(_self, source, _tree) {
         let mut findings = Vec::new();
+        let cleaned = strip_comments(source);
 
         // Detect ssl_protocols without TLSv1.3
-        let protocols_re = Regex::new(r"(?i)ssl_protocols\s+[^;]+;").unwrap();
-        for m in protocols_re.find_iter(source) {
+        for m in nginx_protocols_re().find_iter(&cleaned) {
             let directive = m.as_str();
             if !directive.contains("TLSv1.3") {
                 findings.push(make_finding_from_offsets(
@@ -36,8 +97,7 @@ impl_rule! {
         }
 
         // Detect ssl_ciphers without PQ-safe suites
-        let ciphers_re = Regex::new(r"(?i)ssl_ciphers\s+[^;]+;").unwrap();
-        for m in ciphers_re.find_iter(source) {
+        for m in nginx_ciphers_re().find_iter(&cleaned) {
             let directive = m.as_str().to_uppercase();
             if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
                 findings.push(make_finding_from_offsets(
@@ -69,10 +129,10 @@ impl_rule! {
     language = Language::ApacheConf,
     fn check(_self, source, _tree) {
         let mut findings = Vec::new();
+        let cleaned = strip_comments(source);
 
         // Detect SSLProtocol without TLSv1.3
-        let protocol_re = Regex::new(r"(?i)SSLProtocol\s+.+").unwrap();
-        for m in protocol_re.find_iter(source) {
+        for m in apache_protocol_re().find_iter(&cleaned) {
             let directive = m.as_str();
             if !directive.contains("TLSv1.3") {
                 findings.push(make_finding_from_offsets(
@@ -88,8 +148,7 @@ impl_rule! {
         }
 
         // Detect SSLCipherSuite without PQ-safe suites
-        let cipher_re = Regex::new(r"(?i)SSLCipherSuite\s+.+").unwrap();
-        for m in cipher_re.find_iter(source) {
+        for m in apache_cipher_re().find_iter(&cleaned) {
             let directive = m.as_str().to_uppercase();
             if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
                 findings.push(make_finding_from_offsets(
@@ -121,10 +180,10 @@ impl_rule! {
     language = Language::HAProxyConf,
     fn check(_self, source, _tree) {
         let mut findings = Vec::new();
+        let cleaned = strip_comments(source);
 
         // Detect ssl-default-bind-options without TLSv1.3
-        let options_re = Regex::new(r"(?i)ssl-default-bind-options\s+.+").unwrap();
-        for m in options_re.find_iter(source) {
+        for m in haproxy_options_re().find_iter(&cleaned) {
             let directive = m.as_str();
             if !directive.contains("ssl-min-ver TLSv1.3")
                 && !directive.contains("min-ver TLSv1.3")
@@ -142,8 +201,7 @@ impl_rule! {
         }
 
         // Detect ssl-default-bind-ciphers without PQ suites
-        let ciphers_re = Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+").unwrap();
-        for m in ciphers_re.find_iter(source) {
+        for m in haproxy_ciphers_re().find_iter(&cleaned) {
             let directive = m.as_str().to_uppercase();
             if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
                 findings.push(make_finding_from_offsets(
@@ -175,12 +233,9 @@ impl_rule! {
     language = Language::Dockerfile,
     fn check(_self, source, _tree) {
         let mut findings = Vec::new();
+        let cleaned = strip_comments(source);
 
-        let insecure_env_re = Regex::new(
-            r#"(?im)^(?:ENV|ARG)\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|CURL_CA_BUNDLE\s*=\s*(?:''|""|$)|REQUESTS_CA_BUNDLE\s*=\s*(?:''|""|$)|SSL_CERT_FILE\s*=\s*/dev/null)"#
-        ).unwrap();
-
-        for m in insecure_env_re.find_iter(source) {
+        for m in dockerfile_insecure_env_re().find_iter(&cleaned) {
             findings.push(make_finding_from_offsets(
                 _self.id(),
                 _self.severity(),

--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -56,6 +56,11 @@ fn haproxy_ciphers_re() -> &'static Regex {
     RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+").unwrap())
 }
 
+fn haproxy_ciphersuites_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-ciphersuites\s+.+").unwrap())
+}
+
 fn dockerfile_insecure_env_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
@@ -214,6 +219,22 @@ impl_rule! {
                     _self.severity(),
                     _self.cwe(),
                     "ssl-default-bind-ciphers uses only classical key exchange — consider enabling PQ-safe cipher suites",
+                    source,
+                    m.start(),
+                    m.end(),
+                ));
+            }
+        }
+
+        // Also check ssl-default-bind-ciphersuites (TLS 1.3 cipher config)
+        for m in haproxy_ciphersuites_re().find_iter(&cleaned) {
+            let directive = m.as_str().to_uppercase();
+            if !directive.contains("MLKEM") && !directive.contains("X25519MLKEM") {
+                findings.push(make_finding_from_offsets(
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
+                    "ssl-default-bind-ciphersuites uses only classical key exchange — consider enabling PQ-safe cipher suites",
                     source,
                     m.start(),
                     m.end(),

--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -131,10 +131,15 @@ impl_rule! {
         let mut findings = Vec::new();
         let cleaned = strip_comments(source);
 
-        // Detect SSLProtocol without TLSv1.3
+        // Detect SSLProtocol without TLSv1.3.
+        // `SSLProtocol all` on modern Apache (2.4.30+) includes TLSv1.3,
+        // so only flag when standalone `all` is absent AND TLSv1.3 isn't explicit.
         for m in apache_protocol_re().find_iter(&cleaned) {
             let directive = m.as_str();
-            if !directive.contains("TLSv1.3") {
+            let upper = directive.to_uppercase();
+            let has_all = upper.split_whitespace().any(|t| t == "ALL");
+            let has_tls13 = directive.contains("TLSv1.3");
+            if !has_all && !has_tls13 {
                 findings.push(make_finding_from_offsets(
                     _self.id(),
                     _self.severity(),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,4 +1,5 @@
 pub mod common;
+pub mod config;
 pub mod cross_file;
 pub mod csharp;
 pub mod go;
@@ -388,6 +389,12 @@ impl RuleRegistry {
         registry.register(Box::new(rust_lang::NoSsrf));
         registry.register(Box::new(rust_lang::NoPathTraversal));
         registry.register(Box::new(rust_lang::NoUnwrapInLib));
+
+        // Register config file rules
+        registry.register(Box::new(config::NginxPqVulnerableTls));
+        registry.register(Box::new(config::ApachePqVulnerableTls));
+        registry.register(Box::new(config::HAProxyPqVulnerableTls));
+        registry.register(Box::new(config::DockerfileInsecureTlsEnv));
 
         registry
     }

--- a/tests/fixtures/config/apache_safe/httpd.conf
+++ b/tests/fixtures/config/apache_safe/httpd.conf
@@ -1,0 +1,15 @@
+# Safe Apache TLS config — TLSv1.3 + PQ-aware suite
+Listen 443
+
+<VirtualHost *:443>
+    ServerName example.com
+    DocumentRoot /var/www/html
+
+    SSLEngine on
+    SSLCertificateFile    /etc/apache2/cert.pem
+    SSLCertificateKeyFile /etc/apache2/key.pem
+
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
+    SSLCipherSuite X25519MLKEM768:ECDHE-RSA-AES256-GCM-SHA384
+    SSLHonorCipherOrder on
+</VirtualHost>

--- a/tests/fixtures/config/apache_vulnerable/httpd.conf
+++ b/tests/fixtures/config/apache_vulnerable/httpd.conf
@@ -9,7 +9,7 @@ Listen 443
     SSLCertificateFile    /etc/apache2/cert.pem
     SSLCertificateKeyFile /etc/apache2/key.pem
 
-    SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    SSLProtocol -all +TLSv1.2
     SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384
     SSLHonorCipherOrder on
 </VirtualHost>

--- a/tests/fixtures/config/apache_vulnerable/httpd.conf
+++ b/tests/fixtures/config/apache_vulnerable/httpd.conf
@@ -1,0 +1,15 @@
+# Vulnerable Apache TLS config — classical-only, pre-PQ
+Listen 443
+
+<VirtualHost *:443>
+    ServerName example.com
+    DocumentRoot /var/www/html
+
+    SSLEngine on
+    SSLCertificateFile    /etc/apache2/cert.pem
+    SSLCertificateKeyFile /etc/apache2/key.pem
+
+    SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384
+    SSLHonorCipherOrder on
+</VirtualHost>

--- a/tests/fixtures/config/dockerfile_insecure/Dockerfile
+++ b/tests/fixtures/config/dockerfile_insecure/Dockerfile
@@ -1,0 +1,16 @@
+# Insecure Dockerfile — disables TLS verification in multiple ways
+FROM node:20-alpine
+
+WORKDIR /app
+
+ENV NODE_TLS_REJECT_UNAUTHORIZED=0
+ENV PYTHONHTTPSVERIFY=0
+ENV GIT_SSL_NO_VERIFY=true
+ARG CURL_CA_BUNDLE=""
+
+COPY package.json ./
+RUN npm install
+
+COPY . .
+
+CMD ["node", "server.js"]

--- a/tests/fixtures/config/dockerfile_insecure/Dockerfile
+++ b/tests/fixtures/config/dockerfile_insecure/Dockerfile
@@ -10,6 +10,7 @@ ARG CURL_CA_BUNDLE=""
 
 COPY package.json ./
 RUN npm install
+RUN curl --insecure https://example.com/setup.sh | sh
 
 COPY . .
 

--- a/tests/fixtures/config/dockerfile_safe/Dockerfile
+++ b/tests/fixtures/config/dockerfile_safe/Dockerfile
@@ -1,0 +1,14 @@
+# Safe Dockerfile — no TLS-disabling env vars
+FROM node:20-alpine
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=8080
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+CMD ["node", "server.js"]

--- a/tests/fixtures/config/haproxy_safe/haproxy.cfg
+++ b/tests/fixtures/config/haproxy_safe/haproxy.cfg
@@ -1,0 +1,18 @@
+# Safe HAProxy TLS config — TLSv1.3 minimum + PQ-aware ciphers
+global
+    log /dev/log local0
+    ssl-default-bind-options ssl-min-ver TLSv1.3
+    ssl-default-bind-ciphers X25519MLKEM768:ECDHE-RSA-AES256-GCM-SHA384
+
+defaults
+    mode http
+    timeout connect 5s
+    timeout client  50s
+    timeout server  50s
+
+frontend https-in
+    bind *:443 ssl crt /etc/haproxy/cert.pem
+    default_backend app
+
+backend app
+    server app1 127.0.0.1:8080

--- a/tests/fixtures/config/haproxy_vulnerable/haproxy.cfg
+++ b/tests/fixtures/config/haproxy_vulnerable/haproxy.cfg
@@ -1,0 +1,18 @@
+# Vulnerable HAProxy TLS config — classical-only, pre-PQ
+global
+    log /dev/log local0
+    ssl-default-bind-options ssl-min-ver TLSv1.2
+    ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384
+
+defaults
+    mode http
+    timeout connect 5s
+    timeout client  50s
+    timeout server  50s
+
+frontend https-in
+    bind *:443 ssl crt /etc/haproxy/cert.pem
+    default_backend app
+
+backend app
+    server app1 127.0.0.1:8080

--- a/tests/fixtures/config/nginx_safe/nginx.conf
+++ b/tests/fixtures/config/nginx_safe/nginx.conf
@@ -1,0 +1,16 @@
+# Safe nginx TLS config — TLSv1.3 + PQ-aware cipher suite (via oqs-provider)
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/nginx/cert.pem;
+    ssl_certificate_key /etc/nginx/key.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers X25519MLKEM768:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://upstream;
+    }
+}

--- a/tests/fixtures/config/nginx_vulnerable/nginx.conf
+++ b/tests/fixtures/config/nginx_vulnerable/nginx.conf
@@ -1,0 +1,16 @@
+# Vulnerable nginx TLS config — classical-only, pre-PQ
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate     /etc/nginx/cert.pem;
+    ssl_certificate_key /etc/nginx/key.pem;
+
+    ssl_protocols TLSv1.2;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://upstream;
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3575,19 +3575,24 @@ mod config_files {
             detect_language(Path::new("Dockerfile.prod")),
             Some(Language::Dockerfile)
         );
+        // Case-insensitive
+        assert_eq!(
+            detect_language(Path::new("dockerfile")),
+            Some(Language::Dockerfile)
+        );
     }
 
     #[test]
-    fn detect_language_rejects_unrelated_conf_files() {
-        // Regression guard: detect_language matches exact filenames only.
-        // Fragments under `conf.d/` (e.g. ssl.conf, default.conf) are NOT
-        // mapped to NginxConf today — this is a known limitation of the
-        // initial PR #230 landing. If the author later widens the filename
-        // match, flip this assertion to `Some(Language::NginxConf)`.
-        assert_eq!(detect_language(Path::new("conf.d/ssl.conf")), None);
+    fn detect_language_recognises_config_include_dirs() {
+        // conf.d/ fragments are detected as nginx config
+        assert_eq!(
+            detect_language(Path::new("conf.d/ssl.conf")),
+            Some(Language::NginxConf)
+        );
+        // sites-enabled/ fragments are detected as Apache config
         assert_eq!(
             detect_language(Path::new("sites-enabled/default.conf")),
-            None
+            Some(Language::ApacheConf)
         );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3350,3 +3350,245 @@ fn pqc_on_safe_fixture_returns_zero_findings() {
         }
     }
 }
+
+// ─── Config file PQ-scanning (PR #230) ──────────────────────────────────────
+//
+// These tests cover the four TLS/config-file rules added by PR #230:
+//   - config/nginx-pq-vulnerable-tls
+//   - config/apache-pq-vulnerable-tls
+//   - config/haproxy-pq-vulnerable-tls
+//   - config/dockerfile-insecure-tls-env
+//
+// Fixtures live under `tests/fixtures/config/<kind>_<vuln|safe>/`. Each
+// vulnerable/safe pair uses the exact filename that `detect_language`
+// recognises (`nginx.conf`, `httpd.conf`, `haproxy.cfg`, `Dockerfile`), so
+// running the scanner against the parent directory is sufficient to exercise
+// the rule. Separate subdirectories keep the positive and negative fixtures
+// from colliding on the same filename.
+mod config_files {
+    use super::*;
+    use foxguard::engine::scanner::detect_language;
+    use foxguard::Language;
+
+    fn scan_fixture_dir(relative: &str) -> Vec<serde_json::Value> {
+        let output = foxguard_cmd()
+            .args([&format!("tests/fixtures/config/{relative}"), "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+        serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+            panic!(
+                "invalid JSON output for {relative}: {e}; stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })
+    }
+
+    fn findings_for_rule<'a>(
+        findings: &'a [serde_json::Value],
+        rule_id: &str,
+    ) -> Vec<&'a serde_json::Value> {
+        findings
+            .iter()
+            .filter(|f| f["rule_id"].as_str() == Some(rule_id))
+            .collect()
+    }
+
+    // ── nginx ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn nginx_rule_fires_on_vulnerable_fixture() {
+        let findings = scan_fixture_dir("nginx_vulnerable");
+        let matches = findings_for_rule(&findings, "config/nginx-pq-vulnerable-tls");
+        assert!(
+            !matches.is_empty(),
+            "config/nginx-pq-vulnerable-tls should fire on nginx_vulnerable/nginx.conf; \
+             all findings: {findings:?}"
+        );
+        // Classical-only config trips both the ssl_protocols and ssl_ciphers
+        // branches — assert both fire so the rule isn't secretly wrapped in
+        // an early-return.
+        assert!(
+            matches.len() >= 2,
+            "expected at least two nginx PQ findings (protocols + ciphers), got {}",
+            matches.len()
+        );
+    }
+
+    #[test]
+    fn nginx_rule_silent_on_safe_fixture() {
+        let findings = scan_fixture_dir("nginx_safe");
+        let matches = findings_for_rule(&findings, "config/nginx-pq-vulnerable-tls");
+        assert!(
+            matches.is_empty(),
+            "nginx PQ rule must not fire when TLSv1.3 + X25519MLKEM768 are present; \
+             findings: {matches:?}"
+        );
+    }
+
+    // ── Apache ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn apache_rule_fires_on_vulnerable_fixture() {
+        let findings = scan_fixture_dir("apache_vulnerable");
+        let matches = findings_for_rule(&findings, "config/apache-pq-vulnerable-tls");
+        assert!(
+            !matches.is_empty(),
+            "config/apache-pq-vulnerable-tls should fire on apache_vulnerable/httpd.conf; \
+             all findings: {findings:?}"
+        );
+        assert!(
+            matches.len() >= 2,
+            "expected at least two apache PQ findings (SSLProtocol + SSLCipherSuite), got {}",
+            matches.len()
+        );
+    }
+
+    #[test]
+    fn apache_rule_silent_on_safe_fixture() {
+        let findings = scan_fixture_dir("apache_safe");
+        let matches = findings_for_rule(&findings, "config/apache-pq-vulnerable-tls");
+        assert!(
+            matches.is_empty(),
+            "apache PQ rule must not fire on a TLSv1.3 + PQ-aware config; findings: {matches:?}"
+        );
+    }
+
+    // ── HAProxy ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn haproxy_rule_fires_on_vulnerable_fixture() {
+        let findings = scan_fixture_dir("haproxy_vulnerable");
+        let matches = findings_for_rule(&findings, "config/haproxy-pq-vulnerable-tls");
+        assert!(
+            !matches.is_empty(),
+            "config/haproxy-pq-vulnerable-tls should fire on haproxy_vulnerable/haproxy.cfg; \
+             all findings: {findings:?}"
+        );
+        assert!(
+            matches.len() >= 2,
+            "expected at least two HAProxy PQ findings (bind-options + bind-ciphers), got {}",
+            matches.len()
+        );
+    }
+
+    #[test]
+    fn haproxy_rule_silent_on_safe_fixture() {
+        let findings = scan_fixture_dir("haproxy_safe");
+        let matches = findings_for_rule(&findings, "config/haproxy-pq-vulnerable-tls");
+        assert!(
+            matches.is_empty(),
+            "HAProxy PQ rule must not fire when ssl-min-ver TLSv1.3 + X25519MLKEM768 are set; \
+             findings: {matches:?}"
+        );
+    }
+
+    // ── Dockerfile ──────────────────────────────────────────────────────
+
+    #[test]
+    fn dockerfile_rule_fires_on_insecure_fixture() {
+        let findings = scan_fixture_dir("dockerfile_insecure");
+        let matches = findings_for_rule(&findings, "config/dockerfile-insecure-tls-env");
+        assert!(
+            !matches.is_empty(),
+            "config/dockerfile-insecure-tls-env should fire on dockerfile_insecure/Dockerfile; \
+             all findings: {findings:?}"
+        );
+        // Fixture has four insecure env/arg lines — assert we catch them all
+        // so a regression that collapses the regex to only one form is loud.
+        assert!(
+            matches.len() >= 4,
+            "expected at least four Dockerfile insecure-TLS findings, got {}",
+            matches.len()
+        );
+    }
+
+    #[test]
+    fn dockerfile_rule_silent_on_safe_fixture() {
+        let findings = scan_fixture_dir("dockerfile_safe");
+        let matches = findings_for_rule(&findings, "config/dockerfile-insecure-tls-env");
+        assert!(
+            matches.is_empty(),
+            "Dockerfile rule must not fire on a Dockerfile without TLS-disabling env vars; \
+             findings: {matches:?}"
+        );
+    }
+
+    // ── detect_language wiring ──────────────────────────────────────────
+    //
+    // These assertions pin down the filename → Language mapping for the four
+    // new variants. If any rename lands (e.g. we start matching
+    // `conf.d/*.conf`), this test forces the author to update both sides.
+
+    #[test]
+    fn detect_language_recognises_nginx_conf() {
+        assert_eq!(
+            detect_language(Path::new("nginx.conf")),
+            Some(Language::NginxConf)
+        );
+        assert_eq!(
+            detect_language(Path::new("/etc/nginx/nginx.conf")),
+            Some(Language::NginxConf)
+        );
+    }
+
+    #[test]
+    fn detect_language_recognises_apache_filenames() {
+        assert_eq!(
+            detect_language(Path::new("httpd.conf")),
+            Some(Language::ApacheConf)
+        );
+        assert_eq!(
+            detect_language(Path::new("apache2.conf")),
+            Some(Language::ApacheConf)
+        );
+        assert_eq!(
+            detect_language(Path::new("/etc/apache2/apache2.conf")),
+            Some(Language::ApacheConf)
+        );
+    }
+
+    #[test]
+    fn detect_language_recognises_haproxy_cfg() {
+        assert_eq!(
+            detect_language(Path::new("haproxy.cfg")),
+            Some(Language::HAProxyConf)
+        );
+        assert_eq!(
+            detect_language(Path::new("/etc/haproxy/haproxy.cfg")),
+            Some(Language::HAProxyConf)
+        );
+    }
+
+    #[test]
+    fn detect_language_recognises_dockerfiles() {
+        assert_eq!(
+            detect_language(Path::new("Dockerfile")),
+            Some(Language::Dockerfile)
+        );
+        // `Dockerfile.<suffix>` variants (e.g. Dockerfile.prod) are treated
+        // as Dockerfiles too.
+        assert_eq!(
+            detect_language(Path::new("Dockerfile.insecure-tls")),
+            Some(Language::Dockerfile)
+        );
+        assert_eq!(
+            detect_language(Path::new("Dockerfile.prod")),
+            Some(Language::Dockerfile)
+        );
+    }
+
+    #[test]
+    fn detect_language_rejects_unrelated_conf_files() {
+        // Regression guard: detect_language matches exact filenames only.
+        // Fragments under `conf.d/` (e.g. ssl.conf, default.conf) are NOT
+        // mapped to NginxConf today — this is a known limitation of the
+        // initial PR #230 landing. If the author later widens the filename
+        // match, flip this assertion to `Some(Language::NginxConf)`.
+        assert_eq!(detect_language(Path::new("conf.d/ssl.conf")), None);
+        assert_eq!(
+            detect_language(Path::new("sites-enabled/default.conf")),
+            None
+        );
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3494,11 +3494,10 @@ mod config_files {
             "config/dockerfile-insecure-tls-env should fire on dockerfile_insecure/Dockerfile; \
              all findings: {findings:?}"
         );
-        // Fixture has four insecure env/arg lines — assert we catch them all
-        // so a regression that collapses the regex to only one form is loud.
+        // Fixture has four insecure ENV/ARG lines + one insecure RUN line.
         assert!(
-            matches.len() >= 4,
-            "expected at least four Dockerfile insecure-TLS findings, got {}",
+            matches.len() >= 5,
+            "expected at least five Dockerfile insecure-TLS findings (4 ENV/ARG + 1 RUN), got {}",
             matches.len()
         );
     }

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -224,6 +224,22 @@ const kotlinRules: Rule[] = [
   { id: 'kt/taint-ssrf', cwe: 'CWE-918', desc: 'Untrusted input from Ktor/Spring handler reaches HTTP/URL sink', severity: 'high' },
 ];
 
+const nginxconfRules: Rule[] = [
+  { id: 'config/nginx-pq-vulnerable-tls', cwe: 'CWE-327', desc: 'Nginx TLS configuration uses quantum-vulnerable protocols or ciphers', severity: 'medium' },
+];
+
+const apacheconfRules: Rule[] = [
+  { id: 'config/apache-pq-vulnerable-tls', cwe: 'CWE-327', desc: 'Apache TLS configuration uses quantum-vulnerable protocols or ciphers', severity: 'medium' },
+];
+
+const haproxyconfRules: Rule[] = [
+  { id: 'config/haproxy-pq-vulnerable-tls', cwe: 'CWE-327', desc: 'HAProxy TLS configuration uses quantum-vulnerable protocols or ciphers', severity: 'medium' },
+];
+
+const dockerfileRules: Rule[] = [
+  { id: 'config/dockerfile-insecure-tls-env', cwe: 'CWE-295', desc: 'Dockerfile disables TLS certificate verification via environment variable', severity: 'high' },
+];
+
 export const ruleGroups: RuleGroup[] = [
   { name: 'JavaScript / TypeScript', slug: 'js', rules: jsRules },
   { name: 'Python', slug: 'py', rules: pyRules },
@@ -235,7 +251,11 @@ export const ruleGroups: RuleGroup[] = [
   { name: 'C#', slug: 'cs', rules: csharpRules },
   { name: 'Swift', slug: 'swift', rules: swiftRules },
   { name: 'Kotlin', slug: 'kt', rules: kotlinRules },
+  { name: 'Nginx', slug: 'nginxconf', rules: nginxconfRules },
+  { name: 'Apache', slug: 'apacheconf', rules: apacheconfRules },
+  { name: 'HAProxy', slug: 'haproxyconf', rules: haproxyconfRules },
+  { name: 'Dockerfile', slug: 'dockerfile', rules: dockerfileRules },
 ];
 
 export const totalRules = ruleGroups.reduce((sum, g) => sum + g.rules.length, 0);
-export const productLanguageCount = 10;
+export const productLanguageCount = 14;

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -237,7 +237,7 @@ const haproxyconfRules: Rule[] = [
 ];
 
 const dockerfileRules: Rule[] = [
-  { id: 'config/dockerfile-insecure-tls-env', cwe: 'CWE-295', desc: 'Dockerfile disables TLS certificate verification via environment variable', severity: 'high' },
+  { id: 'config/dockerfile-insecure-tls-env', cwe: 'CWE-295', desc: 'Dockerfile disables TLS certificate verification via environment variable or insecure command', severity: 'high' },
 ];
 
 export const ruleGroups: RuleGroup[] = [


### PR DESCRIPTION
## Summary
- Adds 4 new `Language` variants for config files (NginxConf, ApacheConf, HAProxyConf, Dockerfile)
- Uses `tree-sitter-bash` as stand-in grammar — rules use regex on raw source, tree is ignored
- Detects files by filename (`nginx.conf`, `httpd.conf`, `haproxy.cfg`, `Dockerfile`)
- 4 new regex-based rules:
  - `config/nginx-pq-vulnerable-tls` — `ssl_protocols` without TLSv1.3, classical-only ciphers
  - `config/apache-pq-vulnerable-tls` — `SSLProtocol` / `SSLCipherSuite` checks
  - `config/haproxy-pq-vulnerable-tls` — `ssl-default-bind-*` checks
  - `config/dockerfile-insecure-tls-env` — `NODE_TLS_REJECT_UNAUTHORIZED=0`, `GIT_SSL_NO_VERIFY`, etc.

Ref: #222

Closes #222