### PR TITLE
Add CBOM output format (CycloneDX 1.6)

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -173,6 +173,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ pub enum OutputFormat {
     Terminal,
     Json,
     Sarif,
+    Cbom,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1218,6 +1218,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let (config_path, added) =
@@ -1280,6 +1281,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -286,6 +286,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,4 +110,8 @@ pub struct Finding {
     /// `None` for non-taint rules. Used by `scan.thresholds.taint.max_hops`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub taint_hops: Option<u8>,
+    /// Cryptographic algorithm name (e.g. "RSA", "ECDSA", "TLS").
+    /// Set by crypto-related rules at emission time. Used by the CBOM formatter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crypto_algorithm: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if let Some(pr_number) = result.args.github_pr {
@@ -151,6 +152,7 @@ fn run_secrets(args: &SecretsArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if !result.findings.is_empty() {
@@ -185,6 +187,7 @@ fn run_diff_cmd(args: &DiffArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if new_count > 0 {

--- a/src/report/cbom.rs
+++ b/src/report/cbom.rs
@@ -1,0 +1,399 @@
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::Finding;
+
+/// CycloneDX 1.6 crypto asset properties, looked up by algorithm name.
+struct CryptoProps {
+    asset_type: &'static str,
+    primitive: Option<&'static str>,
+    functions: &'static [&'static str],
+    protocol_type: Option<&'static str>,
+}
+
+fn crypto_props(algo: &str) -> CryptoProps {
+    match algo {
+        "RSA" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("pk-encryption"),
+            functions: &["encrypt", "sign"],
+            protocol_type: None,
+        },
+        "ECDSA" | "DSA" | "Ed25519" | "Ed448" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("signature"),
+            functions: &["sign", "verify"],
+            protocol_type: None,
+        },
+        "ECDH" | "DH" | "X25519" | "X448" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("key-agree"),
+            functions: &["keyagree"],
+            protocol_type: None,
+        },
+        "AES" | "AES-CBC" | "AES-GCM" | "DES" | "3DES" | "Blowfish" | "RC4" | "RC2" => {
+            CryptoProps {
+                asset_type: "algorithm",
+                primitive: Some("block-cipher"),
+                functions: &["encrypt", "decrypt"],
+                protocol_type: None,
+            }
+        }
+        "MD5" | "SHA1" | "SHA-1" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("hash"),
+            functions: &["digest"],
+            protocol_type: None,
+        },
+        "TLS" => CryptoProps {
+            asset_type: "protocol",
+            primitive: None,
+            functions: &[],
+            protocol_type: Some("tls"),
+        },
+        _ => CryptoProps {
+            asset_type: "related-crypto-material",
+            primitive: None,
+            functions: &[],
+            protocol_type: None,
+        },
+    }
+}
+
+fn build_component(
+    algo: &str,
+    bom_ref: &str,
+    findings: &[&Finding],
+    props: &CryptoProps,
+) -> serde_json::Value {
+    let occurrences: Vec<_> = findings
+        .iter()
+        .map(|f| {
+            json!({
+                "location": format!("{}:{}:{}", f.file, f.line, f.column),
+                "additionalContext": f.snippet.trim()
+            })
+        })
+        .collect();
+
+    let mut crypto_properties = json!({ "assetType": props.asset_type });
+
+    if props.asset_type == "algorithm" {
+        let mut algo_props = serde_json::Map::new();
+        if let Some(prim) = props.primitive {
+            algo_props.insert("primitive".to_string(), json!(prim));
+        }
+        if !props.functions.is_empty() {
+            algo_props.insert("cryptoFunctions".to_string(), json!(props.functions));
+        }
+        crypto_properties["algorithmProperties"] = json!(algo_props);
+    } else if props.asset_type == "protocol" {
+        if let Some(proto) = props.protocol_type {
+            crypto_properties["protocolProperties"] = json!({ "type": proto });
+        }
+    }
+
+    json!({
+        "type": "cryptographic-asset",
+        "bom-ref": bom_ref,
+        "name": algo,
+        "cryptoProperties": crypto_properties,
+        "evidence": {
+            "occurrences": occurrences
+        }
+    })
+}
+
+fn build_vulnerability(algo: &str, bom_ref: &str, findings: &[&Finding]) -> serde_json::Value {
+    // Use the highest severity from the group
+    let max_severity = findings
+        .iter()
+        .map(|f| f.severity)
+        .max()
+        .unwrap_or(crate::Severity::Low);
+
+    let severity_str = match max_severity {
+        crate::Severity::Critical => "critical",
+        crate::Severity::High => "high",
+        crate::Severity::Medium => "medium",
+        crate::Severity::Low => "low",
+    };
+
+    // Collect unique CWEs
+    let cwes: Vec<u32> = findings
+        .iter()
+        .filter_map(|f| f.cwe.as_ref())
+        .filter_map(|c| c.strip_prefix("CWE-").and_then(|n| n.parse().ok()))
+        .collect::<std::collections::BTreeSet<u32>>()
+        .into_iter()
+        .collect();
+
+    // Use first available fix suggestion as recommendation
+    let recommendation = findings
+        .iter()
+        .find_map(|f| f.fix_suggestion.as_ref())
+        .cloned()
+        .or_else(|| findings.first().map(|f| f.description.clone()))
+        .unwrap_or_default();
+
+    let mut vuln = json!({
+        "id": format!("foxguard-{}", algo.to_lowercase()),
+        "source": { "name": "foxguard" },
+        "ratings": [{ "severity": severity_str, "method": "other" }],
+        "description": findings.first().map(|f| f.description.as_str()).unwrap_or(""),
+        "affects": [{ "ref": bom_ref }],
+        "recommendation": recommendation
+    });
+
+    if !cwes.is_empty() {
+        vuln["cwes"] = json!(cwes);
+    }
+
+    vuln
+}
+
+fn iso8601_now() -> String {
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+
+    // Manual UTC breakdown (no chrono dependency)
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Days since 1970-01-01 to Y-M-D
+    let mut y = 1970i64;
+    let mut remaining = days as i64;
+    loop {
+        let days_in_year = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+    let month_days: [i64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 0usize;
+    for (i, &md) in month_days.iter().enumerate() {
+        if remaining < md {
+            m = i;
+            break;
+        }
+        remaining -= md;
+    }
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m + 1,
+        remaining + 1,
+        hours,
+        minutes,
+        seconds
+    )
+}
+
+fn deterministic_uuid(components_json: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(components_json.as_bytes());
+    let hash = hasher.finalize();
+    format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]),
+        u16::from_be_bytes([hash[4], hash[5]]),
+        u16::from_be_bytes([hash[6], hash[7]]),
+        u16::from_be_bytes([hash[8], hash[9]]),
+        // Take 6 bytes for the last segment
+        u64::from_be_bytes([0, 0, hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]])
+    )
+}
+
+/// Print findings as a CycloneDX 1.6 Cryptographic Bill of Materials (CBOM).
+///
+/// Only findings with `crypto_algorithm` set are included. Findings are
+/// grouped by algorithm name into components, with linked vulnerability
+/// entries.
+pub fn print_cbom(findings: &[Finding]) {
+    // Group findings by crypto_algorithm
+    let mut groups: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+    for f in findings {
+        if let Some(algo) = &f.crypto_algorithm {
+            groups.entry(algo.clone()).or_default().push(f);
+        }
+    }
+
+    if groups.is_empty() && !findings.is_empty() {
+        eprintln!(
+            "Warning: no cryptographic findings detected; CBOM is empty. \
+             Use 'foxguard pqc' to scan for quantum-vulnerable cryptography."
+        );
+    }
+
+    let mut components = Vec::new();
+    let mut vulnerabilities = Vec::new();
+
+    for (algo, group_findings) in &groups {
+        let bom_ref = format!("crypto-{}", algo.to_lowercase().replace(' ', "-"));
+        let props = crypto_props(algo);
+
+        components.push(build_component(algo, &bom_ref, group_findings, &props));
+        vulnerabilities.push(build_vulnerability(algo, &bom_ref, group_findings));
+    }
+
+    let components_json = serde_json::to_string(&components).unwrap_or_default();
+    let serial = deterministic_uuid(&components_json);
+
+    let cbom = json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "serialNumber": format!("urn:uuid:{serial}"),
+        "metadata": {
+            "timestamp": iso8601_now(),
+            "tools": {
+                "components": [{
+                    "type": "application",
+                    "name": "foxguard",
+                    "version": env!("CARGO_PKG_VERSION")
+                }]
+            }
+        },
+        "components": components,
+        "vulnerabilities": vulnerabilities
+    });
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&cbom).expect("Failed to serialize CBOM")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_crypto_finding(algo: &str, file: &str, line: usize) -> Finding {
+        Finding {
+            rule_id: format!("test/pq-vulnerable-{}", algo.to_lowercase()),
+            severity: crate::Severity::High,
+            cwe: Some("CWE-327".to_string()),
+            description: format!("{algo} is quantum-vulnerable"),
+            file: file.to_string(),
+            line,
+            column: 1,
+            end_line: line,
+            end_column: 10,
+            snippet: format!("use_{}()", algo.to_lowercase()),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: Some(format!("Migrate from {algo} to ML-KEM")),
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            crypto_algorithm: Some(algo.to_string()),
+        }
+    }
+
+    #[test]
+    fn cbom_groups_by_algorithm() {
+        let findings = vec![
+            make_crypto_finding("RSA", "src/auth.py", 10),
+            make_crypto_finding("RSA", "src/crypto.py", 42),
+            make_crypto_finding("ECDSA", "src/sign.py", 5),
+        ];
+
+        let mut groups: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+        for f in &findings {
+            if let Some(algo) = &f.crypto_algorithm {
+                groups.entry(algo.clone()).or_default().push(f);
+            }
+        }
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups["RSA"].len(), 2);
+        assert_eq!(groups["ECDSA"].len(), 1);
+    }
+
+    #[test]
+    fn cbom_empty_without_crypto_findings() {
+        let findings = vec![Finding {
+            rule_id: "py/no-eval".to_string(),
+            severity: crate::Severity::High,
+            cwe: Some("CWE-95".to_string()),
+            description: "eval() is dangerous".to_string(),
+            file: "app.py".to_string(),
+            line: 1,
+            column: 1,
+            end_line: 1,
+            end_column: 10,
+            snippet: "eval(x)".to_string(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            crypto_algorithm: None,
+        }];
+
+        let groups: BTreeMap<String, Vec<&Finding>> = findings
+            .iter()
+            .filter_map(|f| f.crypto_algorithm.as_ref().map(|a| (a.clone(), f)))
+            .fold(BTreeMap::new(), |mut acc, (algo, f)| {
+                acc.entry(algo).or_default().push(f);
+                acc
+            });
+
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn iso8601_format_is_valid() {
+        let ts = iso8601_now();
+        assert!(ts.ends_with('Z'));
+        assert_eq!(ts.len(), 20); // "2026-04-19T12:34:56Z"
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+    }
+
+    #[test]
+    fn deterministic_uuid_is_stable() {
+        let input = r#"[{"name":"RSA"}]"#;
+        let u1 = deterministic_uuid(input);
+        let u2 = deterministic_uuid(input);
+        assert_eq!(u1, u2);
+        assert_eq!(u1.len(), 36); // UUID format: 8-4-4-4-12
+    }
+}

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -183,6 +183,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         }
     }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,3 +1,4 @@
