### PR TITLE
Add cnsa2_deadline field to Finding

### DIFF
--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -175,6 +175,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1227,6 +1227,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let (config_path, added) =
@@ -1291,6 +1292,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -288,6 +288,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,4 +116,8 @@ pub struct Finding {
     /// Set by crypto-related rules at emission time. Used by the CBOM formatter.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub crypto_algorithm: Option<String>,
+    /// CNSA 2.0 compliance deadline (e.g. "2030"). Populated by the
+    /// compliance module after scanning. `None` for non-crypto findings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cnsa2_deadline: Option<String>,
 }

--- a/src/report/cbom.rs
+++ b/src/report/cbom.rs
@@ -333,6 +333,7 @@ mod tests {
             taint_hops: None,
             tags: vec!["PQ".to_string()],
             crypto_algorithm: Some(algo.to_string()),
+            cnsa2_deadline: None,
         }
     }
 
@@ -380,6 +381,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         }];
 
         let groups: BTreeMap<String, Vec<&Finding>> = findings

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -185,6 +185,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         }
     }
 

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -232,6 +232,7 @@ pub fn make_finding(
         taint_hops: None,
         tags: vec![],
         crypto_algorithm: None,
+        cnsa2_deadline: None,
     }
 }
 
@@ -279,6 +280,7 @@ pub fn make_finding_from_offsets(
         taint_hops: None,
         tags: vec![],
         crypto_algorithm: None,
+        cnsa2_deadline: None,
     }
 }
 

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -873,6 +873,7 @@ fn map_go_taint_findings(
             taint_hops: Some(t.hops),
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -1598,6 +1599,7 @@ pub fn run_go_taint_batched(
                 taint_hops: Some(t.hops),
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1833,6 +1833,7 @@ fn map_js_taint_findings(
             taint_hops: Some(t.hops),
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -2839,6 +2840,7 @@ pub fn run_js_taint_batched(
                 taint_hops: Some(t.hops),
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1137,6 +1137,7 @@ fn run_kt_taint(
                     taint_hops: None,
                     tags: vec![],
                     crypto_algorithm: None,
+                    cnsa2_deadline: None,
                 });
             }
         }

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1782,6 +1782,7 @@ fn map_taint_findings(
             taint_hops: Some(t.hops),
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         })
         .collect()
 }
@@ -2726,6 +2727,7 @@ pub fn run_py_taint_batched(
                 taint_hops: Some(t.hops),
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             })
         })
         .collect()

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -210,6 +210,7 @@ impl Rule for SemgrepRule {
                 taint_hops: None,
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             });
         }
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -330,6 +330,7 @@ impl Rule for SemgrepTaintRule {
                 taint_hops: Some(t.hops),
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             })
             .collect()
     }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -283,6 +283,7 @@ pub fn scan_paths_with_config_and_notices(
                         taint_hops: None,
                         tags: vec![],
                         crypto_algorithm: None,
+                        cnsa2_deadline: None,
                     });
                 }
             }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2667,6 +2667,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         let medium = Finding {
             severity: Severity::Medium,
@@ -2709,6 +2710,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -2753,6 +2755,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         assert_eq!(
@@ -2788,6 +2791,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = open_target_lines(&finding, OpenFocus::Finding)
@@ -2827,6 +2831,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(
@@ -2899,6 +2904,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         assert_eq!(
@@ -2948,6 +2954,7 @@ mod tests {
                 taint_hops: None,
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3026,6 +3033,7 @@ mod tests {
                 taint_hops: None,
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3085,6 +3093,7 @@ mod tests {
                 taint_hops: None,
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3169,6 +3178,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3212,6 +3222,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Source)
@@ -3254,6 +3265,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(
@@ -3396,6 +3408,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         let low_conf_high_sev = Finding {
             severity: Severity::Critical,
@@ -3462,6 +3475,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         let low_conf = Finding {
             confidence: 0.5,
@@ -3533,6 +3547,7 @@ mod tests {
                 taint_hops: None,
                 tags: vec![],
                 crypto_algorithm: None,
+                cnsa2_deadline: None,
             }],
             files_scanned: 1,
             duration: Duration::from_secs(1),
@@ -3587,6 +3602,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3648,6 +3664,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,
@@ -3698,6 +3715,7 @@ mod tests {
             taint_hops: None,
             tags: vec![],
             crypto_algorithm: None,
+            cnsa2_deadline: None,
         };
 
         let rendered = render_source_context(


### PR DESCRIPTION
## Summary
- Adds `cnsa2_deadline: Option<String>` to `Finding` struct
- `skip_serializing_if` keeps existing JSON/SARIF output unchanged
- All construction sites initialized to `None`

First slice of #231 per review feedback — lands the field so the compliance module can populate it in a follow-up PR with properly sourced CNSA 2.0 deadlines, opt-in output, and tests.

## Test plan
- [x] All existing tests pass unchanged (field defaults to `None`)
- [x] JSON/SARIF output is byte-identical (skip_serializing_if)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CNSA 2.0 compliance deadline tracking for cryptographic findings. The optional deadline field is now supported and populated for crypto-related vulnerabilities by the compliance module, while remaining absent for other finding types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->