### PR TITLE
feat: add Coccinelle rule bridge

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,8 +1,8 @@
 # foxguard Compatibility
 
-Fast local security guard for changed files, built-in rules, and Semgrep-compatible YAML.
+Fast local security guard for changed files, built-in rules, Semgrep-compatible YAML, and Coccinelle semantic patches.
 
-foxguard supports a focused Semgrep-compatible YAML subset for local rule loading.
+foxguard supports a focused Semgrep-compatible YAML subset for local rule loading and an additive Coccinelle bridge for C semantic patches.
 
 That supported subset is regression-tested in-repo and parity-checked in CI against the real `semgrep` CLI.
 
@@ -23,6 +23,12 @@ External-rules-only compatibility run:
 
 ```sh
 foxguard --no-builtins --rules ./rules .
+```
+
+Coccinelle-backed C rule:
+
+```sh
+foxguard --rules ./kernel-rules .
 ```
 
 Adoption baseline:
@@ -85,6 +91,40 @@ Rule loading:
 - load a single YAML file
 - load a directory recursively
 - deduplicate language aliases that map to the same foxguard parser
+
+## Coccinelle bridge
+
+Rules with `engine: coccinelle` are loaded from the same `--rules` YAML files or directories as Semgrep-compatible rules:
+
+```yaml
+rules:
+  - id: kernel/dirty-frag-inplace-crypto-no-cow
+    engine: coccinelle
+    severity: high
+    languages: [c]
+    metadata:
+      cwe: CWE-362
+    message: In-place crypto on skb data without a preceding copy-on-write gate.
+    script_path: dirty-frag-inplace-crypto-no-cow.cocci
+```
+
+Supported Coccinelle rule keys:
+
+- `id`
+- `engine: coccinelle`
+- `message`
+- `severity` (`critical`, `high`, `medium`, `low`, plus Semgrep-style `ERROR`, `WARNING`, `INFO`)
+- `languages: [c]`
+- `metadata.cwe`
+- `script` for inline SmPL
+- `script_path` for a `.cocci` file relative to the YAML file
+
+Execution model:
+
+- foxguard shells out to upstream `spatch`; whatever SmPL surface your installed `spatch` accepts is the supported SmPL surface.
+- Coccinelle currently scans `.c` and `.h` files.
+- Findings are normalized into the same `Finding` shape used by built-in and Semgrep-compatible rules, so terminal, JSON, SARIF, CBOM, and baselines work through the existing report path.
+- If `spatch` is missing, foxguard emits one warning and skips Coccinelle rules while continuing the rest of the scan.
 
 ## Important limitations
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "uuid",
+ "wait-timeout",
  "walkdir",
 ]
 
@@ -1960,6 +1961,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ toml = "0.8"
 shlex = "1"
 unicode-segmentation = "1"
 unicode-width = "0.2"
+wait-timeout = "0.2.1"
 
 [[bin]]
 name = "foxguard-mcp"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <br/>
   scan &middot; diff &middot; secrets &middot; post-quantum crypto audit &middot; interactive TUI triage
   <br/>
-  170+ built-in rules across 11 languages &middot; cross-file taint tracking &middot; Semgrep-compatible YAML bridge
+  170+ built-in rules across 11 languages &middot; cross-file taint tracking &middot; Semgrep-compatible YAML and Coccinelle bridges
   <br/><br/>
   <a href="https://foxguard.dev">foxguard.dev</a> &middot; <a href="https://www.npmjs.com/package/foxguard">npm</a> &middot; <a href="https://crates.io/crates/foxguard">crates.io</a>
 </p>
@@ -33,7 +33,7 @@
   <br/><em><code>foxguard tui .</code> — interactive triage with scan, diff, secrets, and PQ modes. <a href="https://foxguard.dev/blog/foxguard-0-7-0-tui-launch">Launch post</a>.</em>
 </p>
 
-foxguard is a security scanner you can run on every save. A single Rust binary with 170+ built-in rules across 10 source languages, plus C via Semgrep-compatible YAML rule packs (kernel/dirty-frag class shipped), cross-file taint tracking, Semgrep-compatible YAML loading, and four top-level modes — general scan, diff-against-branch, secrets, and post-quantum crypto audit — all reachable from the same CLI or interactive TUI.
+foxguard is a security scanner you can run on every save. A single Rust binary with 170+ built-in rules across 10 source languages, plus C via Semgrep-compatible YAML rule packs and Coccinelle-backed semantic patches (kernel/dirty-frag class shipped), cross-file taint tracking, Semgrep-compatible YAML loading, and four top-level modes — general scan, diff-against-branch, secrets, and post-quantum crypto audit — all reachable from the same CLI or interactive TUI.
 
 It is fast enough for pre-commit hooks and the `--changed` path runs in milliseconds on a real repo. Output formats: terminal, JSON, SARIF (for GitHub Code Scanning), and CycloneDX 1.6 CBOM.
 
@@ -73,7 +73,7 @@ All four are reachable from `foxguard tui .` — interactive triage with review,
 | Area | What you get |
 |------|--------------|
 | **Outputs** | Terminal, JSON, SARIF (GitHub Code Scanning), CycloneDX 1.6 CBOM (`--format cbom`). Each CBOM component links back to a source location and severity. |
-| **Semgrep compatibility** | Loads a Semgrep/OpenGrep YAML subset via `--rules`. Parity-tested in CI against the real `semgrep` CLI. See [`COMPATIBILITY.md`](./COMPATIBILITY.md). |
+| **External rule bridges** | Loads a Semgrep/OpenGrep YAML subset and `engine: coccinelle` SmPL rules via `--rules`. Semgrep parity is tested in CI; Coccinelle rules shell out to `spatch` when installed. See [`COMPATIBILITY.md`](./COMPATIBILITY.md). |
 | **CI integration** | Native GitHub Action (below), SARIF upload, `--github-pr` for PR review comments, exit code on findings. |
 | **Config** | `.foxguard.yml` for per-rule enable/disable, severity overrides, entropy and taint-hop thresholds, per-rule options. |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,8 +6,8 @@ use crate::config::{
 };
 use crate::diff::run_diff_with_warnings;
 use crate::engine::{
-    scan_directory_with_notices, scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult,
-    ScanStats,
+    coccinelle, scan_directory_with_notices, scan_paths_with_root_with_notices,
+    PathExcludeMatcher, ScanResult, ScanStats,
 };
 use crate::git::changed_files;
 use crate::rules::semgrep_compat::load_semgrep_rules;
@@ -118,6 +118,10 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     apply_scan_thresholds(config.as_ref());
 
     let mut registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
+    let (mut coccinelle_rules, mut coccinelle_notices) = match scan.rules.as_deref() {
+        Some(rules_path) => coccinelle::load_coccinelle_rules(Path::new(rules_path)),
+        None => (Vec::new(), Vec::new()),
+    };
     if let Some(ref config) = config {
         if !config.scan.rule_options.is_empty() {
             let warnings = registry.configure_rules(&config.scan.rule_options)?;
@@ -128,6 +132,7 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     }
     let excludes = PathExcludeMatcher::new(&scan.exclude)?;
     let targets = collect_changed_targets(&scan.path, scan.changed)?;
+    let coccinelle_rule_ids = coccinelle::rule_ids(&coccinelle_rules);
 
     // In PQ mode, filter to only PQ-related rules
     let pq_enable: Vec<String>;
@@ -144,17 +149,28 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
                  Install a version with post-quantum crypto rules to use 'foxguard pqc'."
             );
         }
-        registry.apply_rule_filter(&pq_enable, &[])
+        coccinelle::apply_rule_filter(&mut coccinelle_rules, &pq_enable, &[]);
+        registry.apply_rule_filter_with_known(&pq_enable, &[], &coccinelle_rule_ids)
     } else if let Some(config) = config.as_ref() {
-        registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)
+        coccinelle::apply_rule_filter(
+            &mut coccinelle_rules,
+            &config.scan.enable_rules,
+            &config.scan.disable_rules,
+        );
+        registry.apply_rule_filter_with_known(
+            &config.scan.enable_rules,
+            &config.scan.disable_rules,
+            &coccinelle_rule_ids,
+        )
     } else {
-        registry.apply_rule_filter(&[], &[])
+        registry.apply_rule_filter_with_known(&[], &[], &coccinelle_rule_ids)
     };
 
