### PR TITLE
ci(release): publish foxguard-github-app image to GHCR on tagged release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/pwnkit-labs/foxguard-github-app:${{ github.ref_name }}
-            ghcr.io/pwnkit-labs/foxguard-github-app:latest
+            ghcr.io/0sec-labs/foxguard-github-app:${{ github.ref_name }}
+            ghcr.io/0sec-labs/foxguard-github-app:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,3 +240,49 @@ jobs:
           fi
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+  publish-ghcr-github-app:
+    name: Publish foxguard-github-app image (GHCR)
+    needs: github-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Dockerfile presence
+        id: check
+        run: |
+          if [ -f Dockerfile.github-app ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Dockerfile.github-app not present at this tag — skipping image publish."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/setup-qemu-action@v3
+        if: steps.check.outputs.exists == 'true'
+
+      - uses: docker/setup-buildx-action@v3
+        if: steps.check.outputs.exists == 'true'
+
+      - uses: docker/login-action@v3
+        if: steps.check.outputs.exists == 'true'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        if: steps.check.outputs.exists == 'true'
+        with:
+          context: .
+          file: Dockerfile.github-app
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/pwnkit-labs/foxguard-github-app:${{ github.ref_name }}
+            ghcr.io/pwnkit-labs/foxguard-github-app:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Extends \`release.yml\` so each tagged release builds \`Dockerfile.github-app\` (multi-arch: linux/amd64 + linux/arm64) and pushes the result to \`ghcr.io/pwnkit-labs/foxguard-github-app\` with both \`vX.Y.Z\` and \`latest\` tags.

Image is consumed by the corresponding manifests in [peaktwilight/k8s#3](https://github.com/peaktwilight/k8s/pull/3) (\`apps/foxguard-github-app-vega/\`) and by anyone self-hosting via \`docker run\` per the Phase-1 plan in #246.

## Self-skipping

If \`Dockerfile.github-app\` is missing at the tagged ref — e.g. tags cut before #289 (which adds the Dockerfile) lands on main — the docker steps are gated off via \`steps.check.outputs.exists\`. The job runs as a no-op so the rest of the release stays green.

That means this PR is safe to merge ahead of #289. The job goes live the moment the Dockerfile lands on main.

## Permissions model

Per-job \`contents: read\` + \`packages: write\` rather than widening the top-level \`permissions\` block. Other jobs keep their current \`contents: write\` default for the GitHub Release upload.

## Caching

\`cache-from: type=gha\` + \`cache-to: type=gha,mode=max\` reuses builder layers across releases. First build will be cold; subsequent releases should be ~minutes faster.

## Test plan

- [x] \`yamllint\` clean (no syntax errors in the new job)
- [x] Verified per-job \`permissions:\` block scope (only this job gets packages:write)
- [x] Verified \`steps.check.outputs.exists\` gates every build step
- [ ] (For maintainer) On the next tagged release after #289 + this PR are both on main: confirm \`ghcr.io/pwnkit-labs/foxguard-github-app:vX.Y.Z\` and \`:latest\` are pushed and pullable, and that the multi-arch manifest contains amd64 + arm64.

## Related

- Tracking issue: #246
- Code: #289 (draft, ships the Dockerfile this job builds)
- k8s deploy: peaktwilight/k8s#3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Docker image publishing to container registry with multi-architecture support (AMD64 and ARM64) and version tagging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->