### PR TITLE
refactor(taint): deduplicate shared engine mechanics

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -35,7 +35,10 @@
 //! `TaintSpec`.
 
 use super::common::AliasTable;
-use super::taint_engine::{node_text, sanitizer_fingerprints_eq, TaintState};
+use super::taint_engine::{
+    build_batched_taint_groups, cross_file_taint_finding, match_call_sink, node_text,
+    push_attributed_findings, taint_finding_for_node, TaintState,
+};
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
 };
@@ -185,75 +188,13 @@ pub fn analyze_tree_batched<'a>(
         return Vec::new();
     }
 
-    // Group rules that share the same sanitizer matchers. Sanitizers
-    // change taint-state semantics (they clear taint) so rules with
-    // different sanitizer profiles must NOT be merged into the same
-    // spec. Sinks and sources, by contrast, don't affect state during
-    // a walk — only findings — so we can safely union them within a
-    // group.
-    let mut groups: Vec<Vec<usize>> = Vec::new();
-    for (i, r) in rules.iter().enumerate() {
-        let mut placed = false;
-        for g in groups.iter_mut() {
-            // First rule in each group is representative.
-            let rep = rules[g[0]].spec;
-            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
-                g.push(i);
-                placed = true;
-                break;
-            }
-        }
-        if !placed {
-            groups.push(vec![i]);
-        }
-    }
-
     let mut out: Vec<(String, TaintFinding)> = Vec::new();
-    for group in &groups {
-        // Union all sources and sinks from every rule in the group.
-        // Using dedup-by-description keeps the matcher list tight
-        // without sacrificing correctness (duplicate descriptions would
-        // only cause duplicate findings).
-        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
-        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut seen_source_descs: HashSet<String> = HashSet::new();
-        let mut seen_sink_descs: HashSet<String> = HashSet::new();
-        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
-        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
-
-        for &idx in group {
-            let r = &rules[idx];
-            allowed_rule_ids.insert(r.rule_id.to_string());
-            for src in &r.spec.sources {
-                if seen_source_descs.insert(src.description().to_string()) {
-                    merged_sources.push(src.clone());
-                }
-            }
-            for sink in &r.spec.sinks {
-                // If two rules declare the same sink description, keep
-                // the first rule's attribution. In the default ruleset
-                // sink descriptions are unique per rule.
-                sink_to_rule
-                    .entry(sink.description().to_string())
-                    .or_insert_with(|| r.rule_id.to_string());
-                if seen_sink_descs.insert(sink.description().to_string()) {
-                    merged_sinks.push(sink.clone());
-                }
-            }
-        }
-
-        let sanitizers = rules[group[0]].spec.sanitizers.clone();
-        let merged_spec = TaintSpec {
-            sources: merged_sources,
-            sinks: merged_sinks,
-            sanitizers,
-        };
-
+    for group in build_batched_taint_groups(rules) {
         // Pass 1: compute summaries once for the entire group.
         let empty_summary = ReturnSummary::new();
         let pass1_ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &empty_summary,
             cross_file: None,
@@ -273,36 +214,22 @@ pub fn analyze_tree_batched<'a>(
         let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
             same_package_paths: cf.same_package_paths,
             summaries: cf.summaries,
-            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+            rule_filter: RuleFilter::Any(&group.allowed_rule_ids),
         });
         let ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&sink_to_rule),
+            sink_to_rule: Some(&group.sink_to_rule),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_defs(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        // Attribute each finding back to the rule id. Intra-file
-        // findings carry a `rule_id_hint` set by `handle_call`.
-        // Cross-file findings carry one set by `handle_cross_file_call`.
-        // For safety, fall back to the sink-description lookup when the
-        // hint is missing.
-        for mut f in group_findings {
-            let rule_id = f
-                .rule_id_hint
-                .clone()
-                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
-            if let Some(rid) = rule_id {
-                f.rule_id_hint = Some(rid.clone());
-                out.push((rid, f));
-            }
-        }
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
     }
 
     out
@@ -950,55 +877,22 @@ fn handle_call(
         Some(a) => a.resolve(callee_raw.as_ref()),
         None => Cow::Borrowed(callee_raw.as_ref()),
     };
-    // The final segment of the callee; used by `MethodName` sink
-    // matching. For `db.Query` this is `"Query"`; for a bare `exec`
-    // it's `"exec"`.
-    let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_ref());
 
-    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
-        NodeMatcher::Call {
-            canonical,
-            description,
-        } if canonical.as_str() == resolved.as_ref() => Some(description.clone()),
-        NodeMatcher::MethodName {
-            method,
-            description,
-        } if method == final_segment => Some(description.clone()),
-        _ => None,
-    });
-    // When the engine is running in batched mode, map the matched sink
-    // description back to the rule it came from so the caller can
-    // dispatch the finding correctly. `None` in single-rule mode.
-    let sink_desc = sink_desc.map(|d| {
-        let rule = ctx
-            .sink_to_rule
-            .and_then(|m| m.get(d.as_str()))
-            .map(|s| s.to_string());
-        (d, rule)
-    });
-
-    if let Some((sink_desc, sink_rule_id)) = sink_desc {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rule) {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-                let start = node.start_position();
-                let end = node.end_position();
-                findings.push(TaintFinding {
-                    sink_start_byte: node.start_byte(),
-                    sink_end_byte: node.end_byte(),
-                    sink_line: start.row + 1,
-                    sink_column: start.column + 1,
-                    sink_end_line: end.row + 1,
-                    sink_end_column: end.column + 1,
-                    source_description: source_desc,
-                    sink_description: sink_desc.clone(),
-                    source_line: src_line,
-                    rule_id_hint: sink_rule_id.clone(),
-                    hops: 1,
-                });
+                findings.push(taint_finding_for_node(
+                    node,
+                    source_desc,
+                    sink.description.clone(),
+                    src_line,
+                    sink.rule_id_hint.clone(),
+                    1,
+                ));
                 break;
             }
         }
@@ -1069,24 +963,14 @@ fn handle_cross_file_call(
         }
         let arg = arg_nodes[flow.param_index];
         if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-            let start = node.start_position();
