### PR TITLE
fix(tui): add taint_hops field to test Finding constructors

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3366,6 +3366,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: 0.95,
+            taint_hops: None,
         };
         let low_conf_high_sev = Finding {
             severity: Severity::Critical,
@@ -3429,6 +3430,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: 1.0,
+            taint_hops: None,
         };
         let low_conf = Finding {
             confidence: 0.5,
@@ -3497,6 +3499,7 @@ mod tests {
                 sink_start_byte: None,
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
+                taint_hops: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3548,6 +3551,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3606,6 +3610,7 @@ mod tests {
             sink_start_byte: None,
             sink_end_byte: None,
             confidence: crate::default_confidence(),
+            taint_hops: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,


### PR DESCRIPTION
## Summary
- Main CI broke after #232 merged without rebasing on #216
- Five `Finding { … }` literals in `src/tui.rs` test helpers (added by #216 at 16:34 UTC) are missing the `taint_hops` field (#232 added at 16:42 UTC)
- This PR adds `taint_hops: None` to those five constructors — pure mechanical fix

## Root cause
Classic merge-skew: #232's CI was green against pre-#216 main, and GitHub merged it without requiring a rebase. The new test helpers introduced by #216 were invisible to #232's build, so the missing-field errors only surfaced on main.

## Test plan
- [x] `cargo test --all` — 345 + 86 + 15 + 12 + 6 + 3 + 1 all pass locally
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean