### PR TITLE
feat: add first-class TypeScript and TSX parser support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -82,7 +82,7 @@ Taint rules (`mode: taint`):
 
 Language mapping:
 
-- JavaScript / TypeScript
+- JavaScript / TypeScript (`.ts` and `.tsx` use dedicated TypeScript/TSX parsers, then map onto the JavaScript-compatible rule surface)
 - Python
 - Go
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-swift",
+ "tree-sitter-typescript",
  "unicode-segmentation",
  "unicode-width",
  "uuid",
@@ -1871,6 +1872,16 @@ name = "tree-sitter-swift"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef216011c3e3df4fa864736f347cb8d509b1066cf0c8549fb1fd81ac9832e59"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 clap = { version = "4", features = ["derive"] }
 tree-sitter = "0.25"
 tree-sitter-javascript = "0.23"
+tree-sitter-typescript = "0.23"
 tree-sitter-python = "0.23"
 tree-sitter-go = "0.23"
 tree-sitter-ruby = "0.23"

--- a/docs/taint-tracking.md
+++ b/docs/taint-tracking.md
@@ -12,7 +12,7 @@ The taint engine answers the second, on a narrower footprint. It lets us ship ru
 
 The taint engine supports:
 
-- **Three languages**: Python, JavaScript/TypeScript, and Go, each with its own engine (`src/rules/python_taint.rs`, `src/rules/javascript_taint.rs`, `src/rules/go_taint.rs`) sharing an identical surface (`TaintSpec`, `NodeMatcher`, `TaintFinding`, `analyze_tree`). `.ts` files are parsed through tree-sitter-javascript, so the JS engine also covers TypeScript source.
+- **Three languages**: Python, JavaScript/TypeScript, and Go, each with its own engine (`src/rules/python_taint.rs`, `src/rules/javascript_taint.rs`, `src/rules/go_taint.rs`) sharing an identical surface (`TaintSpec`, `NodeMatcher`, `TaintFinding`, `analyze_tree`). `.ts` and `.tsx` files use dedicated tree-sitter TypeScript/TSX grammars, then run through the JavaScript-compatible rule and taint surface where semantics align.
 - **Intraprocedural**: each function body is analyzed independently.
 - **Flow-insensitive**: statements are processed in source order. Reassigning a tainted variable to a clean value drops the taint. Branches are not modeled — taint observed in one branch of an `if` persists through the fall-through.
 - **One level of attribute propagation**: `x.y` is tainted when `x` is tainted.

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -2,7 +2,7 @@ pub mod coccinelle;
 pub mod parser;
 pub mod scanner;
 