-            let end = node.end_position();
-            findings.push(TaintFinding {
-                sink_start_byte: node.start_byte(),
-                sink_end_byte: node.end_byte(),
-                sink_line: start.row + 1,
-                sink_column: start.column + 1,
-                sink_end_line: end.row + 1,
-                sink_end_column: end.column + 1,
-                source_description: source_desc,
-                sink_description: format!(
-                    "{} (via cross-file call to {})",
-                    flow.sink_description, func_name
-                ),
-                source_line: src_line,
-                rule_id_hint: Some(flow.sink_rule_id.clone()),
-                hops: 2,
-            });
+            findings.push(cross_file_taint_finding(
+                node,
+                source_desc,
+                src_line,
+                &flow.sink_description,
+                func_name,
+                &flow.sink_rule_id,
+            ));
             // One finding per cross-file call is enough.
             return;
         }

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -36,8 +36,8 @@
 
 use super::common::AliasTable;
 use super::taint_engine::{
-    build_batched_taint_groups, cross_file_taint_finding, match_call_sink, node_text,
-    push_attributed_findings, taint_finding_for_node, TaintState,
+    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
+    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
@@ -86,7 +86,7 @@ struct AnalysisContext<'a> {
     /// When the batched analyzer merges sinks from multiple rules into a
     /// single `TaintSpec`, this map attributes each matched sink back to
     /// its owning rule id. `None` in single-rule mode.
-    sink_to_rule: Option<&'a HashMap<String, String>>,
+    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
 }
 
 /// Run the taint engine over every function/method body inside `root`
@@ -125,7 +125,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -141,7 +141,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
@@ -198,7 +198,7 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &empty_summary,
             cross_file: None,
-            sink_to_rule: None,
+            sink_to_rules: None,
         };
         let mut summaries = ReturnSummary::new();
         collect_function_defs(root, &mut |func_node| {
@@ -222,14 +222,14 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&group.sink_to_rule),
+            sink_to_rules: Some(&group.sink_to_rules),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_defs(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rules);
     }
 
     out
@@ -438,7 +438,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
-                sink_to_rule: None,
+                sink_to_rules: None,
             };
             let (_, ret_taint) = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -456,7 +456,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -482,7 +482,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -878,19 +878,20 @@ fn handle_call(
         None => Cow::Borrowed(callee_raw.as_ref()),
     };
 
