### PR TITLE
Upgrade PQ fix suggestions to hybrid approaches (reopens #227)

### DIFF
--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -480,13 +480,22 @@ fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str)> {
     }
     // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA"
     if upper.contains("WITHRSA") {
-        return Some(("RSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
+        return Some((
+            "RSA",
+            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+        ));
     }
     if upper.contains("WITHECDSA") {
-        return Some(("ECDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
+        return Some((
+            "ECDSA",
+            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+        ));
     }
     if upper.contains("WITHDSA") && !upper.contains("ML-DSA") {
-        return Some(("DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
+        return Some((
+            "DSA",
+            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+        ));
     }
     None
 }

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -464,29 +464,29 @@ impl_rule! {
 fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str)> {
     // Exact matches for KeyPairGenerator / KeyAgreement / KeyFactory
     match algo {
-        "RSA" => return Some(("RSA", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)")),
-        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ML-DSA (FIPS 204)")),
-        "DSA" => return Some(("DSA", "ML-DSA (FIPS 204)")),
-        "DH" | "ECDH" | "DiffieHellman" => return Some(("DH/ECDH", "ML-KEM (FIPS 203)")),
-        "Ed25519" | "Ed448" | "EdDSA" => return Some(("EdDSA", "ML-DSA (FIPS 204)")),
-        "X25519" | "X448" | "XDH" => return Some(("XDH", "ML-KEM (FIPS 203)")),
+        "RSA" => return Some(("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)")),
+        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "DSA" => return Some(("DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "DH" | "ECDH" | "DiffieHellman" => return Some(("DH/ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "Ed25519" | "Ed448" | "EdDSA" => return Some(("EdDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "X25519" | "X448" | "XDH" => return Some(("XDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
         _ => {}
     }
     // Non-exact matches need case-insensitive comparison
     let upper = algo.to_uppercase();
     // RSA cipher modes: "RSA/ECB/PKCS1Padding", "RSA/ECB/OAEPWithSHA-256..."
     if upper.starts_with("RSA/") || upper.starts_with("RSA_") {
-        return Some(("RSA", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)"));
+        return Some(("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)"));
     }
     // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA"
     if upper.contains("WITHRSA") {
-        return Some(("RSA", "ML-DSA (FIPS 204)"));
+        return Some(("RSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
     }
     if upper.contains("WITHECDSA") {
-        return Some(("ECDSA", "ML-DSA (FIPS 204)"));
+        return Some(("ECDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
     }
     if upper.contains("WITHDSA") && !upper.contains("ML-DSA") {
-        return Some(("DSA", "ML-DSA (FIPS 204)"));
+        return Some(("DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"));
     }
     None
 }
@@ -526,9 +526,9 @@ impl_rule! {
                                             None => return,
                                         };
                                         let replacement = if obj_text == "KeyAgreement" {
-                                            "ML-KEM (FIPS 203)"
+                                            "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)"
                                         } else if obj_text == "Signature" {
-                                            "ML-DSA (FIPS 204)"
+                                            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"
                                         } else {
                                             replacement
                                         };

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -482,10 +482,10 @@ impl_rule! {
                                     let val = &src[first_arg.byte_range()];
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
                                     let (algo, replacement) = match inner.to_lowercase().as_str() {
-                                            "rsa" => ("RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
-                                            "ec" => ("EC", "ML-KEM (FIPS 203) for key exchange or ML-DSA (FIPS 204) for signatures"),
-                                            "dsa" => ("DSA", "ML-DSA (FIPS 204)"),
-                                            "ed25519" | "ed448" => ("Ed25519/Ed448", "ML-DSA (FIPS 204)"),
+                                            "rsa" => ("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+                                            "ec" => ("EC", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+                                            "dsa" => ("DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+                                            "ed25519" | "ed448" => ("Ed25519/Ed448", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
                                             _ => return,
                                         };
                                     let mut f = make_finding(
@@ -512,7 +512,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "Diffie-Hellman is quantum-vulnerable — migrate to ML-KEM (FIPS 203)",
+                            "Diffie-Hellman is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203)",
                             node,
                             src,
                         );
@@ -526,7 +526,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "ECDH is quantum-vulnerable — migrate to ML-KEM (FIPS 203)",
+                            "ECDH is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203)",
                             node,
                             src,
                         );
@@ -548,7 +548,7 @@ impl_rule! {
                                             _self.severity(),
                                             _self.cwe(),
                                             &format!(
-                                                "{}('{}') uses a quantum-vulnerable signature algorithm — migrate to ML-DSA (FIPS 204)",
+                                                "{}('{}') uses a quantum-vulnerable signature algorithm — migrate to ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition",
                                                 func_name, inner
                                             ),
                                             node,

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -533,14 +533,14 @@ impl_rule! {
 
         // Canonical prefixes for quantum-vulnerable asymmetric crypto
         let pq_vulnerable: &[(&str, &str, &str)] = &[
-            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
-            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ML-KEM (FIPS 203) for key exchange or ML-DSA (FIPS 204) for signatures"),
-            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "ML-DSA (FIPS 204)"),
-            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "ML-DSA (FIPS 204)"),
-            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "ML-KEM (FIPS 203)"),
-            ("Crypto.PublicKey.RSA", "RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
-            ("Crypto.PublicKey.DSA", "DSA", "ML-DSA (FIPS 204)"),
-            ("Crypto.PublicKey.ECC", "ECC", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)"),
+            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "X25519MLKEM768 hybrid KEM for key exchange, or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)"),
+            ("Crypto.PublicKey.RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("Crypto.PublicKey.DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("Crypto.PublicKey.ECC", "ECC", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains"),
         ];
 
         walk_tree(tree.root_node(), source, &mut |node, src| {

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -275,17 +275,17 @@ impl_rule! {
                     }
                     // No regex needed — check func_lower directly
                     let (algo, replacement) = if func_lower.contains("ed25519") {
-                        ("Ed25519", "ML-DSA (FIPS 204)")
+                        ("Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else if func_lower.contains("x25519") {
-                        ("X25519", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)")
+                        ("X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)")
                     } else if func_lower.contains("rsa") {
-                        ("RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures")
+                        ("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures")
                     } else if func_lower.contains("ecdsa") {
-                        ("ECDSA", "ML-DSA (FIPS 204)")
+                        ("ECDSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else if func_lower.contains("p256") || func_lower.contains("p384") || func_lower.contains("p521") || func_lower.contains("k256") {
-                        ("ECDH/ECDSA (elliptic curve)", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)")
+                        ("ECDH/ECDSA (elliptic curve)", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains")
                     } else if func_lower.contains("dsa") {
-                        ("DSA", "ML-DSA (FIPS 204)")
+                        ("DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else {
                         return;
                     };


### PR DESCRIPTION
## Summary
Reopens #227, which GitHub auto-closed after its base branch (`feat/pq-vulnerable-crypto-rules`) was deleted when #217 was squash-merged. The remediation-text polish didn't ship with #217's squash so this content is still missing from main.

Identical diff to what #227 carried: swaps ML-KEM / ML-DSA remediation strings for X25519MLKEM768 hybrid KEM and ML-DSA-65 with hybrid cert chains, aligning with current NIST transition guidance and Java JEP 527. Go rules already had hybrid wording and are unchanged.

- Cherry-picked commit `ff7eb6d` from the original #227 branch onto current main
- Authorship preserved (Darkroom4364)
- +33/-33 across 4 files (Java, Python, JS, Rust)

## Test plan
- [x] `cargo test --all` — 345 passed locally
- [x] `cargo build --tests` clean

Closes original #227.