-    let (result, mut notices) = if let Some(files) = targets {
+    let scan_started = std::time::Instant::now();
+    let (result, mut notices) = if let Some(files) = targets.as_ref() {
         scan_paths_with_root_with_notices(
             Path::new(&scan.path),
-            &files,
+            files,
             &registry,
             scan.max_file_size,
             Some(&excludes),
@@ -162,6 +178,7 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     } else {
         scan_directory_with_notices(&scan.path, &registry, scan.max_file_size, Some(&excludes))
     };
+    notices.append(&mut coccinelle_notices);
 
     if !rule_filter_unknown.is_empty() {
         notices.insert(
@@ -178,10 +195,41 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
         );
     }
 
-    let files_scanned = result.files_scanned;
-    let duration = result.duration;
+    let mut files_scanned = result.files_scanned;
     let stats = result.stats;
     let mut findings = result.findings;
+    let mut coccinelle_candidate_files = 0;
+
+    if !coccinelle_rules.is_empty() {
+        let coccinelle_result = if let Some(files) = targets.as_ref() {
+            coccinelle::scan_paths_with_notices(
+                Path::new(&scan.path),
+                files,
+                &coccinelle_rules,
+                scan.max_file_size,
+                Some(&excludes),
+            )
+        } else {
+            coccinelle::scan_path_with_notices(
+                Path::new(&scan.path),
+                &coccinelle_rules,
+                scan.max_file_size,
+                Some(&excludes),
+            )
+        };
+        coccinelle_candidate_files = coccinelle_result.candidate_files;
+        files_scanned += coccinelle_result.files_scanned;
+        notices.extend(coccinelle_result.notices);
+        findings.extend(coccinelle_result.findings);
+        findings.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.line.cmp(&b.line))
+                .then(a.column.cmp(&b.column))
+                .then(a.rule_id.cmp(&b.rule_id))
+        });
+    }
+    let duration = scan_started.elapsed();
     append_scan_stats_notice(&mut notices, &stats);
 
     // CNSA 2.0 deadline annotation. Runs regardless of the `--cnsa2`
@@ -190,7 +238,7 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     // `src/main.rs`).
     crate::compliance::annotate_cnsa2_deadlines(&mut findings, &registry);
 
-    let known_rule_ids = collect_rule_ids(&registry);
+    let known_rule_ids = collect_rule_ids(&registry, &coccinelle_rules);
     let override_warnings =
         apply_severity_overrides(&mut findings, config.as_ref(), &known_rule_ids);
     notices.extend(override_warnings);
@@ -225,12 +273,14 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
 
     findings = suppress_with_baseline_at_root(findings, baseline.as_ref(), &identity_root);
 
