### PR TITLE
Wire min_entropy and max_hops config thresholds

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -150,6 +150,13 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
         findings.retain(|f| f.confidence >= min_conf);
     }
 
+    // Filter taint findings exceeding max_hops threshold
+    if let Some(ref cfg) = config {
+        if let Some(max) = cfg.scan.thresholds.taint.max_hops {
+            findings.retain(|f| f.taint_hops.map_or(true, |h| (h as usize) <= max));
+        }
+    }
+
     if let Some(ref min_severity) = scan.severity {
         let min = min_severity.to_severity();
         findings.retain(|f| f.severity >= min);

--- a/src/app.rs
+++ b/src/app.rs
@@ -153,7 +153,7 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     // Filter taint findings exceeding max_hops threshold
     if let Some(ref cfg) = config {
         if let Some(max) = cfg.scan.thresholds.taint.max_hops {
-            findings.retain(|f| f.taint_hops.map_or(true, |h| (h as usize) <= max));
+            findings.retain(|f| f.taint_hops.is_none_or(|h| (h as usize) <= max));
         }
     }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -172,6 +172,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 use crate::cli::{ScanArgs, SecretsArgs, SeverityFilter};
-use crate::rules::common::set_hardcoded_secret_min_length_override;
+use crate::rules::common::{
+    set_hardcoded_secret_min_entropy_override, set_hardcoded_secret_min_length_override,
+};
 use crate::{Finding, Severity};
 use serde::Deserialize;
 use serde_yaml::{Mapping, Sequence, Value};
@@ -64,12 +66,9 @@ pub struct ScanThresholds {
 
 /// Thresholds for `*-hardcoded-secret` rules.
 ///
-/// `min_length` is live: it replaces the previously hardcoded `inner.len()
-/// check (`>= 4`) used across every language's secret rule. `min_entropy`
-/// is reserved — no rule in the codebase computes Shannon entropy today,
-/// so enabling it would require inventing new behavior rather than
-/// exposing an existing threshold. It is parsed and validated so a future
-/// PR can wire it without a config schema change.
+/// Both fields are live: `min_length` replaces the previously hardcoded
+/// `inner.len() >= 4` check, and `min_entropy` adds a Shannon entropy
+/// gate so low-entropy strings like `"test"` or `"changeme"` are skipped.
 #[derive(Debug, Clone, Default)]
 pub struct SecretsThresholds {
     pub min_length: Option<usize>,
@@ -78,11 +77,9 @@ pub struct SecretsThresholds {
 
 /// Thresholds for taint-propagation rules.
 ///
-/// `max_hops` is reserved — the taint engine runs a fixed two-pass
-/// pipeline with no iteration counter to clamp, so there is no
-/// "hardcoded cap" to expose today. Parsed and validated so users can set
-/// it now without a schema break when the engine grows a convergence
-/// loop.
+/// `max_hops` filters taint findings by propagation depth. Findings with
+/// more hops than `max_hops` are suppressed after scanning. Currently
+/// hops are 1 (intra-file direct) or 2 (cross-file).
 #[derive(Debug, Clone, Default)]
 pub struct TaintThresholds {
     pub max_hops: Option<usize>,
@@ -427,15 +424,12 @@ pub fn suppress_with_scan_ignores(
 /// scanner's process-wide state. Idempotent: calling with a fresh config
 /// overwrites any previous override, so repeated scans in the same
 /// process (e.g. the TUI) cannot leak a stale value.
-///
-/// Currently only `secrets.min_length` has an active hook (it feeds the
-/// `is_secret_value_long_enough` helper used by every
-/// `*-hardcoded-secret` rule). The other threshold fields are parsed and
-/// validated but have no behavioral effect yet; they are reserved for
-/// follow-up PRs (see issue #210).
 pub fn apply_scan_thresholds(config: Option<&FoxguardConfig>) {
     let min_length = config.and_then(|cfg| cfg.scan.thresholds.secrets.min_length);
     set_hardcoded_secret_min_length_override(min_length);
+
+    let min_entropy = config.and_then(|cfg| cfg.scan.thresholds.secrets.min_entropy);
+    set_hardcoded_secret_min_entropy_override(min_entropy);
 }
 
 pub fn editable_config_path(
@@ -983,6 +977,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let (config_path, added) =
@@ -1044,6 +1039,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -285,6 +285,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,4 +106,8 @@ pub struct Finding {
     /// inherently fuzzier than curated built-in AST-walked rules.
     #[serde(default = "default_confidence")]
     pub confidence: f32,
+    /// Number of taint propagation hops (1 = direct, 2 = cross-file).
+    /// `None` for non-taint rules. Used by `scan.thresholds.taint.max_hops`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub taint_hops: Option<u8>,
 }

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -182,6 +182,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         }
     }
 

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -4,6 +4,52 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{Finding, Severity};
 
+// ─── Min-entropy threshold (atomic global, same pattern as min_length) ────
+
+/// Process-wide override for the hardcoded-secret minimum entropy threshold.
+/// `0` bits (stored as `u32` via `f32::to_bits()`) means "no override".
+static HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(0);
+
+/// Install a process-wide `scan.thresholds.secrets.min_entropy` override.
+pub fn set_hardcoded_secret_min_entropy_override(value: Option<f32>) {
+    let bits = match value {
+        Some(v) => v.to_bits(),
+        None => 0,
+    };
+    HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE.store(bits, Ordering::Relaxed);
+}
+
+/// Returns the configured min-entropy threshold, or `None` if unset.
+fn hardcoded_secret_min_entropy() -> Option<f32> {
+    let bits = HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE.load(Ordering::Relaxed);
+    if bits == 0 {
+        None
+    } else {
+        Some(f32::from_bits(bits))
+    }
+}
+
+/// Compute Shannon entropy (bits per character) for a byte string.
+pub fn shannon_entropy(s: &str) -> f32 {
+    if s.is_empty() {
+        return 0.0;
+    }
+    let mut counts = [0u32; 256];
+    for &b in s.as_bytes() {
+        counts[b as usize] += 1;
+    }
+    let len = s.len() as f32;
+    let mut entropy: f32 = 0.0;
+    for &c in &counts {
+        if c > 0 {
+            let p = c as f32 / len;
+            entropy -= p * p.log2();
+        }
+    }
+    entropy
+}
+
 /// Default minimum length for strings flagged as a hardcoded secret.
 ///
 /// Historically this was hardcoded as `>= 4` across every language-specific
@@ -43,11 +89,20 @@ pub fn hardcoded_secret_min_length() -> usize {
     }
 }
 
-/// True when `inner` (the unquoted content of a string literal) is long
-/// enough to be reported by a `*-hardcoded-secret` rule, per the
-/// `scan.secrets.min_length` threshold.
+/// True when `inner` (the unquoted content of a string literal) passes
+/// the configured thresholds for a `*-hardcoded-secret` rule:
+/// - `scan.thresholds.secrets.min_length` (default 4)
+/// - `scan.thresholds.secrets.min_entropy` (optional, disabled by default)
 pub fn is_secret_value_long_enough(inner: &str) -> bool {
-    inner.len() >= hardcoded_secret_min_length()
+    if inner.len() < hardcoded_secret_min_length() {
+        return false;
+    }
+    if let Some(min_ent) = hardcoded_secret_min_entropy() {
+        if shannon_entropy(inner) < min_ent {
+            return false;
+        }
+    }
+    true
 }
 
 /// Shared per-file import alias table.
@@ -174,6 +229,7 @@ pub fn make_finding(
         sink_start_byte: None,
         sink_end_byte: None,
         confidence: crate::default_confidence(),
+        taint_hops: None,
     }
 }
 
@@ -218,6 +274,7 @@ pub fn make_finding_from_offsets(
         sink_start_byte: None,
         sink_end_byte: None,
         confidence: crate::default_confidence(),
+        taint_hops: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -772,6 +772,7 @@ fn map_go_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            taint_hops: Some(t.hops),
         })
         .collect()
 }
@@ -1494,6 +1495,7 @@ pub fn run_go_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                taint_hops: Some(t.hops),
             })
         })
         .collect()

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1707,6 +1707,7 @@ fn map_js_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            taint_hops: Some(t.hops),
         })
         .collect()
 }