-    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rule) {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rules) {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
+                let rule_hint = attribution_hint_for_sink(&sink);
                 findings.push(taint_finding_for_node(
                     node,
                     source_desc,
-                    sink.description.clone(),
+                    sink.description,
                     src_line,
-                    sink.rule_id_hint.clone(),
+                    rule_hint,
                     1,
                 ));
                 break;

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -26,9 +26,9 @@
 
 use super::common::AliasTable;
 use super::taint_engine::{
-    build_batched_taint_groups, cross_file_taint_finding, match_call_sink,
-    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node,
-    TaintState,
+    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
+    match_call_sink, match_member_assign_sink, node_text, push_attributed_findings,
+    taint_finding_for_node, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
@@ -75,7 +75,7 @@ struct AnalysisContext<'a> {
     /// When the batched analyzer merges sinks from multiple rules into a
     /// single `TaintSpec`, this map attributes each matched sink back to
     /// its owning rule id. `None` in single-rule mode.
-    sink_to_rule: Option<&'a HashMap<String, String>>,
+    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
 }
 
 /// Run the taint engine over every function/method body inside `root` and
@@ -116,7 +116,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     collect_summary_targets(root, source, &mut |name, func_node| {
         let ret = summarize_function(func_node, &pass1_ctx);
@@ -129,7 +129,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     let mut findings = Vec::new();
     collect_function_scopes(root, &mut |func_node| {
@@ -178,7 +178,7 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &empty_summary,
             cross_file: None,
-            sink_to_rule: None,
+            sink_to_rules: None,
         };
         let mut summaries = ReturnSummary::new();
         collect_summary_targets(root, source, &mut |name, func_node| {
@@ -198,14 +198,14 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&group.sink_to_rule),
+            sink_to_rules: Some(&group.sink_to_rules),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_scopes(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rules);
     }
 
     out
@@ -421,7 +421,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
-                sink_to_rule: None,
+                sink_to_rules: None,
             };
             let ret_taint = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -439,7 +439,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -465,7 +465,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -1368,14 +1368,15 @@ fn handle_assignment(
     if left.kind() == "member_expression" {
         if let Some(prop) = left.child_by_field_name("property") {
             let prop_name = node_text(prop, ctx.source);
-            if let Some(sink) = match_member_assign_sink(ctx.spec, prop_name, ctx.sink_to_rule) {
+            if let Some(sink) = match_member_assign_sink(ctx.spec, prop_name, ctx.sink_to_rules) {
                 if let Some((src_desc, src_line)) = expression_taint(right, ctx, state) {
+                    let rule_hint = attribution_hint_for_sink(&sink);
                     findings.push(taint_finding_for_node(
                         node,
                         src_desc,
                         sink.description,
                         src_line,
-                        sink.rule_id_hint,
+                        rule_hint,
                         1,
                     ));
                 }
@@ -1425,19 +1426,20 @@ fn handle_call(
         None => Cow::Borrowed(callee_text),
     };
 
-    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rule) {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rules) {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
+                let rule_hint = attribution_hint_for_sink(&sink);
                 findings.push(taint_finding_for_node(
                     node,
                     source_desc,
-                    sink.description.clone(),
+                    sink.description,
                     src_line,
-                    sink.rule_id_hint.clone(),
+                    rule_hint,
                     1,
                 ));
                 break;

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -25,7 +25,11 @@
 //! Everything specific to a library is expressed declaratively via `TaintSpec`.
 
 use super::common::AliasTable;
-use super::taint_engine::{node_text, sanitizer_fingerprints_eq, TaintState};
+use super::taint_engine::{
+    build_batched_taint_groups, cross_file_taint_finding, match_call_sink,
+    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node,
+    TaintState,
+};
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
 };
@@ -164,62 +168,13 @@ pub fn analyze_tree_batched<'a>(
         return Vec::new();
     }
 
-    // Group rules that share the same sanitizer matchers.
-    let mut groups: Vec<Vec<usize>> = Vec::new();
-    for (i, r) in rules.iter().enumerate() {
-        let mut placed = false;
-        for g in groups.iter_mut() {
-            let rep = rules[g[0]].spec;
-            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
-                g.push(i);
-                placed = true;
-                break;
-            }
-        }
-        if !placed {
-            groups.push(vec![i]);
-        }
-    }
-
     let mut out: Vec<(String, TaintFinding)> = Vec::new();
-    for group in &groups {
-        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
-        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut seen_source_descs: HashSet<String> = HashSet::new();
-        let mut seen_sink_descs: HashSet<String> = HashSet::new();
-        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
-        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
-
-        for &idx in group {
-            let r = &rules[idx];
-            allowed_rule_ids.insert(r.rule_id.to_string());
-            for src in &r.spec.sources {
-                if seen_source_descs.insert(src.description().to_string()) {
-                    merged_sources.push(src.clone());
-                }
-            }
-            for sink in &r.spec.sinks {
-                sink_to_rule
-                    .entry(sink.description().to_string())
-                    .or_insert_with(|| r.rule_id.to_string());
-                if seen_sink_descs.insert(sink.description().to_string()) {
-                    merged_sinks.push(sink.clone());
-                }
-            }
-        }
-
-        let sanitizers = rules[group[0]].spec.sanitizers.clone();
-        let merged_spec = TaintSpec {
-            sources: merged_sources,
-            sinks: merged_sinks,
-            sanitizers,
-        };
-
+    for group in build_batched_taint_groups(rules) {
         // Pass 1: compute summaries once for the entire group.
         let empty_summary = ReturnSummary::new();
         let pass1_ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &empty_summary,
             cross_file: None,
@@ -235,32 +190,22 @@ pub fn analyze_tree_batched<'a>(
         let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
             import_to_path: cf.import_to_path,
             summaries: cf.summaries,
-            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+            rule_filter: RuleFilter::Any(&group.allowed_rule_ids),
         });
         let ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&sink_to_rule),
+            sink_to_rule: Some(&group.sink_to_rule),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_scopes(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        // Attribute each finding back to the rule id.
-        for mut f in group_findings {
-            let rule_id = f
-                .rule_id_hint
-                .clone()
-                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
-            if let Some(rid) = rule_id {
-                f.rule_id_hint = Some(rid.clone());
-                out.push((rid, f));
-            }
-        }
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
     }
 
     out
@@ -1423,32 +1368,16 @@ fn handle_assignment(
     if left.kind() == "member_expression" {
         if let Some(prop) = left.child_by_field_name("property") {
             let prop_name = node_text(prop, ctx.source);
-            if let Some(sink_desc) = ctx.spec.sinks.iter().find_map(|m| match m {
-                NodeMatcher::MemberAssign { field, description } if field == prop_name => {
-                    Some(description.clone())
-                }
-                _ => None,
-            }) {
+            if let Some(sink) = match_member_assign_sink(ctx.spec, prop_name, ctx.sink_to_rule) {
                 if let Some((src_desc, src_line)) = expression_taint(right, ctx, state) {
-                    let start = node.start_position();
-                    let end = node.end_position();
-                    let rule_id_hint = ctx
-                        .sink_to_rule
-                        .and_then(|m| m.get(sink_desc.as_str()))
-                        .map(|s| s.to_string());
-                    findings.push(TaintFinding {
-                        sink_start_byte: node.start_byte(),
-                        sink_end_byte: node.end_byte(),
-                        sink_line: start.row + 1,
-                        sink_column: start.column + 1,
-                        sink_end_line: end.row + 1,
-                        sink_end_column: end.column + 1,
-                        source_description: src_desc,
-                        sink_description: sink_desc,
-                        source_line: src_line,
-                        rule_id_hint,
-                        hops: 1,
-                    });
+                    findings.push(taint_finding_for_node(
+                        node,
+                        src_desc,
+                        sink.description,
+                        src_line,
+                        sink.rule_id_hint,
+                        1,
+                    ));
                 }
             }
         }
@@ -1495,52 +1424,22 @@ fn handle_call(
         Some(a) => a.resolve(callee_text),
         None => Cow::Borrowed(callee_text),
     };
-    let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_ref());
 
-    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
-        NodeMatcher::Call {
-            canonical,
-            description,
-        } if canonical.as_str() == resolved.as_ref() => Some(description.clone()),
-        NodeMatcher::MethodName {
-            method,
-            description,
-        } if method == final_segment => Some(description.clone()),
-        _ => None,
-    });
-    // When the engine is running in batched mode, map the matched sink
-    // description back to the rule it came from so the caller can
-    // dispatch the finding correctly. `None` in single-rule mode.
-    let sink_desc = sink_desc.map(|d| {
-        let rule = ctx
-            .sink_to_rule
-            .and_then(|m| m.get(d.as_str()))
-            .map(|s| s.to_string());
-        (d, rule)
-    });
-
-    if let Some((sink_desc, sink_rule_id)) = sink_desc {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_ref(), ctx.sink_to_rule) {
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
         };
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-                let start = node.start_position();
-                let end = node.end_position();
-                findings.push(TaintFinding {
-                    sink_start_byte: node.start_byte(),
-                    sink_end_byte: node.end_byte(),
-                    sink_line: start.row + 1,
-                    sink_column: start.column + 1,
-                    sink_end_line: end.row + 1,
-                    sink_end_column: end.column + 1,
-                    source_description: source_desc,
-                    sink_description: sink_desc.clone(),
-                    source_line: src_line,
-                    rule_id_hint: sink_rule_id.clone(),
-                    hops: 1,
-                });
+                findings.push(taint_finding_for_node(
+                    node,
+                    source_desc,
+                    sink.description.clone(),
+                    src_line,
+                    sink.rule_id_hint.clone(),
+                    1,
+                ));
                 break;
             }
         }
@@ -1600,24 +1499,14 @@ fn handle_cross_file_call(
         }
         let arg = arg_nodes[flow.param_index];
         if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-            let start = node.start_position();
-            let end = node.end_position();
-            findings.push(TaintFinding {
-                sink_start_byte: node.start_byte(),
-                sink_end_byte: node.end_byte(),
-                sink_line: start.row + 1,
-                sink_column: start.column + 1,
-                sink_end_line: end.row + 1,
-                sink_end_column: end.column + 1,
-                source_description: source_desc,
-                sink_description: format!(
-                    "{} (via cross-file call to {})",
-                    flow.sink_description, func_name
-                ),
-                source_line: src_line,
-                rule_id_hint: Some(flow.sink_rule_id.clone()),
-                hops: 2,
-            });
+            findings.push(cross_file_taint_finding(
+                node,
+                source_desc,
+                src_line,
+                &flow.sink_description,
+                &func_name,
+                &flow.sink_rule_id,
+            ));
             return;
         }
     }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -33,8 +33,8 @@
 use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use crate::rules::taint_engine::{
-    build_batched_taint_groups, cross_file_taint_finding, match_call_sink, node_text,
-    push_attributed_findings, taint_finding_for_node, TaintState,
+    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
+    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
@@ -79,7 +79,7 @@ struct AnalysisContext<'a> {
     /// When the batched analyzer merges sinks from multiple rules into a
     /// single `TaintSpec`, this map attributes each matched sink back to
     /// its owning rule id. `None` in single-rule mode.
-    sink_to_rule: Option<&'a HashMap<String, String>>,
+    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
 }
 
 /// Run the taint engine over every function definition inside `root` and