-    if files_scanned == 0 {
+    if files_scanned == 0 && coccinelle_candidate_files == 0 {
         if stats.files_discovered == 0 {
-            notices.push(
-                "Warning: no files found. Supported: .js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
-                    .to_string(),
-            );
+            let supported = if coccinelle_rules.is_empty() {
+                ".js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt"
+            } else {
+                ".js, .ts, .py, .go, .rb, .java, .php, .rs, .cs, .swift, .kt, .c, .h"
+            };
+            notices.push(format!("Warning: no files found. Supported: {supported}"));
         } else {
             notices.push(
                 "Warning: no files were scanned. See skipped-file summary for reasons.".to_string(),
@@ -337,7 +387,7 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     // Annotate CNSA 2.0 deadlines on the new findings surfaced by this diff.
     crate::compliance::annotate_cnsa2_deadlines(&mut diff_result.new_findings, &registry);
 
-    let known_rule_ids = collect_rule_ids(&registry);
+    let known_rule_ids = collect_rule_ids(&registry, &[]);
     let override_warnings = apply_severity_overrides(
         &mut diff_result.new_findings,
         config.as_ref(),
@@ -490,12 +540,17 @@ fn tui_secrets_args(args: &TuiArgs) -> SecretsArgs {
     }
 }
 
-fn collect_rule_ids(registry: &RuleRegistry) -> std::collections::HashSet<String> {
-    registry
+fn collect_rule_ids(
+    registry: &RuleRegistry,
+    coccinelle_rules: &[coccinelle::CoccinelleRule],
+) -> std::collections::HashSet<String> {
+    let mut ids: std::collections::HashSet<String> = registry
         .all_rules()
         .iter()
         .map(|rule| rule.id().to_string())
-        .collect()
+        .collect();
+    ids.extend(coccinelle_rules.iter().map(|rule| rule.id().to_string()));
+    ids
 }
 
 fn finding_identity_root(scan_path: &Path, config: Option<&FoxguardConfig>) -> PathBuf {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,8 +6,8 @@ use crate::config::{
 };
 use crate::diff::run_diff_with_coccinelle_warnings;
 use crate::engine::{
-    coccinelle, scan_directory_with_notices, scan_paths_with_root_with_notices,
-    PathExcludeMatcher, ScanResult, ScanStats,
+    coccinelle, scan_directory_with_notices, scan_paths_with_root_with_notices, PathExcludeMatcher,
+    ScanResult, ScanStats,
 };
 use crate::git::changed_files;
 use crate::rules::semgrep_compat::load_semgrep_rules;

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ use crate::secrets::{
     scan_directory_with_config_and_notices, scan_paths_with_config_and_notices, SecretScanConfig,
 };
 use crate::Finding;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 pub struct ScanExecution {
@@ -137,12 +138,7 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     // In PQ mode, filter to only PQ-related rules
     let pq_enable: Vec<String>;
     let rule_filter_unknown = if scan.pq_mode {
-        pq_enable = registry
-            .all_rules()
-            .iter()
-            .map(|r| r.id().to_string())
-            .filter(|id| is_pq_rule_id(id))
-            .collect();
+        pq_enable = collect_pq_rule_ids(&registry, &coccinelle_rule_ids);
         if pq_enable.is_empty() {
             eprintln!(
                 "Warning: no PQ rules registered in this build. \
@@ -568,8 +564,8 @@ fn tui_secrets_args(args: &TuiArgs) -> SecretsArgs {
 fn collect_rule_ids(
     registry: &RuleRegistry,
     coccinelle_rules: &[coccinelle::CoccinelleRule],
-) -> std::collections::HashSet<String> {
-    let mut ids: std::collections::HashSet<String> = registry
+) -> HashSet<String> {
+    let mut ids: HashSet<String> = registry
         .all_rules()
         .iter()
         .map(|rule| rule.id().to_string())
@@ -583,6 +579,26 @@ fn finding_identity_root(scan_path: &Path, config: Option<&FoxguardConfig>) -> P
         scan_path,
         config.map(|config| config.project_root.as_path()),
     )
+}
+
+fn collect_pq_rule_ids(
+    registry: &RuleRegistry,
+    coccinelle_rule_ids: &HashSet<String>,
+) -> Vec<String> {
+    let mut ids: Vec<String> = registry
+        .all_rules()
+        .iter()
+        .map(|rule| rule.id().to_string())
+        .filter(|id| is_pq_rule_id(id))
+        .collect();
+
+    for id in coccinelle_rule_ids {
+        if is_pq_rule_id(id) && !ids.iter().any(|existing| existing == id) {
+            ids.push(id.clone());
+        }
+    }
+
+    ids
 }
 
 fn build_registry(no_builtins: bool, rules: Option<&str>) -> Result<RuleRegistry, String> {
@@ -652,4 +668,23 @@ fn count_secret_files(scan_path: &Path) -> usize {
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
         .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pq_rule_ids_include_coccinelle_rules() {
+        let registry = RuleRegistry::empty();
+        let coccinelle_rule_ids = HashSet::from([
+            "kernel/pq-vulnerable-cocci".to_string(),
+            "kernel/non-pq-cocci".to_string(),
+        ]);
+
+        let ids = collect_pq_rule_ids(&registry, &coccinelle_rule_ids);
+
+        assert!(ids.contains(&"kernel/pq-vulnerable-cocci".to_string()));
+        assert!(!ids.contains(&"kernel/non-pq-cocci".to_string()));
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::config::{
     apply_scan_defaults, apply_scan_thresholds, apply_secrets_defaults, apply_severity_overrides,
     load_for_scan, suppress_with_scan_ignores, FoxguardConfig,
 };
-use crate::diff::run_diff_with_warnings;
+use crate::diff::run_diff_with_coccinelle_warnings;
 use crate::engine::{
     coccinelle, scan_directory_with_notices, scan_paths_with_root_with_notices,
     PathExcludeMatcher, ScanResult, ScanStats,
@@ -359,14 +359,39 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     let config = load_for_scan(Path::new(&args.path), None)?;
     let identity_root = finding_identity_root(Path::new(&args.path), config.as_ref());
     apply_scan_thresholds(config.as_ref());
-    let mut registry = build_registry(args.no_builtins, args.rules.as_deref())?;
-    let rule_filter_unknown = if let Some(config) = config.as_ref() {
-        registry.apply_rule_filter(&config.scan.enable_rules, &config.scan.disable_rules)
-    } else {
-        registry.apply_rule_filter(&[], &[])
+    let rules_path = args.rules.as_deref().or_else(|| {
+        config
+            .as_ref()
+            .and_then(|config| config.scan.rules.as_deref())
+    });
+    let mut registry = build_registry(args.no_builtins, rules_path)?;
+    let (mut coccinelle_rules, mut coccinelle_notices) = match rules_path {
+        Some(rules_path) => coccinelle::load_coccinelle_rules(Path::new(rules_path)),
+        None => (Vec::new(), Vec::new()),
     };
-    let ((scan_result, mut diff_result), mut notices) =
-        run_diff_with_warnings(&args.path, &args.target, &registry, args.max_file_size)?;
+    let coccinelle_rule_ids = coccinelle::rule_ids(&coccinelle_rules);
+    let rule_filter_unknown = if let Some(config) = config.as_ref() {
+        coccinelle::apply_rule_filter(
+            &mut coccinelle_rules,
+            &config.scan.enable_rules,
+            &config.scan.disable_rules,
+        );
+        registry.apply_rule_filter_with_known(
+            &config.scan.enable_rules,
+            &config.scan.disable_rules,
+            &coccinelle_rule_ids,
+        )
+    } else {
+        registry.apply_rule_filter_with_known(&[], &[], &coccinelle_rule_ids)
+    };
+    let ((scan_result, mut diff_result), mut notices) = run_diff_with_coccinelle_warnings(
+        &args.path,
+        &args.target,
+        &registry,
+        &coccinelle_rules,
+        args.max_file_size,
+    )?;
+    notices.append(&mut coccinelle_notices);
     append_scan_stats_notice(&mut notices, &scan_result.stats);
 
     if !rule_filter_unknown.is_empty() {
@@ -387,7 +412,7 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     // Annotate CNSA 2.0 deadlines on the new findings surfaced by this diff.
     crate::compliance::annotate_cnsa2_deadlines(&mut diff_result.new_findings, &registry);
 
-    let known_rule_ids = collect_rule_ids(&registry, &[]);
+    let known_rule_ids = collect_rule_ids(&registry, &coccinelle_rules);
     let override_warnings = apply_severity_overrides(
         &mut diff_result.new_findings,
         config.as_ref(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub struct ScanArgs {
     #[arg(short, long, value_enum)]
     pub severity: Option<SeverityFilter>,
 
-    /// Path to Semgrep YAML rule file or directory
+    /// Path to external YAML rule file or directory
     #[arg(short, long)]
     pub rules: Option<String>,
 
@@ -297,7 +297,7 @@ pub struct DiffArgs {
     #[arg(short, long, value_enum)]
     pub severity: Option<SeverityFilter>,
 
-    /// Path to Semgrep YAML rule file or directory
+    /// Path to external YAML rule file or directory
     #[arg(short, long)]
     pub rules: Option<String>,
 
@@ -328,7 +328,7 @@ pub struct TuiArgs {
     #[arg(short, long, value_enum)]
     pub severity: Option<SeverityFilter>,
 
-    /// Path to Semgrep YAML rule file or directory
+    /// Path to external YAML rule file or directory
     #[arg(short, long)]
     pub rules: Option<String>,
 
@@ -502,7 +502,7 @@ pub enum Command {
 #[derive(Parser, Debug)]
 #[command(
     name = "foxguard",
-    about = "Fast local security guard for changed files, built-in rules, and Semgrep-compatible YAML",
+    about = "Fast local security guard for changed files, built-in rules, and external YAML",
     version
 )]
 pub struct Cli {

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,5 +1,6 @@
 use crate::engine::{
-    scan_directory_with_notices, scan_paths_with_root_with_notices, ScanResult, ScanStats,
+    coccinelle, scan_directory_with_notices, scan_paths_with_root_with_notices, ScanResult,
+    ScanStats,
 };
 use crate::rules::RuleRegistry;
 use crate::Finding;
@@ -75,6 +76,7 @@ fn scan_target_branch_files_with_warnings(
     target: &str,
     changed_files: &[PathBuf],
     registry: &RuleRegistry,
+    coccinelle_rules: &[coccinelle::CoccinelleRule],
     max_file_size: u64,
 ) -> Result<(ScanResult, Vec<String>), String> {
     let temp_dir =
@@ -117,13 +119,29 @@ fn scan_target_branch_files_with_warnings(
         ));
     }
 
-    Ok(scan_paths_with_root_with_notices(
+    let (mut result, mut warnings) = scan_paths_with_root_with_notices(
         temp_dir.path(),
         &temp_paths,
         registry,
         max_file_size,
         None,
-    ))
+    );
+
+    if !coccinelle_rules.is_empty() {
+        append_coccinelle_scan(
+            &mut result,
+            &mut warnings,
+            coccinelle::scan_paths_with_notices(
+                temp_dir.path(),
+                &temp_paths,
+                coccinelle_rules,
+                max_file_size,
+                None,
+            ),
+        );
+    }
+
+    Ok((result, warnings))
 }
 
 /// Two findings are "the same" if they share the same rule_id and snippet content.
@@ -186,6 +204,16 @@ pub fn run_diff_with_warnings(
     registry: &RuleRegistry,
     max_file_size: u64,
 ) -> Result<((ScanResult, DiffResult), Vec<String>), String> {
+    run_diff_with_coccinelle_warnings(scan_path, target, registry, &[], max_file_size)
+}
+
+pub fn run_diff_with_coccinelle_warnings(
+    scan_path: &str,
+    target: &str,
+    registry: &RuleRegistry,
+    coccinelle_rules: &[coccinelle::CoccinelleRule],
+    max_file_size: u64,
+) -> Result<((ScanResult, DiffResult), Vec<String>), String> {
     let scan_root = Path::new(scan_path);
     let repo = repo_root(scan_root)?;
 
@@ -194,8 +222,15 @@ pub fn run_diff_with_warnings(
         .map_err(|_| format!("Target ref '{}' does not exist", target))?;
 
     // Scan current working tree
-    let (current_result, mut warnings) =
+    let (mut current_result, mut warnings) =
         scan_directory_with_notices(scan_path, registry, max_file_size, None);
+    if !coccinelle_rules.is_empty() {
+        append_coccinelle_scan(
+            &mut current_result,
+            &mut warnings,
+            coccinelle::scan_path_with_notices(scan_root, coccinelle_rules, max_file_size, None),
+        );
+    }
 
     // Get changed files between target and HEAD
     let changed = changed_files_vs_target(&repo, target)?;
@@ -221,8 +256,14 @@ pub fn run_diff_with_warnings(
         ));
     }
 
-    let (base_result, base_warnings) =
-        scan_target_branch_files_with_warnings(&repo, target, &changed, registry, max_file_size)?;
+    let (base_result, base_warnings) = scan_target_branch_files_with_warnings(
+        &repo,
+        target,
+        &changed,
+        registry,
+        coccinelle_rules,
+        max_file_size,
+    )?;
     warnings.extend(base_warnings);
     let current_files_scanned = current_result.files_scanned;
     let current_stats = current_result.stats.clone();
@@ -266,6 +307,27 @@ pub fn run_diff_with_warnings(
         ),
         warnings,
     ))
+}
+
+fn append_coccinelle_scan(
+    result: &mut ScanResult,
+    warnings: &mut Vec<String>,
+    coccinelle_result: coccinelle::CoccinelleScanResult,
+) {
+    if coccinelle_result.candidate_files == 0 {
+        return;
+    }
+
+    result.files_scanned += coccinelle_result.files_scanned;
+    result.findings.extend(coccinelle_result.findings);
+    result.findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then(a.line.cmp(&b.line))
+            .then(a.column.cmp(&b.column))
+            .then(a.rule_id.cmp(&b.rule_id))
+    });
+    warnings.extend(coccinelle_result.notices);
 }
 
 #[cfg(test)]

--- a/src/engine/coccinelle.rs
+++ b/src/engine/coccinelle.rs
@@ -6,7 +6,6 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_yaml::Value as YamlValue;
 use std::collections::HashSet;
-use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -250,8 +249,7 @@ fn scan_candidates(
         };
     }
 
-    let spatch = spatch_command();
-    if let Err(error) = probe_spatch(&spatch) {
+    if let Err(error) = probe_spatch() {
         return CoccinelleScanResult {
             findings: Vec::new(),
             files_scanned: 0,
@@ -288,7 +286,7 @@ fn scan_candidates(
         }
 
         for path in &candidates {
-            match run_spatch(&spatch, temp_rule.path(), path) {
+            match run_spatch(temp_rule.path(), path) {
                 Ok(output) => {
                     scanned_files.insert(path.clone());
                     findings.extend(parse_spatch_output(rule, path, scan_root, &output));
@@ -319,8 +317,8 @@ fn scan_candidates(
     }
 }
 
-fn run_spatch(spatch: &OsString, script_path: &Path, target: &Path) -> Result<String, String> {
-    let output = Command::new(spatch)
+fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
+    let output = Command::new("spatch")
         .arg("--very-quiet")
         .arg("--sp-file")
         .arg(script_path)
@@ -355,8 +353,8 @@ fn run_spatch(spatch: &OsString, script_path: &Path, target: &Path) -> Result<St
     }
 }
 
-fn probe_spatch(spatch: &OsString) -> Result<(), String> {
-    match Command::new(spatch).arg("--version").output() {
+fn probe_spatch() -> Result<(), String> {
+    match Command::new("spatch").arg("--version").output() {
         Ok(output) if output.status.success() => Ok(()),
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -372,10 +370,6 @@ fn probe_spatch(spatch: &OsString) -> Result<(), String> {
         }
         Err(e) => Err(format!("failed to run spatch --version: {}", e)),
     }
-}
-
-fn spatch_command() -> OsString {
-    std::env::var_os("FOXGUARD_SPATCH").unwrap_or_else(|| OsString::from("spatch"))
 }
 
 fn parse_spatch_output(

--- a/src/engine/coccinelle.rs
+++ b/src/engine/coccinelle.rs
@@ -1,0 +1,703 @@
+use crate::engine::scanner::PathExcludeMatcher;
+use crate::rules::common::get_source_line;
+use crate::{Finding, Severity};
+use ignore::WalkBuilder;
+use regex::Regex;
+use serde::Deserialize;
+use serde_yaml::Value as YamlValue;
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+#[derive(Debug, Clone)]
+pub struct CoccinelleRule {
+    pub id: String,
+    pub message: String,
+    pub severity: Severity,
+    pub cwe: Option<String>,
+    script: String,
+    languages: Vec<String>,
+}
+
+pub struct CoccinelleScanResult {
+    pub findings: Vec<Finding>,
+    pub files_scanned: usize,
+    pub candidate_files: usize,
+    pub notices: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoccinelleRuleYaml {
+    id: String,
+    #[serde(default)]
+    engine: Option<String>,
+    message: String,
+    severity: FlexibleSeverity,
+    #[serde(default)]
+    languages: Vec<String>,
+    #[serde(default)]
+    metadata: Option<CoccinelleMetadata>,
+    #[serde(default)]
+    script: Option<String>,
+    #[serde(default)]
+    script_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoccinelleMetadata {
+    cwe: Option<CweValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CweValue {
+    Single(String),
+    List(Vec<String>),
+}
+
+#[derive(Debug)]
+struct FlexibleSeverity(Severity);
+
+impl<'de> Deserialize<'de> for FlexibleSeverity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        let severity = match raw.to_ascii_lowercase().as_str() {
+            "critical" | "error" => Severity::Critical,
+            "high" | "warning" => Severity::High,
+            "medium" | "info" => Severity::Medium,
+            "low" => Severity::Low,
+            other => {
+                return Err(serde::de::Error::custom(format!(
+                    "unsupported Coccinelle severity '{}'",
+                    other
+                )))
+            }
+        };
+        Ok(Self(severity))
+    }
+}
+
+impl CoccinelleRule {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn applies_to_c(&self) -> bool {
+        self.languages.is_empty()
+            || self.languages.iter().any(|lang| {
+                matches!(
+                    lang.to_ascii_lowercase().as_str(),
+                    "c" | "cocci" | "coccinelle"
+                )
+            })
+    }
+}
+
+pub fn rule_ids(rules: &[CoccinelleRule]) -> HashSet<String> {
+    rules.iter().map(|rule| rule.id.clone()).collect()
+}
+
+pub fn apply_rule_filter(rules: &mut Vec<CoccinelleRule>, enable: &[String], disable: &[String]) {
+    if !enable.is_empty() {
+        let enable_set: HashSet<&str> = enable.iter().map(|id| id.as_str()).collect();
+        rules.retain(|rule| enable_set.contains(rule.id()));
+    }
+
+    if !disable.is_empty() {
+        let disable_set: HashSet<&str> = disable.iter().map(|id| id.as_str()).collect();
+        rules.retain(|rule| !disable_set.contains(rule.id()));
+    }
+}
+
+pub fn load_coccinelle_rules(path: &Path) -> (Vec<CoccinelleRule>, Vec<String>) {
+    let mut rules = Vec::new();
+    let mut notices = Vec::new();
+
+    if path.is_file() {
+        match parse_coccinelle_file(path) {
+            Ok(parsed) => rules.extend(parsed),
+            Err(error) => notices.push(format!("Warning: {}", error)),
+        }
+    } else if path.is_dir() {
+        let walker = walkdir::WalkDir::new(path)
+            .into_iter()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry.file_type().is_file()
+                    && matches!(
+                        entry.path().extension().and_then(|ext| ext.to_str()),
+                        Some("yaml" | "yml")
+                    )
+            });
+
+        for entry in walker {
+            match parse_coccinelle_file(entry.path()) {
+                Ok(parsed) => rules.extend(parsed),
+                Err(error) => notices.push(format!("Warning: {}", error)),
+            }
+        }
+    }
+
+    (rules, notices)
+}
+
+pub fn parse_coccinelle_file(path: &Path) -> Result<Vec<CoccinelleRule>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    let raw_doc: YamlValue = serde_yaml::from_str(&content)
+        .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
+
+    let Some(raw_rules) = raw_doc.get("rules").and_then(YamlValue::as_sequence) else {
+        return Ok(Vec::new());
+    };
+
+    let mut rules = Vec::new();
+    for raw_rule in raw_rules {
+        if !is_coccinelle_rule(raw_rule) {
+            continue;
+        }
+
+        let yaml: CoccinelleRuleYaml = serde_yaml::from_value(raw_rule.clone()).map_err(|e| {
+            format!(
+                "Failed to parse Coccinelle rule in {}: {}",
+                path.display(),
+                e
+            )
+        })?;
+
+        let engine = yaml.engine.as_deref().unwrap_or_default();
+        if !engine.eq_ignore_ascii_case("coccinelle") {
+            continue;
+        }
+
+        let script = resolve_script(path, &yaml)?;
+        let cwe = yaml
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.cwe.as_ref())
+            .and_then(extract_cwe);
+
+        rules.push(CoccinelleRule {
+            id: yaml.id,
+            message: yaml.message,
+            severity: yaml.severity.0,
+            cwe,
+            script,
+            languages: yaml.languages,
+        });
+    }
+
+    Ok(rules)
+}
+
+pub fn scan_path_with_notices(
+    root: &Path,
+    rules: &[CoccinelleRule],
+    max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
+) -> CoccinelleScanResult {
+    let scan_root = scan_root(root);
+    let candidates = collect_c_files(root, scan_root, max_file_size, excludes);
+    scan_candidates(scan_root, candidates, rules)
+}
+
+pub fn scan_paths_with_notices(
+    root: &Path,
+    paths: &[PathBuf],
+    rules: &[CoccinelleRule],
+    max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
+) -> CoccinelleScanResult {
+    let scan_root = scan_root(root);
+    let candidates = paths
+        .iter()
+        .filter(|path| is_c_file(path))
+        .filter(|path| {
+            !excludes
+                .is_some_and(|matcher| matcher.is_excluded(&relative_scan_path(scan_root, path)))
+        })
+        .filter_map(|path| {
+            if std::fs::metadata(path).ok()?.len() > max_file_size {
+                return None;
+            }
+            Some(path.clone())
+        })
+        .collect();
+    scan_candidates(scan_root, candidates, rules)
+}
+
+fn scan_candidates(
+    scan_root: &Path,
+    candidates: Vec<PathBuf>,
+    rules: &[CoccinelleRule],
+) -> CoccinelleScanResult {
+    let candidate_files = candidates.len();
+    let active_rules: Vec<&CoccinelleRule> =
+        rules.iter().filter(|rule| rule.applies_to_c()).collect();
+
+    if active_rules.is_empty() || candidates.is_empty() {
+        return CoccinelleScanResult {
+            findings: Vec::new(),
+            files_scanned: 0,
+            candidate_files,
+            notices: Vec::new(),
+        };
+    }
+
+    let spatch = spatch_command();
+    if let Err(error) = probe_spatch(&spatch) {
+        return CoccinelleScanResult {
+            findings: Vec::new(),
+            files_scanned: 0,
+            candidate_files,
+            notices: vec![format!(
+                "Warning: Coccinelle engine skipped: {}; install Coccinelle (`spatch`) to run engine: coccinelle rules",
+                error
+            )],
+        };
+    }
+
+    let mut findings = Vec::new();
+    let mut notices = Vec::new();
+    let mut scanned_files = HashSet::new();
+
+    for rule in active_rules {
+        let mut temp_rule = match tempfile::NamedTempFile::new() {
+            Ok(file) => file,
+            Err(e) => {
+                notices.push(format!(
+                    "Warning: Coccinelle rule '{}' skipped: failed to create temp file: {}",
+                    rule.id, e
+                ));
+                continue;
+            }
+        };
+
+        if let Err(e) = temp_rule.write_all(rule.script.as_bytes()) {
+            notices.push(format!(
+                "Warning: Coccinelle rule '{}' skipped: failed to write SmPL temp file: {}",
+                rule.id, e
+            ));
+            continue;
+        }
+
+        for path in &candidates {
+            match run_spatch(&spatch, temp_rule.path(), path) {
+                Ok(output) => {
+                    scanned_files.insert(path.clone());
+                    findings.extend(parse_spatch_output(rule, path, scan_root, &output));
+                }
+                Err(error) => notices.push(format!(
+                    "Warning: Coccinelle rule '{}' failed on {}: {}",
+                    rule.id,
+                    path.display(),
+                    error
+                )),
+            }
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.file
+            .cmp(&b.file)
+            .then(a.line.cmp(&b.line))
+            .then(a.column.cmp(&b.column))
+            .then(a.rule_id.cmp(&b.rule_id))
+    });
+
+    CoccinelleScanResult {
+        findings,
+        files_scanned: scanned_files.len(),
+        candidate_files,
+        notices,
+    }
+}
+
+fn run_spatch(spatch: &OsString, script_path: &Path, target: &Path) -> Result<String, String> {
+    let output = Command::new(spatch)
+        .arg("--very-quiet")
+        .arg("--sp-file")
+        .arg(script_path)
+        .arg(target)
+        .output()
+        .map_err(|e| format!("failed to run spatch: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if stderr.trim().is_empty() {
+        stdout.to_string()
+    } else if stdout.trim().is_empty() {
+        stderr.to_string()
+    } else {
+        format!("{stdout}\n{stderr}")
+    };
+
+    if output.status.success()
+        || combined.contains("\n@@ ")
+        || combined.starts_with("@@ ")
+        || combined.contains("\n--- ")
+        || combined.starts_with("--- ")
+    {
+        Ok(combined)
+    } else {
+        let message = combined.trim();
+        if message.is_empty() {
+            Err("spatch exited without output".to_string())
+        } else {
+            Err(message.to_string())
+        }
+    }
+}
+
+fn probe_spatch(spatch: &OsString) -> Result<(), String> {
+    match Command::new(spatch).arg("--version").output() {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let message = stderr.trim();
+            if message.is_empty() {
+                Err("spatch --version failed".to_string())
+            } else {
+                Err(message.to_string())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err("spatch not found on PATH".to_string())
+        }
+        Err(e) => Err(format!("failed to run spatch --version: {}", e)),
+    }
+}
+
+fn spatch_command() -> OsString {
+    std::env::var_os("FOXGUARD_SPATCH").unwrap_or_else(|| OsString::from("spatch"))
+}
+
+fn parse_spatch_output(
+    rule: &CoccinelleRule,
+    target: &Path,
+    scan_root: &Path,
+    output: &str,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let mut seen = HashSet::new();
+
+    for line in diff_hunk_lines(output) {
+        if seen.insert(line) {
+            findings.push(make_finding(rule, target, scan_root, line));
+        }
+    }
+
+    if findings.is_empty() {
+        for line in file_line_matches(output, target) {
+            if seen.insert(line) {
+                findings.push(make_finding(rule, target, scan_root, line));
+            }
+        }
+    }
+
+    findings
+}
+
+fn diff_hunk_lines(output: &str) -> Vec<usize> {
+    static HUNK_RE: OnceLock<Regex> = OnceLock::new();
+    let hunk_re = HUNK_RE.get_or_init(|| {
+        Regex::new(r"^@@\s+-(?P<line>\d+)(?:,\d+)?\s+\+(?:\d+)(?:,\d+)?\s+@@")
+            .expect("invalid Coccinelle hunk regex")
+    });
+    static CONTEXT_HUNK_RE: OnceLock<Regex> = OnceLock::new();
+    let context_hunk_re = CONTEXT_HUNK_RE.get_or_init(|| {
+        Regex::new(r"^\*\*\*\s+(?P<line>\d+)(?:,\d+)?\s+\*\*\*\*")
+            .expect("invalid Coccinelle context hunk regex")
+    });
+
+    output
+        .lines()
+        .filter_map(|line| {
+            hunk_re
+                .captures(line)
+                .or_else(|| context_hunk_re.captures(line))
+                .and_then(|captures| captures.name("line"))
+                .and_then(|line| line.as_str().parse::<usize>().ok())
+        })
+        .collect()
+}
+
+fn file_line_matches(output: &str, target: &Path) -> Vec<usize> {
+    static FILE_LINE_RE: OnceLock<Regex> = OnceLock::new();
+    let file_line_re = FILE_LINE_RE.get_or_init(|| {
+        Regex::new(r"(?m)^(?P<file>[^:\n]+):(?P<line>\d+)(?::\d+)?:")
+            .expect("invalid Coccinelle file-line regex")
+    });
+    let target_name = target.file_name().and_then(|name| name.to_str());
+
+    file_line_re
+        .captures_iter(output)
+        .filter_map(|captures| {
+            let file = captures.name("file")?.as_str();
+            if target_name.is_some_and(|name| file.ends_with(name)) || target.ends_with(file) {
+                captures.name("line")?.as_str().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn make_finding(rule: &CoccinelleRule, target: &Path, scan_root: &Path, line: usize) -> Finding {
+    let source = std::fs::read_to_string(target).unwrap_or_default();
+    let line_start = byte_offset_for_line(&source, line);
+    let snippet = get_source_line(&source, line_start);
+    let column = 1;
+    let end_column = snippet.chars().count().max(1) + 1;
+
+    Finding {
+        rule_id: rule.id.clone(),
+        severity: rule.severity,
+        cwe: rule.cwe.clone(),
+        description: rule.message.clone(),
+        file: display_scan_path(scan_root, target),
+        line,
+        column,
+        end_line: line,
+        end_column,
+        snippet,
+        source_line: None,
+        source_description: None,
+        sink_line: None,
+        sink_description: None,
+        fix_suggestion: None,
+        sink_start_byte: None,
+        sink_end_byte: None,
+        confidence: 0.8,
+        taint_hops: None,
+        tags: vec![],
+        crypto_algorithm: None,
+        cnsa2_deadline: None,
+        dep_name: None,
+    }
+}
+
+fn byte_offset_for_line(source: &str, line: usize) -> usize {
+    if line <= 1 {
+        return 0;
+    }
+
+    let mut current = 1;
+    for (idx, byte) in source.bytes().enumerate() {
+        if byte == b'\n' {
+            current += 1;
+            if current == line {
+                return idx + 1;
+            }
+        }
+    }
+    source.len()
+}
+
+fn collect_c_files(
+    root: &Path,
+    scan_root: &Path,
+    max_file_size: u64,
+    excludes: Option<&PathExcludeMatcher>,
+) -> Vec<PathBuf> {
+    if root.is_file() {
+        if is_c_file(root)
+            && !excludes
+                .is_some_and(|matcher| matcher.is_excluded(&relative_scan_path(scan_root, root)))
+            && std::fs::metadata(root).is_ok_and(|metadata| metadata.len() <= max_file_size)
+        {
+            return vec![root.to_path_buf()];
+        }
+        return Vec::new();
+    }
+
+    WalkBuilder::new(root)
+        .follow_links(false)
+        .hidden(true)
+        .git_ignore(true)
+        .build()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .map(|entry| entry.into_path())
+        .filter(|path| is_c_file(path))
+        .filter(|path| {
+            !excludes
+                .is_some_and(|matcher| matcher.is_excluded(&relative_scan_path(scan_root, path)))
+        })
+        .filter(|path| {
+            std::fs::metadata(path).is_ok_and(|metadata| metadata.len() <= max_file_size)
+        })
+        .collect()
+}
+
+fn is_c_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("c" | "h")
+    )
+}
+
+fn scan_root(path: &Path) -> &Path {
+    if path.is_file() {
+        path.parent().unwrap_or_else(|| Path::new("."))
+    } else {
+        path
+    }
+}
+
+fn relative_scan_path(scan_root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(scan_root).unwrap_or(path).to_path_buf()
+}
+
+fn display_scan_path(scan_root: &Path, path: &Path) -> String {
+    path.strip_prefix(scan_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn is_coccinelle_rule(raw_rule: &YamlValue) -> bool {
+    raw_rule
+        .get("engine")
+        .and_then(YamlValue::as_str)
+        .is_some_and(|engine| engine.eq_ignore_ascii_case("coccinelle"))
+}
+
+fn resolve_script(path: &Path, yaml: &CoccinelleRuleYaml) -> Result<String, String> {
+    match (&yaml.script, &yaml.script_path) {
+        (Some(script), None) => Ok(script.clone()),
+        (None, Some(script_path)) => {
+            let script_path = resolve_script_path(path, script_path);
+            std::fs::read_to_string(&script_path).map_err(|e| {
+                format!(
+                    "Failed to read Coccinelle script_path {}: {}",
+                    script_path.display(),
+                    e
+                )
+            })
+        }
+        (Some(_), Some(_)) => Err(format!(
+            "Coccinelle rule '{}' in {} must use either script or script_path, not both",
+            yaml.id,
+            path.display()
+        )),
+        (None, None) => Err(format!(
+            "Coccinelle rule '{}' in {} is missing script or script_path",
+            yaml.id,
+            path.display()
+        )),
+    }
+}
+
+fn resolve_script_path(rule_file: &Path, script_path: &str) -> PathBuf {
+    let path = Path::new(script_path);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        rule_file
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(path)
+    }
+}
+
+fn extract_cwe(cwe: &CweValue) -> Option<String> {
+    match cwe {
+        CweValue::Single(cwe) => Some(cwe.clone()),
+        CweValue::List(cwes) => cwes.first().cloned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn sample_rule() -> CoccinelleRule {
+        CoccinelleRule {
+            id: "kernel/test-cocci".to_string(),
+            message: "missing guard".to_string(),
+            severity: Severity::High,
+            cwe: Some("CWE-362".to_string()),
+            script: "@@\n@@\n".to_string(),
+            languages: vec!["c".to_string()],
+        }
+    }
+
+    #[test]
+    fn parses_coccinelle_yaml_rule() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"
+rules:
+  - id: kernel/test-cocci
+    engine: coccinelle
+    severity: high
+    languages: [c]
+    message: missing guard
+    metadata:
+      cwe: CWE-362
+    script: |
+      @@
+      @@
+"#,
+        )
+        .unwrap();
+
+        let rules = parse_coccinelle_file(file.path()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].id, "kernel/test-cocci");
+        assert_eq!(rules[0].severity, Severity::High);
+        assert_eq!(rules[0].cwe.as_deref(), Some("CWE-362"));
+    }
+
+    #[test]
+    fn parses_unified_diff_hunk_as_finding_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vulnerable.c");
+        std::fs::write(
+            &target,
+            "int f(void) {\n  int ok = 0;\n  crypto_aead_decrypt(skb);\n}\n",
+        )
+        .unwrap();
+
+        let output = format!(
+            "--- {}\n+++ /tmp/cocci-output\n@@ -3,7 +3,7 @@\n",
+            target.display()
+        );
+        let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), &output);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 3);
+        assert!(findings[0].snippet.contains("crypto_aead_decrypt"));
+        assert_eq!(findings[0].file, "vulnerable.c");
+    }
+
+    #[test]
+    fn parses_context_diff_hunk_as_finding_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("vulnerable.c");
+        std::fs::write(
+            &target,
+            "int f(void) {\n  int ok = 0;\n  crypto_aead_decrypt(skb);\n}\n",
+        )
+        .unwrap();
+
+        let output = format!(
+            "*** {}\n--- /tmp/cocci-output\n***************\n*** 3,7 ****\n",
+            target.display()
+        );
+        let findings = parse_spatch_output(&sample_rule(), &target, dir.path(), &output);
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 3);
+        assert!(findings[0].snippet.contains("crypto_aead_decrypt"));
+    }
+}

--- a/src/engine/coccinelle.rs
+++ b/src/engine/coccinelle.rs
@@ -6,10 +6,12 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_yaml::Value as YamlValue;
 use std::collections::HashSet;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::OnceLock;
+use std::time::Duration;
+use wait_timeout::ChildExt;
 
 #[derive(Debug, Clone)]
 pub struct CoccinelleRule {
@@ -120,7 +122,10 @@ pub fn load_coccinelle_rules(path: &Path) -> (Vec<CoccinelleRule>, Vec<String>) 
 
     if path.is_file() {
         match parse_coccinelle_file(path) {
-            Ok(parsed) => rules.extend(parsed),
+            Ok((parsed, mut parsed_notices)) => {
+                rules.extend(parsed);
+                notices.append(&mut parsed_notices);
+            }
             Err(error) => notices.push(format!("Warning: {}", error)),
         }
     } else if path.is_dir() {
@@ -137,7 +142,10 @@ pub fn load_coccinelle_rules(path: &Path) -> (Vec<CoccinelleRule>, Vec<String>) 
 
         for entry in walker {
             match parse_coccinelle_file(entry.path()) {
-                Ok(parsed) => rules.extend(parsed),
+                Ok((parsed, mut parsed_notices)) => {
+                    rules.extend(parsed);
+                    notices.append(&mut parsed_notices);
+                }
                 Err(error) => notices.push(format!("Warning: {}", error)),
             }
         }
@@ -146,36 +154,60 @@ pub fn load_coccinelle_rules(path: &Path) -> (Vec<CoccinelleRule>, Vec<String>) 
     (rules, notices)
 }
 
-pub fn parse_coccinelle_file(path: &Path) -> Result<Vec<CoccinelleRule>, String> {
+pub fn parse_coccinelle_file(path: &Path) -> Result<(Vec<CoccinelleRule>, Vec<String>), String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
     let raw_doc: YamlValue = serde_yaml::from_str(&content)
         .map_err(|e| format!("Failed to parse YAML {}: {}", path.display(), e))?;
 
     let Some(raw_rules) = raw_doc.get("rules").and_then(YamlValue::as_sequence) else {
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     };
 
     let mut rules = Vec::new();
-    for raw_rule in raw_rules {
+    let mut notices = Vec::new();
+    for (index, raw_rule) in raw_rules.iter().enumerate() {
         if !is_coccinelle_rule(raw_rule) {
             continue;
         }
 
-        let yaml: CoccinelleRuleYaml = serde_yaml::from_value(raw_rule.clone()).map_err(|e| {
-            format!(
-                "Failed to parse Coccinelle rule in {}: {}",
-                path.display(),
-                e
-            )
-        })?;
+        let rule_position = index + 1;
+        let raw_id = raw_rule
+            .get("id")
+            .and_then(YamlValue::as_str)
+            .unwrap_or("<unknown>");
+        let yaml: CoccinelleRuleYaml = match serde_yaml::from_value(raw_rule.clone()) {
+            Ok(yaml) => yaml,
+            Err(error) => {
+                notices.push(format!(
+                    "Warning: Coccinelle rule '{}' in {} at rule {} skipped: {}",
+                    raw_id,
+                    path.display(),
+                    rule_position,
+                    error
+                ));
+                continue;
+            }
+        };
 
         let engine = yaml.engine.as_deref().unwrap_or_default();
         if !engine.eq_ignore_ascii_case("coccinelle") {
             continue;
         }
 
-        let script = resolve_script(path, &yaml)?;
+        let script = match resolve_script(path, &yaml) {
+            Ok(script) => script,
+            Err(error) => {
+                notices.push(format!(
+                    "Warning: Coccinelle rule '{}' in {} at rule {} skipped: {}",
+                    yaml.id,
+                    path.display(),
+                    rule_position,
+                    error
+                ));
+                continue;
+            }
+        };
         let cwe = yaml
             .metadata
             .as_ref()
@@ -192,7 +224,7 @@ pub fn parse_coccinelle_file(path: &Path) -> Result<Vec<CoccinelleRule>, String>
         });
     }
 
-    Ok(rules)
+    Ok((rules, notices))
 }
 
 pub fn scan_path_with_notices(
@@ -318,16 +350,42 @@ fn scan_candidates(
 }
 
 fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
-    let output = Command::new("spatch")
+    let timeout = spatch_timeout();
+    let mut child = Command::new("spatch")
         .arg("--very-quiet")
         .arg("--sp-file")
         .arg(script_path)
         .arg(target)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("failed to run spatch: {}", e))?;
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let status = match child
+        .wait_timeout(timeout)
+        .map_err(|e| format!("failed to wait for spatch: {}", e))?
+    {
+        Some(status) => status,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("spatch timed out after {}s", timeout.as_secs()));
+        }
+    };
+
+    let mut stdout = Vec::new();
+    if let Some(mut pipe) = child.stdout.take() {
+        pipe.read_to_end(&mut stdout)
+            .map_err(|e| format!("failed to read spatch stdout: {}", e))?;
+    }
+    let mut stderr = Vec::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        pipe.read_to_end(&mut stderr)
+            .map_err(|e| format!("failed to read spatch stderr: {}", e))?;
+    }
+
+    let stdout = String::from_utf8_lossy(&stdout);
+    let stderr = String::from_utf8_lossy(&stderr);
     let combined = if stderr.trim().is_empty() {
         stdout.to_string()
     } else if stdout.trim().is_empty() {
@@ -336,7 +394,7 @@ fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
         format!("{stdout}\n{stderr}")
     };
 
-    if output.status.success()
+    if status.success()
         || combined.contains("\n@@ ")
         || combined.starts_with("@@ ")
         || combined.contains("\n--- ")
@@ -351,6 +409,15 @@ fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
             Err(message.to_string())
         }
     }
+}
+
+fn spatch_timeout() -> Duration {
+    let secs = std::env::var("FOXGUARD_SPATCH_TIMEOUT_SECS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(60);
+    Duration::from_secs(secs)
 }
 
 fn probe_spatch() -> Result<(), String> {
@@ -380,17 +447,33 @@ fn parse_spatch_output(
 ) -> Vec<Finding> {
     let mut findings = Vec::new();
     let mut seen = HashSet::new();
+    let source = std::fs::read_to_string(target).unwrap_or_default();
+    let line_starts = line_start_offsets(&source);
 
     for line in diff_hunk_lines(output) {
         if seen.insert(line) {
-            findings.push(make_finding(rule, target, scan_root, line));
+            findings.push(make_finding(
+                rule,
+                target,
+                scan_root,
+                line,
+                &source,
+                &line_starts,
+            ));
         }
     }
 
     if findings.is_empty() {
         for line in file_line_matches(output, target) {
             if seen.insert(line) {
-                findings.push(make_finding(rule, target, scan_root, line));
+                findings.push(make_finding(
+                    rule,
+                    target,
+                    scan_root,
+                    line,
+                    &source,
+                    &line_starts,
+                ));
             }
         }
     }
@@ -443,10 +526,16 @@ fn file_line_matches(output: &str, target: &Path) -> Vec<usize> {
         .collect()
 }
 
-fn make_finding(rule: &CoccinelleRule, target: &Path, scan_root: &Path, line: usize) -> Finding {
-    let source = std::fs::read_to_string(target).unwrap_or_default();
-    let line_start = byte_offset_for_line(&source, line);
-    let snippet = get_source_line(&source, line_start);
+fn make_finding(
+    rule: &CoccinelleRule,
+    target: &Path,
+    scan_root: &Path,
+    line: usize,
+    source: &str,
+    line_starts: &[usize],
+) -> Finding {
+    let line_start = byte_offset_for_line(line_starts, source.len(), line);
+    let snippet = get_source_line(source, line_start);
     let column = 1;
     let end_column = snippet.chars().count().max(1) + 1;
 
@@ -477,21 +566,21 @@ fn make_finding(rule: &CoccinelleRule, target: &Path, scan_root: &Path, line: us
     }
 }
 
-fn byte_offset_for_line(source: &str, line: usize) -> usize {
-    if line <= 1 {
-        return 0;
-    }
-
-    let mut current = 1;
+fn line_start_offsets(source: &str) -> Vec<usize> {
+    let mut offsets = vec![0];
     for (idx, byte) in source.bytes().enumerate() {
         if byte == b'\n' {
-            current += 1;
-            if current == line {
-                return idx + 1;
-            }
+            offsets.push(idx + 1);
         }
     }
-    source.len()
+    offsets
+}
+
+fn byte_offset_for_line(line_starts: &[usize], source_len: usize, line: usize) -> usize {
+    line_starts
+        .get(line.saturating_sub(1))
+        .copied()
+        .unwrap_or(source_len)
 }
 
 fn collect_c_files(
@@ -645,11 +734,52 @@ rules:
         )
         .unwrap();
 
-        let rules = parse_coccinelle_file(file.path()).unwrap();
+        let (rules, notices) = parse_coccinelle_file(file.path()).unwrap();
+        assert!(notices.is_empty());
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].id, "kernel/test-cocci");
         assert_eq!(rules[0].severity, Severity::High);
         assert_eq!(rules[0].cwe.as_deref(), Some("CWE-362"));
+    }
+
+    #[test]
+    fn skips_malformed_coccinelle_rule_with_notice() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(
+            br#"
+rules:
+  - id: kernel/good-cocci
+    engine: coccinelle
+    severity: high
+    message: good
+    script: |
+      @@
+      @@
+  - id: kernel/bad-cocci
+    engine: coccinelle
+    severity: unknown
+    message: bad
+    script: |
+      @@
+      @@
+  - id: kernel/second-good-cocci
+    engine: coccinelle
+    severity: low
+    message: second good
+    script: |
+      @@
+      @@
+"#,
+        )
+        .unwrap();
+
+        let (rules, notices) = parse_coccinelle_file(file.path()).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].id, "kernel/good-cocci");
+        assert_eq!(rules[1].id, "kernel/second-good-cocci");
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("kernel/bad-cocci"));
+        assert!(notices[0].contains("rule 2"));
     }
 
     #[test]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod coccinelle;
 pub mod parser;
 pub mod scanner;
 

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -192,7 +192,7 @@ impl PathExcludeMatcher {
         Ok(Self { prefixes, globset })
     }
 
-    fn is_excluded(&self, path: &Path) -> bool {
+    pub(crate) fn is_excluded(&self, path: &Path) -> bool {
         let normalized = normalize_match_path(path);
 
         self.prefixes.iter().any(|prefix| {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -541,12 +541,24 @@ impl RuleRegistry {
     /// correspond to any registered rule. Callers should surface these
     /// as a single warning so users catch typos without failing the scan.
     pub fn apply_rule_filter(&mut self, enable: &[String], disable: &[String]) -> Vec<String> {
+        self.apply_rule_filter_with_known(enable, disable, &std::collections::HashSet::new())
+    }
+
+    pub fn apply_rule_filter_with_known(
+        &mut self,
+        enable: &[String],
+        disable: &[String],
+        additional_known: &std::collections::HashSet<String>,
+    ) -> Vec<String> {
         let known: std::collections::HashSet<&str> = self.rules.iter().map(|r| r.id()).collect();
 
         let mut unknown: Vec<String> = Vec::new();
         let mut seen_unknown: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for id in enable.iter().chain(disable.iter()) {
-            if !known.contains(id.as_str()) && seen_unknown.insert(id.as_str()) {
+            if !known.contains(id.as_str())
+                && !additional_known.contains(id.as_str())
+                && seen_unknown.insert(id.as_str())
+            {
                 unknown.push(id.clone());
             }
         }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -979,6 +979,14 @@ pub fn parse_semgrep_file(path: &Path) -> Result<Vec<Box<dyn Rule>>, String> {
 
     if let Some(raw_rules) = raw_doc.get("rules").and_then(YamlValue::as_sequence) {
         for raw_rule in raw_rules {
+            if raw_rule
+                .get("engine")
+                .and_then(YamlValue::as_str)
+                .is_some_and(|engine| engine.eq_ignore_ascii_case("coccinelle"))
+            {
+                continue;
+            }
+
             match semgrep_taint::parse_taint_rule(raw_rule) {
                 TaintRuleParse::Compiled(r) => rules.push(Box::new(r)),
                 TaintRuleParse::Skip(msg) => eprintln!("Warning: {}", msg),

--- a/tests/coccinelle_integration.rs
+++ b/tests/coccinelle_integration.rs
@@ -65,7 +65,12 @@ fn coccinelle_rule_runs_via_spatch_and_normalizes_json() {
 
     let output = foxguard_cmd()
         .current_dir(repo.path())
-        .env("FOXGUARD_SPATCH", fake_spatch)
+        .env(
+            "PATH",
+            fake_spatch
+                .parent()
+                .expect("fake spatch should have a parent"),
+        )
         .args([
             ".",
             "-f",
@@ -116,7 +121,7 @@ fn missing_spatch_skips_coccinelle_once_without_failing_scan() {
 
     let output = foxguard_cmd()
         .current_dir(repo.path())
-        .env("FOXGUARD_SPATCH", repo.path().join("missing-spatch"))
+        .env("PATH", repo.path())
         .args([
             ".",
             "-f",

--- a/tests/coccinelle_integration.rs
+++ b/tests/coccinelle_integration.rs
@@ -1,0 +1,153 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn foxguard_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_foxguard"))
+}
+
+fn fixture_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("coccinelle")
+        .join(relative)
+}
+
+fn write_fake_spatch(dir: &Path, hunk_line: usize) -> PathBuf {
+    let path = dir.join("spatch");
+    let script = format!(
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "spatch version fake"
+  exit 0
+fi
+last=""
+while [ "$#" -gt 0 ]; do
+  last="$1"
+  shift
+done
+echo "--- $last"
+echo "+++ /tmp/cocci-output"
+echo "@@ -{hunk_line},7 +{hunk_line},7 @@"
+exit 0
+"#
+    );
+    fs::write(&path, script).expect("failed to write fake spatch");
+
+    let mut perms = fs::metadata(&path)
+        .expect("failed to stat fake spatch")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&path, perms).expect("failed to chmod fake spatch");
+    path
+}
+
+fn repo_with_c_fixture() -> TempDir {
+    let repo = TempDir::new().expect("failed to create temp repo");
+    fs::copy(
+        fixture_path("dirty_frag_vulnerable.c"),
+        repo.path().join("vulnerable.c"),
+    )
+    .expect("failed to copy C fixture");
+    repo
+}
+
+#[test]
+fn coccinelle_rule_runs_via_spatch_and_normalizes_json() {
+    let repo = repo_with_c_fixture();
+    let fake_spatch = write_fake_spatch(repo.path(), 11);
+    let rules = fixture_path("dirty-frag-rules.yml");
+
+    let output = foxguard_cmd()
+        .current_dir(repo.path())
+        .env("FOXGUARD_SPATCH", fake_spatch)
+        .args([
+            ".",
+            "-f",
+            "json",
+            "--no-builtins",
+            "--rules",
+            rules.to_str().expect("rules path is UTF-8"),
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        !output.status.success(),
+        "findings should make foxguard exit non-zero"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert_eq!(findings.len(), 1, "expected one Coccinelle finding");
+
+    let finding = &findings[0];
+    assert_eq!(
+        finding["rule_id"].as_str(),
+        Some("kernel/dirty-frag-inplace-crypto-no-cow")
+    );
+    assert_eq!(finding["severity"].as_str(), Some("high"));
+    assert_eq!(finding["cwe"].as_str(), Some("CWE-362"));
+    assert_eq!(finding["line"].as_u64(), Some(11));
+    assert_eq!(finding["column"].as_u64(), Some(1));
+    assert!(
+        finding["file"]
+            .as_str()
+            .unwrap_or_default()
+            .ends_with("vulnerable.c"),
+        "unexpected file field: {:?}",
+        finding["file"]
+    );
+    assert!(finding["snippet"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("crypto_aead_decrypt"));
+}
+
+#[test]
+fn missing_spatch_skips_coccinelle_once_without_failing_scan() {
+    let repo = repo_with_c_fixture();
+    let rules = fixture_path("dirty-frag-rules.yml");
+
+    let output = foxguard_cmd()
+        .current_dir(repo.path())
+        .env("FOXGUARD_SPATCH", repo.path().join("missing-spatch"))
+        .args([
+            ".",
+            "-f",
+            "json",
+            "--no-builtins",
+            "--rules",
+            rules.to_str().expect("rules path is UTF-8"),
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success(),
+        "missing spatch should skip Coccinelle rules, not fail the scan"
+    );
+
+    let findings: Vec<serde_json::Value> =
+        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    assert!(
+        findings.is_empty(),
+        "missing spatch should emit no findings"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("spatch not found"),
+        "expected missing spatch warning, got: {stderr}"
+    );
+    assert_eq!(
+        stderr.matches("Coccinelle engine skipped").count(),
+        1,
+        "expected a single missing dependency warning, got: {stderr}"
+    );
+}

--- a/tests/coccinelle_integration.rs
+++ b/tests/coccinelle_integration.rs
@@ -57,6 +57,14 @@ fn repo_with_c_fixture() -> TempDir {
     repo
 }
 
+fn json_findings(stdout: &[u8]) -> Vec<serde_json::Value> {
+    let report: serde_json::Value = serde_json::from_slice(stdout).expect("invalid JSON output");
+    report["findings"]
+        .as_array()
+        .expect("JSON report should include findings array")
+        .clone()
+}
+
 #[test]
 fn coccinelle_rule_runs_via_spatch_and_normalizes_json() {
     let repo = repo_with_c_fixture();
@@ -87,8 +95,7 @@ fn coccinelle_rule_runs_via_spatch_and_normalizes_json() {
         "findings should make foxguard exit non-zero"
     );
 
-    let findings: Vec<serde_json::Value> =
-        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    let findings = json_findings(&output.stdout);
     assert_eq!(findings.len(), 1, "expected one Coccinelle finding");
 
     let finding = &findings[0];
@@ -138,8 +145,7 @@ fn missing_spatch_skips_coccinelle_once_without_failing_scan() {
         "missing spatch should skip Coccinelle rules, not fail the scan"
     );
 
-    let findings: Vec<serde_json::Value> =
-        serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+    let findings = json_findings(&output.stdout);
     assert!(
         findings.is_empty(),
         "missing spatch should emit no findings"

--- a/tests/fixtures/coccinelle/dirty-frag-inplace-crypto-no-cow.cocci
+++ b/tests/fixtures/coccinelle/dirty-frag-inplace-crypto-no-cow.cocci
@@ -1,0 +1,10 @@
+@@
+identifier fn;
+expression skb, req;
+@@
+fn(...) {
+  <...
+  when != skb_cow_data(skb, ...)
+  crypto_aead_decrypt(req)
+  ...>
+}

--- a/tests/fixtures/coccinelle/dirty-frag-rules.yml
+++ b/tests/fixtures/coccinelle/dirty-frag-rules.yml
@@ -1,0 +1,9 @@
+rules:
+  - id: kernel/dirty-frag-inplace-crypto-no-cow
+    engine: coccinelle
+    severity: high
+    languages: [c]
+    metadata:
+      cwe: CWE-362
+    message: In-place crypto on skb data without a preceding copy-on-write gate.
+    script_path: dirty-frag-inplace-crypto-no-cow.cocci

--- a/tests/fixtures/coccinelle/dirty_frag_safe.c
+++ b/tests/fixtures/coccinelle/dirty_frag_safe.c
@@ -1,0 +1,20 @@
+struct sk_buff;
+struct aead_request;
+
+int esp_input(struct sk_buff *skb, struct aead_request *req)
+{
+    int err = 0;
+
+    if (!skb)
+        return -1;
+
+    err = skb_cow_data(skb, 0, 0);
+    if (err)
+        return err;
+
+    err = crypto_aead_decrypt(req);
+    if (err)
+        return err;
+
+    return 0;
+}

--- a/tests/fixtures/coccinelle/dirty_frag_vulnerable.c
+++ b/tests/fixtures/coccinelle/dirty_frag_vulnerable.c
@@ -1,0 +1,16 @@
+struct sk_buff;
+struct aead_request;
+
+int esp_input(struct sk_buff *skb, struct aead_request *req)
+{
+    int err = 0;
+
+    if (!skb)
+        return -1;
+
+    err = crypto_aead_decrypt(req);
+    if (err)
+        return err;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add an engine: coccinelle YAML loader and spatch subprocess runner
- normalize Coccinelle diff output into standard foxguard Finding values
- wire Coccinelle rules into scan flow, config rule filters, excludes, and missing-spatch warnings
- add Dirty Frag-style fixtures, fake-spatch integration coverage, and compatibility docs

## Tests
- cargo test

Refs #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Coccinelle semantic-patch support for scanning C sources and merging those findings into regular scans and diffs; external rules via --rules now accept both Semgrep YAML and Coccinelle SmPL.

* **Documentation**
  * Updated compatibility guide and README to describe the Coccinelle bridge, supported keys, execution behavior, and cross-file analysis.

* **CLI**
  * Clarified help/about text to reflect expanded rule engine support.

* **Tests**
  * Added unit and integration tests covering Coccinelle rule parsing, execution, result normalization, and missing-tool handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PwnKit-Labs/foxguard/pull/306)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->