### PR TITLE
docs: prepare Claude Code plugin marketplace release notes

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -82,4 +82,6 @@ npx foxguard --changed --severity high .
 
 The plugin can be loaded locally today with `--plugin-dir`. Publishing to an official Claude plugin marketplace is an external release step: it requires final marketplace metadata, a release/versioning decision, local plugin smoke testing in Claude Code, and submission through Anthropic's plugin form.
 
-Track the publishing checklist in the GitHub issue linked from the README/PR queue rather than treating it as part of the scanner binary release.
+Track the publishing checklist in the GitHub issue linked from the README/PR queue rather than treating it as part of the scanner binary release. Marketplace copy, versioning notes, and local validation commands live in [`plugins/claude-code/MARKETPLACE.md`](../plugins/claude-code/MARKETPLACE.md).
+
+This integration is intentionally Claude Code-specific. Generalizing foxguard for other agent or editor hook systems should be handled as a separate design and implementation issue.

--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -1,0 +1,108 @@
+# Claude Code Marketplace Release Notes
+
+This package is intentionally scoped to Claude Code. Broader agent or editor
+integrations should reuse the scanner behavior where it fits, but they should be
+tracked separately from the Claude Code marketplace release.
+
+## Versioning
+
+The initial marketplace version is `0.1.0`, matching
+`.claude-plugin/plugin.json`.
+
+Before each marketplace submission:
+
+- Bump the plugin version when any manifest, hook, skill, or bundled prompt
+  behavior changes.
+- Keep the version in `.claude-plugin/plugin.json` as the source of truth.
+- Tag the plugin release only after local smoke testing passes.
+
+## Marketplace Copy
+
+Name:
+
+```text
+foxguard
+```
+
+Short summary:
+
+```text
+Fast local security scanning for Claude Code.
+```
+
+Description:
+
+```text
+foxguard scans files as Claude Code writes or edits them, then feeds actionable
+security findings back into the agent session. It includes slash commands for
+full scans, diff scans, post-quantum crypto audits, secrets scans, and TUI
+triage, plus secure-coding defaults for common vulnerability classes.
+```
+
+Repository:
+
+```text
+https://github.com/PwnKit-Labs/foxguard
+```
+
+Homepage:
+
+```text
+https://foxguard.dev
+```
+
+License:
+
+```text
+MIT
+```
+
+Suggested categories:
+
+```text
+security, static-analysis, developer-tools, agent-hooks
+```
+
+Suggested demo checklist:
+
+- Start Claude Code with `claude --plugin-dir ./plugins/claude-code`.
+- Run `/foxguard:setup`.
+- Edit a file with a known command-injection or hardcoded-secret pattern.
+- Show the `PostToolUse` stderr finding summary.
+- Fix the issue and show the hook staying silent on the clean edit.
+- Run `/foxguard:scan .` or `/foxguard:diff-scan main` for an on-demand scan.
+
+## Local Validation
+
+The hook was validated directly with:
+
+```sh
+printf '{"tool_input":{"file_path":"tests/fixtures/safe.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
+printf '{"tool_input":{"file_path":"tests/fixtures/vulnerable.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
+printf '{"tool_input":{"path":"tests/fixtures/vulnerable.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
+printf '{"tool_input":{"file_path":"/does/not/exist.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+```
+
+Expected results:
+
+- Clean supported files exit `0` and stay silent.
+- Missing files exit `0` and stay silent.
+- Finding input exits `2` and emits a compact finding summary to stderr.
+- Both `tool_input.file_path` and `tool_input.path` are accepted.
+
+`claude plugin validate plugins/claude-code` was attempted with Claude Code
+`2.1.119`, but did not return and was stopped locally. Treat an in-session
+Claude Code smoke test as still required before submission.
+
+## External Submission
+
+Submit through the Anthropic plugin submission flow once the in-session smoke
+test has passed. After acceptance, update this file, the plugin README, and the
+top-level README with marketplace installation instructions.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -47,6 +47,9 @@ claude --plugin-dir /path/to/foxguard/plugins/claude-code
 
 Or add to your settings to load it permanently. Once installed, run `/foxguard:setup` to confirm it's wired up.
 
+Marketplace submission copy, versioning notes, and local validation commands are
+tracked in [MARKETPLACE.md](MARKETPLACE.md).
+
 ## Configuration
 
 Environment variables:
@@ -100,6 +103,8 @@ plugins/claude-code/
 - The hook calls `foxguard` from `PATH` first, then falls back to `npx --yes foxguard`. If neither is available it stays silent — run `/foxguard:setup` to fix that.
 - `--severity medium` is the default cutoff. Drop to `low` for stricter coverage; raise to `high` for noisier projects.
 - foxguard's exit codes: `0` clean, `1` findings, `2` error. The hook checks for findings via the JSON, not the exit code, so a piped error doesn't trigger a false alarm.
+- This package is scoped to Claude Code. Broader agent or editor integration
+  design should be tracked separately from the Claude Code marketplace release.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Add Claude Code marketplace release notes with copy, versioning policy, demo checklist, and local validation commands.
- Link the marketplace notes from the plugin README and Claude Code integration docs.
- Keep #285 scoped to Claude Code and point broader agent/editor generalization at #290.

## Verification

- `git diff --check`
- `printf {tool_input.file_path=tests/fixtures/safe.py} | plugins/claude-code/scripts/scan-edited-file.sh` exits 0 and stays silent.
- `printf {tool_input.file_path=tests/fixtures/vulnerable.py} | plugins/claude-code/scripts/scan-edited-file.sh` exits 2 and emits a 37-finding stderr summary.
- `printf {tool_input.path=tests/fixtures/vulnerable.py} | plugins/claude-code/scripts/scan-edited-file.sh` exits 2.
- `printf {tool_input.file_path=/does/not/exist.py} | plugins/claude-code/scripts/scan-edited-file.sh` exits 0 and stays silent.

## Notes

`claude plugin validate plugins/claude-code` was attempted locally with Claude Code 2.1.119, but it did not return and was stopped. In-session Claude Code smoke testing remains tracked in #285.

Closes part of #285.
Related: #290


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced publishing documentation directing users to new marketplace release notes and submission guidance
  * Introduced comprehensive marketplace documentation file with versioning discipline, submission copy templates, demo checklist, and local validation procedures with example commands
  * Updated README to include marketplace submission references and clarification of package scope specific to Claude Code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->