### PR TITLE
Add CNSA 2.0 compliance mapping and PQ migration level

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -23,6 +23,7 @@ pub struct ScanExecution {
     pub files_scanned: usize,
     pub duration: std::time::Duration,
     pub notices: Vec<String>,
+    pub pq_migration_level: Option<crate::compliance::PqMigrationLevel>,
 }
 
 pub struct SecretsExecution {
@@ -169,6 +170,10 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
 
     findings = suppress_with_baseline(findings, baseline.as_ref());
 
+    // Annotate PQ-related findings with CNSA 2.0 compliance deadlines
+    crate::compliance::annotate_cnsa2_deadlines(&mut findings);
+    let pq_migration_level = crate::compliance::compute_pq_migration_level(&findings);
+
     if files_scanned == 0 {
         notices.push(
             "Warning: no files with supported extensions found. Supported: .js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
@@ -182,6 +187,7 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
         files_scanned,
         duration,
         notices,
+        pq_migration_level,
     })
 }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -172,6 +172,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/compliance.rs
+++ b/src/compliance.rs
@@ -1,0 +1,97 @@
+use crate::Finding;
+
+/// Map a PQ-related rule ID to its CNSA 2.0 compliance deadline.
+///
+/// Returns `None` for non-PQ rules. Deadlines follow the NSA CNSA 2.0
+/// timeline:
+/// - `"2027-01"` — Jan 2027: all new NSS systems must use quantum-resistant
+///   algorithms (key exchange / encryption)
+/// - `"2030-12"` — Dec 2030: all deployed software using quantum-resistant
+///   signatures
+/// - `"2035"` — full transition complete (general / config rules)
+pub fn cnsa2_deadline_for_rule(rule_id: &str) -> Option<&'static str> {
+    // Key exchange / encryption — earliest deadline
+    if rule_id.contains("pq-vulnerable") {
+        // Distinguish by description context would be ideal, but rule_id
+        // alone doesn't tell us key-exchange vs signature. Use the earlier
+        // deadline since key exchange is the primary concern.
+        return Some("2027-01");
+    }
+
+    // Crypto agility rules — general migration timeline
+    if rule_id.contains("hardcoded-crypto-algorithm") {
+        return Some("2035");
+    }
+
+    // Config file TLS rules — need TLSv1.3 for PQ key exchange
+    if rule_id.starts_with("config/") && rule_id.contains("tls") {
+        return Some("2027-01");
+    }
+
+    // Dockerfile TLS verification — not directly PQ but security hygiene
+    if rule_id.contains("dockerfile-insecure-tls") {
+        return Some("2035");
+    }
+
+    None
+}
+
+/// Annotate findings with CNSA 2.0 deadlines based on rule ID.
+pub fn annotate_cnsa2_deadlines(findings: &mut [Finding]) {
+    for finding in findings.iter_mut() {
+        finding.cnsa2_deadline = cnsa2_deadline_for_rule(&finding.rule_id).map(|s| s.to_string());
+    }
+}
+
+/// PQ migration readiness level (1–5), inspired by Meta's framework.
+#[derive(Debug, Clone)]
+pub struct PqMigrationLevel {
+    pub level: u8,
+    pub label: &'static str,
+    pub pq_finding_count: usize,
+    pub agility_finding_count: usize,
+}
+
+/// Compute the PQ migration readiness level from scan findings.
+///
+/// Levels:
+/// - 5 PQ-Enabled: no PQ-vulnerable findings
+/// - 4 PQ-Hardened: only crypto agility findings (no direct PQ vulnerability)
+/// - 3 PQ-Ready: few PQ-vulnerable findings (≤ 5)
+/// - 2 PQ-Aware: PQ findings exist (we're scanning)
+/// - 1 PQ-Unaware: not assessed (no PQ rules matched — codebase may not use crypto)
+pub fn compute_pq_migration_level(findings: &[Finding]) -> Option<PqMigrationLevel> {
+    let pq_findings: Vec<_> = findings
+        .iter()
+        .filter(|f| f.cnsa2_deadline.is_some() && !f.rule_id.contains("hardcoded-crypto-algorithm"))
+        .collect();
+
+    let agility_findings = findings
+        .iter()
+        .filter(|f| f.rule_id.contains("hardcoded-crypto-algorithm"))
+        .count();
+
+    let pq_count = pq_findings.len();
+
+    // If no PQ-related findings at all, don't report a level
+    if pq_count == 0 && agility_findings == 0 {
+        return None;
+    }
+
+    let (level, label) = if pq_count == 0 && agility_findings == 0 {
+        (5, "PQ-Enabled")
+    } else if pq_count == 0 && agility_findings > 0 {
+        (4, "PQ-Hardened")
+    } else if pq_count <= 5 {
+        (3, "PQ-Ready")
+    } else {
+        (2, "PQ-Aware")
+    };
+
+    Some(PqMigrationLevel {
+        level,
+        label,
+        pq_finding_count: pq_count,
+        agility_finding_count: agility_findings,
+    })
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -983,6 +983,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let (config_path, added) =
@@ -1044,6 +1045,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -285,6 +285,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod baseline;
 pub mod cli;
+pub mod compliance;
 pub mod config;
 pub mod diff;
 pub mod engine;
@@ -106,4 +107,8 @@ pub struct Finding {
     /// inherently fuzzier than curated built-in AST-walked rules.
     #[serde(default = "default_confidence")]
     pub confidence: f32,
+    /// CNSA 2.0 compliance deadline, if this finding relates to
+    /// quantum-vulnerable cryptography. Format: "2027-01", "2030-12", "2035".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cnsa2_deadline: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ fn run_scan(scan: &ScanArgs) -> i32 {
                     result.duration,
                     result.args.explain,
                     result.args.show_confidence,
+                    result.pq_migration_level.as_ref(),
                 );
             }
         }

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -182,6 +182,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -35,6 +35,10 @@ pub fn print_sarif(findings: &[Finding]) {
             let clamped_conf = f.confidence.clamp(0.0, 1.0);
             props.insert("confidence".to_string(), json!(clamped_conf));
 
+            if let Some(deadline) = &f.cnsa2_deadline {
+                props.insert("cnsa2_deadline".to_string(), json!(deadline));
+            }
+
             // SARIF `rank` is a native 0.0..=100.0 ordering hint. Map
             // confidence linearly so 1.0 → 100 and 0.0 → 0.
             let rank = clamped_conf as f64 * 100.0;

--- a/src/report/terminal.rs
+++ b/src/report/terminal.rs
@@ -46,7 +46,14 @@ pub fn print_findings_with_options(
     duration: std::time::Duration,
     explain: bool,
 ) {
-    print_findings_with_options_and_confidence(findings, files_scanned, duration, explain, false);
+    print_findings_with_options_and_confidence(
+        findings,
+        files_scanned,
+        duration,
+        explain,
+        false,
+        None,
+    );
 }
 
 /// Variant of [`print_findings_with_options`] that also controls whether
@@ -60,6 +67,7 @@ pub fn print_findings_with_options_and_confidence(
     duration: std::time::Duration,
     explain: bool,
     show_confidence: bool,
+    pq_migration_level: Option<&crate::compliance::PqMigrationLevel>,
 ) {
     if findings.is_empty() {
         if files_scanned > 0 {
@@ -107,6 +115,7 @@ pub fn print_findings_with_options_and_confidence(
     }
 
     print_summary(findings, files_scanned, duration);
+    print_pq_summary(findings, pq_migration_level);
 }
 
 fn severity_badge(severity: Severity) -> colored::ColoredString {
@@ -199,6 +208,17 @@ fn print_finding(f: &Finding, explain: bool, show_confidence: bool) {
         }
     }
 
+    // CNSA 2.0 deadline
+    if let Some(deadline) = f.cnsa2_deadline.as_ref() {
+        let label = match deadline.as_str() {
+            "2027-01" => "CNSA 2.0: migrate by Jan 2027",
+            "2030-12" => "CNSA 2.0: migrate by Dec 2030",
+            "2035" => "CNSA 2.0: migrate by 2035",
+            _ => deadline.as_str(),
+        };
+        println!("    {accent}   {}", label.yellow().dimmed());
+    }
+
     // Fix suggestion
     if let Some(fix) = f.fix_suggestion.as_ref() {
         println!("    {accent} {} {}", "Fix:".green().bold(), fix);
@@ -269,4 +289,57 @@ fn print_summary(findings: &[Finding], files_scanned: usize, duration: std::time
     println!();
     println!("  {}", badges.join("  "));
     println!();
+}
+
+fn print_pq_summary(
+    findings: &[Finding],
+    pq_migration_level: Option<&crate::compliance::PqMigrationLevel>,
+) {
+    // CNSA 2.0 deadline breakdown
+    let by_2027 = findings
+        .iter()
+        .filter(|f| f.cnsa2_deadline.as_deref() == Some("2027-01"))
+        .count();
+    let by_2030 = findings
+        .iter()
+        .filter(|f| f.cnsa2_deadline.as_deref() == Some("2030-12"))
+        .count();
+    let by_2035 = findings
+        .iter()
+        .filter(|f| f.cnsa2_deadline.as_deref() == Some("2035"))
+        .count();
+
+    if by_2027 > 0 || by_2030 > 0 || by_2035 > 0 {
+        let mut parts = Vec::new();
+        if by_2027 > 0 {
+            parts.push(format!("{by_2027} by Jan 2027"));
+        }
+        if by_2030 > 0 {
+            parts.push(format!("{by_2030} by Dec 2030"));
+        }
+        if by_2035 > 0 {
+            parts.push(format!("{by_2035} by 2035"));
+        }
+        println!(
+            "  {} {}",
+            "CNSA 2.0:".yellow().bold(),
+            parts.join(" \u{00b7} ").dimmed(),
+        );
+    }
+
+    // PQ migration level
+    if let Some(level) = pq_migration_level {
+        println!(
+            "  {} Level {}/5 \u{2014} {} ({} PQ findings, {} agility findings)",
+            "PQ migration:".cyan().bold(),
+            level.level,
+            level.label,
+            level.pq_finding_count,
+            level.agility_finding_count,
+        );
+    }
+
+    if by_2027 > 0 || by_2030 > 0 || by_2035 > 0 || pq_migration_level.is_some() {
+        println!();
+    }
 }

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -174,6 +174,7 @@ pub fn make_finding(
         sink_start_byte: None,
         sink_end_byte: None,
         confidence: crate::default_confidence(),
+        cnsa2_deadline: None,
     }
 }
 
@@ -218,6 +219,7 @@ pub fn make_finding_from_offsets(
         sink_start_byte: None,
         sink_end_byte: None,
         confidence: crate::default_confidence(),
+        cnsa2_deadline: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -772,6 +772,7 @@ fn map_go_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -1494,6 +1495,7 @@ pub fn run_go_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1707,6 +1707,7 @@ fn map_js_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -2710,6 +2711,7 @@ pub fn run_js_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1134,6 +1134,7 @@ fn run_kt_taint(
                     sink_start_byte: None,
                     sink_end_byte: None,
                     confidence: crate::default_confidence(),
+                    cnsa2_deadline: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1697,6 +1697,7 @@ fn map_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -2638,6 +2639,7 @@ pub fn run_py_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -207,6 +207,7 @@ impl Rule for SemgrepRule {
                 // External Semgrep rules are inherently fuzzier than
                 // curated built-in AST-walked rules. See issue #207.
                 confidence: 0.7,
+                cnsa2_deadline: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -327,6 +327,7 @@ impl Rule for SemgrepTaintRule {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                cnsa2_deadline: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -280,6 +280,7 @@ pub fn scan_paths_with_config_and_notices(
                         sink_start_byte: None,
                         sink_end_byte: None,
                         confidence: crate::default_confidence(),
+                        cnsa2_deadline: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2188,6 +2188,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2227,6 +2228,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2268,6 +2270,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         assert_eq!(
@@ -2300,6 +2303,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2336,6 +2340,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(
@@ -2405,6 +2410,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         assert_eq!(
@@ -2451,6 +2457,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2526,6 +2533,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2582,6 +2590,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2663,6 +2672,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -2703,6 +2713,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -2742,6 +2753,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(
@@ -2792,6 +2804,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
## Summary
- Adds `cnsa2_deadline` field to `Finding` — auto-annotated for PQ-related rules based on algorithm category
- New `src/compliance.rs` module with deadline mapping (Jan 2027 / Dec 2030 / 2035) and migration level scoring (1–5)
- Terminal: deadline shown per-finding, CNSA 2.0 breakdown + migration level in summary
- SARIF/JSON: deadline exposed in output

Ref: #224, #225

Closes #224

Closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan results now include CNSA 2.0 compliance deadlines (2027, 2030, 2035) for cryptographic and post-quantum migration findings with human-readable labels.
  * Introduced post-quantum migration readiness assessment to quantify cryptographic agility and migration progress toward quantum resistance.
  * Enhanced terminal and SARIF report outputs to display compliance deadlines and post-quantum migration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->