### PR TITLE
test(kernel/dirty-frag): expand fixtures + tighten negative-regex (Tier 1 + FP shapes)

### DIFF
--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
@@ -6,6 +6,28 @@
 # primitive that Copy Fail and Dirty Frag both abuse in
 # crypto_authenc_esn_decrypt (crypto/authencesn.c).
 #
+# Tier 1 sibling sites this rule also catches (see
+# scatterwalk_authenc_store_vulnerable.c):
+#   - crypto/authenc.c::crypto_authenc_decrypt (non-ESN sibling)
+#   - any out-of-tree authenc clone that mirrors the STORE primitive
+#
+# Recall caveats — shapes this rule MISSES:
+#   - the STORE done via memcpy_to_sglist or sg_pcopy_to_buffer instead of
+#     scatterwalk_map_and_copy — distinct primitives that need their own
+#     positive regex (deferred to follow-up).
+#   - cross-function setup (set_crypt in caller, STORE in callee).
+#   - calls where the `out` argument is a named constant (e.g.
+#     `SCATTERWALK_STORE`) instead of literal `1`.
+#
+# Precision caveats — false-positive shapes NOT suppressed:
+#   - in-place AEAD setup followed by a STORE that DOES happen after a
+#     cow gate above the set_crypt call (regex has no negative-regex on
+#     this rule because adding one would suppress the real Copy Fail
+#     primitive in authencesn). Triage step: confirm no skb_cow_data /
+#     skb_unshare dominates the STORE.
+#   - encrypt-side AEAD setup followed by a STORE — encrypt is technically
+#     also a write, but the auth-fail-then-write race is decrypt-specific.
+#
 # This is a SYNTACTIC / structural rule — it does not prove dst aliases the
 # shared SGL via taint analysis. Path-sensitive analysis (CodeQL) is required
 # to confirm aliasing; see PR body for the deferred-work pointer.

--- a/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
@@ -9,6 +9,28 @@
 # f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4 (extends skip_cow gate with
 # !skb_has_shared_frag()).
 #
+# Tier 1 sibling sites this rule also catches (see ah_aead_no_cow_vulnerable.c):
+#   - net/ipv4/ah4.c::ah_input, net/ipv6/ah6.c::ah6_input (AH integrity)
+#   - any out-of-tree splice → in-place AEAD decrypt clone
+#
+# Recall caveats — shapes this rule MISSES:
+#   - cross-function cow gates (caller does skb_cow_data, callee does
+#     in-place decrypt). Regex is single-function bounded by `}`.
+#   - aead_request_set_crypt invoked via macro / wrapper (e.g. some inline
+#     helpers in TLS / MACsec). Add the wrapper symbol to the positive regex
+#     if the wrapper becomes a pattern in mainline.
+#   - encrypt-side counterpart (crypto_aead_encrypt) — the OOB-write class
+#     is decrypt-only per Hyunwoo Kim's 2026-05-07 advisory; encrypt is
+#     intentionally out of scope.
+#
+# Precision caveats — false-positive shapes NOT suppressed:
+#   - cow gate hidden behind a wrapper (e.g. tls_strp_msg_cow,
+#     pskb_carve_inside_*) — adding every wrapper would hide too many real
+#     positives. Triage step: confirm no helper between the gate and the
+#     in-place decrypt internally calls one of the listed cow primitives.
+#   - dominating gate that is in a loop's `continue` path or behind a
+#     condition that is always false — regex sees the textual call.
+#
 # This is a SYNTACTIC / structural rule — it does not prove the cow gate is
 # unreachable. Path-sensitive analysis (Coccinelle / CodeQL) is required for
 # definitive flagging; see PR body for the deferred-work pointer.
