### PR TITLE
fix(pq): split remediation by audience — ML-KEM-1024/ML-DSA-87 for CNSA 2.0, ML-KEM-768/ML-DSA-65 for commercial (closes #253)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -495,7 +495,7 @@ fn validate_rules_path(rules: Option<&str>) -> Result<(), String> {
 fn is_pq_rule_id(id: &str) -> bool {
     id.contains("pq-vulnerable")
         || id.contains("hardcoded-crypto-algorithm")
-        || (id.starts_with("config/") && (id.contains("tls") || id.contains("dockerfile")))
+        || (id.starts_with("config/") && id.contains("tls"))
 }
 
 fn collect_changed_targets(path: &str, changed: bool) -> Result<Option<Vec<PathBuf>>, String> {

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -399,12 +399,12 @@ impl_rule! {
                         std::borrow::Cow::Borrowed(raw)
                     };
                     let (algo, canonical_algo, replacement) = match func_text.as_ref() {
-                        s if s.starts_with("rsa.") => ("RSA", "RSA", "ML-KEM (FIPS 203) or HQC (code-based diversity hedge, draft) for encryption, or ML-DSA (FIPS 204) / FN-DSA (FIPS 206, draft) for signatures"),
-                        s if s.starts_with("ecdsa.") => ("ECDSA", "ECDSA", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
-                        s if s.starts_with("ecdh.") => ("ECDH", "ECDH", "ML-KEM (FIPS 203) or HQC (code-based diversity hedge, draft)"),
-                        s if s.starts_with("dsa.") => ("DSA", "DSA", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
-                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ECDH", "ML-KEM (FIPS 203) / HQC (draft) or ML-DSA (FIPS 204) / FN-DSA (FIPS 206, draft)"),
-                        s if s.starts_with("ed25519.") => ("Ed25519", "Ed25519", "ML-DSA (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures"),
+                        s if s.starts_with("rsa.") => ("RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+                        s if s.starts_with("ecdsa.") => ("ECDSA", "ECDSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+                        s if s.starts_with("ecdh.") => ("ECDH", "ECDH", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203) or HQC (code-based diversity hedge, draft). CNSA 2.0 / NSS: ML-KEM-1024 for key establishment."),
+                        s if s.starts_with("dsa.") => ("DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+                        s if s.starts_with("elliptic.") => ("ECDH/ECDSA (elliptic)", "ECDH", "General use (FIPS category III): X25519MLKEM768 hybrid KEM / HQC (draft) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft). CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+                        s if s.starts_with("ed25519.") => ("Ed25519", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
                         _ => return,
                     };
                     let mut f = make_finding(

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -467,24 +467,24 @@ fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str, &'st
     // PQ-safe algorithms (ML-KEM/ML-DSA/SLH-DSA and the draft FN-DSA / HQC
     // standards) are intentionally absent from this table and therefore skipped.
     match algo {
-        "RSA" => return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures (Java JEP 527)")),
-        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ECDSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
-        "DSA" => return Some(("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
-        "DH" | "DiffieHellman" => return Some(("DH", "DH", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)")),
-        "ECDH" => return Some(("ECDH", "ECDH", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)")),
-        "Ed25519" => return Some(("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
-        "Ed448" => return Some(("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
-        "EdDSA" => return Some(("EdDSA", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)")),
-        "X25519" => return Some(("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
-        "X448" => return Some(("X448", "X448", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
-        "XDH" => return Some(("XDH", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) (Java JEP 527)")),
+        "RSA" => return Some(("RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures (Java JEP 527).")),
+        "EC" | "ECDSA" => return Some(("ECDSA/EC", "ECDSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).")),
+        "DSA" => return Some(("DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).")),
+        "DH" | "DiffieHellman" => return Some(("DH", "DH", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527).")),
+        "ECDH" => return Some(("ECDH", "ECDH", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527).")),
+        "Ed25519" => return Some(("Ed25519", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).")),
+        "Ed448" => return Some(("Ed448", "Ed448", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).")),
+        "EdDSA" => return Some(("EdDSA", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).")),
+        "X25519" => return Some(("X25519", "X25519", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft). CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527).")),
+        "X448" => return Some(("X448", "X448", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft). CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527).")),
+        "XDH" => return Some(("XDH", "X25519", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft). CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527).")),
         _ => {}
     }
     // Non-exact matches need case-insensitive comparison
     let upper = algo.to_uppercase();
     // RSA cipher modes: "RSA/ECB/PKCS1Padding", "RSA/ECB/OAEPWithSHA-256..."
     if upper.starts_with("RSA/") || upper.starts_with("RSA_") {
-        return Some(("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures (Java JEP 527)"));
+        return Some(("RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures (Java JEP 527)."));
     }
     // Signature combos: "SHA256withRSA", "SHA384withECDSA", "SHA256withDSA".
     // The PQ-safe exclusions below ensure future hybrid names containing the
@@ -494,14 +494,14 @@ fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str, &'st
         return Some((
             "RSA",
             "RSA",
-            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
+            "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).",
         ));
     }
     if upper.contains("WITHECDSA") {
         return Some((
             "ECDSA",
             "ECDSA",
-            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
+            "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).",
         ));
     }
     if upper.contains("WITHDSA")
@@ -513,7 +513,7 @@ fn classify_java_pq_algo(algo: &str) -> Option<(&'static str, &'static str, &'st
         return Some((
             "DSA",
             "DSA",
-            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)",
+            "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527).",
         ));
     }
     None
@@ -556,9 +556,9 @@ impl_rule! {
                                             None => return,
                                         };
                                         let replacement = if obj_text == "KeyAgreement" {
-                                            "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative (Java JEP 527)"
+                                            "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment (Java JEP 527)."
                                         } else if obj_text == "Signature" {
-                                            "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains (Java JEP 527)"
+                                            "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid cert chains. CNSA 2.0 / NSS: ML-DSA-87 for signatures (Java JEP 527)."
                                         } else {
                                             replacement
                                         };

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -485,11 +485,11 @@ impl_rule! {
                                     let val = &src[first_arg.byte_range()];
                                     let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
                                     let (algo, canonical_algo, replacement) = match inner.to_lowercase().as_str() {
-                                            "rsa" => ("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
-                                            "ec" => ("EC", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
-                                            "dsa" => ("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
-                                            "ed25519" => ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
-                                            "ed448" => ("Ed448", "Ed448", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
+                                            "rsa" => ("RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+                                            "ec" => ("EC", "ECDSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+                                            "dsa" => ("DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+                                            "ed25519" => ("Ed25519", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+                                            "ed448" => ("Ed448", "Ed448", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
                                             _ => return,
                                         };
                                     let mut f = make_finding(
@@ -517,7 +517,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "Diffie-Hellman is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative",
+                            "Diffie-Hellman is quantum-vulnerable — General use (FIPS category III): migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment.",
                             node,
                             src,
                         );
@@ -532,7 +532,7 @@ impl_rule! {
                             _self.id(),
                             _self.severity(),
                             _self.cwe(),
-                            "ECDH is quantum-vulnerable — migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative",
+                            "ECDH is quantum-vulnerable — General use (FIPS category III): migrate to X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment.",
                             node,
                             src,
                         );
@@ -556,7 +556,7 @@ impl_rule! {
                                             _self.severity(),
                                             _self.cwe(),
                                             &format!(
-                                                "{}('{}') uses a quantum-vulnerable signature algorithm — migrate to ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition",
+                                                "{}('{}') uses a quantum-vulnerable signature algorithm — General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures.",
                                                 func_name, inner
                                             ),
                                             node,

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -539,14 +539,14 @@ impl_rule! {
         // Canonical prefixes for quantum-vulnerable asymmetric crypto.
         // Tuple: (module prefix, display algo, canonical CBOM algo, replacement)
         let pq_vulnerable: &[(&str, &str, &str, &str)] = &[
-            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for key exchange, or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures"),
-            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
-            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative"),
-            ("Crypto.PublicKey.RSA", "RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption, or ML-KEM-768 (FIPS 203) standalone"),
-            ("Crypto.PublicKey.DSA", "DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition"),
-            ("Crypto.PublicKey.ECC", "ECC", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC, draft) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains"),
+            ("cryptography.hazmat.primitives.asymmetric.rsa", "RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+            ("cryptography.hazmat.primitives.asymmetric.ec", "ECDSA/ECDH", "ECDSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC, draft) for key exchange, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+            ("cryptography.hazmat.primitives.asymmetric.dsa", "DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+            ("cryptography.hazmat.primitives.asymmetric.ed25519", "Ed25519", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+            ("cryptography.hazmat.primitives.asymmetric.x25519", "X25519", "X25519", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment."),
+            ("Crypto.PublicKey.RSA", "RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC, draft) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
+            ("Crypto.PublicKey.DSA", "DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures."),
+            ("Crypto.PublicKey.ECC", "ECC", "ECDSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC, draft) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures."),
         ];
 
         walk_tree(tree.root_node(), source, &mut |node, src| {

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -284,17 +284,17 @@ impl_rule! {
                     }
                     // No regex needed — check func_lower directly
                     let (algo, canonical_algo, replacement) = if func_lower.contains("ed25519") {
-                        ("Ed25519", "Ed25519", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
+                        ("Ed25519", "Ed25519", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures.")
                     } else if func_lower.contains("x25519") {
-                        ("X25519", "X25519", "X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative")
+                        ("X25519", "X25519", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (FIPS 203), or HQC (code-based diversity hedge, draft) as a non-lattice alternative. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment.")
                     } else if func_lower.contains("rsa") {
-                        ("RSA", "RSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) for encryption, or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures")
+                        ("RSA", "RSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) for encryption, ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures.")
                     } else if func_lower.contains("ecdsa") {
-                        ("ECDSA", "ECDSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
+                        ("ECDSA", "ECDSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures.")
                     } else if func_lower.contains("p256") || func_lower.contains("p384") || func_lower.contains("p521") || func_lower.contains("k256") {
-                        ("ECDH/ECDSA (elliptic curve)", "ECDSA", "X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains")
+                        ("ECDH/ECDSA (elliptic curve)", "ECDSA", "General use (FIPS category III): X25519MLKEM768 hybrid KEM (or HQC for code-based diversity) or ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87 for signatures.")
                     } else if func_lower.contains("dsa") {
-                        ("DSA", "DSA", "ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition")
+                        ("DSA", "DSA", "General use (FIPS category III): ML-DSA-65 (FIPS 204) or FN-DSA (FIPS 206, draft) for smaller signatures, with hybrid certificate chains during transition. CNSA 2.0 / NSS: ML-DSA-87 for signatures.")
                     } else {
                         return;
                     };

--- a/tests/cnsa2_compliance.rs
+++ b/tests/cnsa2_compliance.rs
@@ -165,9 +165,23 @@ fn cnsa2_flag_off_does_not_mention_cnsa_in_terminal() {
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);
+    // The remediation text itself references "CNSA 2.0 / NSS:" to distinguish
+    // the general-use FIPS-cat-III parameter sets from the CNSA 2.0 / NSS
+    // parameter sets (issue #253). The `--cnsa2` flag controls the separate
+    // *compliance annotations* — the per-finding "CNSA 2.0: migrate before
+    // end of YYYY" line and the summary block. Assert on the annotation
+    // markers rather than the bare substring "CNSA 2.0".
     assert!(
-        !text.contains("CNSA 2.0"),
-        "default terminal output must not mention CNSA 2.0; got:\n{text}"
+        !text.contains("CNSA 2.0:"),
+        "default terminal output must not render the per-finding CNSA 2.0 deadline annotation; got:\n{text}"
+    );
+    assert!(
+        !text.contains("migrate before end of"),
+        "default terminal output must not render the per-finding CNSA 2.0 deadline annotation; got:\n{text}"
+    );
+    assert!(
+        !text.contains(" at-risk ") && !text.contains(" on-track ") && !text.contains(" clean "),
+        "default terminal output must not render the CNSA 2.0 summary level label; got:\n{text}"
     );
 }
 
@@ -179,9 +193,13 @@ fn cnsa2_flag_on_adds_deadline_annotation_and_summary() {
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);
+    // The flag renders the per-finding annotation line ("CNSA 2.0: migrate
+    // before end of YYYY"). The bare substring "CNSA 2.0" now also appears
+    // in remediation text regardless of the flag (see issue #253), so check
+    // for the annotation-specific marker.
     assert!(
-        text.contains("CNSA 2.0"),
-        "--cnsa2 should surface the CNSA label in terminal output; got:\n{text}"
+        text.contains("CNSA 2.0:") || text.contains("migrate before end of"),
+        "--cnsa2 should surface the per-finding CNSA deadline annotation; got:\n{text}"
     );
     // Summary block names the migration level and per-year counts.
     assert!(


### PR DESCRIPTION
## Summary
Fixes the self-contradiction between the CNSA 2.0 compliance module and PQ-rule remediation text caught in the pre-release fact-check.

Every `*/pq-vulnerable-crypto` rule previously recommended ML-KEM-768 / ML-DSA-65 (NIST category III general-use parameters). But foxguard also ships `--cnsa2` and `src/compliance.rs` annotating findings with CNSA 2.0 deadlines for NSS users. CNSA 2.0 mandates ML-KEM-**1024** / ML-DSA-**87** (highest parameter sets). So a user running `foxguard pqc . --cnsa2` saw "migrate by 2030 per CNSA" alongside remediation text recommending the wrong parameters for CNSA.

This is the class of mistake a NIST cryptographer would dunk on in a top-level HN comment. Fixed before v0.8.0 / blog post goes out.

## Change
Every remediation string now reads as two segments:

**Before**:
```
X25519MLKEM768 hybrid KEM for encryption, or ML-KEM-768 (FIPS 203) standalone
```

**After**:
```
General use (FIPS category III): X25519MLKEM768 hybrid KEM for encryption,
ML-DSA-65 (FIPS 204) / FN-DSA (FIPS 206, draft) with hybrid cert chains for
signatures. CNSA 2.0 / NSS: ML-KEM-1024 for key establishment, ML-DSA-87
for signatures.
```

## String counts (per language)
- Python: 8 strings (one per `pq_vulnerable` tuple)
- JavaScript: 8 strings (generateKeyPair match arms + DH + ECDH + sign/verify)
- Java: 18 strings (11 `classify_java_pq_algo` match arms + RSA cipher-mode fallthrough + 3 signature-combo branches + 2 in-check overrides)
- Rust: 6 strings (Ed25519, X25519, RSA, ECDSA, Pxxx elliptic, DSA)
- Go: 6 strings — Go did NOT actually have hybrid wording before (contrary to the PR that supposedly added it); plain `ML-KEM (FIPS 203)` / `ML-DSA (FIPS 204)` were there. Brought to parity with the other languages as part of this fix.

## Batched-in small fixes
- **Dead `dockerfile` branch in `is_pq_rule_id`** (`src/app.rs`): the `config/` + `dockerfile` clause had no matching rule — `config/dockerfile-insecure-tls-env` already matches via the `tls` branch. Trimmed for honesty.
- **Cloudflare "~38%" number**: not present anywhere in the repo (only in the #223 issue body on GitHub). No edit needed in this PR.
- **JEP 527 status text**: left as `(Java JEP 527)`. Adding `(integrated, JDK 27)` on top of the now-longer two-segment remediation would bloat every string noticeably. OPTIONAL per #253, deferred.

## Test updates
- `tests/cnsa2_compliance.rs::cnsa2_flag_off_does_not_mention_cnsa_in_terminal` — previous assertion `!text.contains("CNSA 2.0")` now legitimately trips on the new remediation (which contains "CNSA 2.0 / NSS"). Rewrote to assert on the per-finding annotation marker (`"CNSA 2.0:"`, `"migrate before end of"`) and summary level labels (`" at-risk "`, `" on-track "`, `" clean "`).
- `tests/cnsa2_compliance.rs::cnsa2_flag_on_adds_deadline_annotation_and_summary` — same root cause; tightened to assert on what `--cnsa2` actually toggles, not a bare substring.

## Verification
- `cargo test --all` → 374+ passing, 0 failing
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- End-to-end: `foxguard tests/fixtures/vulnerable.py -f json` shows the new split `description` text and unchanged `cnsa2_deadline: "2033"` metadata. `--cnsa2` still renders the `CNSA 2.0: migrate before end of 2033` annotation lines and the summary block.

Closes #253.