### PR TITLE
fix(tui): add pq_mode field to test helper to unblock main CI

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3853,6 +3853,7 @@ mod tests {
             secrets: false,
             explain: false,
             max_file_size: 1_048_576,
+            pq_mode: false,
         });
         app.result = Some(TuiExecution {
             mode: TuiMode::Scan,


### PR DESCRIPTION
## Summary
Main CI broke on commit `42c2b98` (#250 merge) because the `app_with_single_finding` test helper's `TuiArgs` literal was missing the `pq_mode` field that #249 added.

## Root cause
Classic merge-skew: #249 and #250 were both open at once. #250's CI was green against pre-#249 main, and GitHub merged it without a required rebase, so the new field wasn't in the helper.

## Fix
One line — `pq_mode: false` on the test-only `TuiArgs` literal at `src/tui.rs:3843`.

## Verification
- `cargo test --all` → 370+106+7+15+12+6+3+1 = all passing
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean