### PR TITLE
fix: remove unwraps from rule execution paths

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -371,15 +371,14 @@ fn go_collect_import_spec(aliases: &mut AliasTable, node: Node<'_>, source: &str
     // Canonical: last segment of the import path, e.g. `net/http` -> `http`.
     let canonical = path.rsplit('/').next().unwrap_or(path).to_string();
 
-    let name_node = node.child_by_field_name("name");
-    match name_node.map(|n| n.kind()) {
+    match node.child_by_field_name("name") {
         // `import . "fmt"` -- out of scope; record nothing.
-        Some("dot") => {}
+        Some(name_node) if name_node.kind() == "dot" => {}
         // `import _ "foo"` -- out of scope; record nothing.
-        Some("blank_identifier") => {}
+        Some(name_node) if name_node.kind() == "blank_identifier" => {}
         // `import f "fmt"` -- local alias `f` -> canonical `fmt`.
-        Some("package_identifier") => {
-            let local = node_text(name_node.unwrap(), source).to_string();
+        Some(name_node) if name_node.kind() == "package_identifier" => {
+            let local = node_text(name_node, source).to_string();
             aliases.insert(local, canonical);
         }
         // Plain `import "fmt"` -- the local name is the canonical.

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -289,11 +289,13 @@ impl_rule! {
                     // Skip RegExp.prototype.exec() — only flag bare exec()
                     // or child_process.exec() receivers.
                     if func_name == "exec" && func_text.contains('.') {
-                        let receiver = &func_text[..func_text.rfind('.').unwrap()];
-                        if !receiver.contains("child_process")
-                            && !["cp", "proc", "subprocess"].contains(&receiver)
-                        {
-                            return;
+                        if let Some(dot_index) = func_text.rfind('.') {
+                            let receiver = &func_text[..dot_index];
+                            if !receiver.contains("child_process")
+                                && !["cp", "proc", "subprocess"].contains(&receiver)
+                            {
+                                return;
+                            }
                         }
                     }
 

--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -326,14 +326,13 @@ impl Rule for CargoLockPqCrypto {
             }
 
             // Pick the highest-confidence seed
-            let (_, best) = reached_seeds
-                .iter()
-                .max_by(|(k1, v1), (k2, v2)| {
-                    v1.confidence
-                        .total_cmp(&v2.confidence)
-                        .then_with(|| k1.cmp(k2))
-                })
-                .unwrap();
+            let Some((_, best)) = reached_seeds.iter().max_by(|(k1, v1), (k2, v2)| {
+                v1.confidence
+                    .total_cmp(&v2.confidence)
+                    .then_with(|| k1.cmp(k2))
+            }) else {
+                continue;
+            };
 
             // Find byte offset of this package entry.
             // Use name+version to disambiguate duplicate crate names (e.g. syn 1.x vs 2.x).


### PR DESCRIPTION
## Summary
- Remove an input-path `unwrap()` in JS command-injection receiver handling.
- Remove an input-path `unwrap()` in Go import alias collection.
- Replace Cargo PQ seed selection `unwrap()` with an explicit empty-case guard.

## Verification
- `cargo fmt --check`
- `cargo test --lib`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Refs #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes in JavaScript command injection detection rule.
  * Fixed potential crashes in manifest file analysis when evaluating dependency security.

* **Refactor**
  * Improved stability of Go import handling to eliminate crash risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->