@@ -2710,6 +2711,7 @@ pub fn run_js_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                taint_hops: Some(t.hops),
             })
         })
         .collect()

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1134,6 +1134,7 @@ fn run_kt_taint(
                     sink_start_byte: None,
                     sink_end_byte: None,
                     confidence: crate::default_confidence(),
+                    taint_hops: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1697,6 +1697,7 @@ fn map_taint_findings(
             sink_start_byte: Some(t.sink_start_byte),
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
+            taint_hops: Some(t.hops),
         })
         .collect()
 }
@@ -2638,6 +2639,7 @@ pub fn run_py_taint_batched(
                 sink_start_byte: Some(t.sink_start_byte),
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                taint_hops: Some(t.hops),
             })
         })
         .collect()

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -207,6 +207,7 @@ impl Rule for SemgrepRule {
                 // External Semgrep rules are inherently fuzzier than
                 // curated built-in AST-walked rules. See issue #207.
                 confidence: 0.7,
+                taint_hops: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -327,6 +327,7 @@ impl Rule for SemgrepTaintRule {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
+                taint_hops: Some(t.hops),
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -280,6 +280,7 @@ pub fn scan_paths_with_config_and_notices(
                         sink_start_byte: None,
                         sink_end_byte: None,
                         confidence: crate::default_confidence(),
+                        taint_hops: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2188,6 +2188,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2227,6 +2228,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2268,6 +2270,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         assert_eq!(
@@ -2300,6 +2303,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2336,6 +2340,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = render_source_context(
@@ -2405,6 +2410,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         assert_eq!(
@@ -2451,6 +2457,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                taint_hops: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2526,6 +2533,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                taint_hops: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2582,6 +2590,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                taint_hops: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -2663,6 +2672,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -2703,6 +2713,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -2742,6 +2753,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = render_source_context(
@@ -2792,6 +2804,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
## Summary
Both config knobs were already parsed and validated but had no effect. Now they're live:

- **`scan.thresholds.secrets.min_entropy`** — Shannon entropy gate for secret detection. Low-entropy strings like `"test"` (~1.5 bits) or `"changeme"` (~2.5 bits) are skipped. Disabled by default (no behavior change).
- **`scan.thresholds.taint.max_hops`** — filters taint findings by propagation depth. `taint_hops` field added to `Finding` (1 = intra-file, 2 = cross-file). Findings exceeding the threshold are suppressed.

```yaml
scan:
  thresholds:
    secrets:
      min_entropy: 3.0    # skip low-entropy strings
    taint:
      max_hops: 1         # only direct source→sink flows
```

Ref: #207, #210

Closes #207

Closes #210