### PR TITLE
fix: normalize paths for scan ignores and baselines

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
-use crate::baseline::{load_baseline, suppress_with_baseline, write_baseline};
+use crate::baseline::{load_baseline, suppress_with_baseline_at_root, write_baseline_at_root};
 use crate::cli::{DiffArgs, OutputFormat, ScanArgs, SecretsArgs, TuiArgs};
 use crate::config::{
     apply_scan_defaults, apply_scan_thresholds, apply_secrets_defaults, apply_severity_overrides,
-    load_for_scan, suppress_with_scan_ignores,
+    load_for_scan, suppress_with_scan_ignores, FoxguardConfig,
 };
 use crate::diff::run_diff_with_warnings;
 use crate::engine::{
@@ -94,6 +94,7 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
     let config = load_for_scan(Path::new(&scan.path), scan.config.as_deref())?;
     validate_root_path(&scan.path)?;
     validate_rules_path(scan.rules.as_deref())?;
+    let identity_root = finding_identity_root(Path::new(&scan.path), config.as_ref());
 
     // Install any `scan.thresholds.*` overrides into process-wide state
     // before the rules run. Must happen after config load and before
@@ -192,10 +193,10 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
         findings.retain(|f| f.severity >= min);
     }
 
-    findings = suppress_with_scan_ignores(findings, config.as_ref());
+    findings = suppress_with_scan_ignores(findings, config.as_ref(), &identity_root);
 
     if let Some(ref path) = scan.write_baseline {
-        write_baseline(Path::new(path), &findings)?;
+        write_baseline_at_root(Path::new(path), &findings, &identity_root)?;
         notices.push(format!("Wrote baseline to {}", path));
     }
 
@@ -204,7 +205,7 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
         None => None,
     };
 
