### PR TITLE
Add FN-DSA (FIPS 206) and HQC awareness to PQ rules (closes #226)

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -397,12 +397,12 @@ impl_rule! {
                         std::borrow::Cow::Borrowed(raw)
                     };
                     let (algo, canonical_algo, replacement) = match func_text.as_ref() {
-                        s if s.starts_with("rsa.") => ("RSA", "RSA", "ML-KEM (FIPS 203) for encryption or ML-DSA (FIPS 204) for signatures"),
-                        s if s.starts_with("ecdsa.") => ("ECDSA", "ECDSA", "ML-DSA (FIPS 204)"),
-                        s if s.starts_with("ecdh.") => ("ECDH", "ECDH", "ML-KEM (FIPS 203)"),
-                        s if s.starts_with("dsa.") => ("DSA", "DSA", "ML-DSA (FIPS 204)"),
-                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ECDH", "ML-KEM (FIPS 203) or ML-DSA (FIPS 204)"),
-                        s if s.starts_with("ed25519.") => ("Ed25519", "Ed25519", "ML-DSA (FIPS 204)"),
+                        s if s.starts_with("rsa.") => ("RSA", "RSA", "ML-KEM (FIPS 203) or HQC (code-based diversity hedge, draft) for encryption, or ML-DSA (FIPS 204) / FN-DSA (FIPS 206, draft) for signatures"),
+                        s if s.starts_with("ecdsa.") => ("ECDSA", "ECDSA", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
+                        s if s.starts_with("ecdh.") => ("ECDH", "ECDH", "ML-KEM (FIPS 203) or HQC (code-based diversity hedge, draft)"),
+                        s if s.starts_with("dsa.") => ("DSA", "DSA", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
+                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ECDH", "ML-KEM (FIPS 203) / HQC (draft) or ML-DSA (FIPS 204) / FN-DSA (FIPS 206, draft)"),
+                        s if s.starts_with("ed25519.") => ("Ed25519", "Ed25519", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
                         _ => return,
                     };
                     let mut f = make_finding(

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -463,47 +463,57 @@ impl_rule! {
 /// Returns (algo_label, canonical_algo, default_replacement) or None if not PQ-vulnerable.
 /// `canonical_algo` is the normalized CBOM algorithm name (e.g. "RSA", "ECDSA", "DH").
 fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str, &'static str)> {
-    // Exact matches for KeyPairGenerator / KeyAgreement / KeyFactory
+    // Exact matches for KeyPairGenerator / KeyAgreement / KeyFactory.
+    // PQ-safe algorithms (ML-KEM/ML-DSA/SLH-DSA and the draft FN-DSA / HQC
+    // standards) are intentionally absent from this table and therefore skipped.
     match algo {
-        "RSA" => return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)")),
-        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ECDSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "DSA" => return Some(("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "DH" | "DiffieHellman" => return Some(("DH", "DH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
-        "ECDH" => return Some(("ECDH", "ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
-        "Ed25519" => return Some(("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "Ed448" => return Some(("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "EdDSA" => return Some(("EdDSA", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)")),
-        "X25519" => return Some(("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
-        "X448" => return Some(("X448", "X448", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
-        "XDH" => return Some(("XDH", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)")),
+        "RSA" => return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures (Java JEP 527)")),
+        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ECDSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
+        "DSA" => return Some(("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
+        "DH" | "DiffieHellman" => return Some(("DH", "DH", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)")),
+        "ECDH" => return Some(("ECDH", "ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)")),
+        "Ed25519" => return Some(("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
+        "Ed448" => return Some(("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
+        "EdDSA" => return Some(("EdDSA", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
+        "X25519" => return Some(("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
+        "X448" => return Some(("X448", "X448", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
+        "XDH" => return Some(("XDH", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
         _ => {}
     }
     // Non-exact matches need case-insensitive comparison
     let upper = algo.to_uppercase();
     // RSA cipher modes: "RSA/ECB/PKCS1Padding", "RSA/ECB/OAEPWithSHA-256..."
     if upper.starts_with("RSA/") || upper.starts_with("RSA_") {
-        return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures (Java JEP 527)"));
+        return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures (Java JEP 527)"));
     }
-    // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA"
+    // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA".
+    // The PQ-safe exclusions below ensure future hybrid names containing the
+    // substring "DSA" (e.g. "ML-DSA", "SLH-DSA", "FN-DSA") or the code-based
+    // KEM "HQC" are not misclassified.
     if upper.contains("WITHRSA") {
         return Some((
             "RSA",
             "RSA",
-            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
         ));
     }
     if upper.contains("WITHECDSA") {
         return Some((
             "ECDSA",
             "ECDSA",
-            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
         ));
     }
-    if upper.contains("WITHDSA") && !upper.contains("ML-DSA") {
+    if upper.contains("WITHDSA")
+        && !upper.contains("ML-DSA")
+        && !upper.contains("SLH-DSA")
+        && !upper.contains("FN-DSA")
+        && !upper.contains("HQC")
+    {
         return Some((
             "DSA",
             "DSA",
-            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)",
+            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
         ));
     }
     None
@@ -544,9 +554,9 @@ impl_rule! {
                                             None => return,
                                         };
                                         let replacement = if obj_text == "KeyAgreement" {
-                                            "X25519MLKEM768 hybrid KEM (FIPS 203, Java JEP 527)"
+                                            "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)"
                                         } else if obj_text == "Signature" {
-                                            "ML-DSA-65 (FIPS 204) with hybrid cert chains (Java JEP 527)"
+                                            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)"
                                         } else {
                                             replacement
                                         };

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -482,11 +482,11 @@ impl_rule! {
                                     let val = &src[first_arg.byte_range()];
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
                                     let (algo, canonical_algo, replacement) = match inner.to_lowercase().as_str() {
-                                            "rsa" => ("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-                                            "ec" => ("EC", "ECDSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-                                            "dsa" => ("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-                                            "ed25519" => ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-                                            "ed448" => ("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
+                                            "rsa" => ("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
+                                            "ec" => ("EC", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
+                                            "dsa" => ("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+                                            "ed25519" => ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+                                            "ed448" => ("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
                                             _ => return,
                                         };
                                     let mut f = make_finding(
@@ -514,7 +514,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "Diffie-Hellman is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203)",
+                            "Diffie-Hellman is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative",
                             node,
                             src,
                         );
@@ -529,7 +529,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "ECDH is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203)",
+                            "ECDH is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative",
                             node,
                             src,
                         );
@@ -553,7 +553,7 @@ impl_rule! {
                                             _self.severity(),
                                             _self.cwe(),
                                             &format!(
-                                                "{}('{}') uses a quantum-vulnerable signature algorithm — migrate to ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition",
+                                                "{}('{}') uses a quantum-vulnerable signature algorithm — migrate to ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition",
                                                 func_name, inner
                                             ),
                                             node,

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -534,14 +534,14 @@ impl_rule! {
         // Canonical prefixes for quantum-vulnerable asymmetric crypto.
         // Tuple: (module prefix, display algo, canonical CBOM algo, replacement)
         let pq_vulnerable: &[(&str, &str, &str, &str)] = &[
-            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ECDSA", "X25519MLKEM768 hybrid KEM for key exchange, or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures"),
-            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)"),
-            ("Crypto.PublicKey.RSA", "RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("Crypto.PublicKey.DSA", "DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition"),
-            ("Crypto.PublicKey.ECC", "ECC", "ECDSA", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains"),
+            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for key exchange, or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
+            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative"),
+            ("Crypto.PublicKey.RSA", "RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption, or ML-KEM-768 (FIPS 203) standalone"),
+            ("Crypto.PublicKey.DSA", "DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+            ("Crypto.PublicKey.ECC", "ECC", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains"),
         ];
 
         walk_tree(tree.root_node(), source, &mut |node, src| {

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -269,23 +269,30 @@ impl_rule! {
                     }
                     let func_text = &src[func.byte_range()];
                     let func_lower = func_text.to_lowercase();
-                    // Skip PQ-safe algorithms
-                    if func_lower.contains("ml_dsa") || func_lower.contains("ml_kem") || func_lower.contains("slh_dsa") {
+                    // Skip PQ-safe algorithms. fn_dsa (FIPS 206, draft) and hqc
+                    // (5th NIST selection, code-based KEM, draft std 2026) are
+                    // recognised here so early adopters of those crates aren't flagged.
+                    if func_lower.contains("ml_dsa")
+                        || func_lower.contains("ml_kem")
+                        || func_lower.contains("slh_dsa")
+                        || func_lower.contains("fn_dsa")
+                        || func_lower.contains("hqc")
+                    {
                         return;
                     }
                     // No regex needed — check func_lower directly
                     let (algo, canonical_algo, replacement) = if func_lower.contains("ed25519") {
-                        ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                        ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
                     } else if func_lower.contains("x25519") {
-                        ("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203)")
+                        ("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative")
                     } else if func_lower.contains("rsa") {
-                        ("RSA", "RSA", "X25519MLKEM768 hybrid KEM for encryption or ML-DSA-65 (FIPS 204) with hybrid cert chains for signatures")
+                        ("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) for encryption, or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures")
                     } else if func_lower.contains("ecdsa") {
-                        ("ECDSA", "ECDSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                        ("ECDSA", "ECDSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
                     } else if func_lower.contains("p256") || func_lower.contains("p384") || func_lower.contains("p521") || func_lower.contains("k256") {
-                        ("ECDH/ECDSA (elliptic curve)", "ECDSA", "X25519MLKEM768 hybrid KEM or ML-DSA-65 (FIPS 204) with hybrid cert chains")
+                        ("ECDH/ECDSA (elliptic curve)", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains")
                     } else if func_lower.contains("dsa") {
-                        ("DSA", "DSA", "ML-DSA-65 (FIPS 204) with hybrid certificate chains during transition")
+                        ("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
                     } else {
                         return;
                     };

--- a/tests/fixtures/safe_pq_draft.go
+++ b/tests/fixtures/safe_pq_draft.go
@@ -1,0 +1,19 @@
+package main
+
+// Positive non-match fixture for go/pq-vulnerable-crypto.
+// Imports of draft NIST PQC standards (FN-DSA / FIPS 206 and HQC, selected
+// March 2025 as the 5th NIST PQC algorithm) should NOT trigger the rule.
+// Package-prefix matching on rsa./ecdsa./ecdh./dsa./elliptic./ed25519.
+// already excludes these; this fixture locks that in.
+
+import (
+	"example.com/fndsa"
+	"example.com/hqc"
+	"example.com/mlkem"
+)
+
+func safePq() {
+	_ = mlkem.GenerateKey()
+	_ = fndsa.GenerateKey()
+	_ = hqc.Encapsulate(nil)
+}

--- a/tests/fixtures/safe_pq_draft.java
+++ b/tests/fixtures/safe_pq_draft.java
@@ -1,0 +1,25 @@
+// tests/fixtures/safe_pq_draft.java
+//
+// Positive non-match fixture for java/pq-vulnerable-crypto.
+// KeyPairGenerator/Signature.getInstance with PQ-safe names — including the
+// draft NIST standards FN-DSA (FIPS 206) and HQC (5th NIST PQC algorithm,
+// selected March 2025) — must NOT fire. classify_java_pq_algo excludes
+// FN-DSA/HQC from the WITHDSA fallback explicitly.
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+
+public class SafePqDraft {
+    public void pqSafe() throws Exception {
+        // Already PQ-safe — no findings expected
+        KeyPairGenerator.getInstance("ML-DSA");
+        KeyPairGenerator.getInstance("ML-KEM");
+        KeyPairGenerator.getInstance("SLH-DSA");
+
+        // Draft NIST standards — must also be ignored
+        KeyPairGenerator.getInstance("FN-DSA");
+        KeyPairGenerator.getInstance("HQC");
+
+        Signature.getInstance("SHA256withFN-DSA");
+        Signature.getInstance("SHA256withML-DSA");
+    }
+}

--- a/tests/fixtures/safe_pq_draft.js
+++ b/tests/fixtures/safe_pq_draft.js
@@ -1,0 +1,19 @@
+// tests/fixtures/safe_pq_draft.js
+//
+// Positive non-match fixture for js/pq-vulnerable-crypto.
+// generateKeyPair('ml-dsa'|'fn-dsa'|'hqc') must NOT fire: the rule matches
+// on the literal algorithm argument, and draft NIST PQC names (FN-DSA /
+// FIPS 206, HQC — selected March 2025) are not in the quantum-vulnerable
+// table.
+
+const crypto = require("crypto");
+
+// PQ-safe KEMs/signatures — no findings expected
+crypto.generateKeyPair("ml-dsa", {});
+crypto.generateKeyPair("ml-kem", {});
+crypto.generateKeyPair("fn-dsa", {});
+crypto.generateKeyPair("hqc", {});
+
+// crypto.sign with a PQ-safe algorithm name must also stay quiet
+crypto.sign("ml-dsa-65", Buffer.from("msg"), privateKey);
+crypto.sign("fn-dsa", Buffer.from("msg"), privateKey);

--- a/tests/fixtures/safe_pq_draft.py
+++ b/tests/fixtures/safe_pq_draft.py
@@ -1,0 +1,16 @@
+# tests/fixtures/safe_pq_draft.py
+#
+# Positive non-match fixture for py/pq-vulnerable-crypto.
+# Draft NIST PQC standards (FN-DSA / FIPS 206 and HQC, selected March 2025)
+# live outside the cryptography.hazmat.primitives.asymmetric.{rsa,ec,dsa,
+# ed25519,x25519} module tree and therefore must not fire.
+
+from cryptography.hazmat.primitives.asymmetric import ml_dsa, ml_kem
+from pqc import fn_dsa, hqc
+
+
+def pq_safe() -> None:
+    ml_dsa.generate_private_key()
+    ml_kem.generate_private_key()
+    fn_dsa.generate_private_key()
+    hqc.generate_private_key()

--- a/tests/fixtures/safe_pq_draft.rs
+++ b/tests/fixtures/safe_pq_draft.rs
@@ -1,0 +1,17 @@
+// tests/fixtures/safe_pq_draft.rs
+//
+// Positive non-match fixture for rs/pq-vulnerable-crypto.
+// Early adopters of draft NIST PQC standards (FN-DSA / FIPS 206 and HQC,
+// selected March 2025 as the 5th NIST PQC algorithm) should NOT be flagged
+// alongside existing PQ-safe crates (ml_dsa, ml_kem, slh_dsa).
+
+fn pq_safe() {
+    // Already PQ-safe — expected not to fire
+    let _ = ml_dsa::MlDsa65::keygen();
+    let _ = ml_kem::MlKem768::keygen();
+    let _ = slh_dsa::Sha2_128s::keygen();
+
+    // Draft NIST standards — should also be ignored by the allowlist
+    let _ = fn_dsa::FnDsa512::keygen();
+    let _ = hqc::Hqc128::keygen();
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3445,6 +3445,40 @@ fn pqc_on_safe_fixture_returns_zero_findings() {
     }
 }
 
+/// Draft-standard awareness: early adopters of FN-DSA (FIPS 206 draft) and
+/// HQC (5th NIST PQC algorithm, selected March 2025) must NOT be flagged by
+/// the per-language `pq-vulnerable-crypto` rules alongside ML-DSA / ML-KEM /
+/// SLH-DSA. See issue #226.
+#[test]
+fn pq_draft_standards_are_not_flagged() {
+    for fixture in [
+        "safe_pq_draft.rs",
+        "safe_pq_draft.go",
+        "safe_pq_draft.py",
+        "safe_pq_draft.js",
+        "safe_pq_draft.java",
+    ] {
+        let output = foxguard_cmd()
+            .args([fixture_path(fixture).to_str().unwrap(), "-f", "json"])
+            .output()
+            .expect("failed to run foxguard");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() {
+            continue;
+        }
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_str(&stdout).expect("invalid JSON output");
+        for f in &findings {
+            let rule_id = f["rule_id"].as_str().unwrap_or("");
+            assert!(
+                !rule_id.ends_with("/pq-vulnerable-crypto"),
+                "{fixture}: pq-vulnerable-crypto must not fire on PQ-safe draft standards (FN-DSA / HQC). \
+                 finding={f:?}"
+            );
+        }
+    }
+}
+
 // ─── Config file PQ-scanning (PR #230) ──────────────────────────────────────
 //
 // These tests cover the four TLS/config-file rules added by PR #230:


### PR DESCRIPTION
## Summary

Recognizes upcoming NIST PQC standards (FN-DSA and HQC) as valid quantum-safe targets in both detection allowlists and fix-suggestion remediation text, so early adopters of the draft standards aren't incorrectly flagged as quantum-vulnerable.

## Changes per language

- **Rust** (`src/rules/rust_lang.rs`) — extended the PQ-safe allowlist from `{ml_dsa, ml_kem, slh_dsa}` to also include `fn_dsa` and `hqc`. Snake_case matches the sibling ML-* crate naming convention used in the existing guard.
- **Java** (`src/rules/java.rs`) — `classify_java_pq_algo` now has a defensive `WITHDSA` negative-guard list that skips `ML-DSA`, `SLH-DSA`, `FN-DSA`, and `HQC` consistently (previously only `!ML-DSA`).
- **Go / Python / JavaScript** — no allowlist changes needed; existing prefix/literal matching inherently excludes FN-DSA/HQC identifiers. Only remediation text updated.

## Remediation text delta

- Signature findings (RSA/EC/DSA/Ed25519/Ed448/EdDSA + Java `Signature` + `WITHxxx` fallbacks) now say **`ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures`**
- KEM / DH / ECDH findings now reference **`HQC (code-based diversity hedge, draft)`** as a non-lattice alternative alongside the existing hybrid and ML-KEM recommendations
- RSA findings (dual-use) mention both alternatives

## Tests

- 5 new negative fixtures: `tests/fixtures/safe_pq_draft.{rs,go,py,js,java}` exercising FN-DSA/HQC identifiers
- New integration test `pq_draft_standards_are_not_flagged` asserts no `*/pq-vulnerable-crypto` finding fires on any of them

## Verification

- `cargo test --all` → 499 passing
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean

Sanity check (all 5 fixtures print `[]`):
```
=== safe_pq_draft.rs ===   []
=== safe_pq_draft.go ===   []
=== safe_pq_draft.py ===   []
=== safe_pq_draft.js ===   []
=== safe_pq_draft.java === []
```

## Notes

- FN-DSA (FIPS 206) is still in NIST draft — expected final late 2026/early 2027 per the #226 issue context
- HQC was selected March 2025 as the 5th NIST PQC algorithm; draft standard expected early 2026
- Once the canonical Rust crate names land on crates.io, the substring allowlist (`fn_dsa`, `hqc`) will still match common snake_case module-path patterns; hyphenated crate names like `fn-dsa` still hit the lowercased substring check on `func_text`

Closes #226.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced post-quantum cryptography detection to correctly recognize draft NIST standards (FN-DSA, HQC) as safe alternatives, reducing false positives.

* **Documentation**
  * Expanded remediation guidance for quantum-vulnerable cryptography across multiple languages to include additional draft standards and non-lattice alternatives.

* **Tests**
  * Added test fixtures to verify draft post-quantum standards are properly recognized and not flagged as vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->