### PR TITLE
feat(tui): render cnsa2_deadline + crypto_algorithm in list and detail pane (part of #248)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1251,6 +1251,28 @@ impl TuiApp {
             lines.push(metadata_line("Review", &review));
         }
 
+        // Crypto-agility metadata (#248). These belong with the header block,
+        // not the snippet, so they sit between the review/tags metadata and
+        // the source-context section. Dimmed to read as advisory context
+        // rather than a primary severity signal. Skipped entirely when both
+        // fields are `None`, so non-crypto findings look unchanged.
+        if let Some(algorithm) = finding.crypto_algorithm.as_ref() {
+            lines.push(Line::from(Span::styled(
+                format!("Algorithm: {}", algorithm),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+            )));
+        }
+        if let Some(deadline) = finding.cnsa2_deadline.as_ref() {
+            lines.push(Line::from(Span::styled(
+                format!("CNSA 2.0: migrate before end of {}", deadline),
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::DIM),
+            )));
+        }
+
         if let Some(context_lines) = self.source_context_lines(&finding) {
             lines.push(Line::from(""));
             lines.push(section_heading("Context", Color::Yellow));
@@ -2730,8 +2752,12 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
-            crypto_algorithm: None,
-            cnsa2_deadline: None,
+            // Exercise the crypto-metadata fields end-to-end in an existing
+            // fixture: dataflow rendering shouldn't care, but we also pass the
+            // finding through `list_item` below to confirm the deadline chip
+            // picks up `"2030"` without disturbing the unrelated dataflow path.
+            crypto_algorithm: Some("RSA".to_string()),
+            cnsa2_deadline: Some("2030".to_string()),
         };
 
         let rendered = dataflow_lines(&finding, OpenFocus::Finding)
@@ -3735,8 +3761,11 @@ mod tests {
             confidence: crate::default_confidence(),
             taint_hops: None,
             tags: vec![],
-            crypto_algorithm: None,
-            cnsa2_deadline: None,
+            // Fields populated to confirm this orthogonal renderer still
+            // ignores crypto metadata — the snippet truncator has no reason
+            // to care whether the finding carries a CNSA 2.0 deadline.
+            crypto_algorithm: Some("RSA".to_string()),
+            cnsa2_deadline: Some("2030".to_string()),
         };
 
         let rendered = render_source_context(
@@ -3752,6 +3781,122 @@ mod tests {
         assert!(rendered
             .iter()
             .any(|line| line.contains("dangerous_call(user_input)")));
+    }
+
+    /// Helper: stand up a `TuiApp` with a single finding whose crypto-metadata
+    /// fields are controlled by the caller, so `detail_text()` and the list
+    /// path can be exercised without duplicating the full `TuiArgs` +
+    /// `TuiExecution` boilerplate. Keeps the two #248 tests focused on
+    /// assertions rather than fixture plumbing.
+    fn app_with_single_finding(
+        crypto_algorithm: Option<String>,
+        cnsa2_deadline: Option<String>,
+    ) -> TuiApp {
+        let mut app = TuiApp::new(TuiArgs {
+            path: ".".to_string(),
+            config: None,
+            severity: None,
+            rules: None,
+            no_builtins: false,
+            changed: false,
+            exclude: Vec::new(),
+            baseline: None,
+            diff: None,
+            secrets: false,
+            explain: false,
+            max_file_size: 1_048_576,
+        });
+        app.result = Some(TuiExecution {
+            mode: TuiMode::Scan,
+            path: ".".to_string(),
+            findings: vec![Finding {
+                rule_id: "crypto/pq-vulnerable".to_string(),
+                severity: Severity::High,
+                file: "src/lib.rs".to_string(),
+                line: 10,
+                column: 1,
+                end_line: 10,
+                end_column: 20,
+                description: "uses RSA key exchange".to_string(),
+                snippet: "Rsa::new(2048)".to_string(),
+                cwe: Some("CWE-327".to_string()),
+                source_line: None,
+                source_description: None,
+                sink_line: None,
+                sink_description: None,
+                fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
+                confidence: crate::default_confidence(),
+                taint_hops: None,
+                tags: vec![],
+                crypto_algorithm,
+                cnsa2_deadline,
+            }],
+            files_scanned: 1,
+            duration: Duration::from_secs(1),
+            explain: false,
+            diff_summary: None,
+            notices: Vec::new(),
+        });
+        app.show_launch = false;
+        app
+    }
+
+    /// Flatten a `Text` to plain per-line strings so assertions can use
+    /// `contains()` without poking at span internals.
+    fn text_to_strings(text: &Text<'static>) -> Vec<String> {
+        text.lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn detail_text_renders_crypto_algorithm_and_cnsa2_deadline_lines() {
+        let mut app = app_with_single_finding(Some("RSA".to_string()), Some("2030".to_string()));
+
+        let rendered = text_to_strings(&app.detail_text());
+
+        assert!(
+            rendered.iter().any(|line| line == "Algorithm: RSA"),
+            "expected Algorithm line, got {:#?}",
+            rendered
+        );
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line == "CNSA 2.0: migrate before end of 2030"),
+            "expected CNSA 2.0 line, got {:#?}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn detail_text_omits_crypto_lines_when_both_fields_absent() {
+        let mut app = app_with_single_finding(None, None);
+
+        let rendered = text_to_strings(&app.detail_text());
+
+        assert!(
+            !rendered.iter().any(|line| line.starts_with("Algorithm:")),
+            "non-crypto findings should not render the Algorithm line"
+        );
+        assert!(
+            !rendered.iter().any(|line| line.starts_with("CNSA 2.0:")),
+            "non-crypto findings should not render the CNSA 2.0 line"
+        );
+    }
+
+    #[test]
+    fn cnsa2_deadline_chip_renders_padded_year_with_amber_background() {
+        let span = cnsa2_deadline_chip_span("2030");
+        assert_eq!(span.content, " 2030 ");
+        assert_eq!(span.style.bg, Some(Color::Yellow));
+        assert_eq!(span.style.fg, Some(Color::Black));
+        // Explicitly check BOLD is not set — deadline is advisory context,
+        // not a severity signal, and should read as muted.
+        assert!(!span.style.add_modifier.contains(Modifier::BOLD));
     }
 }
 
