### PR TITLE
fix: suppress Dirty Frag crypto template wrapper FPs

### DIFF
--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
@@ -1,0 +1,22 @@
+# Dirty Frag class — authencesn exception for scatterwalk STORE on shared SGL.
+#
+# The broad Dirty Frag rules exclude crypto/** because most hits there are
+# AEAD/skcipher template wrappers with no skb-frag bug-class semantics.
+# crypto/authencesn.c is the named exception: it is a confirmed advisory site
+# for the scatterwalk_map_and_copy STORE primitive.
+rules:
+  - id: kernel/dirty-frag/scatterwalk-store-on-shared-sgl-authencesn
+    pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?scatterwalk_map_and_copy\s*\([^,]+,[^,]+,[^,]+,[^,]+,\s*1\s*\)'
+    message: |
+      scatterwalk_map_and_copy STORE (out=1) on the authencesn in-place AEAD
+      scatterlist (Dirty Frag class). crypto/authencesn.c is intentionally
+      included even though broader crypto template wrappers are excluded.
+      Verify the destination scatterlist aliases attacker-controllable input
+      before AEAD auth rejects the message.
+    severity: ERROR
+    languages: [c]
+    paths:
+      include:
+        - crypto/authencesn*.c
+    metadata:
+      cwe: "CWE-787"

--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
@@ -3,13 +3,13 @@
 # Pattern: scatterwalk_map_and_copy(..., dst, off, len, /*out=*/1) where dst
 # is part of an in-place AEAD request set up earlier in the same function via
 # aead_request_set_crypt(req, sg, sg, ...). This is the secondary STORE
-# primitive that Copy Fail and Dirty Frag both abuse in
-# crypto_authenc_esn_decrypt (crypto/authencesn.c).
+# primitive used by Copy Fail / Dirty Frag-style authenc clones. The confirmed
+# crypto/authencesn.c advisory site is handled by the narrower authencesn
+# exception rule because this broad rule excludes crypto/** template wrappers.
 #
 # Tier 1 sibling sites this rule also catches (see
 # scatterwalk_authenc_store_vulnerable.c):
-#   - crypto/authenc.c::crypto_authenc_decrypt (non-ESN sibling)
-#   - any out-of-tree authenc clone that mirrors the STORE primitive
+#   - any non-crypto-path authenc clone that mirrors the STORE primitive
 #
 # Recall caveats — shapes this rule MISSES:
 #   - the STORE done via memcpy_to_sglist or sg_pcopy_to_buffer instead of
@@ -43,9 +43,13 @@ rules:
       (Dirty Frag class). The destination scatterlist is shared with the
       attacker-controllable source SGL via aead_request_set_crypt(req, sg, sg, ...);
       a 4-byte STORE lands in caller-pinned memory regardless of AEAD auth
-      result. Calibration site: crypto/authencesn.c::crypto_authenc_esn_decrypt.
+      result. The confirmed crypto/authencesn.c site is covered by the
+      scatterwalk-store-on-shared-sgl-authencesn exception rule.
       See oss-security 2026-05-07 advisory and pwnkit issue #263.
     severity: ERROR
     languages: [c]
