### PR TITLE
Add foxguard pqc subcommand

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,12 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
             .map(|r| r.id().to_string())
             .filter(|id| is_pq_rule_id(id))
             .collect();
+        if pq_enable.is_empty() {
+            eprintln!(
+                "Warning: no PQ rules registered in this build. \
+                 Install a version with post-quantum crypto rules to use 'foxguard pqc'."
+            );
+        }
         registry.apply_rule_filter(&pq_enable, &[])
     } else if let Some(config) = config.as_ref() {
         registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,7 +104,17 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     let excludes = PathExcludeMatcher::new(&scan.exclude)?;
     let targets = collect_changed_targets(&scan.path, scan.changed)?;
 
-    let rule_filter_unknown = if let Some(config) = config.as_ref() {
+    // In PQ mode, filter to only PQ-related rules
+    let pq_enable: Vec<String>;
+    let rule_filter_unknown = if scan.pq_mode {
+        pq_enable = registry
+            .all_rules()
+            .iter()
+            .map(|r| r.id().to_string())
+            .filter(|id| is_pq_rule_id(id))
+            .collect();
+        registry.apply_rule_filter(&pq_enable, &[])
+    } else if let Some(config) = config.as_ref() {
         registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)
     } else {
         Vec::new()
@@ -374,6 +384,7 @@ fn tui_scan_args(args: &TuiArgs) -> ScanArgs {
         fix: false,
         show_confidence: false,
         min_confidence: None,
+        pq_mode: false,
     }
 }
 
@@ -447,6 +458,13 @@ fn validate_rules_path(rules: Option<&str>) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Returns `true` if the rule ID belongs to the PQ audit rule set.
+fn is_pq_rule_id(id: &str) -> bool {
+    id.contains("pq-vulnerable")
+        || id.contains("hardcoded-crypto-algorithm")
+        || (id.starts_with("config/") && (id.contains("tls") || id.contains("dockerfile")))
 }
 
 fn collect_changed_targets(path: &str, changed: bool) -> Result<Option<Vec<PathBuf>>, String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -301,6 +301,14 @@ pub struct PqcArgs {
     /// Post findings as inline review comments on a GitHub PR
     #[arg(long)]
     pub github_pr: Option<u64>,
+
+    /// Apply a baseline file to suppress known findings
+    #[arg(long)]
+    pub baseline: Option<String>,
+
+    /// Show per-finding confidence scores in terminal output
+    #[arg(long, default_value_t = false)]
+    pub show_confidence: bool,
 }
 
 impl PqcArgs {
@@ -315,14 +323,14 @@ impl PqcArgs {
             no_builtins: false,
             changed: self.changed,
             exclude: self.exclude.clone(),
-            baseline: None,
+            baseline: self.baseline.clone(),
             write_baseline: None,
             explain: self.explain,
             fix: false,
             github_pr: self.github_pr,
             quiet: self.quiet,
             max_file_size: self.max_file_size,
-            show_confidence: false,
+            show_confidence: self.show_confidence,
             min_confidence: None,
             pq_mode: true,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,10 @@ pub struct ScanArgs {
     /// threshold are suppressed. Defaults to 0.0 (report all).
     #[arg(long)]
     pub min_confidence: Option<f32>,
+
+    /// Internal: set by the `pqc` subcommand to filter to PQ rules only.
+    #[arg(hide = true, long, default_value_t = false)]
+    pub pq_mode: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -256,6 +260,75 @@ pub struct TuiArgs {
     pub max_file_size: u64,
 }
 
+#[derive(Args, Debug, Clone)]
+pub struct PqcArgs {
+    /// Path to scan
+    #[arg(default_value = ".")]
+    pub path: String,
+
+    /// Path to foxguard config file
+    #[arg(long)]
+    pub config: Option<String>,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value = "terminal")]
+    pub format: OutputFormat,
+
+    /// Minimum severity to report
+    #[arg(short, long, value_enum)]
+    pub severity: Option<SeverityFilter>,
+
+    /// Scan changed files only (staged first, then unstaged)
+    #[arg(long, default_value_t = false)]
+    pub changed: bool,
+
+    /// Exclude scan-relative paths by glob or prefix (repeatable)
+    #[arg(long)]
+    pub exclude: Vec<String>,
+
+    /// Show source-to-sink dataflow traces on taint findings
+    #[arg(long, default_value_t = false)]
+    pub explain: bool,
+
+    /// Suppress terminal output (exit code still reflects findings)
+    #[arg(short, long)]
+    pub quiet: bool,
+
+    /// Maximum file size in bytes to scan (default: 1 MB)
+    #[arg(long, default_value_t = 1_048_576)]
+    pub max_file_size: u64,
+
+    /// Post findings as inline review comments on a GitHub PR
+    #[arg(long)]
+    pub github_pr: Option<u64>,
+}
+
+impl PqcArgs {
+    /// Convert to `ScanArgs` with `pq_mode` enabled.
+    pub fn to_scan_args(&self) -> ScanArgs {
+        ScanArgs {
+            path: self.path.clone(),
+            config: self.config.clone(),
+            format: self.format,
+            severity: self.severity,
+            rules: None,
+            no_builtins: false,
+            changed: self.changed,
+            exclude: self.exclude.clone(),
+            baseline: None,
+            write_baseline: None,
+            explain: self.explain,
+            fix: false,
+            github_pr: self.github_pr,
+            quiet: self.quiet,
+            max_file_size: self.max_file_size,
+            show_confidence: false,
+            min_confidence: None,
+            pq_mode: true,
+        }
+    }
+}
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum Command {
     /// Install a pre-commit hook for local foxguard runs
@@ -268,6 +341,8 @@ pub enum Command {
     Diff(DiffArgs),
     /// Explore scan findings in the interactive terminal TUI
     Tui(TuiArgs),
+    /// Post-quantum cryptography audit — scan for quantum-vulnerable algorithms
+    Pqc(PqcArgs),
 }
 
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use foxguard::app::{
 };
 use foxguard::baseline::write_baseline;
 use foxguard::cli::{
-    BaselineArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat, ScanArgs, SecretsArgs, TuiArgs,
+    BaselineArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat, PqcArgs, ScanArgs, SecretsArgs,
+    TuiArgs,
 };
 use foxguard::config::load_for_scan;
 use foxguard::tui::run_scan_tui;
@@ -24,10 +25,16 @@ fn main() {
         Some(Command::Secrets(args)) => run_secrets(&args),
         Some(Command::Diff(args)) => run_diff_cmd(&args),
         Some(Command::Tui(args)) => run_tui(&args),
+        Some(Command::Pqc(args)) => run_pqc(&args),
         None => run_scan(&cli.scan),
     };
 
     std::process::exit(exit_code);
+}
+
+fn run_pqc(args: &PqcArgs) -> i32 {
+    let scan = args.to_scan_args();
+    run_scan(&scan)
 }
 
 fn run_scan(scan: &ScanArgs) -> i32 {
@@ -294,6 +301,7 @@ fn run_init(args: &InitArgs) -> i32 {
                 max_file_size: 1_048_576,
                 show_confidence: false,
                 min_confidence: None,
+                pq_mode: false,
             },
             output: repo_root.join(&args.baseline).display().to_string(),
         };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3299,3 +3299,49 @@ rules:
         );
     }
 }