-pub use parser::parse_file;
+pub use parser::{parse_file, parse_path};
 pub use scanner::{
     detect_language, scan_directory, scan_directory_with_notices, scan_paths, scan_paths_with_root,
     scan_paths_with_root_with_notices, PathExcludeMatcher, ScanResult, ScanStats,

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -1,11 +1,25 @@
 use crate::Language;
+use std::path::Path;
 
 /// Parse source code into a tree-sitter Tree for the given language.
 pub fn parse_file(source: &str, language: Language) -> Option<tree_sitter::Tree> {
+    parse_source_for_path(source, language, None)
+}
+
+/// Parse source code, selecting path-specific grammar variants where needed.
+pub fn parse_path(source: &str, language: Language, path: &Path) -> Option<tree_sitter::Tree> {
+    parse_source_for_path(source, language, Some(path))
+}
+
+fn parse_source_for_path(
+    source: &str,
+    language: Language,
+    path: Option<&Path>,
+) -> Option<tree_sitter::Tree> {
     let mut parser = tree_sitter::Parser::new();
 
     let ts_language = match language {
-        Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+        Language::JavaScript => javascript_language_for_path(path),
         Language::Python => tree_sitter_python::LANGUAGE.into(),
         Language::Go => tree_sitter_go::LANGUAGE.into(),
         Language::Ruby => tree_sitter_ruby::LANGUAGE.into(),
@@ -25,4 +39,38 @@ pub fn parse_file(source: &str, language: Language) -> Option<tree_sitter::Tree>
 
     parser.set_language(&ts_language).ok()?;
     parser.parse(source, None)
+}
+
+fn javascript_language_for_path(path: Option<&Path>) -> tree_sitter::Language {
+    match path
+        .and_then(|path| path.extension())
+        .and_then(|ext| ext.to_str())
+    {
+        Some("ts" | "mts" | "cts") => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        Some("tsx") => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        _ => tree_sitter_javascript::LANGUAGE.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_typescript_syntax_without_errors() {
+        let source = "interface User { id: number }\nconst id = (user: User): number => user.id;\n";
+        let tree = parse_path(source, Language::JavaScript, Path::new("src/user.ts"))
+            .expect("TypeScript parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_tsx_syntax_without_errors() {
+        let source = "type Props = { title: string };\nexport const Card = ({ title }: Props) => <h1>{title}</h1>;\n";
+        let tree = parse_path(source, Language::JavaScript, Path::new("src/Card.tsx"))
+            .expect("TSX parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
 }

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -789,7 +789,7 @@ fn scan_files(
                 if is_minified(&source) {
                     return None;
                 }
-                let tree = super::parser::parse_file(&source, Language::JavaScript)?;
+                let tree = super::parser::parse_path(&source, Language::JavaScript, path)?;
                 if treats_tree_errors_as_parse_failures(Language::JavaScript, path)
                     && tree.root_node().has_error()
                 {
@@ -983,7 +983,7 @@ fn scan_files(
                 }
                 &prepared.tree
             } else {
-                let Some(parsed_tree) = super::parser::parse_file(source, *language) else {
+                let Some(parsed_tree) = super::parser::parse_path(source, *language, path) else {
                     warnings.lock().expect("lock poisoned").push(format!(
                         "warning: skipping {} (parser could not build a syntax tree)",
                         path.display()
@@ -1257,22 +1257,14 @@ fn resolve_canonical_path(lookup: &HashMap<PathBuf, PathBuf>, path: &Path) -> Pa
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-fn treats_tree_errors_as_parse_failures(language: Language, path: &Path) -> bool {
-    match language {
-        Language::JavaScript => !is_typescript_path(path),
+fn treats_tree_errors_as_parse_failures(language: Language, _path: &Path) -> bool {
+    !matches!(
+        language,
         Language::NginxConf
-        | Language::ApacheConf
-        | Language::HAProxyConf
-        | Language::Dockerfile
-        | Language::Manifest => false,
-        _ => true,
-    }
-}
-
-fn is_typescript_path(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|extension| extension.to_str()),
-        Some("ts" | "tsx" | "mts" | "cts")
+            | Language::ApacheConf
+            | Language::HAProxyConf
+            | Language::Dockerfile
+            | Language::Manifest
     )
 }
 

--- a/src/fix/mod.rs
+++ b/src/fix/mod.rs
@@ -2,7 +2,7 @@ pub mod command_injection;
 pub mod sql_injection;
 pub mod xss;
 
-use crate::engine::{detect_language, parse_file};
+use crate::engine::{detect_language, parse_path};
 use crate::Finding;
 use colored::Colorize;
 use std::collections::HashMap;
@@ -92,7 +92,7 @@ pub fn apply_all_fixes(findings: &[Finding], scan_root: &str) -> usize {
             None => continue,
         };
 
-        let tree = match parse_file(&source, language) {
+        let tree = match parse_path(&source, language, &file_path) {
             Some(t) => t,
             None => continue,
         };

--- a/tests/fixtures/vulnerable_tsx.tsx
+++ b/tests/fixtures/vulnerable_tsx.tsx
@@ -1,0 +1,7 @@
+type CardProps = {
+    expression: string;
+};
+
+export function Card({ expression }: CardProps) {
+    return <section>{eval(expression)}</section>;
+}

--- a/tests/fixtures/vulnerable_typescript.ts
+++ b/tests/fixtures/vulnerable_typescript.ts
@@ -1,0 +1,7 @@
+interface RenderRequest {
+    payload: string;
+}
+
+export function render(request: RenderRequest): unknown {
+    return eval(request.payload as string);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -818,6 +818,55 @@ mod javascript {
     }
 
     #[test]
+    fn test_typescript_syntax_uses_typescript_parser() {
+        let output = foxguard_cmd_isolated()
+            .args(["tests/fixtures/vulnerable_typescript.ts", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        assert!(
+            !output.status.success(),
+            "TypeScript fixture should report eval"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("parse error"),
+            "TypeScript fixture should parse cleanly, stderr={stderr}"
+        );
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding["rule_id"].as_str() == Some("js/no-eval")),
+            "TypeScript fixture should run compatible JavaScript rules, findings={findings:?}"
+        );
+    }
+
+    #[test]
+    fn test_tsx_syntax_uses_tsx_parser() {
+        let output = foxguard_cmd_isolated()
+            .args(["tests/fixtures/vulnerable_tsx.tsx", "-f", "json"])
+            .output()
+            .expect("failed to execute foxguard");
+
+        assert!(!output.status.success(), "TSX fixture should report eval");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("parse error"),
+            "TSX fixture should parse cleanly, stderr={stderr}"
+        );
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert!(
+            findings
+                .iter()
+                .any(|finding| finding["rule_id"].as_str() == Some("js/no-eval")),
+            "TSX fixture should run compatible JavaScript rules, findings={findings:?}"
+        );
+    }
+
+    #[test]
     fn test_safe_nextjs_taint_has_no_taint_findings() {
         let output = foxguard_cmd_isolated()
             .args(["tests/fixtures/safe_nextjs_taint.ts", "-f", "json"])


### PR DESCRIPTION
## Summary
- route `.ts`/`.mts`/`.cts` files through the tree-sitter TypeScript grammar and `.tsx` through the TSX grammar
- keep TypeScript mapped onto the JavaScript-compatible rule surface while treating TS parse errors as real parse failures
- add parser unit tests, TS/TSX fixtures, integration coverage, and docs updates

Closes #318

## Verification
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native TypeScript and TSX language support with dedicated parsers for `.ts`, `.tsx`, `.mts`, and `.cts` files.
  * TypeScript/TSX files now parse correctly through their dedicated grammars before applying JavaScript-compatible analysis rules.

* **Documentation**
  * Updated language mapping and taint tracking documentation to clarify TypeScript/TSX parser integration.

* **Tests**
  * Added integration tests for TypeScript and TSX file analysis to ensure proper syntax handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->