+pub mod cbom;
 pub mod github_pr;
 pub mod json;
 pub mod sarif;

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -230,6 +230,7 @@ pub fn make_finding(
         sink_end_byte: None,
         confidence: crate::default_confidence(),
         taint_hops: None,
+        crypto_algorithm: None,
     }
 }
 
@@ -275,6 +276,7 @@ pub fn make_finding_from_offsets(
         sink_end_byte: None,
         confidence: crate::default_confidence(),
         taint_hops: None,
+        crypto_algorithm: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -773,6 +773,7 @@ fn map_go_taint_findings(
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -1496,6 +1497,7 @@ pub fn run_go_taint_batched(
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1708,6 +1708,7 @@ fn map_js_taint_findings(
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -2712,6 +2713,7 @@ pub fn run_js_taint_batched(
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1135,6 +1135,7 @@ fn run_kt_taint(
                     sink_end_byte: None,
                     confidence: crate::default_confidence(),
                     taint_hops: None,
+                    crypto_algorithm: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1698,6 +1698,7 @@ fn map_taint_findings(
             sink_end_byte: Some(t.sink_end_byte),
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -2640,6 +2641,7 @@ pub fn run_py_taint_batched(
                 sink_end_byte: Some(t.sink_end_byte),
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -208,6 +208,7 @@ impl Rule for SemgrepRule {
                 // curated built-in AST-walked rules. See issue #207.
                 confidence: 0.7,
                 taint_hops: None,
+                crypto_algorithm: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -328,6 +328,7 @@ impl Rule for SemgrepTaintRule {
                 sink_end_byte: None,
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
+                crypto_algorithm: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -281,6 +281,7 @@ pub fn scan_paths_with_config_and_notices(
                         sink_end_byte: None,
                         confidence: crate::default_confidence(),
                         taint_hops: None,
+                        crypto_algorithm: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2662,6 +2662,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2702,6 +2703,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2744,6 +2746,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         assert_eq!(
@@ -2777,6 +2780,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2814,6 +2818,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(
@@ -2884,6 +2889,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         assert_eq!(
@@ -2931,6 +2937,7 @@ mod tests {
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
                 taint_hops: None,
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3007,6 +3014,7 @@ mod tests {
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
                 taint_hops: None,
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3064,6 +3072,7 @@ mod tests {
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
                 taint_hops: None,
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3146,6 +3155,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3187,6 +3197,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -3227,6 +3238,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(
@@ -3367,6 +3379,7 @@ mod tests {
             sink_end_byte: None,
             confidence: 0.95,
             taint_hops: None,
+            crypto_algorithm: None,
         };
         let low_conf_high_sev = Finding {
             severity: Severity::Critical,
@@ -3431,6 +3444,7 @@ mod tests {
             sink_end_byte: None,
             confidence: 1.0,
             taint_hops: None,
+            crypto_algorithm: None,
         };
         let low_conf = Finding {
             confidence: 0.5,
@@ -3500,6 +3514,7 @@ mod tests {
                 sink_end_byte: None,
                 confidence: crate::default_confidence(),
                 taint_hops: None,
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3552,6 +3567,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3611,6 +3627,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3659,6 +3676,7 @@ mod tests {
             sink_end_byte: None,
             confidence: crate::default_confidence(),
             taint_hops: None,
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
## Summary
New `--format cbom` output for Cryptographic Bill of Materials in CycloneDX 1.6 format.

- Groups findings by `crypto_algorithm` into CycloneDX `cryptographic-asset` components
- Each component has `cryptoProperties` (algorithm primitive, functions, protocol type)
- Linked `vulnerabilities[]` with severity, CWE, and remediation recommendations
- Deterministic serial number via SHA-256 hash of component data
- Adds `crypto_algorithm: Option<String>` field to `Finding` — set by rules at emission time, no free-text parsing

```
foxguard pqc . --format cbom    # PQ crypto inventory
foxguard scan . --format cbom   # all crypto findings as CBOM
```

Available on all scan commands. Findings without `crypto_algorithm` are skipped. Empty CBOM is valid output with stderr warning.

Ref: #219

Closes #219