### PR TITLE
fix: finish non-test unwrap audit

### DIFF
--- a/src/rules/config.rs
+++ b/src/rules/config.rs
@@ -28,37 +28,55 @@ fn strip_comments(source: &str) -> String {
 
 fn nginx_protocols_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)ssl_protocols\s+[^;]+;").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)ssl_protocols\s+[^;]+;")
+            .expect("static nginx protocols regex should compile")
+    })
 }
 
 fn nginx_ciphers_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)ssl_ciphers\s+[^;]+;").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)ssl_ciphers\s+[^;]+;").expect("static nginx ciphers regex should compile")
+    })
 }
 
 fn apache_protocol_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)SSLProtocol\s+.+").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)SSLProtocol\s+.+").expect("static Apache protocol regex should compile")
+    })
 }
 
 fn apache_cipher_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)SSLCipherSuite\s+.+").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)SSLCipherSuite\s+.+").expect("static Apache cipher regex should compile")
+    })
 }
 
 fn haproxy_options_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-options\s+.+").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)ssl-default-bind-options\s+.+")
+            .expect("static HAProxy options regex should compile")
+    })
 }
 
 fn haproxy_ciphers_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)ssl-default-bind-ciphers\s+.+")
+            .expect("static HAProxy ciphers regex should compile")
+    })
 }
 
 fn haproxy_ciphersuites_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    RE.get_or_init(|| Regex::new(r"(?i)ssl-default-bind-ciphersuites\s+.+").unwrap())
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)ssl-default-bind-ciphersuites\s+.+")
+            .expect("static HAProxy ciphersuites regex should compile")
+    })
 }
 
 fn dockerfile_insecure_env_re() -> &'static Regex {
@@ -66,7 +84,7 @@ fn dockerfile_insecure_env_re() -> &'static Regex {
     RE.get_or_init(|| {
         Regex::new(
             r#"(?im)^(?:ENV|ARG)\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|CURL_CA_BUNDLE\s*=\s*(?:''|""|$)|REQUESTS_CA_BUNDLE\s*=\s*(?:''|""|$)|SSL_CERT_FILE\s*=\s*/dev/null)"#
-        ).unwrap()
+        ).expect("static Dockerfile insecure env regex should compile")
     })
 }
 
@@ -75,7 +93,7 @@ fn dockerfile_run_insecure_re() -> &'static Regex {
     RE.get_or_init(|| {
         Regex::new(
             r#"(?im)^RUN\s+.*(?:NODE_TLS_REJECT_UNAUTHORIZED\s*=\s*0|PYTHONHTTPSVERIFY\s*=\s*0|GIT_SSL_NO_VERIFY\s*=\s*(?:true|1)|curl\s+.*--insecure|curl\s+.*-k[\s|&;]|wget\s+.*--no-check-certificate)"#
-        ).unwrap()
+        ).expect("static Dockerfile insecure RUN regex should compile")
     })
 }
 

