### PR TITLE
feat: make taint return summaries parameter-sensitive

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -40,7 +40,8 @@ use super::taint_engine::{
     match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
 };
 pub use super::taint_engine::{
-    BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
+    BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
+    TaintSpec,
 };
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
@@ -128,10 +129,12 @@ pub fn analyze_tree_with_cross_file<'a>(
         sink_to_rules: None,
     };
     collect_function_defs(root, &mut |func_node| {
-        let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+        let (name, ret_taint) = summarize_function_return(func_node, &pass1_ctx);
         if let Some(name) = name {
-            // Last-write-wins on name collisions (v1 limitation).
-            summaries.insert(name, ret_taint);
+            summaries.insert(
+                function_summary_key(&name, collect_param_names(func_node, source).len()),
+                ret_taint,
+            );
         }
     });
 
@@ -202,9 +205,12 @@ pub fn analyze_tree_batched<'a>(
         };
         let mut summaries = ReturnSummary::new();
         collect_function_defs(root, &mut |func_node| {
-            let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+            let (name, ret_taint) = summarize_function_return(func_node, &pass1_ctx);
             if let Some(name) = name {
-                summaries.insert(name, ret_taint);
+                summaries.insert(
+                    function_summary_key(&name, collect_param_names(func_node, source).len()),
+                    ret_taint,
+                );
             }
         });
 
@@ -343,6 +349,15 @@ fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
         }
     }
     names
+}
+
+fn function_summary_key(name: &str, arity: usize) -> String {
+    format!("{name}/{arity}")
+}
+
+fn call_summary_key(name: &str, args: Node<'_>) -> String {
+    let mut cursor = args.walk();
+    function_summary_key(name, args.named_children(&mut cursor).count())
 }
 
 /// Extract cross-file function taint summaries for all functions in a