-    findings = suppress_with_baseline(findings, baseline.as_ref());
+    findings = suppress_with_baseline_at_root(findings, baseline.as_ref(), &identity_root);
 
     if files_scanned == 0 {
         notices.push(
@@ -224,6 +225,8 @@ pub fn execute_scan(scan: &ScanArgs) -> Result<ScanExecution, String> {
 
 pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
     let args = resolve_secrets_args(args)?;
+    let config_for_identity = load_for_scan(Path::new(&args.path), args.config.as_deref())?;
+    let identity_root = finding_identity_root(Path::new(&args.path), config_for_identity.as_ref());
     validate_root_path(&args.path)?;
 
     let scan_path = Path::new(&args.path);
@@ -257,7 +260,7 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
         };
 
     if let Some(ref path) = args.write_baseline {
-        write_baseline(Path::new(path), &findings)?;
+        write_baseline_at_root(Path::new(path), &findings, &identity_root)?;
         notices.push(format!("Wrote secrets baseline to {}", path));
     }
 
@@ -265,7 +268,7 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
         Some(path) => load_baseline(Path::new(path))?,
         None => None,
     };
-    findings = suppress_with_baseline(findings, baseline.as_ref());
+    findings = suppress_with_baseline_at_root(findings, baseline.as_ref(), &identity_root);
 
     Ok(SecretsExecution {
         args,
@@ -279,6 +282,7 @@ pub fn execute_secrets(args: &SecretsArgs) -> Result<SecretsExecution, String> {
 pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), None)?;
+    let identity_root = finding_identity_root(Path::new(&args.path), config.as_ref());
     apply_scan_thresholds(config.as_ref());
     let mut registry = build_registry(args.no_builtins, args.rules.as_deref())?;
     let rule_filter_unknown = if let Some(config) = config.as_ref() {
@@ -321,7 +325,7 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     }
 
     diff_result.new_findings =
-        suppress_with_scan_ignores(diff_result.new_findings, config.as_ref());
+        suppress_with_scan_ignores(diff_result.new_findings, config.as_ref(), &identity_root);
 
     notices.push(format!(
         "foxguard diff vs {}: {} new issue{} ({} total, {} existing)",
@@ -452,6 +456,13 @@ fn collect_rule_ids(registry: &RuleRegistry) -> std::collections::HashSet<String
         .iter()
         .map(|rule| rule.id().to_string())
         .collect()
+}
+
+fn finding_identity_root(scan_path: &Path, config: Option<&FoxguardConfig>) -> PathBuf {
+    crate::path_identity::project_root(
+        scan_path,
+        config.map(|config| config.project_root.as_path()),
+    )
 }
 
 fn build_registry(no_builtins: bool, rules: Option<&str>) -> Result<RuleRegistry, String> {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -26,8 +26,33 @@ impl BaselineFile {
         }
     }
 
+    pub fn from_findings_at_root(findings: &[Finding], identity_root: &Path) -> Self {
+        let entries = findings
+            .iter()
+            .map(|finding| BaselineEntry::from_finding_at_root(finding, identity_root))
+            .collect();
+        Self {
+            version: 1,
+            entries,
+        }
+    }
+
     pub fn add_finding(&mut self, finding: &Finding) -> bool {
         let entry = BaselineEntry::from_finding(finding);
+        if self
+            .entries
+            .iter()
+            .any(|existing| existing.fingerprint == entry.fingerprint)
+        {
+            return false;
+        }
+
+        self.entries.push(entry);
+        true
+    }
+
+    pub fn add_finding_at_root(&mut self, finding: &Finding, identity_root: &Path) -> bool {
+        let entry = BaselineEntry::from_finding_at_root(finding, identity_root);
         if self
             .entries
             .iter()
@@ -50,13 +75,32 @@ impl BaselineEntry {
             line: finding.line,
         }
     }
+
+    pub fn from_finding_at_root(finding: &Finding, identity_root: &Path) -> Self {
+        let normalized_file = crate::path_identity::finding_path_key(identity_root, &finding.file);
+        Self {
+            fingerprint: fingerprint_finding_with_file(finding, &normalized_file),
+            rule_id: finding.rule_id.clone(),
+            file: normalized_file,
+            line: finding.line,
+        }
+    }
 }
 
 pub fn fingerprint_finding(finding: &Finding) -> String {
+    fingerprint_finding_with_file(finding, &finding.file)
+}
+
+pub fn fingerprint_finding_at_root(finding: &Finding, identity_root: &Path) -> String {
+    let normalized_file = crate::path_identity::finding_path_key(identity_root, &finding.file);
+    fingerprint_finding_with_file(finding, &normalized_file)
+}
+
+fn fingerprint_finding_with_file(finding: &Finding, file: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(finding.rule_id.as_bytes());
     hasher.update([0]);
-    hasher.update(finding.file.as_bytes());
+    hasher.update(file.as_bytes());
     hasher.update([0]);
     hasher.update(finding.line.to_string().as_bytes());
     hasher.update([0]);
@@ -84,6 +128,21 @@ pub fn load_baseline(path: &Path) -> Result<Option<BaselineFile>, String> {
 }
 
 pub fn write_baseline(path: &Path, findings: &[Finding]) -> Result<(), String> {
+    write_baseline_file(path, BaselineFile::from_findings(findings))
+}
+
+pub fn write_baseline_at_root(
+    path: &Path,
+    findings: &[Finding],
+    identity_root: &Path,
+) -> Result<(), String> {
+    write_baseline_file(
+        path,
+        BaselineFile::from_findings_at_root(findings, identity_root),
+    )
+}
+
+fn write_baseline_file(path: &Path, baseline: BaselineFile) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
             format!(
@@ -94,7 +153,6 @@ pub fn write_baseline(path: &Path, findings: &[Finding]) -> Result<(), String> {
         })?;
     }
 
-    let baseline = BaselineFile::from_findings(findings);
     let content = serde_json::to_string_pretty(&baseline)
         .map_err(|e| format!("Failed to serialize baseline: {}", e))?;
     std::fs::write(path, content)
@@ -102,6 +160,22 @@ pub fn write_baseline(path: &Path, findings: &[Finding]) -> Result<(), String> {
 }
 
 pub fn append_finding_to_baseline(path: &Path, finding: &Finding) -> Result<bool, String> {
+    append_finding_to_baseline_inner(path, finding, None)
+}
+
+pub fn append_finding_to_baseline_at_root(
+    path: &Path,
+    finding: &Finding,
+    identity_root: &Path,
+) -> Result<bool, String> {
+    append_finding_to_baseline_inner(path, finding, Some(identity_root))
+}
+
+fn append_finding_to_baseline_inner(
+    path: &Path,
+    finding: &Finding,
+    identity_root: Option<&Path>,
+) -> Result<bool, String> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
             format!(
@@ -116,7 +190,11 @@ pub fn append_finding_to_baseline(path: &Path, finding: &Finding) -> Result<bool
         version: 1,
         entries: Vec::new(),
     });
-    let added = baseline.add_finding(finding);
+    let added = if let Some(identity_root) = identity_root {
+        baseline.add_finding_at_root(finding, identity_root)
+    } else {
+        baseline.add_finding(finding)
+    };
 
     let content = serde_json::to_string_pretty(&baseline)
         .map_err(|e| format!("Failed to serialize baseline: {}", e))?;
@@ -130,6 +208,22 @@ pub fn suppress_with_baseline(
     findings: Vec<Finding>,
     baseline: Option<&BaselineFile>,
 ) -> Vec<Finding> {
+    suppress_with_baseline_inner(findings, baseline, None)
+}
+
+pub fn suppress_with_baseline_at_root(
+    findings: Vec<Finding>,
+    baseline: Option<&BaselineFile>,
+    identity_root: &Path,
+) -> Vec<Finding> {
+    suppress_with_baseline_inner(findings, baseline, Some(identity_root))
+}
+
+fn suppress_with_baseline_inner(
+    findings: Vec<Finding>,
+    baseline: Option<&BaselineFile>,
+    identity_root: Option<&Path>,
+) -> Vec<Finding> {
     let Some(baseline) = baseline else {
         return findings;
     };
@@ -137,11 +231,15 @@ pub fn suppress_with_baseline(
     findings
         .into_iter()
         .filter(|finding| {
-            let fingerprint = fingerprint_finding(finding);
-            !baseline
-                .entries
-                .iter()
-                .any(|entry| entry.fingerprint == fingerprint)
+            let fingerprint = identity_root
+                .map(|root| fingerprint_finding_at_root(finding, root))
+                .unwrap_or_else(|| fingerprint_finding(finding));
+            let legacy_fingerprint = fingerprint_finding(finding);
+            !baseline.entries.iter().any(|entry| {
+                entry.fingerprint == fingerprint
+                    || entry.fingerprint == legacy_fingerprint
+                    || entry.fingerprint == fingerprint_finding_with_file(finding, &entry.file)
+            })
         })
         .collect()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_yaml::{Mapping, Sequence, Value};
 use std::collections::HashMap;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 
 const CONFIG_NAMES: [&str; 4] = [
     ".foxguard.yml",
@@ -18,6 +18,7 @@ const CONFIG_NAMES: [&str; 4] = [
 
 #[derive(Debug, Clone, Default)]
 pub struct FoxguardConfig {
+    pub project_root: PathBuf,
     pub scan: ScanConfig,
     pub secrets: SecretsConfig,
 }
@@ -340,6 +341,7 @@ impl FoxguardConfig {
         };
 
         Ok(Self {
+            project_root: allowed_root.to_path_buf(),
             scan: ScanConfig {
                 rules: scan_rules,
                 no_builtins: raw.scan.no_builtins.unwrap_or(false),
@@ -415,6 +417,7 @@ pub fn apply_severity_overrides(
 pub fn suppress_with_scan_ignores(
     findings: Vec<Finding>,
     config: Option<&FoxguardConfig>,
+    identity_root: &Path,
 ) -> Vec<Finding> {
     let Some(config) = config else {
         return findings;
@@ -426,8 +429,11 @@ pub fn suppress_with_scan_ignores(
     findings
         .into_iter()
         .filter(|finding| {
+            let finding_path_key =
+                crate::path_identity::finding_path_key(identity_root, &finding.file);
             !config.scan.ignore_rules.iter().any(|entry| {
-                entry.path == finding.file
+                crate::path_identity::stored_path_key(identity_root, &entry.path)
+                    == finding_path_key
                     && entry
                         .rules
                         .iter()
@@ -461,7 +467,7 @@ pub fn editable_config_path(
         return Ok(path);
     }
 
-    Ok(resolve_scan_root(scan_path).join(".foxguard.yml"))
+    Ok(crate::path_identity::resolve_scan_root(scan_path).join(".foxguard.yml"))
 }
 
 pub fn add_scan_ignore_rule(
@@ -471,11 +477,8 @@ pub fn add_scan_ignore_rule(
 ) -> Result<(PathBuf, bool), String> {
     let config_path = editable_config_path(scan_path, explicit_config)?;
     let config_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
-    let finding_path = Path::new(&finding.file);
-    let stored_path = match finding_path.strip_prefix(config_dir) {
-        Ok(relative) => relative.display().to_string(),
-        Err(_) => finding.file.clone(),
-    };
+    let allowed_root = resolve_allowed_root(scan_path, config_dir);
+    let stored_path = crate::path_identity::finding_path_key(&allowed_root, &finding.file);
 
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent).map_err(|e| {
@@ -531,7 +534,7 @@ pub fn add_scan_ignore_rule(
         let path_matches = item_mapping
             .get(Value::String("path".to_string()))
             .and_then(Value::as_str)
-            .map(|value| value == stored_path)
+            .map(|value| crate::path_identity::stored_path_key(&allowed_root, value) == stored_path)
             .unwrap_or(false);
         if !path_matches {
             continue;
@@ -947,7 +950,7 @@ fn resolve_value_path(
     } else {
         base.join(value)
     };
-    let resolved = resolve_path_for_boundary(&joined);
+    let resolved = crate::path_identity::resolve_path_for_boundary(&joined);
 
     if !resolved.starts_with(allowed_root) {
         return Err(format!(
@@ -962,74 +965,14 @@ fn resolve_value_path(
 }
 
 fn resolve_allowed_root(scan_path: &Path, config_dir: &Path) -> PathBuf {
-    let scan_root = resolve_scan_root(scan_path);
-    let config_dir = resolve_path_for_boundary(config_dir);
+    let scan_root = crate::path_identity::resolve_scan_root(scan_path);
+    let config_dir = crate::path_identity::resolve_path_for_boundary(config_dir);
 
     if scan_root.starts_with(&config_dir) {
         config_dir
     } else {
         scan_root
     }
-}
-
-fn resolve_scan_root(scan_path: &Path) -> PathBuf {
-    let scan_root = resolve_path_for_boundary(scan_path);
-    if scan_root.is_file() {
-        scan_root
-            .parent()
-            .unwrap_or_else(|| Path::new("."))
-            .to_path_buf()
-    } else {
-        scan_root
-    }
-}
-
-fn resolve_path_for_boundary(path: &Path) -> PathBuf {
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-
-    let absolute = absolutize_path(path);
-    for ancestor in absolute.ancestors() {
-        if let Ok(canonical_ancestor) = ancestor.canonicalize() {
-            let suffix = absolute
-                .strip_prefix(ancestor)
-                .unwrap_or_else(|_| Path::new(""));
-            return normalize_path(&canonical_ancestor.join(suffix));
-        }
-    }
-
-    normalize_path(&absolute)
-}
-
-fn absolutize_path(path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(path)
-    }
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
-            Component::RootDir => normalized.push(component.as_os_str()),
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if !normalized.pop() {
-                    normalized.push(component.as_os_str());
-                }
-            }
-            Component::Normal(part) => normalized.push(part),
-        }
-    }
-
-    normalized
 }
 
 #[cfg(test)]
@@ -1048,6 +991,34 @@ mod tests {
         }
         fs::write(&path, content).expect("failed to write config");
         path
+    }
+
+    fn finding_at(path: &Path) -> Finding {
+        Finding {
+            rule_id: "py/no-command-injection".to_string(),
+            severity: crate::Severity::High,
+            cwe: None,
+            description: "tainted input reaches command sink".to_string(),
+            file: path.display().to_string(),
+            line: 10,
+            column: 5,
+            end_line: 10,
+            end_column: 20,
+            snippet: "os.system(cmd)".to_string(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: crate::default_confidence(),
+            taint_hops: None,
+            tags: vec![],
+            crypto_algorithm: None,
+            cnsa2_deadline: None,
+            dep_name: None,
+        }
     }
 
     #[test]
@@ -1120,7 +1091,8 @@ mod tests {
         let loaded = load_for_scan(repo.path(), Some(config.to_str().expect("non-utf8 path")))
             .expect("failed to load config")
             .expect("expected config");
-        let expected = resolve_path_for_boundary(&repo.path().join("fixtures"));
+        let expected =
+            crate::path_identity::resolve_path_for_boundary(&repo.path().join("fixtures"));
 
         assert_eq!(
             loaded.secrets.exclude_paths,
@@ -1215,31 +1187,7 @@ mod tests {
     #[test]
     fn add_scan_ignore_rule_creates_or_updates_config() {
         let repo = TempDir::new().expect("failed to create temp dir");
-        let finding = Finding {
-            rule_id: "py/no-command-injection".to_string(),
-            severity: crate::Severity::High,
-            cwe: None,
-            description: "tainted input reaches command sink".to_string(),
-            file: repo.path().join("src/app.py").display().to_string(),
-            line: 10,
-            column: 5,
-            end_line: 10,
-            end_column: 20,
-            snippet: "os.system(cmd)".to_string(),
-            source_line: None,
-            source_description: None,
-            sink_line: None,
-            sink_description: None,
-            fix_suggestion: None,
-            sink_start_byte: None,
-            sink_end_byte: None,
-            confidence: crate::default_confidence(),
-            taint_hops: None,
-            tags: vec![],
-            crypto_algorithm: None,
-            cnsa2_deadline: None,
-            dep_name: None,
-        };
+        let finding = finding_at(&repo.path().join("src/app.py"));
 
         let (config_path, added) =
             add_scan_ignore_rule(repo.path(), None, &finding).expect("should write ignore rule");
@@ -1258,6 +1206,49 @@ mod tests {
         let (_, added_again) =
             add_scan_ignore_rule(repo.path(), None, &finding).expect("should preserve duplicate");
         assert!(!added_again);
+    }
+
+    #[test]
+    fn add_scan_ignore_rule_merges_legacy_absolute_path_entry() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        let app_path = repo.path().join("src/app.py");
+        write_config(
+            repo.path(),
+            ".foxguard.yml",
+            &format!(
+                "scan:\n  ignore_rules:\n    - path: {}\n      rules:\n        - py/no-sql-injection\n",
+                app_path.display()
+            ),
+        );
+        let finding = finding_at(&app_path);
+
+        let (_, added) =
+            add_scan_ignore_rule(repo.path(), None, &finding).expect("should update ignore rule");
+
+        assert!(added);
+        let content =
+            fs::read_to_string(repo.path().join(".foxguard.yml")).expect("failed to read config");
+        let value: Value = serde_yaml::from_str(&content).expect("failed to parse config");
+        let ignore_rules = value
+            .get("scan")
+            .and_then(|scan| scan.get("ignore_rules"))
+            .and_then(Value::as_sequence)
+            .expect("missing ignore_rules");
+        assert_eq!(
+            ignore_rules.len(),
+            1,
+            "expected existing legacy path entry to be updated"
+        );
+        let rules = ignore_rules[0]
+            .get("rules")
+            .and_then(Value::as_sequence)
+            .expect("missing rules");
+        assert!(
+            rules
+                .iter()
+                .any(|rule| rule.as_str() == Some("py/no-command-injection")),
+            "expected new rule to be merged into existing path entry"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod diff;
 pub mod engine;
 pub mod fix;
 pub mod git;
+pub mod path_identity;
 pub mod report;
 pub mod rules;
 pub mod secrets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use foxguard::app::{
     execute_diff, execute_scan, execute_secrets, resolve_scan_args as resolve_app_scan_args,
     scan_findings,
 };
-use foxguard::baseline::write_baseline;
+use foxguard::baseline::write_baseline_at_root;
 use foxguard::cli::{
     BaselineArgs, Cli, Command, DiffArgs, InitArgs, OutputFormat, PqcArgs, ScanArgs, SecretsArgs,
     TuiArgs,
@@ -116,7 +116,21 @@ fn run_baseline(args: &BaselineArgs) -> i32 {
         }
     };
 
-    if let Err(e) = write_baseline(Path::new(&args.output), &result.findings) {
+    let config = match load_for_scan(Path::new(&scan.path), scan.config.as_deref()) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            return 2;
+        }
+    };
+    let identity_root = foxguard::path_identity::project_root(
+        Path::new(&scan.path),
+        config.as_ref().map(|config| config.project_root.as_path()),
+    );
+
+    if let Err(e) =
+        write_baseline_at_root(Path::new(&args.output), &result.findings, &identity_root)
+    {
         eprintln!("Error: {}", e);
         return 2;
     }

--- a/src/path_identity.rs
+++ b/src/path_identity.rs
@@ -1,0 +1,205 @@
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+/// Resolve the directory that should anchor finding identity.
+///
+/// Prefer an explicitly configured project root, then the Git repository root,
+/// then the scan root. Callers use this as the base for stable baseline and
+/// suppression keys while leaving reported finding paths unchanged.
+pub fn project_root(scan_path: &Path, configured_root: Option<&Path>) -> PathBuf {
+    if let Some(root) = configured_root {
+        return resolve_path_for_boundary(root);
+    }
+
+    git_repo_root(scan_path).unwrap_or_else(|| resolve_scan_root(scan_path))
+}
+
+pub fn resolve_scan_root(scan_path: &Path) -> PathBuf {
+    let scan_root = resolve_path_for_boundary(scan_path);
+    if scan_root.is_file() {
+        scan_root
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf()
+    } else {
+        scan_root
+    }
+}
+
+/// Resolve a path for trust-boundary comparisons.
+///
+/// Existing paths are canonicalized. Missing leaf paths are resolved through
+/// the deepest canonical ancestor so config values like a not-yet-created
+/// baseline still compare against the correct root.
+pub fn resolve_path_for_boundary(path: &Path) -> PathBuf {
+    if is_windows_drive_absolute_path(path) {
+        return normalize_path(path);
+    }
+
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    let absolute = absolutize_path(path);
+    for ancestor in absolute.ancestors() {
+        if let Ok(canonical_ancestor) = ancestor.canonicalize() {
+            let suffix = absolute
+                .strip_prefix(ancestor)
+                .unwrap_or_else(|_| Path::new(""));
+            return normalize_path(&canonical_ancestor.join(suffix));
+        }
+    }
+
+    normalize_path(&absolute)
+}
+
+/// Normalize a scanner-emitted finding file path to the project-root-relative
+/// identity form. Relative finding paths are interpreted the same way the
+/// scanner emitted them: relative to the current process directory.
+pub fn finding_path_key(root: &Path, finding_file: &str) -> String {
+    let value = normalize_separators(finding_file);
+    let path = Path::new(&value);
+    let resolved = if path.is_absolute() || is_windows_drive_absolute(&value) {
+        resolve_path_for_boundary(path)
+    } else {
+        resolve_path_for_boundary(&current_dir().join(path))
+    };
+    root_relative_key(root, &resolved)
+}
+
+/// Normalize a persisted path from config or baseline data. Relative persisted
+/// paths are already project-root-relative; absolute paths are stripped back to
+/// the same identity form when they live under `root`.
+pub fn stored_path_key(root: &Path, stored_path: &str) -> String {
+    let value = normalize_separators(stored_path);
+    let path = Path::new(&value);
+    if path.is_absolute() || is_windows_drive_absolute(&value) {
+        root_relative_key(root, &resolve_path_for_boundary(path))
+    } else {
+        slash_path(&normalize_path(path))
+    }
+}
+
+fn root_relative_key(root: &Path, path: &Path) -> String {
+    let root = resolve_path_for_boundary(root);
+    let path = resolve_path_for_boundary(path);
+    let relative = path.strip_prefix(&root).unwrap_or(path.as_path());
+    slash_path(relative)
+}
+
+fn git_repo_root(scan_path: &Path) -> Option<PathBuf> {
+    let dir = if scan_path.is_dir() {
+        scan_path
+    } else {
+        scan_path.parent().unwrap_or_else(|| Path::new("."))
+    };
+
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let root = String::from_utf8_lossy(&output.stdout);
+    let root = root.trim();
+    if root.is_empty() {
+        None
+    } else {
+        Some(resolve_path_for_boundary(Path::new(root)))
+    }
+}
+
+fn current_dir() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+fn absolutize_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir().join(path)
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => normalized.push(part),
+        }
+    }
+
+    normalized
+}
+
+fn normalize_separators(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn is_windows_drive_absolute_path(path: &Path) -> bool {
+    is_windows_drive_absolute(&path.to_string_lossy().replace('\\', "/"))
+}
+
+fn is_windows_drive_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'/'
+}
+
+fn slash_path(path: &Path) -> String {
+    let normalized = normalize_path(path).to_string_lossy().replace('\\', "/");
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(normalized.as_str())
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn stored_relative_paths_use_forward_slashes() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+
+        assert_eq!(
+            stored_path_key(repo.path(), "src\\nested\\app.py"),
+            "src/nested/app.py"
+        );
+    }
+
+    #[test]
+    fn absolute_paths_under_root_become_root_relative() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        let path = repo.path().join("src/app.py");
+
+        assert_eq!(
+            stored_path_key(repo.path(), path.to_str().expect("non-utf8 path")),
+            "src/app.py"
+        );
+    }
+
+    #[test]
+    fn windows_drive_absolute_paths_are_not_treated_as_cwd_relative() {
+        let root = Path::new("C:/repo");
+
+        assert_eq!(
+            finding_path_key(root, "C:\\repo\\src\\app.py"),
+            "src/app.py"
+        );
+        assert_eq!(stored_path_key(root, "C:\\repo\\src\\app.py"), "src/app.py");
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -8,10 +8,11 @@ use super::widgets::{
 };
 use super::{open_command_spec, resolve_finding_path, OpenTarget, TerminalSession};
 use crate::app::TuiMode;
-use crate::baseline::append_finding_to_baseline;
+use crate::baseline::append_finding_to_baseline_at_root;
 use crate::config::{
     add_disabled_rule_to_config, add_scan_ignore_rule, add_secrets_ignored_rule,
     add_severity_override_to_config, current_severity_override, is_rule_disabled_in_config,
+    load_for_scan,
 };
 use crate::{Finding, Severity};
 use crossterm::event::{self, KeyCode, KeyEvent, MouseEvent, MouseEventKind};
@@ -637,7 +638,16 @@ impl TuiApp {
         match action {
             TriageAction::AddToBaseline => {
                 let baseline_path = self.baseline_path_for_actions()?;
-                let added = append_finding_to_baseline(&baseline_path, &finding)?;
+                let config = load_for_scan(
+                    Path::new(&self.request.path),
+                    self.request.config.as_deref(),
+                )?;
+                let identity_root = crate::path_identity::project_root(
+                    Path::new(&self.request.path),
+                    config.as_ref().map(|config| config.project_root.as_path()),
+                );
+                let added =
+                    append_finding_to_baseline_at_root(&baseline_path, &finding, &identity_root)?;
                 if added {
                     self.push_runtime_notice(format!(
                         "added finding to baseline {}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2084,6 +2084,57 @@ rules:
     }
 
     #[test]
+    fn test_config_baseline_applies_from_nested_working_directory() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        fs::create_dir_all(repo.path().join("src")).expect("failed to create src dir");
+        fs::copy(
+            fixture_path("vulnerable.js"),
+            repo.path().join("src/vulnerable.js"),
+        )
+        .expect("failed to copy vulnerable fixture");
+
+        write_config_file(repo.path(), ".foxguard.yml", "scan: {}\n");
+
+        let baseline = repo.path().join(".foxguard").join("baseline.json");
+        let initial = foxguard_cmd()
+            .current_dir(repo.path())
+            .args([
+                "src/vulnerable.js",
+                "-f",
+                "json",
+                "--write-baseline",
+                baseline.to_str().expect("non-utf8 path"),
+            ])
+            .output()
+            .expect("failed to execute foxguard baseline write");
+
+        assert!(
+            !initial.status.success(),
+            "writing a baseline should still report current findings"
+        );
+
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  baseline: .foxguard/baseline.json\n",
+        );
+
+        let suppressed = foxguard_cmd()
+            .current_dir(repo.path().join("src"))
+            .args([".", "-f", "json", "--config", "../.foxguard.yml"])
+            .output()
+            .expect("failed to execute foxguard from nested cwd");
+
+        assert!(
+            suppressed.status.success(),
+            "root-relative baseline should suppress from nested cwd"
+        );
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&suppressed.stdout).expect("invalid JSON output");
+        assert_eq!(findings.len(), 0, "expected configured baseline to apply");
+    }
+
+    #[test]
     fn test_enable_rules_allowlist_runs_only_listed_ids() {
         let repo = TempDir::new().expect("failed to create temp dir");
         copy_fixture_to(repo.path(), "vulnerable.py", "vulnerable.py");
@@ -2367,6 +2418,34 @@ rules:
                 .as_str()
                 .is_some_and(|file| file.ends_with("src/included.js"))),
             "expected excluded changed files to be skipped"
+        );
+    }
+
+    #[test]
+    fn test_scan_ignore_rules_match_nested_cwd_and_windows_separators() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        fs::create_dir_all(repo.path().join("src")).expect("failed to create src dir");
+        fs::write(repo.path().join("src/ignored.js"), "eval(userInput);\n")
+            .expect("failed to write ignored fixture");
+        write_config_file(
+            repo.path(),
+            ".foxguard.yml",
+            "scan:\n  ignore_rules:\n    - path: src\\ignored.js\n      rules:\n        - js/no-eval\n",
+        );
+
+        let output = foxguard_cmd()
+            .current_dir(repo.path().join("src"))
+            .args([".", "-f", "json", "--config", "../.foxguard.yml"])
+            .output()
+            .expect("failed to execute foxguard with scan.ignore_rules");
+
+        let findings: Vec<serde_json::Value> =
+            serde_json::from_slice(&output.stdout).expect("invalid JSON output");
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding["rule_id"].as_str() != Some("js/no-eval")),
+            "expected scan.ignore_rules to suppress js/no-eval from nested cwd"
         );
     }
 


### PR DESCRIPTION
## Summary
- add a shared path identity helper for project-root-relative finding keys
- normalize baseline fingerprints and scan.ignore_rules matching across absolute, relative, nested-cwd, and Windows-style separator paths
- keep compatibility with existing raw-path baseline fingerprints while writing new normalized baseline entries

Fixes #310

## Tests
- cargo test path_identity
- cargo test test_config_baseline_applies_from_nested_working_directory
- cargo test test_scan_ignore_rules_match_nested_cwd_and_windows_separators
- cargo test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable project root support for improved baseline consistency across different working directories.
  * Enhanced baseline and ignore-rule application to work correctly from nested directories.
  * Improved cross-platform path handling with better support for different path separators.

* **Tests**
  * Added integration tests for nested directory configuration and path handling scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PwnKit-Labs/foxguard/pull/324)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->