@@ -138,7 +138,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &empty_summary,
         cross_file: None,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     collect_function_defs(root, &mut |func_node| {
         let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
@@ -155,7 +155,7 @@ pub fn analyze_tree_with_cross_file<'a>(
         aliases,
         summaries: &summaries,
         cross_file,
-        sink_to_rule: None,
+        sink_to_rules: None,
     };
     let mut findings = Vec::new();
     collect_function_defs(root, &mut |func_node| {
@@ -209,7 +209,7 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &empty_summary,
             cross_file: None,
-            sink_to_rule: None,
+            sink_to_rules: None,
         };
         let mut summaries = ReturnSummary::new();
         collect_function_defs(root, &mut |func_node| {
@@ -233,14 +233,14 @@ pub fn analyze_tree_batched<'a>(
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&group.sink_to_rule),
+            sink_to_rules: Some(&group.sink_to_rules),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_defs(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rules);
     }
 
     out
@@ -339,7 +339,7 @@ pub fn extract_cross_file_summaries(
                 aliases,
                 summaries: &empty_summary,
                 cross_file: None,
-                sink_to_rule: None,
+                sink_to_rules: None,
             };
             let (_, ret_taint) = summarize_function(func_node, &return_ctx);
             if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
@@ -357,7 +357,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &batched_ctx, &mut findings);
@@ -383,7 +383,7 @@ pub fn extract_cross_file_summaries(
                     aliases,
                     summaries: &empty_summary,
                     cross_file: None,
-                    sink_to_rule: None,
+                    sink_to_rules: None,
                 };
                 let mut findings = Vec::new();
                 analyze_function(func_node, &sink_ctx, &mut findings);
@@ -826,7 +826,7 @@ fn handle_call(
         None => callee_text.to_string(),
     };
 
-    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_str(), ctx.sink_to_rule) {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_str(), ctx.sink_to_rules) {
         // Check each argument for taint.
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
@@ -834,12 +834,13 @@ fn handle_call(
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
+                let rule_hint = attribution_hint_for_sink(&sink);
                 findings.push(taint_finding_for_node(
                     node,
                     source_desc,
-                    sink.description.clone(),
+                    sink.description,
                     src_line,
-                    sink.rule_id_hint.clone(),
+                    rule_hint,
                     1,
                 ));
                 // One finding per sink call is enough — don't double-report

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -32,7 +32,10 @@
 
 use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
-use crate::rules::taint_engine::{node_text, sanitizer_fingerprints_eq, TaintState};
+use crate::rules::taint_engine::{
+    build_batched_taint_groups, cross_file_taint_finding, match_call_sink, node_text,
+    push_attributed_findings, taint_finding_for_node, TaintState,
+};
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
 };
@@ -196,75 +199,13 @@ pub fn analyze_tree_batched<'a>(
         return Vec::new();
     }
 
-    // Group rules that share the same sanitizer matchers. Sanitizers
-    // change taint-state semantics (they clear taint) so rules with
-    // different sanitizer profiles must NOT be merged into the same
-    // spec. Sinks and sources, by contrast, don't affect state during
-    // a walk — only findings — so we can safely union them within a
-    // group.
-    let mut groups: Vec<Vec<usize>> = Vec::new();
-    for (i, r) in rules.iter().enumerate() {
-        let mut placed = false;
-        for g in groups.iter_mut() {
-            // First rule in each group is representative.
-            let rep = rules[g[0]].spec;
-            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
-                g.push(i);
-                placed = true;
-                break;
-            }
-        }
-        if !placed {
-            groups.push(vec![i]);
-        }
-    }
-
     let mut out: Vec<(String, TaintFinding)> = Vec::new();