@@ -21,7 +43,7 @@ rules:
     pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?crypto_aead_decrypt\s*\('
     # Negative: a cow / unshare / make-writable / expand-head call appears
     # BEFORE the in-place idiom within the same function body — suppress.
-    pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_copy|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?aead_request_set_crypt\s*\([^}]*?crypto_aead_decrypt\s*\('
+    pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_cow|__skb_cow|skb_copy|skb_copy_expand|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?aead_request_set_crypt\s*\([^}]*?crypto_aead_decrypt\s*\('
     message: |
       In-place AEAD decrypt on skb without a dominating cow/unshare gate
       (Dirty Frag class). Verify skb_cow_data / skb_unshare / skb_make_writable /

--- a/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
@@ -8,6 +8,27 @@
 # Patched by upstream change to add data_len/nonlinear gate (see oss-security
 # advisory 2026-05-07).
 #
+# Tier 1 sibling sites this rule also catches (see
+# ipcomp_skcipher_no_cow_vulnerable.c):
+#   - net/ipv4/ipcomp.c, net/ipv6/ipcomp6.c decompression-adjacent decrypt
+#   - any RxGK / fresh AF_RXRPC security class derived from rxkad
+#   - SUNRPC krb5 wrap/unwrap if it ever moves to in-place skcipher
+#
+# Recall caveats — shapes this rule MISSES:
+#   - cross-function cow gates (caller cows, callee decrypts in place).
+#   - skcipher_request_set_crypt called via static-inline wrapper.
+#   - the out-of-band SCTP-AUTH cipher path which uses HMAC, not skcipher
+#     (different rule territory).
+#
+# Precision caveats — false-positive shapes NOT suppressed:
+#   - dm-crypt's per-bio path: it uses fresh page allocations, not skbs.
+#     dm-crypt does NOT match the regex's skb-bound positive shape, so this
+#     is informational only.
+#   - fscrypt: same — operates on filesystem pages, not skbs. Out of scope.
+#   - kTLS where the cow happens before via tls_strp_msg_cow wrapper.
+#     Triage step: inline the wrapper to confirm one of the listed cow
+#     primitives is actually called.
+#
 # This is a SYNTACTIC / structural rule — it does not prove the cow gate is
 # unreachable. Path-sensitive analysis (Coccinelle / CodeQL) is required for
 # definitive flagging; see PR body for the deferred-work pointer.
@@ -21,7 +42,7 @@ rules:
     # Negative: same idiom, but a cow / unshare / make-writable / expand-head
     # call appears BEFORE it within the same function body. Used to suppress
     # the post-patch / safe-fixture variant.
-    pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_copy|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?skcipher_request_set_crypt\s*\([^}]*?crypto_skcipher_decrypt\s*\('
+    pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_cow|__skb_cow|skb_copy|skb_copy_expand|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?skcipher_request_set_crypt\s*\([^}]*?crypto_skcipher_decrypt\s*\('
     message: |
       In-place skcipher decrypt on skb without a dominating cow/unshare gate
       (Dirty Frag class). Verify skb_cow_data / skb_unshare / skb_make_writable /

--- a/tests/fixtures/kernel/dirty-frag/aead_no_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/aead_no_cow_safe.c
@@ -2,9 +2,9 @@
 // Models post-patch esp_input with skb_cow_data dominating the in-place
 // decrypt path. MUST NOT be flagged.
 
-#include <linux/skbuff.h>
-#include <crypto/aead.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct aead_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/aead_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/aead_no_cow_vulnerable.c
@@ -2,9 +2,9 @@
 // Models net/ipv4/esp4.c::esp_input (pre-patch f4c50a4034e62ab).
 // MUST be flagged by kernel/dirty-frag/skb-inplace-aead-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/aead.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct aead_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c
@@ -1,0 +1,37 @@
+// Positive fixture (Tier 1 sibling): in-place AEAD ICV verify on skb without
+// a cow gate. Models the structural shape of net/ipv4/ah4.c::ah_input and
+// net/ipv6/ah6.c::ah6_input, where the integrity-check path uses
+// aead_request_set_crypt(req, sg, sg, ...) + crypto_aead_decrypt(req).
+//
+// Synthetic minimal reproducer — NOT copied from kernel source. Authored from
+// the patch-hunk shape alone to exercise the regex on a sibling protocol.
+// MUST be flagged by kernel/dirty-frag/skb-inplace-aead-no-cow.
+
+#include <linux/skbuff.h>
+#include <crypto/aead.h>
+
+struct sk_buff;
+struct aead_request;
+struct scatterlist;
+
+extern int skb_to_sgvec_nomark(struct sk_buff *skb, struct scatterlist *sg,
+                               int off, int len);
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern int crypto_aead_decrypt(struct aead_request *req);
+
+int ah4_input(struct sk_buff *skb,
+              struct aead_request *req,
+              struct scatterlist *sg,
+              unsigned int icv_len, void *iv)
+{
+        /* AH integrity check: builds an SGL over the skb (incl. shared frags
+         * from MSG_SPLICE_PAGES on the egress side) and runs an in-place
+         * AEAD decrypt to verify. No skb_cow_data / pskb_expand_head /
+         * skb_unshare on this path. */
+        skb_to_sgvec_nomark(skb, sg, 0, icv_len);
+        aead_request_set_crypt(req, sg, sg, icv_len, iv);
+        return crypto_aead_decrypt(req);
+}

--- a/tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c
@@ -7,9 +7,9 @@
 // the patch-hunk shape alone to exercise the regex on a sibling protocol.
 // MUST be flagged by kernel/dirty-frag/skb-inplace-aead-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/aead.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct aead_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c
@@ -7,9 +7,9 @@
 // from the patch-hunk shape alone to exercise the regex on a sibling site.
 // MUST be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/skcipher.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct skcipher_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c
@@ -1,0 +1,35 @@
+// Positive fixture (Tier 1 sibling): in-place skcipher decrypt on skb without
+// a cow gate. Models the structural shape of net/ipv4/ipcomp.c and
+// net/ipv6/ipcomp6.c (decompression-adjacent decrypt path), where the
+// callee may invoke skcipher in-place over an skb with shared frags.
+//
+// Synthetic minimal reproducer — NOT copied from kernel source. Authored
+// from the patch-hunk shape alone to exercise the regex on a sibling site.
+// MUST be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow.
+
+#include <linux/skbuff.h>
+#include <crypto/skcipher.h>
+
+struct sk_buff;
+struct skcipher_request;
+struct scatterlist;
+
+extern int skb_to_sgvec(struct sk_buff *skb, struct scatterlist *sg,
+                        int off, int len);
+extern void skcipher_request_set_crypt(struct skcipher_request *req,
+                                       struct scatterlist *src,
+                                       struct scatterlist *dst,
+                                       unsigned int cryptlen, void *iv);
+extern int crypto_skcipher_decrypt(struct skcipher_request *req);
+
+int ipcomp_decompress_inplace(struct sk_buff *skb,
+                              struct skcipher_request *req,
+                              struct scatterlist *sg,
+                              unsigned int len, void *iv)
+{
+        /* No cow / unshare / make-writable here: caller's gate only checks
+         * skb_cloned, missing splice()-shared non-linear frags. */
+        skb_to_sgvec(skb, sg, 0, len);
+        skcipher_request_set_crypt(req, sg, sg, len, iv);
+        return crypto_skcipher_decrypt(req);
+}

--- a/tests/fixtures/kernel/dirty-frag/macsec_skcipher_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/macsec_skcipher_cow_safe.c
@@ -1,0 +1,40 @@
+// Negative fixture (Tier 2 known-FP): MACsec / dm-crypt-style in-place
+// skcipher decrypt that is safe because a cow gate dominates the call.
+// Exercises an additional cow-gate name (skb_copy_expand) that appears in
+// some L2 receive paths and shows the rule does not over-fire on legitimate
+// in-place crypto AFTER cow.
+//
+// MUST NOT be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow.
+
+#include <linux/skbuff.h>
+#include <crypto/skcipher.h>
+
+struct sk_buff;
+struct skcipher_request;
+struct scatterlist;
+
+extern struct sk_buff *skb_copy_expand(const struct sk_buff *skb,
+                                       int newheadroom, int newtailroom,
+                                       unsigned int gfp_mask);
+extern int skb_to_sgvec(struct sk_buff *skb, struct scatterlist *sg,
+                        int off, int len);
+extern void skcipher_request_set_crypt(struct skcipher_request *req,
+                                       struct scatterlist *src,
+                                       struct scatterlist *dst,
+                                       unsigned int cryptlen, void *iv);
+extern int crypto_skcipher_decrypt(struct skcipher_request *req);
+
+int macsec_decrypt_safe(struct sk_buff *skb,
+                        struct skcipher_request *req,
+                        struct scatterlist *sg,
+                        unsigned int len, void *iv)
+{
+        /* Allocate a fresh non-shared skb up-front, defeating the splice()-
+         * shared-frag aliasing that Dirty Frag relies on. */
+        struct sk_buff *fresh = skb_copy_expand(skb, 0, 0, 0);
+        if (!fresh)
+                return -1;
+        skb_to_sgvec(fresh, sg, 0, len);
+        skcipher_request_set_crypt(req, sg, sg, len, iv);
+        return crypto_skcipher_decrypt(req);
+}

--- a/tests/fixtures/kernel/dirty-frag/macsec_skcipher_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/macsec_skcipher_cow_safe.c
@@ -6,9 +6,9 @@
 //
 // MUST NOT be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/skcipher.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct skcipher_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
@@ -6,9 +6,9 @@
 // Synthetic minimal reproducer — NOT copied from kernel source.
 // MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
 
-#include <crypto/aead.h>
-#include <crypto/scatterwalk.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct aead_request;
 struct scatterlist;
 

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
@@ -1,0 +1,35 @@
+// Positive fixture (Tier 1 sibling): scatterwalk_map_and_copy STORE on
+// shared in-place AEAD SGL, sibling of crypto_authenc_esn_decrypt — covers
+// the structural shape in crypto/authenc.c::crypto_authenc_decrypt and
+// any downstream module that mirrors the authencesn STORE primitive.
+//
+// Synthetic minimal reproducer — NOT copied from kernel source.
+// MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
+
+#include <crypto/aead.h>
+#include <crypto/scatterwalk.h>
+
+struct aead_request;
+struct scatterlist;
+
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+                                     unsigned int start, unsigned int nbytes,
+                                     int out);
+
+int authenc_store_inplace(struct aead_request *req,
+                          struct scatterlist *sg,
+                          unsigned int assoclen,
+                          unsigned int cryptlen,
+                          void *iv, void *tag)
+{
+        /* in-place AEAD: src == dst == sg, attacker-controllable. */
+        aead_request_set_crypt(req, sg, sg, cryptlen, iv);
+        /* The STORE: writes the computed tag into the shared SGL before
+         * the AEAD verify decision lands. */
+        scatterwalk_map_and_copy(tag, sg, assoclen + cryptlen, 16, 1);
+        return 0;
+}

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_inplace_read_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_inplace_read_safe.c
@@ -6,9 +6,9 @@
 //
 // MUST NOT be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
 
-#include <crypto/aead.h>
-#include <crypto/scatterwalk.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct aead_request;
 struct scatterlist;
 

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_inplace_read_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_inplace_read_safe.c
@@ -1,0 +1,35 @@
+// Negative fixture (Tier 2 known-FP): in-place AEAD setup followed by a
+// scatterwalk_map_and_copy READ (out=0). This tests that the rule's tight
+// `out=1` literal does not over-fire on read-back paths in
+// crypto_authenc_*_decrypt that pull bytes out of the SGL into a temporary
+// buffer for tag comparison.
+//
+// MUST NOT be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
+
+#include <crypto/aead.h>
+#include <crypto/scatterwalk.h>
+
+struct aead_request;
+struct scatterlist;
+
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+                                     unsigned int start, unsigned int nbytes,
+                                     int out);
+
+int authenc_inplace_read_safe(struct aead_request *req,
+                              struct scatterlist *sg,
+                              unsigned int assoclen,
+                              unsigned int cryptlen,
+                              void *iv, void *tmp)
+{
+        /* in-place AEAD: src == dst == sg. */
+        aead_request_set_crypt(req, sg, sg, cryptlen, iv);
+        /* READ-back (out=0): pulls tag bytes from the SGL into tmp.
+         * Not a STORE primitive, so the rule must not fire. */
+        scatterwalk_map_and_copy(tmp, sg, assoclen + cryptlen, 16, 0);
+        return 0;
+}

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_store_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_store_safe.c
@@ -2,9 +2,9 @@
 // Reading the shared SGL is not a STORE primitive and must not be flagged.
 // Also exercises the case where dst is a separate (not-aliased) scatterlist.
 
-#include <crypto/aead.h>
-#include <crypto/scatterwalk.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct aead_request;
 struct scatterlist;
 

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c
@@ -3,9 +3,9 @@
 // STORE primitive abused by Copy Fail and Dirty Frag.
 // MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
 
-#include <crypto/aead.h>
-#include <crypto/scatterwalk.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct aead_request;
 struct scatterlist;
 

--- a/tests/fixtures/kernel/dirty-frag/skcipher_no_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/skcipher_no_cow_safe.c
@@ -2,9 +2,9 @@
 // Models the post-patch RxRPC verify path with skb_cow_data dominating
 // the in-place decrypt. MUST NOT be flagged.
 
-#include <linux/skbuff.h>
-#include <crypto/skcipher.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct skcipher_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c
@@ -2,9 +2,9 @@
 // Models net/rxrpc/rxkad.c::rxkad_verify_packet_1 (pre-patch).
 // MUST be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/skcipher.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct skcipher_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/tls_aead_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/tls_aead_cow_safe.c
@@ -5,9 +5,9 @@
 //
 // MUST NOT be flagged by kernel/dirty-frag/skb-inplace-aead-no-cow.
 
-#include <linux/skbuff.h>
-#include <crypto/aead.h>
 
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
 struct sk_buff;
 struct aead_request;
 struct scatterlist;

--- a/tests/fixtures/kernel/dirty-frag/tls_aead_cow_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/tls_aead_cow_safe.c
@@ -1,0 +1,37 @@
+// Negative fixture (Tier 2 known-FP): kTLS-style in-place AEAD decrypt that
+// is safe because a cow / unshare gate dominates. Exercises the negative
+// regex against an additional cow-gate name (__skb_cow) seen in some TLS
+// receive paths and skbuff helpers.
+//
+// MUST NOT be flagged by kernel/dirty-frag/skb-inplace-aead-no-cow.
+
+#include <linux/skbuff.h>
+#include <crypto/aead.h>
+
+struct sk_buff;
+struct aead_request;
+struct scatterlist;
+
+extern int __skb_cow(struct sk_buff *skb, unsigned int headroom, int cloned);
+extern int skb_to_sgvec(struct sk_buff *skb, struct scatterlist *sg,
+                        int off, int len);
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern int crypto_aead_decrypt(struct aead_request *req);
+
+int tls_decrypt_inplace_safe(struct sk_buff *skb,
+                             struct aead_request *req,
+                             struct scatterlist *sg,
+                             unsigned int len, void *iv)
+{
+        /* kTLS-style: copy-on-write the skb pages before the in-place
+         * AEAD decrypt. The negative regex must suppress this shape. */
+        int err = __skb_cow(skb, 0, 1);
+        if (err)
+                return err;
+        skb_to_sgvec(skb, sg, 0, len);
+        aead_request_set_crypt(req, sg, sg, len, iv);
+        return crypto_aead_decrypt(req);
+}

--- a/tests/kernel_dirty_frag.rs
+++ b/tests/kernel_dirty_frag.rs
@@ -96,3 +96,82 @@ fn scatterwalk_store_on_shared_sgl_ignores_safe_fixture() {
         n
     );
 }
+
+// --- Tier 1 sibling-site fixtures (positive: must flag) ---
+
+#[test]
+fn skb_inplace_aead_no_cow_flags_ah_sibling_fixture() {
+    let n = run_rule(
+        "skb-inplace-aead-no-cow.yaml",
+        "ah_aead_no_cow_vulnerable.c",
+    );
+    assert!(
+        n >= 1,
+        "expected AH-style sibling positive fixture to be flagged, got {} findings",
+        n
+    );
+}
+
+#[test]
+fn skb_inplace_skcipher_no_cow_flags_ipcomp_sibling_fixture() {
+    let n = run_rule(
+        "skb-inplace-skcipher-no-cow.yaml",
+        "ipcomp_skcipher_no_cow_vulnerable.c",
+    );
+    assert!(
+        n >= 1,
+        "expected IPComp-style sibling positive fixture to be flagged, got {} findings",
+        n
+    );
+}
+
+// --- Tier 2 known-FP fixtures (negative: extra cow-gate names dominate) ---
+
+#[test]
+fn skb_inplace_aead_no_cow_ignores_tls_cow_fixture() {
+    let n = run_rule("skb-inplace-aead-no-cow.yaml", "tls_aead_cow_safe.c");
+    assert_eq!(
+        n, 0,
+        "expected kTLS-style cow-gate fixture (__skb_cow) to be unflagged, got {} findings",
+        n
+    );
+}
+
+#[test]
+fn skb_inplace_skcipher_no_cow_ignores_macsec_cow_fixture() {
+    let n = run_rule(
+        "skb-inplace-skcipher-no-cow.yaml",
+        "macsec_skcipher_cow_safe.c",
+    );
+    assert_eq!(
+        n, 0,
+        "expected MACsec-style cow-gate fixture (skb_copy_expand) to be unflagged, got {} findings",
+        n
+    );
+}
+
+#[test]
+fn scatterwalk_store_on_shared_sgl_flags_authenc_sibling_fixture() {
+    let n = run_rule(
+        "scatterwalk-store-on-shared-sgl.yaml",
+        "scatterwalk_authenc_store_vulnerable.c",
+    );
+    assert!(
+        n >= 1,
+        "expected authenc-style sibling positive fixture (in-place + STORE) to be flagged, got {} findings",
+        n
+    );
+}
+
+#[test]
+fn scatterwalk_store_on_shared_sgl_ignores_inplace_read_fixture() {
+    let n = run_rule(
+        "scatterwalk-store-on-shared-sgl.yaml",
+        "scatterwalk_inplace_read_safe.c",
+    );
+    assert_eq!(
+        n, 0,
+        "expected in-place + READ-back (out=0) fixture to be unflagged, got {} findings",
+        n
+    );
+}


### PR DESCRIPTION
## Summary

Iterates on the Dirty Frag class rules shipped in #297 (merged 2026-05-07).
Lifts the calibration test count from **6 to 12** by adding sibling-site
positive fixtures and known-FP negative fixtures, and extends the cow-gate
negative regex with two additional kernel primitives. Still pure regex /
Semgrep-compat — path-sensitive proof of cow-gate dominance is deferred to
foxguard #295 (Coccinelle) and #296 (CodeQL).

## Test count: 6 → 12

## New fixtures (`tests/fixtures/kernel/dirty-frag/`)

**Tier 1 — sibling-site positives (must flag):**
- `ah_aead_no_cow_vulnerable.c` — AH4/AH6 ICV-verify shape mirroring
  `net/ipv4/ah4.c::ah_input` and `net/ipv6/ah6.c::ah6_input`.
- `ipcomp_skcipher_no_cow_vulnerable.c` — IPComp decompression-adjacent
  in-place skcipher decrypt mirroring `net/ipv4/ipcomp.c`.
- `scatterwalk_authenc_store_vulnerable.c` — non-ESN authenc STORE primitive
  mirroring `crypto/authenc.c`.

**Tier 2 — known-FP negatives (must not flag):**
- `tls_aead_cow_safe.c` — kTLS-style cow-then-decrypt using `__skb_cow`.
- `macsec_skcipher_cow_safe.c` — MACsec / dm-crypt-style fresh-skb path
  using `skb_copy_expand`.
- `scatterwalk_inplace_read_safe.c` — in-place AEAD setup followed by a
  scatterwalk READ-back (`out=0`); confirms the literal-1 in the
  scatterwalk regex stays tight.

All fixtures are minimal synthetic reproducers authored from the patch-
hunk shape alone (oss-security 2026-05-07, commit `f4c50a4034e6`). No
kernel source is copied.

## Negative-regex additions

Extended `pattern-not-regex` on the AEAD and skcipher rules to suppress
two more cow-gate primitives:

- `skb_cow` — base form of `skb_cow_data`, used by some non-IPsec callers.
- `__skb_cow` — internal helper exposed in `skbuff.h`, hit by kTLS receive.
- `skb_copy_expand` — full reallocation, defeats shared-frag aliasing.

**Skipped on purpose** (would cost too many true positives):
- `skb_clone` — duplicates pointers, does NOT make data writable.
- `skb_share_check` — only handles the cloned case, not non-linear
  shared frags from `MSG_SPLICE_PAGES`.

## YAML header documentation

Each rule's leading comment block now lists:
- Tier 1 sibling sites the rule catches.
- Recall caveats — shapes the rule MISSES (cross-function gates,
  wrappers, encrypt-side counterparts).
- Precision caveats — false-positive shapes intentionally NOT
  suppressed and the triage step that disambiguates them.

## Honest caveats

- Still regex-only. Real cow-gate dominance proof requires Coccinelle
  (#295) or CodeQL (#296). This PR only widens calibration coverage; it
  does not change the fundamental precision ceiling.
- Cross-function cow gates (caller cows, callee decrypts) remain
  unsuppressed by design — narrowing further would hide too many real
  positives.
- The scatterwalk rule has no negative regex by design; adding one
  would suppress the actual Copy Fail / Dirty Frag STORE primitive in
  `crypto_authenc_esn_decrypt`.

## Test plan

- [x] `cargo test --test kernel_dirty_frag` — 12/12 pass
- [x] `cargo test` — full suite still green
- [x] Each new fixture exercises a distinct shape (sibling site OR
      additional cow-gate name OR literal-1 tightness)
- [x] No new rule files added (only the 3 from #297 edited)
- [x] No path outside `rules/kernel/dirty-frag-class/`,
      `tests/kernel_dirty_frag.rs`, `tests/fixtures/kernel/dirty-frag/`

Refs foxguard #297 (original Dirty Frag rules), pwnkit #263
(variant-hunt orchestrator).