### PR TITLE
feat(tui): add borders to triage and severity popups (closes #242)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,7 +13,7 @@ use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{
@@ -1494,7 +1494,7 @@ impl TuiApp {
             })
             .collect::<Vec<_>>();
         let list = List::new(items)
-            .block(panel_block(Some("Triage"), PANEL_BG))
+            .block(panel_block(None, PANEL_BG))
             .highlight_style(
                 Style::default()
                     .fg(Color::White)
@@ -1502,6 +1502,10 @@ impl TuiApp {
                     .add_modifier(Modifier::BOLD),
             )
             .highlight_symbol("> ");
+        let inner = area.inner(Margin {
+            vertical: 1,
+            horizontal: 1,
+        });
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -1510,10 +1514,16 @@ impl TuiApp {
                 Constraint::Length(4),
                 Constraint::Length(1),
             ])
-            .split(area);
+            .split(inner);
 
         frame.render_widget(Clear, area);
-        frame.render_widget(Block::default().style(Style::default().bg(PANEL_BG)), area);
+        frame.render_widget(
+            Block::default()
+                .title("triage")
+                .borders(Borders::ALL)
+                .style(Style::default().bg(PANEL_BG)),
+            area,
+        );
         frame.render_widget(
             Paragraph::new(Text::from(vec![
                 Line::from(Span::styled(
@@ -1573,7 +1583,7 @@ impl TuiApp {
             })
             .collect::<Vec<_>>();
         let list = List::new(items)
-            .block(panel_block(Some("Lower severity"), PANEL_BG))
+            .block(panel_block(None, PANEL_BG))
             .highlight_style(
                 Style::default()
                     .fg(Color::White)
@@ -1582,6 +1592,10 @@ impl TuiApp {
             )
             .highlight_symbol("> ");
 
+        let inner = area.inner(Margin {
+            vertical: 1,
+            horizontal: 1,
+        });
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
@@ -1590,10 +1604,16 @@ impl TuiApp {
                 Constraint::Length(3),
                 Constraint::Length(1),
             ])
-            .split(area);
+            .split(inner);
 
         frame.render_widget(Clear, area);
-        frame.render_widget(Block::default().style(Style::default().bg(PANEL_BG)), area);
+        frame.render_widget(
+            Block::default()
+                .title("lower severity")
+                .borders(Borders::ALL)
+                .style(Style::default().bg(PANEL_BG)),
+            area,
+        );
 
         let subtitle = match picker.current {
             Some(current) => format!("{}  (current: {})", rule_id, current),


### PR DESCRIPTION
## Summary
Addresses #242 — the two overlay popups introduced in #216 (triage action menu, severity picker) previously only drew a background fill and looked like they "bleed" into the underlying content. The help popup already had `Borders::ALL`; this PR brings the other two to parity.

## Changes (Option A from the issue — smallest diff)

`src/tui.rs` +27/-7, one commit.

**`draw_action_menu` (triage popup)**:
- Inner `panel_block(Some("Triage"), PANEL_BG)` → `panel_block(None, PANEL_BG)` (title moved to outer block — the natural place for a modal title)
- Outer flat-fill block replaced with `Block::default().title("triage").borders(Borders::ALL).style(...)`
- Inner layout now splits `area.inner(Margin { vertical: 1, horizontal: 1 })` to respect the 1-char border

**`draw_severity_picker`**: same three-step treatment with `"lower severity"` title.

**`panel_block()` untouched** — that's Option B from the issue, explicitly deferred to avoid regressing non-popup surfaces that also call it.

## Aesthetic notes
- Titles lowercased (`"triage"`, `"lower severity"`) to match the existing `draw_help` "help" idiom, not the uppercased/padded `panel_block` style that lives on the background-filled inner-block pattern
- The 1-row top+bottom margin eats 2 rows; at current `centered_rect(56, 42, ...)` popups still have slack for typical action lists
- On very short terminals, the footer hint could get clipped — flag as follow-up if anyone reports

## Verification
- `cargo fmt --check` clean
- `cargo clippy -- -D warnings` clean
- `cargo test --all` → 500+ passing, 0 failures

Closes #242.