+
+// ─── PQC subcommand ──────────────────────────────────────────────────────────
+
+#[test]
+fn pqc_help_exits_zero() {
+    let output = foxguard_cmd()
+        .args(["pqc", "--help"])
+        .output()
+        .expect("failed to run foxguard pqc --help");
+    assert!(output.status.success(), "foxguard pqc --help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("post-quantum") || stdout.contains("quantum"),
+        "help text should mention post-quantum, got: {stdout}"
+    );
+}
+
+#[test]
+fn pqc_on_safe_fixture_returns_zero_findings() {
+    let output = foxguard_cmd()
+        .args([
+            "pqc",
+            fixture_path("safe.py").to_str().unwrap(),
+            "-f",
+            "json",
+        ])
+        .output()
+        .expect("failed to run foxguard pqc");
+    // No PQ rules registered on main yet, so zero findings expected.
+    // Once PQ rules land, safe.py should still produce zero PQ findings.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !stdout.trim().is_empty() {
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_str(&stdout).expect("invalid JSON output");
+        // All findings (if any) should be PQ-related
+        for f in &findings {
+            let rule_id = f["rule_id"].as_str().unwrap_or("");
+            assert!(
+                rule_id.contains("pq-vulnerable")
+                    || rule_id.contains("hardcoded-crypto-algorithm")
+                    || rule_id.starts_with("config/"),
+                "pqc subcommand should only return PQ rules, got: {rule_id}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
New `foxguard pqc <path>` subcommand for dedicated post-quantum crypto auditing.

Thin wrapper over `execute_scan()` that filters to PQ-related rules only:
- `*pq-vulnerable-crypto` (RSA, ECDSA, ECDH, DH, Ed25519)
- `*hardcoded-crypto-algorithm` (crypto agility)
- `config/*tls*`, `config/*dockerfile*` (TLS config scanning)

```
foxguard pqc .              # scan current directory for PQ issues
foxguard pqc src/ --format json   # JSON output
foxguard pqc . --explain    # show dataflow traces
```

Supports same flags as `scan` (--format, --severity, --explain, --github-pr, etc.)

Ref: #206

Closes #206