### PR TITLE
feat(github-app): Phase 1 webhook receiver foundation (#246)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,10 +94,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "base64"
@@ -151,6 +232,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -438,6 +525,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -547,10 +635,13 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 name = "foxguard"
 version = "0.8.1"
 dependencies = [
+ "axum",
  "clap",
  "colored",
  "crossterm 0.28.1",
  "globset",
+ "hex",
+ "hmac",
  "ignore",
  "ratatui",
  "rayon",
@@ -561,7 +652,11 @@ dependencies = [
  "sha2",
  "shlex",
  "tempfile",
+ "tokio",
  "toml",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -579,6 +674,39 @@ dependencies = [
  "unicode-width",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -660,6 +788,95 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "id-arena"
@@ -851,6 +1068,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +1102,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -992,6 +1230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,6 +1329,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -1409,6 +1659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1706,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1491,10 +1761,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1536,6 +1822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,6 +1848,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
@@ -1674,6 +1972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +2000,32 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "toml"
@@ -1734,6 +2067,96 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+]
 
 [[package]]
 name = "tree-sitter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,29 @@ shlex = "1"
 unicode-segmentation = "1"
 unicode-width = "0.2"
 
+# Optional deps for the GitHub App webhook receiver (gated behind the
+# `github-app` feature). Off by default so the core scanner build stays
+# lean. See src/github_app/README.md and issue #246.
+axum = { version = "0.7", default-features = false, features = ["http1", "tokio", "json", "macros"], optional = true }
+tokio = { version = "1", default-features = false, features = ["macros", "rt-multi-thread", "signal"], optional = true }
+hmac = { version = "0.12", optional = true }
+hex = { version = "0.4", optional = true }
+tower-http = { version = "0.6", default-features = false, features = ["trace", "limit"], optional = true }
+tracing = { version = "0.1", optional = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"], optional = true }
+
+[features]
+default = []
+# Builds the foxguard-github-app binary plus its dependency closure.
+github-app = ["dep:axum", "dep:tokio", "dep:hmac", "dep:hex", "dep:tower-http", "dep:tracing", "dep:tracing-subscriber"]
+
 [[bin]]
 name = "foxguard-mcp"
 path = "src/bin/foxguard_mcp.rs"
+
+[[bin]]
+name = "foxguard-github-app"
+path = "src/bin/foxguard_github_app.rs"
+required-features = ["github-app"]
 
 [dev-dependencies]

--- a/Dockerfile.github-app
+++ b/Dockerfile.github-app
@@ -1,0 +1,38 @@
+# Reference Dockerfile for the foxguard GitHub App webhook receiver.
+# Built behind the `github-app` feature so the core scanner image
+# stays lean. See src/github_app/README.md and issue #246.
+#
+# Build:
+#   docker build -f Dockerfile.github-app -t foxguard/github-app:latest .
+#
+# Run:
+#   docker run --rm -p 8080:8080 \
+#     -e FOXGUARD_WEBHOOK_SECRET=$(openssl rand -hex 32) \
+#     foxguard/github-app:latest
+
+FROM rust:1.83-slim AS builder
+WORKDIR /usr/src/foxguard
+COPY . .
+# Build only the github-app binary; --features turns on the optional
+# axum/tokio/hmac/etc. closure required for the receiver.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && cargo build --release --features github-app --bin foxguard-github-app
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --create-home --shell /bin/false foxguard
+
+COPY --from=builder /usr/src/foxguard/target/release/foxguard-github-app /usr/local/bin/foxguard-github-app
+
+USER foxguard
+EXPOSE 8080
+ENV FOXGUARD_BIND=0.0.0.0:8080
+# FOXGUARD_WEBHOOK_SECRET MUST be supplied at runtime — the binary
+# refuses to start without one rather than silently accepting every
+# delivery. See src/github_app/webhook.rs.
+
+ENTRYPOINT ["/usr/local/bin/foxguard-github-app"]

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -141,7 +141,10 @@ async fn webhook(
             info!(delivery, "ping received");
         }
         EventKind::Installation => {
-            info!(delivery, "installation event — TODO: persist install metadata");
+            info!(
+                delivery,
+                "installation event — TODO: persist install metadata"
+            );
         }
         EventKind::PullRequest => {
             info!(

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -1,0 +1,171 @@
+//! foxguard-github-app — webhook receiver for the foxguard GitHub App.
+//!
+//! See `src/github_app/README.md` and the tracking issue at
+//! <https://github.com/PwnKit-Labs/foxguard/issues/246> for the design
+//! discussion.
+//!
+//! This binary is intentionally scoped to the *Phase-1 foundation*
+//! described in #246: receive webhook deliveries, verify the
+//! signature, route by event type, acknowledge with 202. The actual
+//! `pull_request` → clone → scan → comment pipeline is wired as a
+//! TODO and lands in a follow-up so the architecture can be reviewed
+//! in isolation first.
+//!
+//! Build:    `cargo build --release --features github-app --bin foxguard-github-app`
+//! Run:      `FOXGUARD_WEBHOOK_SECRET=xxx FOXGUARD_BIND=0.0.0.0:8080 foxguard-github-app`
+//! Docker:   `docker build -f Dockerfile.github-app -t foxguard/github-app .`
+
+use std::net::SocketAddr;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use foxguard::github_app::webhook::{verify_signature, EventKind, SignatureError};
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::trace::TraceLayer;
+use tracing::{info, warn};
+use tracing_subscriber::EnvFilter;
+
+/// Hard cap on incoming webhook body size. GitHub's largest legitimate
+/// `pull_request` payload sits around 200 KB; 1 MiB leaves comfortable
+/// headroom while making it cheap to reject anything weaponised.
+const MAX_BODY_BYTES: usize = 1 << 20; // 1 MiB
+
+#[derive(Clone)]
+struct AppState {
+    webhook_secret: Vec<u8>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info,foxguard=debug")),
+        )
+        .init();
+
+    let secret = std::env::var("FOXGUARD_WEBHOOK_SECRET").map_err(|_| {
+        "FOXGUARD_WEBHOOK_SECRET is required — set it to the same secret you \
+         configured on the GitHub App"
+    })?;
+    if secret.is_empty() {
+        return Err("FOXGUARD_WEBHOOK_SECRET must be non-empty".into());
+    }
+
+    let bind: SocketAddr = std::env::var("FOXGUARD_BIND")
+        .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
+        .parse()?;
+
+    let state = AppState {
+        webhook_secret: secret.into_bytes(),
+    };
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/webhook", post(webhook))
+        // Cap incoming bodies before they hit the handler so a hostile
+        // multi-GB delivery cannot exhaust memory.
+        .layer(RequestBodyLimitLayer::new(MAX_BODY_BYTES))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state);
+
+    info!(%bind, "foxguard-github-app starting");
+    let listener = tokio::net::TcpListener::bind(bind).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("install Ctrl-C handler");
+            info!("shutdown signal received");
+        })
+        .await?;
+
+    Ok(())
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// Webhook handler. Verifies the GitHub HMAC, parses the event type
+/// from the `X-GitHub-Event` header, and dispatches to a per-kind
+/// stub. All paths return 202 except for verification failures
+/// (401) and oversized / unparseable inputs (400) — keeping retry
+/// semantics correct on GitHub's end.
+async fn webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> StatusCode {
+    let signature = match headers
+        .get("X-Hub-Signature-256")
+        .and_then(|h| h.to_str().ok())
+    {
+        Some(v) => v,
+        None => {
+            warn!("webhook delivery missing X-Hub-Signature-256");
+            return StatusCode::UNAUTHORIZED;
+        }
+    };
+
+    if let Err(e) = verify_signature(&state.webhook_secret, signature, &body) {
+        // Log internally with detail; respond externally with the
+        // same status either way so we don't leak the failure mode.
+        match e {
+            SignatureError::MalformedHeader => {
+                warn!("webhook signature header malformed");
+            }
+            SignatureError::Mismatch => {
+                warn!("webhook signature mismatch — possible forgery attempt");
+            }
+        }
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let event = headers
+        .get("X-GitHub-Event")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("");
+    let kind = EventKind::from_header(event);
+    let delivery = headers
+        .get("X-GitHub-Delivery")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("?");
+
+    match kind {
+        EventKind::Ping => {
+            info!(delivery, "ping received");
+        }
+        EventKind::Installation => {
+            info!(delivery, "installation event — TODO: persist install metadata");
+        }
+        EventKind::PullRequest => {
+            info!(
+                delivery,
+                "pull_request event — TODO: clone, run foxguard, post --github-pr comment"
+            );
+        }
+        EventKind::Other => {
+            // Acknowledge so GitHub doesn't retry. We log at debug
+            // because a noisy install can subscribe us to events we
+            // don't care about and we don't want to flood info-level.
+            tracing::debug!(delivery, event, "unhandled event acknowledged");
+        }
+    }
+
+    StatusCode::ACCEPTED
+}
+
+#[cfg(test)]
+mod tests {
+    // The signature verification logic itself is exhaustively tested
+    // in `src/github_app/webhook.rs`. Routing is exercised by the
+    // axum runtime in production; pulling it into unit tests would
+    // require spinning up a tokio runtime per test for low marginal
+    // value. When the pull_request handler lands it should ship with
+    // its own integration tests against a mocked GitHub API.
+}

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -1,0 +1,55 @@
+# foxguard GitHub App — Phase 1 foundation
+
+Tracking issue: [PwnKit-Labs/foxguard#246](https://github.com/PwnKit-Labs/foxguard/issues/246).
+
+This directory hosts the in-tree pieces of the GitHub App webhook receiver. The receiver is built behind the `github-app` feature flag so the core scanner build stays lean for users who only want the CLI:
+
+```sh
+# Build the App receiver binary
+cargo build --release --features github-app --bin foxguard-github-app
+```
+
+## What's here today (Phase 1)
+
+- `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 9 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
+- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, and returns `202 Accepted` for all known kinds with the actual handler bodies stubbed and clearly marked TODO.
+
+## What's NOT here yet (Phase 2)
+
+The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
+
+- **JWT-based App→installation auth.** Generate the App JWT from the `.pem` private key, exchange it for an installation token via the GitHub API, cache the token until expiry. Crate dep: `jsonwebtoken`.
+- **`pull_request` handler.** Clone the head ref into a sandboxed temp dir, run `foxguard scan` with a 60s timeout and a 1 GB repo cap, post the existing `--github-pr` output as a PR comment.
+- **`installation` handler.** Persist install metadata so we know which orgs we're serving. SQLite is fine for Phase 1; the data is small and operationally easy to back up.
+- **Check Runs API.** Inline annotations on the diff once the comment path is solid.
+
+## Running locally
+
+```sh
+export FOXGUARD_WEBHOOK_SECRET=$(openssl rand -hex 32)
+export FOXGUARD_BIND=127.0.0.1:8080
+foxguard-github-app
+```
+
+For testing without GitHub:
+
+```sh
+BODY='{"zen":"hello"}'
+SECRET="$FOXGUARD_WEBHOOK_SECRET"
+SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | cut -d' ' -f2)"
+curl -sS -X POST http://127.0.0.1:8080/webhook \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: ping" \
+  -H "X-GitHub-Delivery: test-1" \
+  -H "X-Hub-Signature-256: $SIG" \
+  --data "$BODY"
+# → 202
+```
+
+## Self-hosting
+
+A reference Dockerfile lives at the repo root: [`Dockerfile.github-app`](../../Dockerfile.github-app). It builds the binary with the `github-app` feature, drops to a non-root user, and exposes `:8080`. Operators can deploy it to anything that runs containers (Fly.io, Railway, ECS, a tiny VM); the only persistent state once the install handler lands will be the install metadata, which is fine on a single small SQLite volume.
+
+## Status
+
+This PR is **Phase 1 only** — webhook foundation, no scan execution, no GitHub API calls outbound. The bones are here; everything else hangs off them. Ready for review on the architecture before the rest follows.

--- a/src/github_app/mod.rs
+++ b/src/github_app/mod.rs
@@ -1,0 +1,22 @@
+//! GitHub App webhook receiver foundation.
+//!
+//! This module hosts the pieces needed to receive `pull_request` and
+//! `installation` events from GitHub and route them into a foxguard
+//! scan. Right now it ships only the foundation:
+//!
+//! * [`webhook::verify_signature`] — constant-time HMAC-SHA256 check
+//!   over the raw request body using the configured webhook secret.
+//! * [`webhook::EventKind`] — minimal enum mapping the
+//!   `X-GitHub-Event` header to the events the receiver actually
+//!   handles.
+//!
+//! The HTTP server, JWT-based installation auth, and the
+//! `pull_request` → scan → comment pipeline live in the
+//! `foxguard-github-app` binary at `src/bin/foxguard_github_app.rs`
+//! and are intentionally kept thin so the architecture can be
+//! reviewed in isolation before the full `pull_request` handler
+//! lands.
+//!
+//! Tracking issue: <https://github.com/PwnKit-Labs/foxguard/issues/246>.
+
+pub mod webhook;

--- a/src/github_app/webhook.rs
+++ b/src/github_app/webhook.rs
@@ -1,0 +1,214 @@
+//! GitHub webhook signature verification.
+//!
+//! GitHub signs every webhook delivery with HMAC-SHA256 over the raw
+//! request body, using the secret configured at App-creation time, and
+//! sends the digest in the `X-Hub-Signature-256` header in the form
+//! `sha256=<hex>`. Receivers MUST verify this before doing anything
+//! with the payload — otherwise an attacker can forge events to the
+//! public webhook URL and trigger scans on arbitrary repositories.
+//!
+//! Documentation: <https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries>.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Errors returned by [`verify_signature`]. Variants are deliberately
+/// coarse — a verification failure should never tell an attacker
+/// *why* the check failed (it could leak something about the secret
+/// shape or header parsing).
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureError {
+    /// Header was missing or did not start with `sha256=`.
+    MalformedHeader,
+    /// Signature decoded successfully but did not match the expected
+    /// HMAC of the body. Always treated as a forgery.
+    Mismatch,
+}
+
+/// Verify the `X-Hub-Signature-256` header against the raw request
+/// body. Returns `Ok(())` on success.
+///
+/// `secret` is the webhook secret configured for the GitHub App.
+/// `header` is the full header value as received (`sha256=…`).
+/// `body` is the raw request body bytes — exactly as received over
+/// the wire, including any whitespace. Re-serializing parsed JSON
+/// will not match.
+///
+/// The comparison runs in constant time relative to the secret and
+/// signature length, so this function is safe to call on every
+/// request.
+pub fn verify_signature(
+    secret: &[u8],
+    header: &str,
+    body: &[u8],
+) -> Result<(), SignatureError> {
+    let prefix = "sha256=";
+    let hex_digest = match header.strip_prefix(prefix) {
+        Some(rest) => rest.trim(),
+        None => return Err(SignatureError::MalformedHeader),
+    };
+
+    if hex_digest.is_empty() {
+        return Err(SignatureError::MalformedHeader);
+    }
+
+    let received = match hex::decode(hex_digest) {
+        Ok(bytes) => bytes,
+        Err(_) => return Err(SignatureError::MalformedHeader),
+    };
+
+    // SHA-256 always emits 32 bytes. A wrong-length input cannot
+    // match a real signature, but we explicitly reject it here so
+    // verify().is_err() doesn't accept short inputs as "no signature
+    // at all" through whatever upstream comparator GitHub picks.
+    if received.len() != 32 {
+        return Err(SignatureError::MalformedHeader);
+    }
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret).map_err(|_| SignatureError::Mismatch)?;
+    mac.update(body);
+
+    // `hmac::Mac::verify_slice` does the constant-time comparison
+    // for us, so we don't have to roll our own subtle-time loop.
+    mac.verify_slice(&received)
+        .map_err(|_| SignatureError::Mismatch)
+}
+
+/// Subset of the GitHub event types this receiver currently routes.
+/// Any other event maps to [`EventKind::Other`] and is acknowledged
+/// with a 202 so GitHub's delivery dashboard stays clean instead of
+/// retrying.
+///
+/// Variants are added as the matching handlers come online; today
+/// none of these events do anything beyond log + 202 from the
+/// binary, but having the enum landed early means follow-up PRs can
+/// wire handlers without re-touching this module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventKind {
+    /// `installation` / `installation_repositories` — App was added
+    /// or removed from one or more repos.
+    Installation,
+    /// `pull_request` — PR opened / synchronised / reopened. The
+    /// scan handler runs against the head ref.
+    PullRequest,
+    /// `ping` — initial delivery sent at App-creation / re-delivery.
+    Ping,
+    /// Anything else GitHub may legitimately deliver. Acknowledged
+    /// without action.
+    Other,
+}
+
+impl EventKind {
+    /// Map the value of the `X-GitHub-Event` header to the routed
+    /// kind. Unknown values map to [`EventKind::Other`] rather than
+    /// erroring so the receiver remains forward-compatible with
+    /// GitHub adding new event types.
+    pub fn from_header(value: &str) -> Self {
+        match value {
+            "installation" | "installation_repositories" => Self::Installation,
+            "pull_request" => Self::PullRequest,
+            "ping" => Self::Ping,
+            _ => Self::Other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Reference vector: a known body + secret produces a known HMAC.
+    // Computed once with `python -c "import hmac, hashlib; print(hmac.new(b'sekret', b'hello', hashlib.sha256).hexdigest())"`.
+    const SECRET: &[u8] = b"sekret";
+    const BODY: &[u8] = b"hello";
+    const KNOWN_DIGEST: &str =
+        "24de3247aa41906931f59dd849ce2bf66043c21955d9f4726c198ee3006c5f47";
+
+    fn ok_header() -> String {
+        format!("sha256={KNOWN_DIGEST}")
+    }
+
+    #[test]
+    fn verify_accepts_known_signature() {
+        assert_eq!(verify_signature(SECRET, &ok_header(), BODY), Ok(()));
+    }
+
+    #[test]
+    fn verify_rejects_modified_body() {
+        assert_eq!(
+            verify_signature(SECRET, &ok_header(), b"hellO"),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_secret() {
+        assert_eq!(
+            verify_signature(b"wrong", &ok_header(), BODY),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_missing_prefix() {
+        assert_eq!(
+            verify_signature(SECRET, KNOWN_DIGEST, BODY),
+            Err(SignatureError::MalformedHeader)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_empty_digest() {
+        assert_eq!(
+            verify_signature(SECRET, "sha256=", BODY),
+            Err(SignatureError::MalformedHeader)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_non_hex() {
+        assert_eq!(
+            verify_signature(SECRET, "sha256=zzzz", BODY),
+            Err(SignatureError::MalformedHeader)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_short_digest() {
+        // 16 bytes worth of hex (32 chars) is wrong length for SHA-256
+        // and must be rejected even though it's structurally hex.
+        assert_eq!(
+            verify_signature(SECRET, "sha256=00112233445566778899aabbccddeeff", BODY),
+            Err(SignatureError::MalformedHeader)
+        );
+    }
+
+    #[test]
+    fn verify_handles_trimming() {
+        // Trailing whitespace on the header value (CRLF artefacts
+        // from a misbehaving proxy) shouldn't break verification.
+        let with_ws = format!("sha256={KNOWN_DIGEST}  ");
+        assert_eq!(verify_signature(SECRET, &with_ws, BODY), Ok(()));
+    }
+
+    #[test]
+    fn event_kind_maps_known_headers() {
+        assert_eq!(EventKind::from_header("pull_request"), EventKind::PullRequest);
+        assert_eq!(EventKind::from_header("installation"), EventKind::Installation);
+        assert_eq!(
+            EventKind::from_header("installation_repositories"),
+            EventKind::Installation
+        );
+        assert_eq!(EventKind::from_header("ping"), EventKind::Ping);
+    }
+
+    #[test]
+    fn event_kind_unknown_falls_back_to_other() {
+        // New GitHub events shouldn't break the receiver.
+        assert_eq!(EventKind::from_header("workflow_run"), EventKind::Other);
+        assert_eq!(EventKind::from_header(""), EventKind::Other);
+    }
+}

--- a/src/github_app/webhook.rs
+++ b/src/github_app/webhook.rs
@@ -39,11 +39,7 @@ pub enum SignatureError {
 /// The comparison runs in constant time relative to the secret and
 /// signature length, so this function is safe to call on every
 /// request.
-pub fn verify_signature(
-    secret: &[u8],
-    header: &str,
-    body: &[u8],
-) -> Result<(), SignatureError> {
+pub fn verify_signature(secret: &[u8], header: &str, body: &[u8]) -> Result<(), SignatureError> {
     let prefix = "sha256=";
     let hex_digest = match header.strip_prefix(prefix) {
         Some(rest) => rest.trim(),
@@ -67,8 +63,7 @@ pub fn verify_signature(
         return Err(SignatureError::MalformedHeader);
     }
 
-    let mut mac =
-        HmacSha256::new_from_slice(secret).map_err(|_| SignatureError::Mismatch)?;
+    let mut mac = HmacSha256::new_from_slice(secret).map_err(|_| SignatureError::Mismatch)?;
     mac.update(body);
 
     // `hmac::Mac::verify_slice` does the constant-time comparison
@@ -124,8 +119,7 @@ mod tests {
     // Computed once with `python -c "import hmac, hashlib; print(hmac.new(b'sekret', b'hello', hashlib.sha256).hexdigest())"`.
     const SECRET: &[u8] = b"sekret";
     const BODY: &[u8] = b"hello";
-    const KNOWN_DIGEST: &str =
-        "24de3247aa41906931f59dd849ce2bf66043c21955d9f4726c198ee3006c5f47";
+    const KNOWN_DIGEST: &str = "24de3247aa41906931f59dd849ce2bf66043c21955d9f4726c198ee3006c5f47";
 
     fn ok_header() -> String {
         format!("sha256={KNOWN_DIGEST}")
@@ -196,8 +190,14 @@ mod tests {
 
     #[test]
     fn event_kind_maps_known_headers() {
-        assert_eq!(EventKind::from_header("pull_request"), EventKind::PullRequest);
-        assert_eq!(EventKind::from_header("installation"), EventKind::Installation);
+        assert_eq!(
+            EventKind::from_header("pull_request"),
+            EventKind::PullRequest
+        );
+        assert_eq!(
+            EventKind::from_header("installation"),
+            EventKind::Installation
+        );
         assert_eq!(
             EventKind::from_header("installation_repositories"),
             EventKind::Installation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@ pub mod config;
 pub mod diff;
 pub mod engine;
 pub mod fix;
+pub mod git;
 #[cfg(feature = "github-app")]
 pub mod github_app;
-pub mod git;
 pub mod output;
 pub mod path_identity;
 pub mod report;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod config;
 pub mod diff;
 pub mod engine;
 pub mod fix;
+#[cfg(feature = "github-app")]
+pub mod github_app;
 pub mod git;
 pub mod output;
 pub mod path_identity;


### PR DESCRIPTION
**Draft — opening for architecture review before sinking another round of work into this.** Scoped strictly to the Phase-1 foundation called out in #246 so the bones can land cleanly first; the actual scan/comment pipeline is staged as the immediate follow-up.

## What's in

### Webhook signature verification (\`src/github_app/webhook.rs\`)

- HMAC-SHA256 over the raw request body using the configured webhook secret. Comparison goes through \`hmac::Mac::verify_slice\`, which does the constant-time check for us — no rolled-our-own subtle-time loop.
- 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing prefix, empty digest, non-hex digest, short-length digest (rejecting 16-byte inputs that are structurally valid hex), trailing whitespace tolerance, and the kind-routing map. Test fixture is a deterministic \`(secret, body, digest)\` triple computed via Python's stdlib HMAC for reproducibility.
- New \`EventKind\` enum maps \`X-GitHub-Event\` to the routed kinds (\`Installation\`, \`PullRequest\`, \`Ping\`, \`Other\`). Unknown values fall back to \`Other\` rather than erroring so the receiver stays forward-compatible with new GitHub event types.

### Webhook server (\`src/bin/foxguard_github_app.rs\`)

- axum-based HTTP server with \`/healthz\` and \`/webhook\` endpoints.
- Verifies signatures, routes by event, returns \`202 Accepted\` for known kinds, \`401\` for verification failures (same status either way so we don't leak the failure mode).
- Actual handler bodies are stubbed with clearly TODO-marked \`tracing::info!\` lines for each event kind — no scan execution, no GitHub API calls outbound yet, on purpose.
- 1 MiB request-body cap layered ahead of the handler via \`tower-http::limit::RequestBodyLimitLayer\` so a hostile multi-GB delivery cannot exhaust memory.

### Self-hosting (\`Dockerfile.github-app\`)

- Multi-stage build that compiles the receiver with the \`github-app\` feature, drops to a non-root user, exposes \`:8080\`. Refuses to start without \`FOXGUARD_WEBHOOK_SECRET\` rather than silently accepting every delivery.

### Build gating

New \`github-app\` Cargo feature flag. The optional dep closure (axum, tokio, hmac, hex, tower-http, tracing, tracing-subscriber) only enters the build when the feature is enabled, so the default \`cargo build\` and the \`foxguard-mcp\` binary stay untouched. Verified:

\`\`\`
cargo build                                                   → clean
cargo build --features github-app --bin foxguard-github-app   → clean
cargo test --lib                                              → 413 existing tests still ok
cargo test --features github-app --lib                        → 10 new tests added, all green
\`\`\`

## What's NOT in

Deliberately deferred so the architecture above can land in isolation. Each is the next PR:

1. **JWT-based App→installation auth.** Generate the App JWT from the \`.pem\` private key, exchange it for an installation token via \`/app/installations/{id}/access_tokens\`, cache the token until expiry. New dep: \`jsonwebtoken\`.
2. **\`pull_request\` handler.** Clone the head ref into a sandboxed temp dir, run \`foxguard scan\` with a 60s timeout and a 1 GB repo cap, post the existing \`--github-pr\` output as a PR comment.
3. **\`installation\` handler.** Persist install metadata (org, installation id, repos) so we know which orgs we're serving. SQLite is fine for Phase 1; data is small and ops is trivial to back up.
4. **Check Runs API.** Inline annotations on the diff once the comment path is solid.
5. **Public webhook host.** Per the issue's open question, I'd lean: publish the Docker image for self-hosters, run a single public instance under PwnKit-Labs for everyone else.

## Open questions for you

- The issue mentions "App owned by PwnKit-Labs org, or a separate app-specific org?" — that's a call for you to make. This PR doesn't take a position; it just gives you the binary that either deployment can run.
- Tracing setup uses the \`info,foxguard=debug\` default filter. If you'd rather a different default, easy one-liner.
- I picked \`/webhook\` and \`/healthz\` for the routes. If there's a convention you'd prefer (\`/api/v1/webhook\`, etc.), happy to swap.

## Test plan

- [x] Default \`cargo build\` clean (no new deps in default closure)
- [x] \`cargo build --features github-app\` clean
- [x] \`cargo test --lib\` — 413 existing pass
- [x] \`cargo test --features github-app --lib github_app::\` — 10 new pass
- [x] Manual smoke test of the binary: \`curl -H "X-Hub-Signature-256: sha256=…" -H "X-GitHub-Event: ping" --data '…'\` returns 202 with valid signature, 401 with invalid
- [x] Manual smoke test of \`Dockerfile.github-app\` build
- [ ] (For maintainer) — actually register a GitHub App, set the webhook URL, verify deliveries in the App's Recent Deliveries panel render as 202.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub App webhook receiver for handling GitHub events with HMAC signature verification.
  * Available via optional `github-app` Cargo feature.
  * Includes dedicated Docker image for containerized deployment.
  * Supports GitHub webhook events including installation, pull requests, and ping.

* **Documentation**
  * Added GitHub App module documentation with setup and testing guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->