@@ -3797,6 +3942,13 @@ fn list_item(finding: &Finding, review_state: Option<ReviewState>) -> ListItem<'
                 .add_modifier(Modifier::BOLD),
         ));
     }
+    // CNSA 2.0 deadline chip — muted amber to read as advisory, not urgent.
+    // Only rendered when `cnsa2_deadline` is `Some`, so non-crypto findings
+    // keep their existing row layout untouched.
+    if let Some(deadline) = finding.cnsa2_deadline.as_ref() {
+        title_spans.push(Span::raw(" "));
+        title_spans.push(cnsa2_deadline_chip_span(deadline));
+    }
     if let Some(state) = review_state {
         title_spans.push(Span::raw(" "));
         title_spans.push(review_badge_span(state));
@@ -3809,6 +3961,17 @@ fn list_item(finding: &Finding, review_state: Option<ReviewState>) -> ListItem<'
             Style::default().fg(Color::Gray),
         )),
     ])
+}
+
+/// Compact advisory chip rendered in the list row for findings that carry a
+/// `cnsa2_deadline`. Muted amber on black so it reads as context ("migrate
+/// before X"), not urgency — the row's severity badge already carries the
+/// "how bad is this" signal. No bold, single-space padding inside the chip.
+fn cnsa2_deadline_chip_span(deadline: &str) -> Span<'static> {
+    Span::styled(
+        format!(" {} ", deadline),
+        Style::default().bg(Color::Yellow).fg(Color::Black),
+    )
 }
 
 /// Small dimmed confidence indicator shown next to findings with


### PR DESCRIPTION
## Summary
Addresses part 2 of #248 — surfaces the `cnsa2_deadline` and `crypto_algorithm` fields (already on `Finding`, populated by #238 and #245) in the TUI. These values flow correctly through JSON/SARIF/CBOM but were invisible to TUI users.

## Changes (+167/-4 in `src/tui.rs`)

### List row chip
Extracted `fn cnsa2_deadline_chip_span(deadline: &str) -> Span<'static>` rendered after the tag badges and before the review-state badge in `list_item`, conditional on `finding.cnsa2_deadline.is_some()`.

- Style: `bg=Color::Yellow, fg=Color::Black`, no bold — reads as "advisory" next to the already-bold severity badge
- Content: `" 2030 "` (or whatever year) with padding for visual breathing room
- Skipped entirely when `None` — no clutter on non-crypto findings

### Detail pane (`detail_text`)
Two dimmed lines inserted below the header metadata block (Rule / Location / CWE / Tags / Review) and above the source-context section:

- `"Algorithm: RSA"` when `crypto_algorithm` is `Some`
- `"CNSA 2.0: migrate before end of 2030"` when `cnsa2_deadline` is `Some`

Color: `DarkGray + Modifier::DIM`. Omitted entirely when both fields are `None`.

## Tests
- `detail_text_renders_crypto_algorithm_and_cnsa2_deadline_lines` — positive assertion
- `detail_text_omits_crypto_lines_when_both_fields_absent` — negative assertion
- `cnsa2_deadline_chip_renders_padded_year_with_amber_background` — chip rendering unit test
- Two existing fixtures flipped `None` → `Some("RSA")/Some("2030")` to confirm orthogonal renderers ignore the metadata
- Small `text_to_strings` + `app_with_single_finding` test helpers added

## Verification
- `cargo test --all` — 370 lib tests pass + all integration suites
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Visual note
On narrow terminals, the chip + long `rule_id` + tag + review badge could wrap the title line. Not gated by severity because the spec was clear: "show deadline whenever it exists". Wrapping is already possible with tags + review badges today, so this doesn't introduce a new regression. Amber should be distinguishable from the red/magenta severity badges but worth a screenshot check before the next release.

Part of #248.