-    for group in &groups {
-        // Union all sources and sinks from every rule in the group.
-        // Using dedup-by-description keeps the matcher list tight
-        // without sacrificing correctness (duplicate descriptions would
-        // only cause duplicate findings).
-        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
-        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut seen_source_descs: HashSet<String> = HashSet::new();
-        let mut seen_sink_descs: HashSet<String> = HashSet::new();
-        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
-        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
-
-        for &idx in group {
-            let r = &rules[idx];
-            allowed_rule_ids.insert(r.rule_id.to_string());
-            for src in &r.spec.sources {
-                if seen_source_descs.insert(src.description().to_string()) {
-                    merged_sources.push(src.clone());
-                }
-            }
-            for sink in &r.spec.sinks {
-                // If two rules declare the same sink description, keep
-                // the first rule's attribution. In the default ruleset
-                // sink descriptions are unique per rule.
-                sink_to_rule
-                    .entry(sink.description().to_string())
-                    .or_insert_with(|| r.rule_id.to_string());
-                if seen_sink_descs.insert(sink.description().to_string()) {
-                    merged_sinks.push(sink.clone());
-                }
-            }
-        }
-
-        let sanitizers = rules[group[0]].spec.sanitizers.clone();
-        let merged_spec = TaintSpec {
-            sources: merged_sources,
-            sinks: merged_sinks,
-            sanitizers,
-        };
-
+    for group in build_batched_taint_groups(rules) {
         // Pass 1: compute summaries once for the entire group.
         let empty_summary = ReturnSummary::new();
         let pass1_ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &empty_summary,
             cross_file: None,
@@ -284,36 +225,22 @@ pub fn analyze_tree_batched<'a>(
         let cross_file_for_group = cross_file.map(|cf| CrossFileInfo {
             import_to_path: cf.import_to_path,
             summaries: cf.summaries,
-            rule_filter: RuleFilter::Any(&allowed_rule_ids),
+            rule_filter: RuleFilter::Any(&group.allowed_rule_ids),
         });
         let ctx = AnalysisContext {
             source,
-            spec: &merged_spec,
+            spec: &group.spec,
             aliases,
             summaries: &summaries,
             cross_file: cross_file_for_group.as_ref(),
-            sink_to_rule: Some(&sink_to_rule),
+            sink_to_rule: Some(&group.sink_to_rule),
         };
         let mut group_findings: Vec<TaintFinding> = Vec::new();
         collect_function_defs(root, &mut |func_node| {
             analyze_function(func_node, &ctx, &mut group_findings);
         });
 
-        // Attribute each finding back to the rule id. Intra-file
-        // findings carry a `rule_id_hint` set by `handle_call`.
-        // Cross-file findings carry one set by `handle_cross_file_call`.
-        // For safety, fall back to the sink-description lookup when the
-        // hint is missing.
-        for mut f in group_findings {
-            let rule_id = f
-                .rule_id_hint
-                .clone()
-                .or_else(|| sink_to_rule.get(f.sink_description.as_str()).cloned());
-            if let Some(rid) = rule_id {
-                f.rule_id_hint = Some(rid.clone());
-                out.push((rid, f));
-            }
-        }
+        push_attributed_findings(&mut out, group_findings, &group.sink_to_rule);
     }
 
     out
@@ -899,35 +826,7 @@ fn handle_call(
         None => callee_text.to_string(),
     };
 
-    // The final attribute segment of the callee, used by `MethodName`
-    // sink matching. For `cursor.execute` this is `"execute"`; for a bare
-    // `eval` it's `"eval"`.
-    let final_segment = resolved.rsplit('.').next().unwrap_or(resolved.as_str());
-
-    // Is this a sink?
-    let sink_desc = ctx.spec.sinks.iter().find_map(|m| match m {
-        NodeMatcher::Call {
-            canonical,
-            description,
-        } if *canonical == resolved => Some(description.clone()),
-        NodeMatcher::MethodName {
-            method,
-            description,
-        } if method == final_segment => Some(description.clone()),
-        _ => None,
-    });
-    // When the engine is running in batched mode, map the matched sink
-    // description back to the rule it came from so the caller can
-    // dispatch the finding correctly. `None` in single-rule mode.
-    let sink_desc = sink_desc.map(|d| {
-        let rule = ctx
-            .sink_to_rule
-            .and_then(|m| m.get(d.as_str()))
-            .map(|s| s.to_string());
-        (d, rule)
-    });
-
-    if let Some((sink_desc, sink_rule_id)) = sink_desc {
+    if let Some(sink) = match_call_sink(ctx.spec, resolved.as_str(), ctx.sink_to_rule) {
         // Check each argument for taint.
         let Some(args) = node.child_by_field_name("arguments") else {
             return;
@@ -935,21 +834,14 @@ fn handle_call(
         let mut cursor = args.walk();
         for arg in args.named_children(&mut cursor) {
             if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-                let start = node.start_position();
-                let end = node.end_position();
-                findings.push(TaintFinding {
-                    sink_start_byte: node.start_byte(),
-                    sink_end_byte: node.end_byte(),
-                    sink_line: start.row + 1,
-                    sink_column: start.column + 1,
-                    sink_end_line: end.row + 1,
-                    sink_end_column: end.column + 1,
-                    source_description: source_desc,
-                    sink_description: sink_desc.clone(),
-                    source_line: src_line,
-                    rule_id_hint: sink_rule_id.clone(),
-                    hops: 1,
-                });
+                findings.push(taint_finding_for_node(
+                    node,
+                    source_desc,
+                    sink.description.clone(),
+                    src_line,
+                    sink.rule_id_hint.clone(),
+                    1,
+                ));
                 // One finding per sink call is enough — don't double-report
                 // when multiple args are tainted.
                 break;
@@ -1015,24 +907,14 @@ fn handle_cross_file_call(
         }
         let arg = arg_nodes[flow.param_index];
         if let Some((source_desc, src_line)) = expression_taint(arg, ctx, state) {
-            let start = node.start_position();
-            let end = node.end_position();
-            findings.push(TaintFinding {
-                sink_start_byte: node.start_byte(),
-                sink_end_byte: node.end_byte(),
-                sink_line: start.row + 1,
-                sink_column: start.column + 1,
-                sink_end_line: end.row + 1,
-                sink_end_column: end.column + 1,
-                source_description: source_desc,
-                sink_description: format!(
-                    "{} (via cross-file call to {})",
-                    flow.sink_description, func_name
-                ),
-                source_line: src_line,
-                rule_id_hint: Some(flow.sink_rule_id.clone()),
-                hops: 2,
-            });
+            findings.push(cross_file_taint_finding(
+                node,
+                source_desc,
+                src_line,
+                &flow.sink_description,
+                &func_name,
+                &flow.sink_rule_id,
+            ));
             // One finding per cross-file call is enough.
             return;
         }

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -118,6 +118,19 @@ pub struct BatchedRule<'a> {
     pub spec: &'a TaintSpec,
 }
 
+/// A merged sanitizer-compatible batch of taint rules.
+pub(super) struct BatchedTaintGroup {
+    pub spec: TaintSpec,
+    pub sink_to_rule: HashMap<String, String>,
+    pub allowed_rule_ids: HashSet<String>,
+}
+
+/// Sink matcher result with the optional owning rule id used in batched mode.
+pub(super) struct MatchedSink {
+    pub description: String,
+    pub rule_id_hint: Option<String>,
+}
+
 // ─── Internal types (pub(super) for language engines) ────────────────────
 
 #[derive(Clone, Debug)]
@@ -149,6 +162,173 @@ impl TaintState {
 
 pub(super) fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
     &source[node.byte_range()]
+}
+
+pub(super) fn build_batched_taint_groups(rules: &[BatchedRule<'_>]) -> Vec<BatchedTaintGroup> {
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    for (i, r) in rules.iter().enumerate() {
+        let mut placed = false;
+        for g in groups.iter_mut() {
+            let rep = rules[g[0]].spec;
+            if sanitizer_fingerprints_eq(&rep.sanitizers, &r.spec.sanitizers) {
+                g.push(i);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            groups.push(vec![i]);
+        }
+    }
+
+    let mut out = Vec::new();
+    for group in groups {
+        let mut merged_sources: Vec<NodeMatcher> = Vec::new();
+        let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
+        let mut seen_source_descs: HashSet<String> = HashSet::new();
+        let mut seen_sink_descs: HashSet<String> = HashSet::new();
+        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
+        let mut allowed_rule_ids: HashSet<String> = HashSet::new();
+
+        for idx in &group {
+            let rule = &rules[*idx];
+            allowed_rule_ids.insert(rule.rule_id.to_string());
+            for src in &rule.spec.sources {
+                if seen_source_descs.insert(src.description().to_string()) {
+                    merged_sources.push(src.clone());
+                }
+            }
+            for sink in &rule.spec.sinks {
+                sink_to_rule
+                    .entry(sink.description().to_string())
+                    .or_insert_with(|| rule.rule_id.to_string());
+                if seen_sink_descs.insert(sink.description().to_string()) {
+                    merged_sinks.push(sink.clone());
+                }
+            }
+        }
+
+        out.push(BatchedTaintGroup {
+            spec: TaintSpec {
+                sources: merged_sources,
+                sinks: merged_sinks,
+                sanitizers: rules[group[0]].spec.sanitizers.clone(),
+            },
+            sink_to_rule,
+            allowed_rule_ids,
+        });
+    }
+    out
+}
+
+pub(super) fn match_call_sink(
+    spec: &TaintSpec,
+    resolved_callee: &str,
+    sink_to_rule: Option<&HashMap<String, String>>,
+) -> Option<MatchedSink> {
+    let final_segment = resolved_callee
+        .rsplit('.')
+        .next()
+        .unwrap_or(resolved_callee);
+    let description = spec.sinks.iter().find_map(|matcher| match matcher {
+        NodeMatcher::Call {
+            canonical,
+            description,
+        } if canonical.as_str() == resolved_callee => Some(description.clone()),
+        NodeMatcher::MethodName {
+            method,
+            description,
+        } if method == final_segment => Some(description.clone()),
+        _ => None,
+    })?;
+    Some(MatchedSink {
+        rule_id_hint: rule_hint_for_sink_description(&description, sink_to_rule),
+        description,
+    })
+}
+
+pub(super) fn match_member_assign_sink(
+    spec: &TaintSpec,
+    field_name: &str,
+    sink_to_rule: Option<&HashMap<String, String>>,
+) -> Option<MatchedSink> {
+    let description = spec.sinks.iter().find_map(|matcher| match matcher {
+        NodeMatcher::MemberAssign { field, description } if field == field_name => {
+            Some(description.clone())
+        }
+        _ => None,
+    })?;
+    Some(MatchedSink {
+        rule_id_hint: rule_hint_for_sink_description(&description, sink_to_rule),
+        description,
+    })
+}
+
+pub(super) fn taint_finding_for_node(
+    node: Node<'_>,
+    source_description: String,
+    sink_description: String,
+    source_line: usize,
+    rule_id_hint: Option<String>,
+    hops: u8,
+) -> TaintFinding {
+    let start = node.start_position();
+    let end = node.end_position();
+    TaintFinding {
+        sink_start_byte: node.start_byte(),
+        sink_end_byte: node.end_byte(),
+        sink_line: start.row + 1,
+        sink_column: start.column + 1,
+        sink_end_line: end.row + 1,
+        sink_end_column: end.column + 1,
+        source_description,
+        sink_description,
+        source_line,
+        rule_id_hint,
+        hops,
+    }
+}
+
+pub(super) fn cross_file_taint_finding(
+    node: Node<'_>,
+    source_description: String,
+    source_line: usize,
+    sink_description: &str,
+    callee_name: &str,
+    sink_rule_id: &str,
+) -> TaintFinding {
+    taint_finding_for_node(
+        node,
+        source_description,
+        format!("{sink_description} (via cross-file call to {callee_name})"),
+        source_line,
+        Some(sink_rule_id.to_string()),
+        2,
+    )
+}
+
+pub(super) fn push_attributed_findings(
+    out: &mut Vec<(String, TaintFinding)>,
+    findings: Vec<TaintFinding>,
+    sink_to_rule: &HashMap<String, String>,
+) {
+    for mut finding in findings {
+        let rule_id = finding
+            .rule_id_hint
+            .clone()
+            .or_else(|| sink_to_rule.get(finding.sink_description.as_str()).cloned());
+        if let Some(rule_id) = rule_id {
+            finding.rule_id_hint = Some(rule_id.clone());
+            out.push((rule_id, finding));
+        }
+    }
+}
+
+fn rule_hint_for_sink_description(
+    sink_description: &str,
+    sink_to_rule: Option<&HashMap<String, String>>,
+) -> Option<String> {
+    sink_to_rule.and_then(|map| map.get(sink_description).cloned())
 }
 
 pub(super) fn sanitizer_fingerprints_eq(a: &[NodeMatcher], b: &[NodeMatcher]) -> bool {

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -121,14 +121,15 @@ pub struct BatchedRule<'a> {
 /// A merged sanitizer-compatible batch of taint rules.
 pub(super) struct BatchedTaintGroup {
     pub spec: TaintSpec,
-    pub sink_to_rule: HashMap<String, String>,
+    pub sink_to_rules: HashMap<String, Vec<String>>,
     pub allowed_rule_ids: HashSet<String>,
 }
 
 /// Sink matcher result with the optional owning rule id used in batched mode.
 pub(super) struct MatchedSink {
     pub description: String,
-    pub rule_id_hint: Option<String>,
+    pub attribution_key: Option<String>,
+    pub rule_ids: Vec<String>,
 }
 
 // ─── Internal types (pub(super) for language engines) ────────────────────
@@ -185,24 +186,27 @@ pub(super) fn build_batched_taint_groups(rules: &[BatchedRule<'_>]) -> Vec<Batch
     for group in groups {
         let mut merged_sources: Vec<NodeMatcher> = Vec::new();
         let mut merged_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut seen_source_descs: HashSet<String> = HashSet::new();
-        let mut seen_sink_descs: HashSet<String> = HashSet::new();
-        let mut sink_to_rule: HashMap<String, String> = HashMap::new();
+        let mut seen_source_keys: HashSet<String> = HashSet::new();
+        let mut seen_sink_keys: HashSet<String> = HashSet::new();
+        let mut sink_to_rules: HashMap<String, Vec<String>> = HashMap::new();
         let mut allowed_rule_ids: HashSet<String> = HashSet::new();
 
         for idx in &group {
             let rule = &rules[*idx];
             allowed_rule_ids.insert(rule.rule_id.to_string());
             for src in &rule.spec.sources {
-                if seen_source_descs.insert(src.description().to_string()) {
+                let source_key = matcher_fingerprint(src);
+                if seen_source_keys.insert(source_key) {
                     merged_sources.push(src.clone());
                 }
             }
             for sink in &rule.spec.sinks {
-                sink_to_rule
-                    .entry(sink.description().to_string())
-                    .or_insert_with(|| rule.rule_id.to_string());
-                if seen_sink_descs.insert(sink.description().to_string()) {
+                let sink_key = matcher_fingerprint(sink);
+                let rule_ids = sink_to_rules.entry(sink_key.clone()).or_default();
+                if !rule_ids.iter().any(|id| id == rule.rule_id) {
+                    rule_ids.push(rule.rule_id.to_string());
+                }
+                if seen_sink_keys.insert(sink_key) {
                     merged_sinks.push(sink.clone());
                 }
             }
@@ -214,7 +218,7 @@ pub(super) fn build_batched_taint_groups(rules: &[BatchedRule<'_>]) -> Vec<Batch
                 sinks: merged_sinks,
                 sanitizers: rules[group[0]].spec.sanitizers.clone(),
             },
-            sink_to_rule,
+            sink_to_rules,
             allowed_rule_ids,
         });
     }
@@ -224,44 +228,82 @@ pub(super) fn build_batched_taint_groups(rules: &[BatchedRule<'_>]) -> Vec<Batch
 pub(super) fn match_call_sink(
     spec: &TaintSpec,
     resolved_callee: &str,
-    sink_to_rule: Option<&HashMap<String, String>>,
+    sink_to_rules: Option<&HashMap<String, Vec<String>>>,
 ) -> Option<MatchedSink> {
     let final_segment = resolved_callee
         .rsplit('.')
         .next()
         .unwrap_or(resolved_callee);
-    let description = spec.sinks.iter().find_map(|matcher| match matcher {
-        NodeMatcher::Call {
-            canonical,
-            description,
-        } if canonical.as_str() == resolved_callee => Some(description.clone()),
-        NodeMatcher::MethodName {
-            method,
-            description,
-        } if method == final_segment => Some(description.clone()),
+    spec.sinks.iter().find_map(|matcher| match matcher {
+        NodeMatcher::Call { canonical, .. } if canonical.as_str() == resolved_callee => {
+            Some(matched_sink_for_matcher(matcher, sink_to_rules))
+        }
+        NodeMatcher::MethodName { method, .. } if method == final_segment => {
+            Some(matched_sink_for_matcher(matcher, sink_to_rules))
+        }
         _ => None,
-    })?;
-    Some(MatchedSink {
-        rule_id_hint: rule_hint_for_sink_description(&description, sink_to_rule),
-        description,
     })
 }
 
 pub(super) fn match_member_assign_sink(
     spec: &TaintSpec,
     field_name: &str,
-    sink_to_rule: Option<&HashMap<String, String>>,
+    sink_to_rules: Option<&HashMap<String, Vec<String>>>,
 ) -> Option<MatchedSink> {
-    let description = spec.sinks.iter().find_map(|matcher| match matcher {
-        NodeMatcher::MemberAssign { field, description } if field == field_name => {
-            Some(description.clone())
+    spec.sinks.iter().find_map(|matcher| match matcher {
+        NodeMatcher::MemberAssign { field, .. } if field == field_name => {
+            Some(matched_sink_for_matcher(matcher, sink_to_rules))
         }
         _ => None,
-    })?;
-    Some(MatchedSink {
-        rule_id_hint: rule_hint_for_sink_description(&description, sink_to_rule),
-        description,
     })
+}
+
+fn matched_sink_for_matcher(
+    matcher: &NodeMatcher,
+    sink_to_rules: Option<&HashMap<String, Vec<String>>>,
+) -> MatchedSink {
+    let key = matcher_fingerprint(matcher);
+    let rule_ids = sink_to_rules
+        .and_then(|map| map.get(&key).cloned())
+        .unwrap_or_default();
+    MatchedSink {
+        attribution_key: if rule_ids.is_empty() { None } else { Some(key) },
+        description: matcher.description().to_string(),
+        rule_ids,
+    }
+}
+
+pub(super) fn attribution_hint_for_sink(sink: &MatchedSink) -> Option<String> {
+    match &sink.attribution_key {
+        Some(key) => Some(key.clone()),
+        None => match sink.rule_ids.as_slice() {
+            [rule_id] => Some(rule_id.clone()),
+            _ => None,
+        },
+    }
+}
+
+pub(super) fn push_attributed_findings(
+    out: &mut Vec<(String, TaintFinding)>,
+    findings: Vec<TaintFinding>,
+    sink_to_rules: &HashMap<String, Vec<String>>,
+) {
+    for finding in findings {
+        let Some(hint) = finding.rule_id_hint.clone() else {
+            continue;
+        };
+        if let Some(rule_ids) = sink_to_rules.get(&hint) {
+            for rule_id in rule_ids {
+                let mut attributed = finding.clone();
+                attributed.rule_id_hint = Some(rule_id.clone());
+                out.push((rule_id.clone(), attributed));
+            }
+        } else {
+            let mut attributed = finding;
+            attributed.rule_id_hint = Some(hint.clone());
+            out.push((hint, attributed));
+        }
+    }
 }
 
 pub(super) fn taint_finding_for_node(
@@ -307,30 +349,6 @@ pub(super) fn cross_file_taint_finding(
     )
 }
 
-pub(super) fn push_attributed_findings(
-    out: &mut Vec<(String, TaintFinding)>,
-    findings: Vec<TaintFinding>,
-    sink_to_rule: &HashMap<String, String>,
-) {
-    for mut finding in findings {
-        let rule_id = finding
-            .rule_id_hint
-            .clone()
-            .or_else(|| sink_to_rule.get(finding.sink_description.as_str()).cloned());
-        if let Some(rule_id) = rule_id {
-            finding.rule_id_hint = Some(rule_id.clone());
-            out.push((rule_id, finding));
-        }
-    }
-}
-
-fn rule_hint_for_sink_description(
-    sink_description: &str,
-    sink_to_rule: Option<&HashMap<String, String>>,
-) -> Option<String> {
-    sink_to_rule.and_then(|map| map.get(sink_description).cloned())
-}
-
 pub(super) fn sanitizer_fingerprints_eq(a: &[NodeMatcher], b: &[NodeMatcher]) -> bool {
     if a.len() != b.len() {
         return false;
@@ -366,5 +384,107 @@ pub(super) fn matcher_fingerprint(m: &NodeMatcher) -> String {
         NodeMatcher::MemberAssign { field, description } => {
             format!("MA|{field}|{description}")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule_spec(source: NodeMatcher, sink: NodeMatcher) -> TaintSpec {
+        TaintSpec {
+            sources: vec![source],
+            sinks: vec![sink],
+            sanitizers: vec![],
+        }
+    }
+
+    fn param_source(name: &str, description: &str) -> NodeMatcher {
+        NodeMatcher::ParamName {
+            names: vec![name.to_string()],
+            description: description.to_string(),
+        }
+    }
+
+    fn call_sink(canonical: &str, description: &str) -> NodeMatcher {
+        NodeMatcher::Call {
+            canonical: canonical.to_string(),
+            description: description.to_string(),
+        }
+    }
+
+    #[test]
+    fn batched_group_keeps_distinct_matchers_with_same_description() {
+        let spec_a = rule_spec(
+            param_source("request", "input"),
+            call_sink("a.exec", "exec"),
+        );
+        let spec_b = rule_spec(param_source("ctx", "input"), call_sink("b.exec", "exec"));
+        let rules = [
+            BatchedRule {
+                rule_id: "rule-a",
+                spec: &spec_a,
+            },
+            BatchedRule {
+                rule_id: "rule-b",
+                spec: &spec_b,
+            },
+        ];
+
+        let groups = build_batched_taint_groups(&rules);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].spec.sources.len(), 2);
+        assert_eq!(groups[0].spec.sinks.len(), 2);
+
+        let matched = match_call_sink(&groups[0].spec, "a.exec", Some(&groups[0].sink_to_rules))
+            .expect("a.exec should match");
+        assert_eq!(matched.rule_ids, vec!["rule-a".to_string()]);
+    }
+
+    #[test]
+    fn batched_group_fans_out_identical_sink_matchers_to_all_owner_rules() {
+        let spec_a = rule_spec(param_source("request", "input"), call_sink("exec", "exec"));
+        let spec_b = rule_spec(param_source("request", "input"), call_sink("exec", "exec"));
+        let rules = [
+            BatchedRule {
+                rule_id: "rule-a",
+                spec: &spec_a,
+            },
+            BatchedRule {
+                rule_id: "rule-b",
+                spec: &spec_b,
+            },
+        ];
+
+        let groups = build_batched_taint_groups(&rules);
+        let group = &groups[0];
+        assert_eq!(group.spec.sources.len(), 1);
+        assert_eq!(group.spec.sinks.len(), 1);
+
+        let matched = match_call_sink(&group.spec, "exec", Some(&group.sink_to_rules))
+            .expect("exec should match");
+        assert_eq!(
+            matched.rule_ids,
+            vec!["rule-a".to_string(), "rule-b".to_string()]
+        );
+
+        let finding = TaintFinding {
+            sink_start_byte: 0,
+            sink_end_byte: 4,
+            sink_line: 1,
+            sink_column: 1,
+            sink_end_line: 1,
+            sink_end_column: 5,
+            source_description: "input".to_string(),
+            sink_description: "exec".to_string(),
+            source_line: 1,
+            rule_id_hint: attribution_hint_for_sink(&matched),
+            hops: 1,
+        };
+        let mut out = Vec::new();
+        push_attributed_findings(&mut out, vec![finding], &group.sink_to_rules);
+
+        let rule_ids: Vec<String> = out.into_iter().map(|(rule_id, _)| rule_id).collect();
+        assert_eq!(rule_ids, vec!["rule-a".to_string(), "rule-b".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary
- Move sanitizer grouping, merged source/sink construction, sink-to-rule attribution, and finding construction into shared taint_engine helpers
- Reuse shared call/member sink matching across JS/Python/Go taint engines
- Keep language-specific traversal, assignment/destructuring, expression taint, and cross-file callee resolution local to each engine

Closes #276

## Test plan
- [x] cargo test python_taint
- [x] cargo test javascript_taint
- [x] cargo test go_taint
- [x] cargo test taint
- [x] cargo test --lib
- [x] cargo test
- [x] cargo fmt --check
- [x] cargo clippy --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated taint analysis across Go, JavaScript, and Python to use a shared batched attribution pipeline and standardized finding construction, reducing duplication and improving consistency.
* **Bug Fixes**
  * Improved sink-to-rule attribution and cross-file finding emission, yielding more accurate and correctly attributed results.
* **Tests**
  * Added unit tests covering batched grouping and sink-rule attribution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->