+    paths:
+      exclude:
+        - crypto/**
     metadata:
       cwe: "CWE-787"

--- a/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
@@ -52,5 +52,8 @@ rules:
       See oss-security 2026-05-07 advisory and pwnkit issue #263.
     severity: ERROR
     languages: [c]
+    paths:
+      exclude:
+        - crypto/**
     metadata:
       cwe: "CWE-787"

--- a/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
@@ -51,5 +51,8 @@ rules:
       See oss-security 2026-05-07 advisory and pwnkit issue #263.
     severity: ERROR
     languages: [c]
+    paths:
+      exclude:
+        - crypto/**
     metadata:
       cwe: "CWE-787"

--- a/tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c
+++ b/tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c
@@ -1,0 +1,37 @@
+// Negative fixture: crypto template-wrapper shape with no skb-frag semantics.
+// Models crypto/*.c false positives such as gcm/ccm/cts template wrappers.
+// MUST NOT be flagged when scanned at a crypto/** path.
+
+struct aead_request;
+struct skcipher_request;
+struct scatterlist;
+
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern int crypto_aead_decrypt(struct aead_request *req);
+extern void skcipher_request_set_crypt(struct skcipher_request *req,
+                                       struct scatterlist *src,
+                                       struct scatterlist *dst,
+                                       unsigned int cryptlen, void *iv);
+extern int crypto_skcipher_decrypt(struct skcipher_request *req);
+extern void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+                                     unsigned int start, unsigned int nbytes,
+                                     int out);
+
+int crypto_template_wrapper(struct aead_request *aead_req,
+                            struct skcipher_request *sk_req,
+                            struct scatterlist *sg,
+                            unsigned int cryptlen,
+                            void *iv, void *tag)
+{
+        aead_request_set_crypt(aead_req, sg, sg, cryptlen, iv);
+        crypto_aead_decrypt(aead_req);
+
+        skcipher_request_set_crypt(sk_req, sg, sg, cryptlen, iv);
+        crypto_skcipher_decrypt(sk_req);
+
+        scatterwalk_map_and_copy(tag, sg, cryptlen, 16, 1);
+        return 0;
+}

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c
@@ -1,7 +1,7 @@
 // Positive fixture (Tier 1 sibling): scatterwalk_map_and_copy STORE on
 // shared in-place AEAD SGL, sibling of crypto_authenc_esn_decrypt — covers
-// the structural shape in crypto/authenc.c::crypto_authenc_decrypt and
-// any downstream module that mirrors the authencesn STORE primitive.
+// the structural shape in downstream modules that mirror the authencesn
+// STORE primitive outside crypto/** template-wrapper paths.
 //
 // Synthetic minimal reproducer — NOT copied from kernel source.
 // MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c
@@ -1,7 +1,8 @@
 // Positive fixture: scatterwalk_map_and_copy STORE on in-place AEAD SGL.
 // Models crypto/authencesn.c::crypto_authenc_esn_decrypt — the secondary
 // STORE primitive abused by Copy Fail and Dirty Frag.
-// MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
+// MUST be flagged by the authencesn exception at crypto/authencesn.c, and by
+// the broad scatterwalk rule when scanned as a non-crypto clone path.
 
 
 /* Tree-sitter fixture — scanned as text by foxguard, never compiled.

--- a/tests/kernel_dirty_frag.rs
+++ b/tests/kernel_dirty_frag.rs
@@ -18,6 +18,10 @@ const RULES_DIR: &str = "rules/kernel/dirty-frag-class";
 const FIXTURES_DIR: &str = "tests/fixtures/kernel/dirty-frag";
 
 fn run_rule(rule_yaml: &str, fixture_basename: &str) -> usize {
+    run_rule_at_path(rule_yaml, fixture_basename, fixture_basename)
+}
+
+fn run_rule_at_path(rule_yaml: &str, fixture_basename: &str, scan_path: &str) -> usize {
     let rules =
         parse_semgrep_file(&Path::new(RULES_DIR).join(rule_yaml)).expect("rule parses cleanly");
     assert_eq!(rules.len(), 1, "expected one rule per yaml file");
@@ -25,6 +29,9 @@ fn run_rule(rule_yaml: &str, fixture_basename: &str) -> usize {
     let source =
         std::fs::read_to_string(Path::new(FIXTURES_DIR).join(fixture_basename)).expect("fixture");
     let tree = parse_file(&source, Language::C).expect("tree-sitter-c parses fixture");
+    if !rules[0].applies_to_path(Path::new(scan_path)) {
+        return 0;
+    }
     rules[0].check(&source, &tree).len()
 }
 
@@ -161,6 +168,40 @@ fn scatterwalk_store_on_shared_sgl_flags_authenc_sibling_fixture() {
         "expected authenc-style sibling positive fixture (in-place + STORE) to be flagged, got {} findings",
         n
     );
+}
+
+#[test]
+fn scatterwalk_authencesn_exception_flags_confirmed_crypto_site() {
+    let n = run_rule_at_path(
+        "scatterwalk-store-on-shared-sgl-authencesn.yaml",
+        "scatterwalk_store_vulnerable.c",
+        "crypto/authencesn.c",
+    );
+    assert!(
+        n >= 1,
+        "expected authencesn exception rule to flag confirmed crypto/authencesn.c shape, got {} findings",
+        n
+    );
+}
+
+#[test]
+fn dirty_frag_rules_ignore_crypto_template_wrapper_fixture() {
+    for rule_yaml in [
+        "skb-inplace-aead-no-cow.yaml",
+        "skb-inplace-skcipher-no-cow.yaml",
+        "scatterwalk-store-on-shared-sgl.yaml",
+        "scatterwalk-store-on-shared-sgl-authencesn.yaml",
+    ] {
+        let n = run_rule_at_path(
+            rule_yaml,
+            "crypto_template_wrapper_no_skb.c",
+            "crypto/gcm.c",
+        );
+        assert_eq!(
+            n, 0,
+            "expected {rule_yaml} to ignore crypto template-wrapper fixture, got {n} findings"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- exclude crypto/** from the broad Dirty Frag structural rules to avoid template-wrapper false positives
- add a narrow crypto/authencesn*.c scatterwalk exception for the confirmed advisory site
- add a crypto/gcm-style template-wrapper regression fixture that matches the old syntax but should not report

Fixes #323

## Tests
- cargo test --test kernel_dirty_frag
- cargo test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new kernel security rule to detect specific code patterns in cryptographic modules.

* **Improvements**
  * Refined kernel security rules to exclude crypto template wrapper implementations from scanning, reducing false positive detections and improving detection accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PwnKit-Labs/foxguard/pull/325)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->