--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -445,7 +445,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern = Regex::new(CSHARP_HARDCODED_SECRET_PATTERN).unwrap();
+        let secret_pattern = Regex::new(CSHARP_HARDCODED_SECRET_PATTERN)
+            .expect("static C# hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: string password = "hardcoded"
@@ -656,7 +657,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let cors_star = Regex::new(r#"WithOrigins\s*\(\s*"\*"\s*\)"#).unwrap();
+        let cors_star = Regex::new(r#"WithOrigins\s*\(\s*"\*"\s*\)"#)
+            .expect("static C# CORS regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "invocation_expression" {

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -27,7 +27,7 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let sql_pattern =
-            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").unwrap();
+            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").expect("static Go SQL regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: "SELECT ... WHERE id = " + userId (binary_expression with +)
@@ -150,7 +150,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Short variable declaration: password := "hardcoded"
@@ -591,7 +591,8 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let pattern = Regex::new(r"InsecureSkipVerify\s*:\s*true").unwrap();
+        let pattern = Regex::new(r"InsecureSkipVerify\s*:\s*true")
+            .expect("static Go TLS regex should compile");
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -753,7 +754,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let hardcoded_byte_re = Regex::new(r#"\[\]byte\(\s*"[^"]{4,}"\s*\)"#).unwrap();
+        let hardcoded_byte_re = Regex::new(r#"\[\]byte\(\s*"[^"]{4,}"\s*\)"#)
+            .expect("static Go JWT secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() != "call_expression" {

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -80,7 +80,8 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let sql_methods =
-            Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery)$").unwrap();
+            Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery)$")
+                .expect("static Java SQL method regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "method_invocation" {
@@ -415,7 +416,8 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let weak_algo =
-            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#).unwrap();
+            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
+                .expect("static Java weak crypto regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "method_invocation" {
@@ -606,7 +608,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: String password = "hardcoded";
@@ -687,9 +689,10 @@ impl_rule! {
         let factory_pattern = Regex::new(
             r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
         )
-        .unwrap();
+        .expect("static Java XXE factory regex should compile");
         let secure_pattern =
-            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(").unwrap();
+            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
+                .expect("static Java XXE hardening regex should compile");
 
         // Simple heuristic: if a factory is created but no setFeature is called
         // in the same file, flag it.
@@ -729,7 +732,7 @@ impl_rule! {
         let csrf_pattern = Regex::new(
             r"\.csrf\(\s*\)\s*\.\s*disable\(\s*\)|csrf\s*\([^)]*\.\s*disable\(\s*\)\s*\)",
         )
-        .unwrap();
+        .expect("static Java CSRF regex should compile");
 
         for matched in csrf_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -905,7 +908,8 @@ impl_rule! {
         let mut findings = Vec::new();
 
         // allowedOrigins("*")
-        let wildcard_pattern = Regex::new(r#"allowedOrigins\s*\(\s*"\*"\s*\)"#).unwrap();
+        let wildcard_pattern = Regex::new(r#"allowedOrigins\s*\(\s*"\*"\s*\)"#)
+            .expect("static Java CORS regex should compile");
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -60,7 +60,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: const password = "hardcoded"
@@ -153,7 +153,7 @@ impl_rule! {
         // This avoids matching plain English like res.send('delete ' + name)
         let sql_pattern = Regex::new(
             r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)"
-        ).unwrap();
+        ).expect("static JavaScript SQL pattern should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: query("SELECT * FROM users WHERE id = " + userId)
@@ -897,7 +897,8 @@ impl_rule! {
         let mut findings = Vec::new();
         // Patterns known to cause catastrophic backtracking: nested quantifiers
         let dangerous_pattern =
-            Regex::new(r"(\([^)]*[+*][^)]*\)[+*]|\([^)]*\|[^)]*\)[+*])").unwrap();
+            Regex::new(r"(\([^)]*[+*][^)]*\)[+*]|\([^)]*\|[^)]*\)[+*])")
+                .expect("static ReDoS regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect regex literals: /pattern/
@@ -1243,11 +1244,12 @@ impl_rule! {
 
         let mut findings = Vec::new();
         // Match user-controlled input objects
-        let user_input_re = Regex::new(r"^req\.(params|query|body|headers)(\b|\[|\.)").unwrap();
+        let user_input_re = Regex::new(r"^req\.(params|query|body|headers)(\b|\[|\.)")
+            .expect("static Express user-input regex should compile");
         // Sanitization wrappers that neutralise XSS risk
         let sanitize_re = Regex::new(
             r"(?i)(escapeHtml|escape|sanitize|encode|encodeURIComponent|encodeURI|htmlEncode|xss|purify|DOMPurify|validator|parseInt|parseFloat|Number|String)\s*\("
-        ).unwrap();
+        ).expect("static JavaScript sanitizer regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: res.send(req.query.foo), res.write(req.body.bar)

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -762,8 +762,7 @@ fn scan_module_exports<'tree, F>(
         }
 
         // `module.exports.foo = function(...)` or `module.exports.foo = someFunc`
-        if left_text.starts_with("module.exports.") {
-            let export_name = left_text.strip_prefix("module.exports.").unwrap();
+        if let Some(export_name) = left_text.strip_prefix("module.exports.") {
             if matches!(right.kind(), "arrow_function" | "function_expression") {
                 visit(export_name.to_string(), right);
             } else if right.kind() == "identifier" {

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -152,7 +152,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let sql_methods =
             Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery|rawQuery|execSQL)$")
-                .unwrap();
+                .expect("static Kotlin SQL method regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -466,7 +466,8 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let weak_algo =
-            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#).unwrap();
+            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
+                .expect("static Kotlin weak crypto regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -523,7 +524,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // property_declaration: val password = "hardcoded"
@@ -624,9 +625,10 @@ impl_rule! {
         let factory_pattern = Regex::new(
             r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
         )
-        .unwrap();
+        .expect("static Kotlin XXE factory regex should compile");
         let secure_pattern =
-            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(").unwrap();
+            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
+                .expect("static Kotlin XXE hardening regex should compile");
 
         if factory_pattern.is_match(source) && !secure_pattern.is_match(source) {
             for matched in factory_pattern.find_iter(source) {
@@ -663,7 +665,8 @@ impl_rule! {
 
         // allowedOrigins("*") / addAllowedOrigin("*")
         let wildcard_pattern =
-            Regex::new(r#"(allowedOrigins|addAllowedOrigin)\s*\(\s*"\*"\s*\)"#).unwrap();
+            Regex::new(r#"(allowedOrigins|addAllowedOrigin)\s*\(\s*"\*"\s*\)"#)
+                .expect("static Kotlin CORS regex should compile");
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),

--- a/src/rules/php.rs
+++ b/src/rules/php.rs
@@ -361,7 +361,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern = Regex::new(HARDCODED_SECRET_PATTERN).unwrap();
+        let secret_pattern = Regex::new(HARDCODED_SECRET_PATTERN)
+            .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: $password = "hardcoded";
@@ -498,7 +499,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let e_modifier = Regex::new(r#"['"][^'"]*/.*/[a-z]*e[a-z]*['"]"#).unwrap();
+        let e_modifier = Regex::new(r#"['"][^'"]*/.*/[a-z]*e[a-z]*['"]"#)
+            .expect("static PHP preg_replace regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "function_call_expression" {

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -79,7 +79,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment: password = "hardcoded"
@@ -136,7 +136,7 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let sql_pattern =
-            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").unwrap();
+            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").expect("static Python SQL regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect f-strings with SQL: f"SELECT * FROM users WHERE id = {user_id}"

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -487,7 +487,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment: variable = "hardcoded"

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -137,7 +137,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_methods = Regex::new(r"(?i)\b(query|sql_query|execute|raw_sql)\b").unwrap();
+        let sql_methods = Regex::new(r"(?i)\b(query|sql_query|execute|raw_sql)\b")
+            .expect("static Rust SQL method regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -186,7 +187,8 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let weak_hash = Regex::new(r"\b(md5|sha1|Md5|Sha1|MD5|SHA1)\b").unwrap();
+        let weak_hash = Regex::new(r"\b(md5|sha1|Md5|Sha1|MD5|SHA1)\b")
+            .expect("static Rust weak hash regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect use declarations: use md5::..., use sha1::...
@@ -338,7 +340,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // let password = "hardcoded";

--- a/src/rules/swift.rs
+++ b/src/rules/swift.rs
@@ -23,7 +23,7 @@ impl_rule! {
         let mut reported_lines = std::collections::HashSet::new();
         let secret_pattern =
             Regex::new(HARDCODED_SECRET_PATTERN)
-                .unwrap();
+                .expect("static hardcoded secret regex should compile");
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Match property declarations: let password = "hardcoded"
@@ -175,7 +175,8 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let pattern =
-            Regex::new(r"\b(CC_MD5|CC_SHA1|\.md5|\.sha1|Insecure\.MD5|Insecure\.SHA1)\b").unwrap();
+            Regex::new(r"\b(CC_MD5|CC_SHA1|\.md5|\.sha1|Insecure\.MD5|Insecure\.SHA1)\b")
+                .expect("static Swift weak crypto regex should compile");
 
         for matched in pattern.find_iter(source) {
             let algo = if matched.as_str().contains("MD5") || matched.as_str().contains("md5") {
@@ -294,11 +295,12 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let sql_keywords =
-            Regex::new(r"(?i)(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\s").unwrap();
+        let sql_keywords = Regex::new(r"(?i)(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\s")
+            .expect("static Swift SQL keyword regex should compile");
 
         // Detect SQL strings with interpolation: "SELECT ... \(variable) ..."
-        let interp_string = Regex::new(r#""[^"]*\\\([^)]+\)[^"]*""#).unwrap();
+        let interp_string = Regex::new(r#""[^"]*\\\([^)]+\)[^"]*""#)
+            .expect("static Swift interpolation regex should compile");
         for matched in interp_string.find_iter(source) {
             let text = matched.as_str();
             if sql_keywords.is_match(text) {
@@ -318,7 +320,7 @@ impl_rule! {
         let sql_concat = Regex::new(
             r#"(?i)(execute|prepare|sqlite3_exec)\s*\([^)]*(?:SELECT|INSERT|UPDATE|DELETE|DROP)[^)]*\+\s*"#,
         )
-        .unwrap();
+        .expect("static Swift SQL concat regex should compile");
         for matched in sql_concat.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),
@@ -352,7 +354,7 @@ impl_rule! {
         let mut findings = Vec::new();
         let pattern =
             Regex::new(r"\b(kSecAttrAccessibleAlways|kSecAttrAccessibleAlwaysThisDeviceOnly)\b")
-                .unwrap();
+                .expect("static Swift keychain regex should compile");
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -390,15 +392,17 @@ impl_rule! {
 
         let patterns = [
             (
-                Regex::new(r"allowsExpiredCertificates\s*=\s*true").unwrap(),
+                Regex::new(r"allowsExpiredCertificates\s*=\s*true")
+                    .expect("static Swift TLS regex should compile"),
                 "allowsExpiredCertificates = true disables certificate expiry validation",
             ),
             (
-                Regex::new(r"allowsExpiredRoots\s*=\s*true").unwrap(),
+                Regex::new(r"allowsExpiredRoots\s*=\s*true")
+                    .expect("static Swift TLS regex should compile"),
                 "allowsExpiredRoots = true disables root certificate expiry validation",
             ),
             (
-                Regex::new(r"\.disableEvaluation").unwrap(),
+                Regex::new(r"\.disableEvaluation").expect("static Swift TLS regex should compile"),
                 ".disableEvaluation disables TLS server trust evaluation entirely",
             ),
         ];

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -86,7 +86,8 @@ fn patterns() -> &'static [SecretPattern] {
                 severity: Severity::Critical,
                 cwe: Some("CWE-798"),
                 description: "Possible AWS access key ID detected",
-                regex: Regex::new(r"\bAKIA[0-9A-Z]{16}\b").unwrap(),
+                regex: Regex::new(r"\bAKIA[0-9A-Z]{16}\b")
+                    .expect("static AWS access key regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/aws-secret-access-key",
@@ -96,7 +97,7 @@ fn patterns() -> &'static [SecretPattern] {
                 regex: Regex::new(
                     r#"(?i)\baws_secret_access_key\b\s*[:=]\s*["']?[A-Za-z0-9/+=]{40}["']?"#,
                 )
-                .unwrap(),
+                .expect("static AWS secret key regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/github-token",
@@ -104,35 +105,39 @@ fn patterns() -> &'static [SecretPattern] {
                 cwe: Some("CWE-798"),
                 description: "Possible GitHub personal access token detected",
                 regex: Regex::new(r"\bghp_[A-Za-z0-9]{36}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b")
-                    .unwrap(),
+                    .expect("static GitHub token regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/gitlab-token",
                 severity: Severity::Critical,
                 cwe: Some("CWE-798"),
                 description: "Possible GitLab personal access token detected",
-                regex: Regex::new(r"\bglpat-[A-Za-z0-9\-_]{20,}\b").unwrap(),
+                regex: Regex::new(r"\bglpat-[A-Za-z0-9\-_]{20,}\b")
+                    .expect("static GitLab token regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/npm-token",
                 severity: Severity::High,
                 cwe: Some("CWE-798"),
                 description: "Possible npm access token detected",
-                regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").unwrap(),
+                regex: Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b")
+                    .expect("static npm token regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/slack-token",
                 severity: Severity::High,
                 cwe: Some("CWE-798"),
                 description: "Possible Slack token detected",
-                regex: Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b").unwrap(),
+                regex: Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")
+                    .expect("static Slack token regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/stripe-live-key",
                 severity: Severity::Critical,
                 cwe: Some("CWE-798"),
                 description: "Possible Stripe live secret key detected",
-                regex: Regex::new(r"\b(?:sk|rk)_live_[0-9A-Za-z]{16,}\b").unwrap(),
+                regex: Regex::new(r"\b(?:sk|rk)_live_[0-9A-Za-z]{16,}\b")
+                    .expect("static Stripe key regex should compile"),
             },
             SecretPattern {
                 rule_id: "secret/private-key",
@@ -140,7 +145,7 @@ fn patterns() -> &'static [SecretPattern] {
                 cwe: Some("CWE-798"),
                 description: "Private key material detected",
                 regex: Regex::new(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH )?PRIVATE KEY-----")
-                    .unwrap(),
+                    .expect("static private key regex should compile"),
             },
         ]
     })


### PR DESCRIPTION
## Summary
- Replace remaining production static-regex `unwrap()` calls with explicit invariant `expect(...)` messages.
- Remove a data-dependent `strip_prefix(...).unwrap()` in JavaScript taint module export summary extraction.
- Leave test-only unwraps in place; the production scan/reporting paths are now audited.

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

Closes #275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to error handling in regex compilation across multiple security rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->