### PR TITLE
Add CBOM output format with working end-to-end wiring (supersedes #235)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-swift",
+ "uuid",
  "walkdir",
 ]
 
@@ -1415,6 +1416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +1867,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ ignore = "0.4"
 regex = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+uuid = { version = "1", features = ["v5"] }
 globset = "0.4"
 tempfile = "3"
 ratatui = "0.30"

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -174,6 +174,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ pub enum OutputFormat {
     Terminal,
     Json,
     Sarif,
+    Cbom,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1219,6 +1219,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let (config_path, added) =
@@ -1282,6 +1283,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -287,6 +287,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,4 +112,8 @@ pub struct Finding {
     pub taint_hops: Option<u8>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
+    /// Cryptographic algorithm name (e.g. "RSA", "ECDSA", "TLS").
+    /// Set by crypto-related rules at emission time. Used by the CBOM formatter.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub crypto_algorithm: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ fn run_scan(scan: &ScanArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if let Some(pr_number) = result.args.github_pr {
@@ -158,6 +159,7 @@ fn run_secrets(args: &SecretsArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if !result.findings.is_empty() {
@@ -192,6 +194,7 @@ fn run_diff_cmd(args: &DiffArgs) -> i32 {
         }
         OutputFormat::Json => foxguard::report::json::print_json(&result.findings),
         OutputFormat::Sarif => foxguard::report::sarif::print_sarif(&result.findings),
+        OutputFormat::Cbom => foxguard::report::cbom::print_cbom(&result.findings),
     }
 
     if new_count > 0 {

--- a/src/report/cbom.rs
+++ b/src/report/cbom.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
-use sha2::{Digest, Sha256};
+use uuid::Uuid;
 
 use crate::Finding;
 
@@ -218,27 +218,20 @@ fn iso8601_now() -> String {
     )
 }
 
-fn deterministic_uuid(components_json: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(components_json.as_bytes());
-    let hash = hasher.finalize();
-    format!(
-        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
-        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]),
-        u16::from_be_bytes([hash[4], hash[5]]),
-        u16::from_be_bytes([hash[6], hash[7]]),
-        u16::from_be_bytes([hash[8], hash[9]]),
-        // Take 6 bytes for the last segment
-        u64::from_be_bytes([0, 0, hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]])
-    )
+/// Build a deterministic RFC 4122 UUIDv5 from the given data.
+///
+/// Uses the OID namespace so two invocations with identical component data
+/// always produce the same serial number, while keeping the correct UUID
+/// version (0x5) and variant (RFC 4122) bits.
+fn deterministic_uuid(data: &str) -> String {
+    Uuid::new_v5(&Uuid::NAMESPACE_OID, data.as_bytes()).to_string()
 }
 
-/// Print findings as a CycloneDX 1.6 Cryptographic Bill of Materials (CBOM).
+/// Build the CBOM JSON value from the supplied findings.
 ///
-/// Only findings with `crypto_algorithm` set are included. Findings are
-/// grouped by algorithm name into components, with linked vulnerability
-/// entries.
-pub fn print_cbom(findings: &[Finding]) {
+/// Pure function: returns a `serde_json::Value`. Separated from [`print_cbom`]
+/// so tests can inspect the structured output without capturing stdout.
+fn build_cbom(findings: &[Finding]) -> (serde_json::Value, bool) {
     // Group findings by crypto_algorithm
     let mut groups: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
     for f in findings {
@@ -247,12 +240,7 @@ pub fn print_cbom(findings: &[Finding]) {
         }
     }
 
-    if groups.is_empty() && !findings.is_empty() {
-        eprintln!(
-            "Warning: no cryptographic findings detected; CBOM is empty. \
-             Use 'foxguard pqc' to scan for quantum-vulnerable cryptography."
-        );
-    }
+    let empty_but_findings_present = groups.is_empty() && !findings.is_empty();
 
     let mut components = Vec::new();
     let mut vulnerabilities = Vec::new();
@@ -287,6 +275,31 @@ pub fn print_cbom(findings: &[Finding]) {
         "vulnerabilities": vulnerabilities
     });
 
+    (cbom, empty_but_findings_present)
+}
+
+/// Serialize findings to a pretty-printed CycloneDX 1.6 CBOM JSON string.
+#[cfg(test)]
+fn serialize_cbom(findings: &[Finding]) -> String {
+    let (cbom, _) = build_cbom(findings);
+    serde_json::to_string_pretty(&cbom).expect("Failed to serialize CBOM")
+}
+
+/// Print findings as a CycloneDX 1.6 Cryptographic Bill of Materials (CBOM).
+///
+/// Only findings with `crypto_algorithm` set are included. Findings are
+/// grouped by algorithm name into components, with linked vulnerability
+/// entries.
+pub fn print_cbom(findings: &[Finding]) {
+    let (cbom, empty_but_findings_present) = build_cbom(findings);
+
+    if empty_but_findings_present {
+        eprintln!(
+            "Warning: no cryptographic findings detected; CBOM is empty. \
+             Use 'foxguard pqc' to scan for quantum-vulnerable cryptography."
+        );
+    }
+
     println!(
         "{}",
         serde_json::to_string_pretty(&cbom).expect("Failed to serialize CBOM")
@@ -318,6 +331,7 @@ mod tests {
             sink_end_byte: None,
             confidence: 1.0,
             taint_hops: None,
+            tags: vec!["PQ".to_string()],
             crypto_algorithm: Some(algo.to_string()),
         }
     }
@@ -344,7 +358,7 @@ mod tests {
 
     #[test]
     fn cbom_empty_without_crypto_findings() {
-        let findings = vec![Finding {
+        let findings = [Finding {
             rule_id: "py/no-eval".to_string(),
             severity: crate::Severity::High,
             cwe: Some("CWE-95".to_string()),
@@ -364,6 +378,7 @@ mod tests {
             sink_end_byte: None,
             confidence: 1.0,
             taint_hops: None,
+            tags: vec![],
             crypto_algorithm: None,
         }];
 
@@ -395,5 +410,112 @@ mod tests {
         let u2 = deterministic_uuid(input);
         assert_eq!(u1, u2);
         assert_eq!(u1.len(), 36); // UUID format: 8-4-4-4-12
+
+        // Parse as RFC 4122 UUID and check version/variant bits.
+        let parsed = Uuid::parse_str(&u1).expect("deterministic_uuid emits valid RFC 4122 UUID");
+        assert_eq!(parsed.get_version_num(), 5);
+        assert_eq!(parsed.get_variant(), uuid::Variant::RFC4122);
+    }
+
+    #[test]
+    fn deterministic_uuid_changes_with_input() {
+        let a = deterministic_uuid(r#"[{"name":"RSA"}]"#);
+        let b = deterministic_uuid(r#"[{"name":"ECDSA"}]"#);
+        assert_ne!(a, b);
+    }
+
+    /// Golden-fixture test: construct findings, serialize to CBOM, parse the
+    /// resulting JSON, and assert the structural shape (serial number,
+    /// components[].cryptoProperties, vulnerabilities[]).
+    #[test]
+    fn cbom_serialization_shape_is_valid() {
+        let findings = vec![
+            make_crypto_finding("RSA", "src/auth.py", 10),
+            make_crypto_finding("RSA", "src/crypto.py", 42),
+            make_crypto_finding("ECDSA", "src/sign.py", 5),
+        ];
+
+        let json_str = serialize_cbom(&findings);
+        let v: serde_json::Value =
+            serde_json::from_str(&json_str).expect("CBOM output is valid JSON");
+
+        // Top-level CycloneDX shape
+        assert_eq!(v["bomFormat"], "CycloneDX");
+        assert_eq!(v["specVersion"], "1.6");
+        assert_eq!(v["version"], 1);
+
+        // Serial number: urn:uuid:<valid RFC 4122 UUID>
+        let serial = v["serialNumber"]
+            .as_str()
+            .expect("serialNumber is a string");
+        let uuid_part = serial
+            .strip_prefix("urn:uuid:")
+            .expect("serialNumber starts with urn:uuid:");
+        let parsed = Uuid::parse_str(uuid_part).expect("serial number is a valid RFC 4122 UUID");
+        assert_eq!(parsed.get_version_num(), 5);
+        assert_eq!(parsed.get_variant(), uuid::Variant::RFC4122);
+
+        // Metadata presence
+        assert!(v["metadata"]["timestamp"].is_string());
+        assert!(v["metadata"]["tools"]["components"][0]["name"]
+            .as_str()
+            .unwrap()
+            .contains("foxguard"));
+
+        // Components: grouped by algorithm (RSA + ECDSA = 2 components)
+        let components = v["components"].as_array().expect("components is an array");
+        assert_eq!(components.len(), 2);
+        let names: std::collections::BTreeSet<&str> = components
+            .iter()
+            .map(|c| c["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains("RSA"));
+        assert!(names.contains("ECDSA"));
+
+        for component in components {
+            assert_eq!(component["type"], "cryptographic-asset");
+            assert!(component["bom-ref"].is_string());
+            let crypto_props = &component["cryptoProperties"];
+            assert_eq!(crypto_props["assetType"], "algorithm");
+            // RSA and ECDSA both have algorithmProperties with primitive + functions
+            let algo_props = &crypto_props["algorithmProperties"];
+            assert!(algo_props["primitive"].is_string());
+            assert!(algo_props["cryptoFunctions"].is_array());
+            // Evidence.occurrences carries at least one file/line/column.
+            let occurrences = component["evidence"]["occurrences"]
+                .as_array()
+                .expect("occurrences is an array");
+            assert!(!occurrences.is_empty());
+            for occ in occurrences {
+                assert!(occ["location"].as_str().unwrap().contains(':'));
+            }
+        }
+
+        // RSA should have two occurrences (grouped from two findings)
+        let rsa_component = components
+            .iter()
+            .find(|c| c["name"] == "RSA")
+            .expect("RSA component present");
+        assert_eq!(
+            rsa_component["evidence"]["occurrences"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+
+        // Vulnerabilities: one per algorithm group
+        let vulns = v["vulnerabilities"]
+            .as_array()
+            .expect("vulnerabilities is an array");
+        assert_eq!(vulns.len(), 2);
+        for vuln in vulns {
+            assert!(vuln["id"].as_str().unwrap().starts_with("foxguard-"));
+            assert_eq!(vuln["source"]["name"], "foxguard");
+            let ratings = vuln["ratings"].as_array().unwrap();
+            assert_eq!(ratings[0]["severity"], "high");
+            assert!(vuln["affects"][0]["ref"].is_string());
+            assert!(vuln["cwes"].is_array());
+        }
     }
 }

--- a/src/report/cbom.rs
+++ b/src/report/cbom.rs
@@ -1,0 +1,399 @@
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::Finding;
+
+/// CycloneDX 1.6 crypto asset properties, looked up by algorithm name.
+struct CryptoProps {
+    asset_type: &'static str,
+    primitive: Option<&'static str>,
+    functions: &'static [&'static str],
+    protocol_type: Option<&'static str>,
+}
+
+fn crypto_props(algo: &str) -> CryptoProps {
+    match algo {
+        "RSA" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("pk-encryption"),
+            functions: &["encrypt", "sign"],
+            protocol_type: None,
+        },
+        "ECDSA" | "DSA" | "Ed25519" | "Ed448" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("signature"),
+            functions: &["sign", "verify"],
+            protocol_type: None,
+        },
+        "ECDH" | "DH" | "X25519" | "X448" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("key-agree"),
+            functions: &["keyagree"],
+            protocol_type: None,
+        },
+        "AES" | "AES-CBC" | "AES-GCM" | "DES" | "3DES" | "Blowfish" | "RC4" | "RC2" => {
+            CryptoProps {
+                asset_type: "algorithm",
+                primitive: Some("block-cipher"),
+                functions: &["encrypt", "decrypt"],
+                protocol_type: None,
+            }
+        }
+        "MD5" | "SHA1" | "SHA-1" => CryptoProps {
+            asset_type: "algorithm",
+            primitive: Some("hash"),
+            functions: &["digest"],
+            protocol_type: None,
+        },
+        "TLS" => CryptoProps {
+            asset_type: "protocol",
+            primitive: None,
+            functions: &[],
+            protocol_type: Some("tls"),
+        },
+        _ => CryptoProps {
+            asset_type: "related-crypto-material",
+            primitive: None,
+            functions: &[],
+            protocol_type: None,
+        },
+    }
+}
+
+fn build_component(
+    algo: &str,
+    bom_ref: &str,
+    findings: &[&Finding],
+    props: &CryptoProps,
+) -> serde_json::Value {
+    let occurrences: Vec<_> = findings
+        .iter()
+        .map(|f| {
+            json!({
+                "location": format!("{}:{}:{}", f.file, f.line, f.column),
+                "additionalContext": f.snippet.trim()
+            })
+        })
+        .collect();
+
+    let mut crypto_properties = json!({ "assetType": props.asset_type });
+
+    if props.asset_type == "algorithm" {
+        let mut algo_props = serde_json::Map::new();
+        if let Some(prim) = props.primitive {
+            algo_props.insert("primitive".to_string(), json!(prim));
+        }
+        if !props.functions.is_empty() {
+            algo_props.insert("cryptoFunctions".to_string(), json!(props.functions));
+        }
+        crypto_properties["algorithmProperties"] = json!(algo_props);
+    } else if props.asset_type == "protocol" {
+        if let Some(proto) = props.protocol_type {
+            crypto_properties["protocolProperties"] = json!({ "type": proto });
+        }
+    }
+
+    json!({
+        "type": "cryptographic-asset",
+        "bom-ref": bom_ref,
+        "name": algo,
+        "cryptoProperties": crypto_properties,
+        "evidence": {
+            "occurrences": occurrences
+        }
+    })
+}
+
+fn build_vulnerability(algo: &str, bom_ref: &str, findings: &[&Finding]) -> serde_json::Value {
+    // Use the highest severity from the group
+    let max_severity = findings
+        .iter()
+        .map(|f| f.severity)
+        .max()
+        .unwrap_or(crate::Severity::Low);
+
+    let severity_str = match max_severity {
+        crate::Severity::Critical => "critical",
+        crate::Severity::High => "high",
+        crate::Severity::Medium => "medium",
+        crate::Severity::Low => "low",
+    };
+
+    // Collect unique CWEs
+    let cwes: Vec<u32> = findings
+        .iter()
+        .filter_map(|f| f.cwe.as_ref())
+        .filter_map(|c| c.strip_prefix("CWE-").and_then(|n| n.parse().ok()))
+        .collect::<std::collections::BTreeSet<u32>>()
+        .into_iter()
+        .collect();
+
+    // Use first available fix suggestion as recommendation
+    let recommendation = findings
+        .iter()
+        .find_map(|f| f.fix_suggestion.as_ref())
+        .cloned()
+        .or_else(|| findings.first().map(|f| f.description.clone()))
+        .unwrap_or_default();
+
+    let mut vuln = json!({
+        "id": format!("foxguard-{}", algo.to_lowercase()),
+        "source": { "name": "foxguard" },
+        "ratings": [{ "severity": severity_str, "method": "other" }],
+        "description": findings.first().map(|f| f.description.as_str()).unwrap_or(""),
+        "affects": [{ "ref": bom_ref }],
+        "recommendation": recommendation
+    });
+
+    if !cwes.is_empty() {
+        vuln["cwes"] = json!(cwes);
+    }
+
+    vuln
+}
+
+fn iso8601_now() -> String {
+    let dur = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = dur.as_secs();
+
+    // Manual UTC breakdown (no chrono dependency)
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Days since 1970-01-01 to Y-M-D
+    let mut y = 1970i64;
+    let mut remaining = days as i64;
+    loop {
+        let days_in_year = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+    let month_days: [i64; 12] = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 0usize;
+    for (i, &md) in month_days.iter().enumerate() {
+        if remaining < md {
+            m = i;
+            break;
+        }
+        remaining -= md;
+    }
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m + 1,
+        remaining + 1,
+        hours,
+        minutes,
+        seconds
+    )
+}
+
+fn deterministic_uuid(components_json: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(components_json.as_bytes());
+    let hash = hasher.finalize();
+    format!(
+        "{:08x}-{:04x}-{:04x}-{:04x}-{:012x}",
+        u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]),
+        u16::from_be_bytes([hash[4], hash[5]]),
+        u16::from_be_bytes([hash[6], hash[7]]),
+        u16::from_be_bytes([hash[8], hash[9]]),
+        // Take 6 bytes for the last segment
+        u64::from_be_bytes([0, 0, hash[10], hash[11], hash[12], hash[13], hash[14], hash[15]])
+    )
+}
+
+/// Print findings as a CycloneDX 1.6 Cryptographic Bill of Materials (CBOM).
+///
+/// Only findings with `crypto_algorithm` set are included. Findings are
+/// grouped by algorithm name into components, with linked vulnerability
+/// entries.
+pub fn print_cbom(findings: &[Finding]) {
+    // Group findings by crypto_algorithm
+    let mut groups: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+    for f in findings {
+        if let Some(algo) = &f.crypto_algorithm {
+            groups.entry(algo.clone()).or_default().push(f);
+        }
+    }
+
+    if groups.is_empty() && !findings.is_empty() {
+        eprintln!(
+            "Warning: no cryptographic findings detected; CBOM is empty. \
+             Use 'foxguard pqc' to scan for quantum-vulnerable cryptography."
+        );
+    }
+
+    let mut components = Vec::new();
+    let mut vulnerabilities = Vec::new();
+
+    for (algo, group_findings) in &groups {
+        let bom_ref = format!("crypto-{}", algo.to_lowercase().replace(' ', "-"));
+        let props = crypto_props(algo);
+
+        components.push(build_component(algo, &bom_ref, group_findings, &props));
+        vulnerabilities.push(build_vulnerability(algo, &bom_ref, group_findings));
+    }
+
+    let components_json = serde_json::to_string(&components).unwrap_or_default();
+    let serial = deterministic_uuid(&components_json);
+
+    let cbom = json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "serialNumber": format!("urn:uuid:{serial}"),
+        "metadata": {
+            "timestamp": iso8601_now(),
+            "tools": {
+                "components": [{
+                    "type": "application",
+                    "name": "foxguard",
+                    "version": env!("CARGO_PKG_VERSION")
+                }]
+            }
+        },
+        "components": components,
+        "vulnerabilities": vulnerabilities
+    });
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&cbom).expect("Failed to serialize CBOM")
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_crypto_finding(algo: &str, file: &str, line: usize) -> Finding {
+        Finding {
+            rule_id: format!("test/pq-vulnerable-{}", algo.to_lowercase()),
+            severity: crate::Severity::High,
+            cwe: Some("CWE-327".to_string()),
+            description: format!("{algo} is quantum-vulnerable"),
+            file: file.to_string(),
+            line,
+            column: 1,
+            end_line: line,
+            end_column: 10,
+            snippet: format!("use_{}()", algo.to_lowercase()),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: Some(format!("Migrate from {algo} to ML-KEM")),
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            crypto_algorithm: Some(algo.to_string()),
+        }
+    }
+
+    #[test]
+    fn cbom_groups_by_algorithm() {
+        let findings = vec![
+            make_crypto_finding("RSA", "src/auth.py", 10),
+            make_crypto_finding("RSA", "src/crypto.py", 42),
+            make_crypto_finding("ECDSA", "src/sign.py", 5),
+        ];
+
+        let mut groups: BTreeMap<String, Vec<&Finding>> = BTreeMap::new();
+        for f in &findings {
+            if let Some(algo) = &f.crypto_algorithm {
+                groups.entry(algo.clone()).or_default().push(f);
+            }
+        }
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups["RSA"].len(), 2);
+        assert_eq!(groups["ECDSA"].len(), 1);
+    }
+
+    #[test]
+    fn cbom_empty_without_crypto_findings() {
+        let findings = vec![Finding {
+            rule_id: "py/no-eval".to_string(),
+            severity: crate::Severity::High,
+            cwe: Some("CWE-95".to_string()),
+            description: "eval() is dangerous".to_string(),
+            file: "app.py".to_string(),
+            line: 1,
+            column: 1,
+            end_line: 1,
+            end_column: 10,
+            snippet: "eval(x)".to_string(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            crypto_algorithm: None,
+        }];
+
+        let groups: BTreeMap<String, Vec<&Finding>> = findings
+            .iter()
+            .filter_map(|f| f.crypto_algorithm.as_ref().map(|a| (a.clone(), f)))
+            .fold(BTreeMap::new(), |mut acc, (algo, f)| {
+                acc.entry(algo).or_default().push(f);
+                acc
+            });
+
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn iso8601_format_is_valid() {
+        let ts = iso8601_now();
+        assert!(ts.ends_with('Z'));
+        assert_eq!(ts.len(), 20); // "2026-04-19T12:34:56Z"
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+    }
+
+    #[test]
+    fn deterministic_uuid_is_stable() {
+        let input = r#"[{"name":"RSA"}]"#;
+        let u1 = deterministic_uuid(input);
+        let u2 = deterministic_uuid(input);
+        assert_eq!(u1, u2);
+        assert_eq!(u1.len(), 36); // UUID format: 8-4-4-4-12
+    }
+}

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -184,6 +184,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         }
     }
 

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -1,3 +1,4 @@
+pub mod cbom;
 pub mod github_pr;
 pub mod json;
 pub mod sarif;

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -231,6 +231,7 @@ pub fn make_finding(
         confidence: crate::default_confidence(),
         taint_hops: None,
         tags: vec![],
+        crypto_algorithm: None,
     }
 }
 
@@ -277,6 +278,7 @@ pub fn make_finding_from_offsets(
         confidence: crate::default_confidence(),
         taint_hops: None,
         tags: vec![],
+        crypto_algorithm: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -871,6 +871,7 @@ fn map_go_taint_findings(
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
             tags: vec![],
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -1595,6 +1596,7 @@ pub fn run_go_taint_batched(
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
                 tags: vec![],
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -396,13 +396,13 @@ impl_rule! {
                     } else {
                         std::borrow::Cow::Borrowed(raw)
                     };
-                    let (algo, replacement) = match func_text.as_ref() {
-                        s if s.starts_with("rsa.") => ("RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
-                        s if s.starts_with("ecdsa.") => ("ECDSA", "ML-DSA (FIPS 204)"),
-                        s if s.starts_with("ecdh.") => ("ECDH", "ML-KEM (FIPS 203)"),
-                        s if s.starts_with("dsa.") => ("DSA", "ML-DSA (FIPS 204)"),
-                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)"),
-                        s if s.starts_with("ed25519.") => ("Ed25519", "ML-DSA (FIPS 204)"),
+                    let (algo, canonical_algo, replacement) = match func_text.as_ref() {
+                        s if s.starts_with("rsa.") => ("RSA", "RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
+                        s if s.starts_with("ecdsa.") => ("ECDSA", "ECDSA", "ML-DSA (FIPS 204)"),
+                        s if s.starts_with("ecdh.") => ("ECDH", "ECDH", "ML-KEM (FIPS 203)"),
+                        s if s.starts_with("dsa.") => ("DSA", "DSA", "ML-DSA (FIPS 204)"),
+                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ECDH", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)"),
+                        s if s.starts_with("ed25519.") => ("Ed25519", "Ed25519", "ML-DSA (FIPS 204)"),
                         _ => return,
                     };
                     let mut f = make_finding(
@@ -417,6 +417,7 @@ impl_rule! {
                         src,
                     );
                     f.tags = vec!["PQ".into()];
+                    f.crypto_algorithm = Some(canonical_algo.to_string());
                     findings.push(f);
                 }
             }

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -460,27 +460,34 @@ impl_rule! {
 // ─── Rule: pq-vulnerable-crypto ───────────────────────────────────────────
 
 /// Classify a Java algorithm string as quantum-vulnerable.
-/// Returns (algo_label, default_replacement) or None if not PQ-vulnerable.
-fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str)> {
+/// Returns (algo_label, canonical_algo, default_replacement) or None if not PQ-vulnerable.
+/// `canonical_algo` is the normalized CBOM algorithm name (e.g. "RSA", "ECDSA", "DH").
+fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str, &'static str)> {
     // Exact matches for KeyPairGenerator / KeyAgreement / KeyFactory
     match algo {
-        "RSA" => return Some(("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)")),
-        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "DSA" => return Some(("DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "DH" | "ECDH" | "DiffieHellman" => return Some(("DH/ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
-        "Ed25519" | "Ed448" | "EdDSA" => return Some(("EdDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "X25519" | "X448" | "XDH" => return Some(("XDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "RSA" => return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)")),
+        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ECDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "DSA" => return Some(("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "DH" | "DiffieHellman" => return Some(("DH", "DH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "ECDH" => return Some(("ECDH", "ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "Ed25519" => return Some(("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "Ed448" => return Some(("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "EdDSA" => return Some(("EdDSA", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
+        "X25519" => return Some(("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "X448" => return Some(("X448", "X448", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "XDH" => return Some(("XDH", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
         _ => {}
     }
     // Non-exact matches need case-insensitive comparison
     let upper = algo.to_uppercase();
     // RSA cipher modes: "RSA/ECB/PKCS1Padding", "RSA/ECB/OAEPWithSHA-256..."
     if upper.starts_with("RSA/") || upper.starts_with("RSA_") {
-        return Some(("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)"));
+        return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)"));
     }
     // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA"
     if upper.contains("WITHRSA") {
         return Some((
+            "RSA",
             "RSA",
             "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
         ));
@@ -488,11 +495,13 @@ fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str)> {
     if upper.contains("WITHECDSA") {
         return Some((
             "ECDSA",
+            "ECDSA",
             "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
         ));
     }
     if upper.contains("WITHDSA") && !upper.contains("ML-DSA") {
         return Some((
+            "DSA",
             "DSA",
             "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
         ));
@@ -530,7 +539,7 @@ impl_rule! {
                                     if let Some(first_arg) = args.named_child(0) {
                                         let arg_text = &src[first_arg.byte_range()];
                                         let inner = arg_text.trim_matches('"');
-                                        let (algo, replacement) = match classify_java_pq_algo(inner) {
+                                        let (algo, canonical_algo, replacement) = match classify_java_pq_algo(inner) {
                                             Some(v) => v,
                                             None => return,
                                         };
@@ -553,6 +562,7 @@ impl_rule! {
                                             src,
                                         );
                                         f.tags = vec!["PQ".into()];
+                                        f.crypto_algorithm = Some(canonical_algo.to_string());
                                         findings.push(f);
                                     }
                                 }

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1826,6 +1826,7 @@ fn map_js_taint_findings(
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
             tags: vec![],
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -2831,6 +2832,7 @@ pub fn run_js_taint_batched(
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
                 tags: vec![],
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -481,11 +481,12 @@ impl_rule! {
                                 if first_arg.kind() == "string" {
                                     let val = &src[first_arg.byte_range()];
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-                                    let (algo, replacement) = match inner.to_lowercase().as_str() {
-                                            "rsa" => ("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-                                            "ec" => ("EC", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-                                            "dsa" => ("DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-                                            "ed25519" | "ed448" => ("Ed25519/Ed448", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+                                    let (algo, canonical_algo, replacement) = match inner.to_lowercase().as_str() {
+                                            "rsa" => ("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+                                            "ec" => ("EC", "ECDSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+                                            "dsa" => ("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+                                            "ed25519" => ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+                                            "ed448" => ("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
                                             _ => return,
                                         };
                                     let mut f = make_finding(
@@ -500,6 +501,7 @@ impl_rule! {
                                         src,
                                     );
                                     f.tags = vec!["PQ".into()];
+                                    f.crypto_algorithm = Some(canonical_algo.to_string());
                                     findings.push(f);
                                 }
                             }
@@ -517,6 +519,7 @@ impl_rule! {
                             src,
                         );
                         f.tags = vec!["PQ".into()];
+                        f.crypto_algorithm = Some("DH".to_string());
                         findings.push(f);
                     }
 
@@ -531,6 +534,7 @@ impl_rule! {
                             src,
                         );
                         f.tags = vec!["PQ".into()];
+                        f.crypto_algorithm = Some("ECDH".to_string());
                         findings.push(f);
                     }
 
@@ -543,6 +547,7 @@ impl_rule! {
                                     let val = &src[first_arg.byte_range()];
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`').to_lowercase();
                                     if inner == "ed25519" || inner == "ed448" {
+                                        let canonical_algo = if inner == "ed25519" { "Ed25519" } else { "Ed448" };
                                         let mut f = make_finding(
                                             _self.id(),
                                             _self.severity(),
@@ -555,6 +560,7 @@ impl_rule! {
                                             src,
                                         );
                                         f.tags = vec!["PQ".into()];
+                                        f.crypto_algorithm = Some(canonical_algo.to_string());
                                         findings.push(f);
                                     }
                                 }

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1136,6 +1136,7 @@ fn run_kt_taint(
                     confidence: crate::default_confidence(),
                     taint_hops: None,
                     tags: vec![],
+                    crypto_algorithm: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1779,6 +1779,7 @@ fn map_taint_findings(
             confidence: crate::rules::common::confidence_for_hops(t.hops),
             taint_hops: Some(t.hops),
             tags: vec![],
+            crypto_algorithm: None,
         })
         .collect()
 }
@@ -2722,6 +2723,7 @@ pub fn run_py_taint_batched(
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
                 tags: vec![],
+                crypto_algorithm: None,
             })
         })
         .collect()

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -531,16 +531,17 @@ impl_rule! {
 
         let mut findings = Vec::new();
 
-        // Canonical prefixes for quantum-vulnerable asymmetric crypto
-        let pq_vulnerable: &[(&str, &str, &str)] = &[
-            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "X25519MLKEM768 hybrid KEM for key exchange, or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)"),
-            ("Crypto.PublicKey.RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("Crypto.PublicKey.DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("Crypto.PublicKey.ECC", "ECC", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains"),
+        // Canonical prefixes for quantum-vulnerable asymmetric crypto.
+        // Tuple: (module prefix, display algo, canonical CBOM algo, replacement)
+        let pq_vulnerable: &[(&str, &str, &str, &str)] = &[
+            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ECDSA", "X25519MLKEM768 hybrid KEM for key exchange, or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
+            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)"),
+            ("Crypto.PublicKey.RSA", "RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("Crypto.PublicKey.DSA", "DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+            ("Crypto.PublicKey.ECC", "ECC", "ECDSA", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains"),
         ];
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -557,7 +558,7 @@ impl_rule! {
                                 if let Some(outer_func) = grandparent.child_by_field_name("function") {
                                     let outer_text = &src[outer_func.byte_range()];
                                     let outer_resolved = resolve_callee(outer_text, ctx);
-                                    for &(prefix, _, _) in pq_vulnerable {
+                                    for &(prefix, _, _, _) in pq_vulnerable {
                                         if outer_resolved.as_ref().starts_with(prefix) {
                                             return;
                                         }
@@ -570,7 +571,7 @@ impl_rule! {
                 if let Some(func) = node.child_by_field_name("function") {
                     let func_text = &src[func.byte_range()];
                     let resolved = resolve_callee(func_text, ctx);
-                    for &(prefix, algo, replacement) in pq_vulnerable {
+                    for &(prefix, algo, canonical_algo, replacement) in pq_vulnerable {
                         if resolved.as_ref().starts_with(prefix) {
                             let mut f = make_finding(
                                 _self.id(),
@@ -584,6 +585,7 @@ impl_rule! {
                                 src,
                             );
                             f.tags = vec!["PQ".into()];
+                            f.crypto_algorithm = Some(canonical_algo.to_string());
                             findings.push(f);
                             return;
                         }

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -274,18 +274,18 @@ impl_rule! {
                         return;
                     }
                     // No regex needed — check func_lower directly
-                    let (algo, replacement) = if func_lower.contains("ed25519") {
-                        ("Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                    let (algo, canonical_algo, replacement) = if func_lower.contains("ed25519") {
+                        ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else if func_lower.contains("x25519") {
-                        ("X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)")
+                        ("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)")
                     } else if func_lower.contains("rsa") {
-                        ("RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures")
+                        ("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures")
                     } else if func_lower.contains("ecdsa") {
-                        ("ECDSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                        ("ECDSA", "ECDSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else if func_lower.contains("p256") || func_lower.contains("p384") || func_lower.contains("p521") || func_lower.contains("k256") {
-                        ("ECDH/ECDSA (elliptic curve)", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains")
+                        ("ECDH/ECDSA (elliptic curve)", "ECDSA", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains")
                     } else if func_lower.contains("dsa") {
-                        ("DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                        ("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
                     } else {
                         return;
                     };
@@ -301,6 +301,7 @@ impl_rule! {
                         src,
                     );
                     f.tags = vec!["PQ".into()];
+                    f.crypto_algorithm = Some(canonical_algo.to_string());
                     findings.push(f);
                 }
             }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -209,6 +209,7 @@ impl Rule for SemgrepRule {
                 confidence: 0.7,
                 taint_hops: None,
                 tags: vec![],
+                crypto_algorithm: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -329,6 +329,7 @@ impl Rule for SemgrepTaintRule {
                 confidence: crate::rules::common::confidence_for_hops(t.hops),
                 taint_hops: Some(t.hops),
                 tags: vec![],
+                crypto_algorithm: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -282,6 +282,7 @@ pub fn scan_paths_with_config_and_notices(
                         confidence: crate::default_confidence(),
                         taint_hops: None,
                         tags: vec![],
+                        crypto_algorithm: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2666,6 +2666,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2707,6 +2708,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2750,6 +2752,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         assert_eq!(
@@ -2784,6 +2787,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2822,6 +2826,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(
@@ -2893,6 +2898,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         assert_eq!(
@@ -2941,6 +2947,7 @@ mod tests {
                 confidence: crate::default_confidence(),
                 taint_hops: None,
                 tags: vec![],
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3018,6 +3025,7 @@ mod tests {
                 confidence: crate::default_confidence(),
                 taint_hops: None,
                 tags: vec![],
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3076,6 +3084,7 @@ mod tests {
                 confidence: crate::default_confidence(),
                 taint_hops: None,
                 tags: vec![],
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3159,6 +3168,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3201,6 +3211,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -3242,6 +3253,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(
@@ -3383,6 +3395,7 @@ mod tests {
             confidence: 0.95,
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         let low_conf_high_sev = Finding {
             severity: Severity::Critical,
@@ -3448,6 +3461,7 @@ mod tests {
             confidence: 1.0,
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         let low_conf = Finding {
             confidence: 0.5,
@@ -3518,6 +3532,7 @@ mod tests {
                 confidence: crate::default_confidence(),
                 taint_hops: None,
                 tags: vec![],
+                crypto_algorithm: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3571,6 +3586,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3631,6 +3647,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3680,6 +3697,7 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
+            crypto_algorithm: None,
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
## Summary
Supersedes #235 — same CycloneDX 1.6 CBOM feature plus the two blocking fixes from the #235 review. First commit preserves @Darkroom4364's original work (authorship preserved); second commit is the review-fix delta.

## What changed vs #235

### 1. `crypto_algorithm` now populated by all PQ rules
Every call site in `*/pq-vulnerable-crypto` rules (go, python, javascript, java, rust_lang) now sets `crypto_algorithm: Some(canonical)` at emission time. Values are normalized to canonical CycloneDX-friendly strings: `RSA`, `ECDSA`, `ECDH`, `DSA`, `DH`, `Ed25519`, `Ed448`, `X25519`, `X448`. Display labels like `"ECDSA/EC"` or `"ECDH/ECDSA (elliptic curve)"` stay in human-facing messages but are not exposed via CBOM grouping.

The #235 review called this "aspirational, not delivered" — `foxguard --format cbom` now emits a real BOM with real components.

### 2. RFC 4122 UUIDv5 serial number
`deterministic_uuid` previously emitted a hand-rolled SHA-256 slice formatted as `8-4-4-4-12` without setting the version nibble or variant bits — strict CycloneDX consumers would reject it. Swapped to `Uuid::new_v5(&Uuid::NAMESPACE_OID, data.as_bytes())`. Added `uuid` crate (v5 feature) to Cargo.toml. Still deterministic, now structurally valid.

### 3. Golden-fixture test
New `cbom_serialization_shape_is_valid` test constructs RSA/ECDSA findings, serializes via the extracted `build_cbom`/`serialize_cbom` functions, parses the JSON with `serde_json::from_str`, and asserts the full CycloneDX shape: top-level `bomFormat`/`specVersion`/`version`, `serialNumber` prefixed with `urn:uuid:` parsing as valid UUIDv5+RFC4122, metadata/tools/components/vulnerabilities. Extended `deterministic_uuid_is_stable` to check version/variant bits; added `deterministic_uuid_changes_with_input`.

## End-to-end verification
```
$ foxguard --format cbom tests/fixtures | jq '.components | length'
5
```
Components: DH, ECDH, ECDSA, Ed25519, RSA. Serial: `urn:uuid:e2528f67-ab21-5b89-a3d4-d272369b4066` (valid v5).

## Test & lint
- `cargo test --all` → 351 + 88 + 15 + 12 + 6 + others passing, 0 failed
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

## Notes
- #235's branch predated the PQ rules (which landed via #217/#233/#236), so this branch was rebased onto current main during the fix pass — 14 trivial field-merge conflicts on `Finding` were resolved by keeping both fields (`tags` from main, `crypto_algorithm` from the PR).
- Invocation is `foxguard --format cbom <PATH>` (flag before path — clap positional ordering).

Closes #235. Closes #219.