### PR TITLE
feat(tui): persist ListState, add mouse scroll and click support

### DIFF
--- a/src/report/sarif.rs
+++ b/src/report/sarif.rs
@@ -48,6 +48,9 @@ pub fn build_sarif(findings: &[Finding]) -> serde_json::Value {
             if let Some(deadline) = &f.cnsa2_deadline {
                 props.insert("cnsa2Deadline".to_string(), json!(deadline));
             }
+            if let Some(dep) = &f.dep_name {
+                props.insert("depName".to_string(), json!(dep));
+            }
 
             // SARIF `rank` is a native 0.0..=100.0 ordering hint. Map
             // confidence linearly so 1.0 → 100 and 0.0 → 0.

--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -140,11 +140,6 @@ const PIP_PACKAGES: &[SeedEntry] = &[
         confidence: 0.8,
     },
     SeedEntry {
-        name: "fabric",
-        crypto_algorithm: None,
-        confidence: 0.7,
-    },
-    SeedEntry {
         name: "pyjwt",
         crypto_algorithm: None,
         confidence: 0.8,
@@ -163,6 +158,11 @@ const PIP_PACKAGES: &[SeedEntry] = &[
         name: "jwcrypto",
         crypto_algorithm: None,
         confidence: 0.8,
+    },
+    SeedEntry {
+        name: "fabric",
+        crypto_algorithm: None,
+        confidence: 0.7,
     },
     SeedEntry {
         name: "m2crypto",

--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -15,6 +15,8 @@ struct SeedEntry {
 
 const MANIFEST_PQ_CWE: &str = "CWE-327";
 const MANIFEST_PQ_DESC: &str = "Dependency uses quantum-vulnerable cryptographic algorithm";
+const CARGO_PQ_DESC: &str =
+    "Dependency uses quantum-vulnerable cryptographic algorithm (dev-dependencies not distinguished)";
 const MANIFEST_PQ_DEADLINE: &str = "2033";
 
 /// Apply shared PQ fields to a manifest finding.
@@ -204,7 +206,7 @@ impl Rule for CargoLockPqCrypto {
         Some(MANIFEST_PQ_CWE)
     }
     fn description(&self) -> &str {
-        MANIFEST_PQ_DESC
+        CARGO_PQ_DESC
     }
     fn language(&self) -> Language {
         Language::Manifest

--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -61,6 +61,26 @@ const CARGO_SEEDS: &[SeedEntry] = &[
         crypto_algorithm: Some("ECDSA"),
         confidence: 0.9,
     },
+    SeedEntry {
+        name: "k256",
+        crypto_algorithm: Some("ECDSA"),
+        confidence: 0.9,
+    },
+    SeedEntry {
+        name: "secp256k1",
+        crypto_algorithm: Some("ECDSA"),
+        confidence: 0.9,
+    },
+    SeedEntry {
+        name: "libsecp256k1",
+        crypto_algorithm: Some("ECDSA"),
+        confidence: 0.9,
+    },
+    SeedEntry {
+        name: "ed448-goldilocks",
+        crypto_algorithm: Some("Ed448"),
+        confidence: 0.9,
+    },
     // Tier 2 — confidence 0.6, mixed algorithms
     SeedEntry {
         name: "ring",
@@ -69,6 +89,11 @@ const CARGO_SEEDS: &[SeedEntry] = &[
     },
     SeedEntry {
         name: "openssl-sys",
+        crypto_algorithm: None,
+        confidence: 0.6,
+    },
+    SeedEntry {
+        name: "openssl",
         crypto_algorithm: None,
         confidence: 0.6,
     },
@@ -114,8 +139,33 @@ const PIP_PACKAGES: &[SeedEntry] = &[
     },
     SeedEntry {
         name: "fabric",
-        crypto_algorithm: Some("RSA"),
+        crypto_algorithm: None,
         confidence: 0.7,
+    },
+    SeedEntry {
+        name: "pyjwt",
+        crypto_algorithm: None,
+        confidence: 0.8,
+    },
+    SeedEntry {
+        name: "authlib",
+        crypto_algorithm: None,
+        confidence: 0.8,
+    },
+    SeedEntry {
+        name: "python-jose",
+        crypto_algorithm: None,
+        confidence: 0.8,
+    },
+    SeedEntry {
+        name: "jwcrypto",
+        crypto_algorithm: None,
+        confidence: 0.8,
+    },
+    SeedEntry {
+        name: "m2crypto",
+        crypto_algorithm: None,
+        confidence: 0.6,
     },
     SeedEntry {
         name: "cryptography",
@@ -817,5 +867,46 @@ version = \"0.17.0\"\n";
     fn pip_empty_input_returns_empty() {
         let tree = dummy_tree("");
         assert!(RequirementsTxtPqCrypto.check("", &tree).is_empty());
+    }
+
+    #[test]
+    fn cargo_k256_seed_flagged() {
+        let src = "\
+[[package]]\n\
+name = \"wallet\"\n\
+version = \"0.1.0\"\n\
+dependencies = [\"k256\"]\n\
+\n\
+[[package]]\n\
+name = \"k256\"\n\
+version = \"0.13.0\"\n";
+        let tree = dummy_tree(src);
+        let findings = CargoLockPqCrypto.check(src, &tree);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].dep_name.as_deref(), Some("wallet"));
+        assert_eq!(findings[0].crypto_algorithm.as_deref(), Some("ECDSA"));
+    }
+
+    #[test]
+    fn pip_jwt_lib_flagged() {
+        let src = "pyjwt>=2.0\n";
+        let tree = dummy_tree(src);
+        let findings = RequirementsTxtPqCrypto.check(src, &tree);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].dep_name.as_deref(), Some("pyjwt"));
+        assert!(findings[0].crypto_algorithm.is_none());
+        assert_eq!(findings[0].confidence, 0.8);
+    }
+
+    #[test]
+    fn pip_fabric_no_algorithm() {
+        let src = "fabric>=3.0\n";
+        let tree = dummy_tree(src);
+        let findings = RequirementsTxtPqCrypto.check(src, &tree);
+        assert_eq!(findings.len(), 1);
+        assert!(
+            findings[0].crypto_algorithm.is_none(),
+            "fabric should not attribute RSA"
+        );
     }
 }

--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -293,7 +293,7 @@ impl Rule for CargoLockPqCrypto {
             visited.insert(i);
             queue.push_back(i);
 
-            let mut reached_seeds: Vec<&SeedEntry> = Vec::new();
+            let mut reached_seeds: HashMap<&str, &SeedEntry> = HashMap::new();
 
             while let Some(node) = queue.pop_front() {
                 for &neighbor in &graph[node] {
@@ -307,7 +307,14 @@ impl Rule for CargoLockPqCrypto {
                         continue;
                     };
                     if let Some(entry) = seed_map.get(neighbor_name) {
-                        reached_seeds.push(entry);
+                        reached_seeds
+                            .entry(entry.name)
+                            .and_modify(|existing| {
+                                if entry.confidence > existing.confidence {
+                                    *existing = entry;
+                                }
+                            })
+                            .or_insert(entry);
                     } else {
                         queue.push_back(neighbor);
                     }
@@ -320,7 +327,7 @@ impl Rule for CargoLockPqCrypto {
 
             // Pick the highest-confidence seed
             let best = reached_seeds
-                .iter()
+                .values()
                 .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
                 .unwrap();
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -7,7 +7,10 @@ use crate::config::{
     load_for_scan,
 };
 use crate::{Finding, Severity};
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
+    MouseEvent, MouseEventKind,
+};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -46,7 +49,95 @@ pub fn run_scan_tui(args: &TuiArgs) -> Result<i32, String> {
             .map_err(|e| e.to_string())?;
 
         if event::poll(Duration::from_millis(100)).map_err(|e| e.to_string())? {
-            let Event::Key(key) = event::read().map_err(|e| e.to_string())? else {
+            let ev = event::read().map_err(|e| e.to_string())?;
+
+            if let Event::Mouse(MouseEvent {
+                kind: kind @ (MouseEventKind::ScrollUp | MouseEventKind::ScrollDown),
+                ..
+            }) = ev
+            {
+                // Drain any queued scroll events so momentum scrolling
+                // doesn't keep moving after the wheel stops.
+                let mut last_kind = kind;
+                while event::poll(Duration::ZERO).unwrap_or(false) {
+                    if let Ok(Event::Mouse(MouseEvent {
+                        kind: k @ (MouseEventKind::ScrollUp | MouseEventKind::ScrollDown),
+                        ..
+                    })) = event::read()
+                    {
+                        last_kind = k;
+                    } else {
+                        break;
+                    }
+                }
+                match last_kind {
+                    MouseEventKind::ScrollUp => app.move_selection(-1),
+                    MouseEventKind::ScrollDown => app.move_selection(1),
+                    _ => {}
+                }
+                continue;
+            }
+
+            if let Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(event::MouseButton::Left),
+                column,
+                row,
+                ..
+            }) = ev
+            {
+                let area = app.list_area;
+                // panel_block uses: title (1 row) + Padding top=1 = 2 rows overhead
+                let content_y = area.y + 2;
+                let content_x = area.x + 1; // Padding left=1
+                let content_h = area.height.saturating_sub(2); // top overhead, no bottom padding
+                let content_w = area.width.saturating_sub(2); // left+right padding
+                if column >= content_x
+                    && column < content_x + content_w
+                    && row >= content_y
+                    && row < content_y + content_h
+                {
+                    let clicked_row = (row - content_y) as usize;
+                    let item_height = 2; // each ListItem is 2 lines (title + path)
+                    let index = app.list_state.offset() + clicked_row / item_height;
+                    let filtered_len = app.filtered_indices().len();
+                    if index < filtered_len {
+                        app.selected = index;
+                        app.detail_scroll = 0;
+                        app.source_context_cache = None;
+                    }
+                }
+                continue;
+            }
+
+            if let Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Moved,
+                column,
+                row,
+                ..
+            }) = ev
+            {
+                let area = app.list_area;
+                let content_y = area.y + 2;
+                let content_h = area.height.saturating_sub(2);
+                if column >= area.x
+                    && column < area.x + area.width
+                    && row >= content_y
+                    && row < content_y + content_h
+                {
+                    let clicked_row = (row - content_y) as usize;
+                    let index = app.list_state.offset() + clicked_row / 2;
+                    if index < app.filtered_indices().len() {
+                        app.hover_index = Some(index);
+                    } else {
+                        app.hover_index = None;
+                    }
+                } else {
+                    app.hover_index = None;
+                }
+                continue;
+            }
+
+            let Event::Key(key) = ev else {
                 continue;
             };
 
@@ -130,6 +221,8 @@ struct TuiApp {
     sort_mode: SortMode,
     selected: usize,
     list_state: ListState,
+    list_area: Rect,
+    hover_index: Option<usize>,
     show_notices: bool,
     show_help: bool,
     /// When on, a CNSA 2.0 migration-readiness strip is drawn at the bottom
@@ -172,6 +265,8 @@ impl TuiApp {
             sort_mode: SortMode::default(),
             selected: 0,
             list_state: ListState::default(),
+            list_area: Rect::default(),
+            hover_index: None,
             show_notices: true,
             show_help: false,
             show_compliance_panel: false,
@@ -1297,12 +1392,18 @@ impl TuiApp {
             .split(body_layout[0]);
 
         let filtered = self.filtered_indices();
+        let hover = self.hover_index;
         let items = if let Some(result) = self.result.as_ref() {
             filtered
                 .iter()
-                .map(|index| {
+                .enumerate()
+                .map(|(i, index)| {
                     let finding = &result.findings[*index];
-                    list_item(finding, self.review_state_for(finding))
+                    let mut item = list_item(finding, self.review_state_for(finding));
+                    if hover == Some(i) && self.selected != i {
+                        item = item.style(Style::default().bg(Color::Rgb(40, 40, 50)));
+                    }
+                    item
                 })
                 .collect::<Vec<_>>()
         } else {
@@ -1341,6 +1442,7 @@ impl TuiApp {
         } else {
             self.list_state.select(None);
         }
+        self.list_area = layout[0];
         frame.render_stateful_widget(list, layout[0], &mut self.list_state);
 
         let detail = Paragraph::new(self.detail_text())
@@ -2637,7 +2739,8 @@ impl TerminalSession {
     fn enter() -> Result<Self, String> {
         enable_raw_mode().map_err(|e| e.to_string())?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen).map_err(|e| e.to_string())?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+            .map_err(|e| e.to_string())?;
         let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend).map_err(|e| e.to_string())?;
         Ok(Self {
@@ -2652,7 +2755,12 @@ impl TerminalSession {
         }
 
         disable_raw_mode().map_err(|e| e.to_string())?;
-        execute!(self.terminal.backend_mut(), LeaveAlternateScreen).map_err(|e| e.to_string())?;
+        execute!(
+            self.terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        )
+        .map_err(|e| e.to_string())?;
         self.terminal.show_cursor().map_err(|e| e.to_string())?;
         self.active = false;
         Ok(())
@@ -2664,7 +2772,12 @@ impl TerminalSession {
         }
 
         enable_raw_mode().map_err(|e| e.to_string())?;
-        execute!(self.terminal.backend_mut(), EnterAlternateScreen).map_err(|e| e.to_string())?;
+        execute!(
+            self.terminal.backend_mut(),
+            EnterAlternateScreen,
+            EnableMouseCapture
+        )
+        .map_err(|e| e.to_string())?;
         self.terminal.clear().map_err(|e| e.to_string())?;
         self.active = true;
         Ok(())
@@ -2674,7 +2787,11 @@ impl TerminalSession {
 impl Drop for TerminalSession {
     fn drop(&mut self) {
         let _ = disable_raw_mode();
-        let _ = execute!(self.terminal.backend_mut(), LeaveAlternateScreen);
+        let _ = execute!(
+            self.terminal.backend_mut(),
+            LeaveAlternateScreen,
+            DisableMouseCapture
+        );
         let _ = self.terminal.show_cursor();
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -129,6 +129,7 @@ struct TuiApp {
     /// legacy severity-desc ordering; cycled via `Shift+C` (feature B).
     sort_mode: SortMode,
     selected: usize,
+    list_state: ListState,
     show_notices: bool,
     show_help: bool,
     /// When on, a CNSA 2.0 migration-readiness strip is drawn at the bottom
@@ -170,6 +171,7 @@ impl TuiApp {
             session_min_confidence: 0.0,
             sort_mode: SortMode::default(),
             selected: 0,
+            list_state: ListState::default(),
             show_notices: true,
             show_help: false,
             show_compliance_panel: false,
@@ -1331,13 +1333,15 @@ impl TuiApp {
                     .bg(DETAIL_BG)
                     .add_modifier(Modifier::BOLD),
             )
-            .highlight_symbol(">> ");
+            .highlight_symbol(">> ")
+            .scroll_padding(0);
 
-        let mut state = ListState::default();
         if !filtered.is_empty() {
-            state.select(Some(self.selected));
+            self.list_state.select(Some(self.selected));
+        } else {
+            self.list_state.select(None);
         }
-        frame.render_stateful_widget(list, layout[0], &mut state);
+        frame.render_stateful_widget(list, layout[0], &mut self.list_state);
 
         let detail = Paragraph::new(self.detail_text())
             .block(panel_block(Some("Detail"), DETAIL_BG))

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2739,8 +2739,7 @@ impl TerminalSession {
     fn enter() -> Result<Self, String> {
         enable_raw_mode().map_err(|e| e.to_string())?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
-            .map_err(|e| e.to_string())?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture).map_err(|e| e.to_string())?;
         let backend = CrosstermBackend::new(stdout);
         let terminal = Terminal::new(backend).map_err(|e| e.to_string())?;
         Ok(Self {

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -244,7 +244,7 @@ const dockerfileRules: Rule[] = [
 ];
 
 const manifestRules: Rule[] = [
-  { id: 'manifest/cargo-pq-vulnerable-dep', cwe: 'CWE-327', desc: 'Dependency uses quantum-vulnerable cryptographic algorithm', severity: 'high' },
+  { id: 'manifest/cargo-pq-vulnerable-dep', cwe: 'CWE-327', desc: 'Dependency uses quantum-vulnerable cryptographic algorithm (dev-dependencies not distinguished)', severity: 'high' },
   { id: 'manifest/pip-pq-vulnerable-dep', cwe: 'CWE-327', desc: 'Dependency uses quantum-vulnerable cryptographic algorithm', severity: 'high' },
 ];
 


### PR DESCRIPTION
## Summary
- Persist `ListState` on `TuiApp` so ratatui preserves scroll offset across frames — fixes selection pinning to viewport edge
- Enable mouse capture for native scroll event handling
- Drain queued scroll events to prevent momentum coasting on high-res wheels (e.g. MX Master 3S)
- Click to select findings in the list
- Subtle hover highlight on mouseover

Closes #269

## Test plan
- [x] j/k scrolling: selection moves freely within viewport, no edge pinning
- [x] Mouse scroll: one item per event, momentum scroll stops immediately
- [x] Click: selects the correct finding
- [x] Hover: subtle background on hovered item
- [x] Trackpad: behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SARIF reports now include dependency name information in result properties
  * Expanded detection of additional post-quantum, cryptography, and JWT/OAuth libraries in manifest and requirements scans

* **Bug Fixes**
  * Terminal interface: full mouse support (click, scroll, hover), improved list selection/hover highlighting and scroll handling, and persistent findings list state
* **Other**
  * Manifest rule description clarified to note dev-dependencies are not distinguished
<!-- end of auto-generated comment: release notes by coderabbit.ai -->