@@ -563,6 +578,46 @@ fn summarize_function(
     let mut scratch: Vec<TaintFinding> = Vec::new();
     walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
+}
+
+fn summarize_function_return(
+    func_node: Node<'_>,
+    ctx: &AnalysisContext<'_>,
+) -> (Option<String>, ReturnTaintSummary) {
+    let (name, direct_source) = summarize_function(func_node, ctx);
+    let mut summary = ReturnTaintSummary {
+        direct_source,
+        params_to_return: Vec::new(),
+    };
+
+    let empty_summary = ReturnSummary::new();
+    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
+        .into_iter()
+        .enumerate()
+    {
+        let synthetic_spec = TaintSpec {
+            sources: vec![NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            }],
+            sinks: vec![],
+            sanitizers: ctx.spec.sanitizers.clone(),
+        };
+        let param_ctx = AnalysisContext {
+            source: ctx.source,
+            spec: &synthetic_spec,
+            aliases: ctx.aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rules: None,
+        };
+        let (_, ret_taint) = summarize_function(func_node, &param_ctx);
+        if ret_taint.is_some() {
+            summary.params_to_return.push(param_idx);
+        }
+    }
+
+    (name, summary)
 }
 
 fn walk_body_for_summary(
@@ -1081,6 +1136,28 @@ fn expression_taint(
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
+            if let Some(func) = expr.child_by_field_name("function") {
+                if func.kind() == "identifier" {
+                    let callee = node_text(func, ctx.source);
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                }
+            }
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
                 if let Some(result) = expression_taint(arg, ctx, state) {
@@ -1107,8 +1184,23 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
-                if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some((format!("{desc} (via {callee})"), expr_line));
+                if let Some(args) = expr.child_by_field_name("arguments") {
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                    }
                 }
             }
             // Method call on an arbitrary receiver with a summary
@@ -1117,8 +1209,24 @@ fn expression_taint(
             if func.kind() == "selector_expression" {
                 if let Some(field) = func.child_by_field_name("field") {
                     let method = node_text(field, ctx.source);
-                    if let Some(Some(desc)) = ctx.summaries.get(method) {
-                        return Some((format!("{desc} (via {method})"), expr_line));
+                    if let Some(args) = expr.child_by_field_name("arguments") {
+                        if let Some(summary) = ctx.summaries.get(&call_summary_key(method, args)) {
+                            if let Some(desc) = &summary.direct_source {
+                                return Some((format!("{desc} (via {method})"), expr_line));
+                            }
+                            let mut cursor = args.walk();
+                            let arg_nodes: Vec<Node<'_>> =
+                                args.named_children(&mut cursor).collect();
+                            for &param_idx in &summary.params_to_return {
+                                if param_idx < arg_nodes.len() {
+                                    if let Some((desc, src_line)) =
+                                        expression_taint(arg_nodes[param_idx], ctx, state)
+                                    {
+                                        return Some((format!("{desc} (via {method})"), src_line));
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1613,6 +1721,25 @@ func staticCmd() string {
 
 func handler() {
     exec.Command(staticCmd())
+}
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_return_is_parameter_sensitive() {
+        let src = r#"
+package main
+
+import "os/exec"
+
+func choose(first, second string) string {
+    return second
+}
+
+func handler(c *gin.Context) {
+    clean := "ls"
+    exec.Command(choose(c.Query("name"), clean))
 }
 "#;
         assert_eq!(run(src).len(), 0);

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -31,7 +31,8 @@ use super::taint_engine::{
     taint_finding_for_node, TaintState,
 };
 pub use super::taint_engine::{
-    BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
+    BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
+    TaintSpec,
 };
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use std::borrow::Cow;
@@ -119,8 +120,11 @@ pub fn analyze_tree_with_cross_file<'a>(
         sink_to_rules: None,
     };
     collect_summary_targets(root, source, &mut |name, func_node| {
-        let ret = summarize_function(func_node, &pass1_ctx);
-        summaries.insert(name, ret);
+        let ret = summarize_function_return(func_node, &pass1_ctx);
+        summaries.insert(
+            function_summary_key(&name, collect_param_names(func_node, source).len()),
+            ret,
+        );
     });
 
     let ctx = AnalysisContext {
@@ -182,8 +186,11 @@ pub fn analyze_tree_batched<'a>(
         };
         let mut summaries = ReturnSummary::new();
         collect_summary_targets(root, source, &mut |name, func_node| {
-            let ret = summarize_function(func_node, &pass1_ctx);
-            summaries.insert(name, ret);
+            let ret = summarize_function_return(func_node, &pass1_ctx);
+            summaries.insert(
+                function_summary_key(&name, collect_param_names(func_node, source).len()),
+                ret,
+            );
         });
 
         // Pass 2: one walk emits findings for every rule in the group.
@@ -294,6 +301,42 @@ fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<
     let mut return_taint: Option<String> = None;
     walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     return_taint
+}
+
+fn summarize_function_return(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> ReturnTaintSummary {
+    let direct_source = summarize_function(func_node, ctx);
+    let mut summary = ReturnTaintSummary {
+        direct_source,
+        params_to_return: Vec::new(),
+    };
+
+    let empty_summary = ReturnSummary::new();
+    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
+        .into_iter()
+        .enumerate()
+    {
+        let synthetic_spec = TaintSpec {
+            sources: vec![NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            }],
+            sinks: vec![],
+            sanitizers: ctx.spec.sanitizers.clone(),
+        };
+        let param_ctx = AnalysisContext {
+            source: ctx.source,
+            spec: &synthetic_spec,
+            aliases: ctx.aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rules: None,
+        };
+        if summarize_function(func_node, &param_ctx).is_some() {
+            summary.params_to_return.push(param_idx);
+        }
+    }
+
+    summary
 }
 
 fn walk_body_for_summary(
@@ -522,6 +565,11 @@ fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
                 }
                 found
             }
+            "required_parameter" | "optional_parameter" => child
+                .child_by_field_name("pattern")
+                .filter(|n| n.kind() == "identifier")
+                .map(|n| node_text(n, source))
+                .or_else(|| first_identifier_child(child, source)),
             _ => None,
         };
         if let Some(name) = param_name {
@@ -529,6 +577,25 @@ fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
         }
     }
     names
+}
+
+fn first_identifier_child<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "identifier" {
+            return Some(node_text(child, source));
+        }
+    }
+    None
+}
+
+fn function_summary_key(name: &str, arity: usize) -> String {
+    format!("{name}/{arity}")
+}
+
+fn call_summary_key(name: &str, args: Node<'_>) -> String {
+    let mut cursor = args.walk();
+    function_summary_key(name, args.named_children(&mut cursor).count())
 }
 
 /// Walk the AST to find exported function declarations and their names.
@@ -1712,6 +1779,28 @@ fn expression_taint(
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
+            if let Some(func) = expr.child_by_field_name("function") {
+                if func.kind() == "identifier" {
+                    let callee = node_text(func, ctx.source);
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                }
+            }
             let mut cursor = args.walk();
             for arg in args.named_children(&mut cursor) {
                 if let Some(result) = expression_taint(arg, ctx, state) {
@@ -1744,8 +1833,23 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
-                if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some((format!("{desc} (via {callee})"), expr_line));
+                if let Some(args) = expr.child_by_field_name("arguments") {
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -2392,6 +2496,21 @@ function cleanHelper() {
 
 function handler() {
     document.write(cleanHelper());
+}
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_return_is_parameter_sensitive() {
+        let src = r#"
+function choose(first, second) {
+    return second;
+}
+
+function handler(req) {
+    const clean = "static";
+    document.write(choose(req.body, clean));
 }
 "#;
         assert_eq!(run(src).len(), 0);

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -37,7 +37,8 @@ use crate::rules::taint_engine::{
     match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
 };
 pub use crate::rules::taint_engine::{
-    BatchedRule, NodeMatcher, ReturnSummary, RuleFilter, TaintFinding, TaintSpec,
+    BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
+    TaintSpec,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -141,9 +142,8 @@ pub fn analyze_tree_with_cross_file<'a>(
         sink_to_rules: None,
     };
     collect_function_defs(root, &mut |func_node| {
-        let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+        let (name, ret_taint) = summarize_function_return(func_node, &pass1_ctx);
         if let Some(name) = name {
-            // Last-write-wins on name collisions (v1 limitation).
             summaries.insert(name, ret_taint);
         }
     });
@@ -213,7 +213,7 @@ pub fn analyze_tree_batched<'a>(
         };
         let mut summaries = ReturnSummary::new();
         collect_function_defs(root, &mut |func_node| {
-            let (name, ret_taint) = summarize_function(func_node, &pass1_ctx);
+            let (name, ret_taint) = summarize_function_return(func_node, &pass1_ctx);
             if let Some(name) = name {
                 summaries.insert(name, ret_taint);
             }
@@ -442,6 +442,15 @@ fn collect_param_names(func_node: Node<'_>, source: &str) -> Vec<String> {
     names
 }
 
+fn function_summary_key(name: &str, arity: usize) -> String {
+    format!("{name}/{arity}")
+}
+
+fn call_summary_key(name: &str, args: Node<'_>) -> String {
+    let mut cursor = args.walk();
+    function_summary_key(name, args.named_children(&mut cursor).count())
+}
+
 /// Pass-1 walker: compute a function's return-taint summary by scanning
 /// its body with the same state machinery used in pass 2, then inspecting
 /// every `return_statement` that appears inside it (excluding nested
@@ -468,6 +477,48 @@ fn summarize_function(
     let mut scratch: Vec<TaintFinding> = Vec::new();
     walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
+}
+
+fn summarize_function_return(
+    func_node: Node<'_>,
+    ctx: &AnalysisContext<'_>,
+) -> (Option<String>, ReturnTaintSummary) {
+    let (name, direct_source) = summarize_function(func_node, ctx);
+    let mut summary = ReturnTaintSummary {
+        direct_source,
+        params_to_return: Vec::new(),
+    };
+
+    let empty_summary = ReturnSummary::new();
+    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
+        .into_iter()
+        .enumerate()
+    {
+        let synthetic_spec = TaintSpec {
+            sources: vec![NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            }],
+            sinks: vec![],
+            sanitizers: ctx.spec.sanitizers.clone(),
+        };
+        let param_ctx = AnalysisContext {
+            source: ctx.source,
+            spec: &synthetic_spec,
+            aliases: ctx.aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rules: None,
+        };
+        let (_, ret_taint) = summarize_function(func_node, &param_ctx);
+        if ret_taint.is_some() {
+            summary.params_to_return.push(param_idx);
+        }
+    }
+
+    let name = name
+        .map(|name| function_summary_key(&name, collect_param_names(func_node, ctx.source).len()));
+    (name, summary)
 }
 
 fn walk_body_for_summary(
@@ -1124,6 +1175,28 @@ fn expression_taint(
             return None;
         }
         if let Some(args) = expr.child_by_field_name("arguments") {
+            if let Some(func) = expr.child_by_field_name("function") {
+                if func.kind() == "identifier" {
+                    let callee = node_text(func, ctx.source);
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                        return None;
+                    }
+                }
+            }
             // When a generator expression is the sole argument,
             // tree-sitter-python places a `generator_expression` node
             // (including the parentheses) where `argument_list` would
@@ -1189,8 +1262,23 @@ fn expression_taint(
         if let Some(func) = expr.child_by_field_name("function") {
             if func.kind() == "identifier" {
                 let callee = node_text(func, ctx.source);
-                if let Some(Some(desc)) = ctx.summaries.get(callee) {
-                    return Some((format!("{desc} (via {callee})"), expr_line));
+                if let Some(args) = expr.child_by_field_name("arguments") {
+                    if let Some(summary) = ctx.summaries.get(&call_summary_key(callee, args)) {
+                        if let Some(desc) = &summary.direct_source {
+                            return Some((format!("{desc} (via {callee})"), expr_line));
+                        }
+                        let mut cursor = args.walk();
+                        let arg_nodes: Vec<Node<'_>> = args.named_children(&mut cursor).collect();
+                        for &param_idx in &summary.params_to_return {
+                            if param_idx < arg_nodes.len() {
+                                if let Some((desc, src_line)) =
+                                    expression_taint(arg_nodes[param_idx], ctx, state)
+                                {
+                                    return Some((format!("{desc} (via {callee})"), src_line));
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -2042,6 +2130,22 @@ def literal_helper():
 
 def handler():
     return pickle.loads(literal_helper())
+"#;
+        assert_eq!(run(src).len(), 0);
+    }
+
+    #[test]
+    fn interprocedural_return_is_parameter_sensitive() {
+        let src = r#"
+import pickle
+from flask import request
+
+def choose(first, second):
+    return second
+
+def handler():
+    data = choose(request.data, b"static")
+    return pickle.loads(data)
 "#;
         assert_eq!(run(src).len(), 0);
     }

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -109,8 +109,18 @@ impl<'a> RuleFilter<'a> {
     }
 }
 
-/// Return-taint summary map keyed by a function's simple name.
-pub type ReturnSummary = HashMap<String, Option<String>>;
+/// Compact same-file return-taint summary keyed by function symbol.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReturnTaintSummary {
+    /// Return value is tainted by a source found inside the function body,
+    /// independent of caller arguments.
+    pub direct_source: Option<String>,
+    /// Caller argument indices that taint the return value.
+    pub params_to_return: Vec<usize>,
+}
+
+/// Return-taint summary map keyed by a function symbol.
+pub type ReturnSummary = HashMap<String, ReturnTaintSummary>;
 
 /// Inputs to the batched taint analyzer.
 pub struct BatchedRule<'a> {


### PR DESCRIPTION
## Summary
- Make same-file taint return summaries parameter-sensitive by tracking which argument indices can taint the returned value.
- Key same-file summaries by callee arity so same-name helpers with different signatures do not collide.
- Preserve direct source summaries and add regressions for Python, JavaScript/TypeScript, and Go false-positive cases.

Closes #320

## Validation
- cargo test interprocedural --lib -- --nocapture
- cargo test realistic_ --test realistic_fixtures -- --nocapture
- cargo test
- cargo clippy -- -D warnings
- git diff --check
