### PR TITLE
perf: make AST rule batching explicit

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -3,7 +3,9 @@ use crate::rules::go_taint::{self, go_aliases_from_tree};
 use crate::rules::javascript_taint::{self, js_aliases_from_tree};
 use crate::rules::python_aliases::{from_tree as py_aliases_from_tree, resolve_imports_to_paths};
 use crate::rules::python_taint;
-use crate::rules::{common::AliasTable, FileContext, RuleRegistry, TaintEngine};
+use crate::rules::{
+    common::AliasTable, AstAnalysisRequirement, FileContext, Rule, RuleRegistry, TaintEngine,
+};
 use crate::{Finding, Language};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
@@ -21,6 +23,63 @@ pub struct ScanResult {
     pub files_scanned: usize,
     pub stats: ScanStats,
     pub duration: std::time::Duration,
+}
+
+struct AstRuleBatch<'a> {
+    entries: Vec<AstRuleBatchEntry<'a>>,
+    syntax_tree_rules: usize,
+    context_rules: usize,
+}
+
+struct AstRuleBatchEntry<'a> {
+    rule: &'a dyn Rule,
+    requirement: AstAnalysisRequirement,
+}
+
+impl<'a> AstRuleBatch<'a> {
+    fn from_rules(rules: &[&'a dyn Rule]) -> Self {
+        let mut syntax_tree_rules = 0;
+        let mut context_rules = 0;
+        let entries = rules
+            .iter()
+            .map(|rule| {
+                let requirement = rule.ast_analysis_requirement();
+                match requirement {
+                    AstAnalysisRequirement::SyntaxTree => syntax_tree_rules += 1,
+                    AstAnalysisRequirement::FileContext => context_rules += 1,
+                }
+                AstRuleBatchEntry {
+                    rule: *rule,
+                    requirement,
+                }
+            })
+            .collect();
+
+        Self {
+            entries,
+            syntax_tree_rules,
+            context_rules,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn run(&self, source: &str, tree: &tree_sitter::Tree, ctx: &FileContext<'_>) -> Vec<Finding> {
+        let mut findings = Vec::with_capacity(self.syntax_tree_rules + self.context_rules);
+        for entry in &self.entries {
+            match entry.requirement {
+                AstAnalysisRequirement::SyntaxTree => {
+                    findings.extend(entry.rule.check(source, tree));
+                }
+                AstAnalysisRequirement::FileContext => {
+                    findings.extend(entry.rule.check_with_context(source, tree, ctx));
+                }
+            }
+        }
+        findings
+    }
 }
 
 /// File accounting for a scan.
@@ -1027,7 +1086,8 @@ fn scan_files(
             let file_str = path.display().to_string();
             let relative_path = relative_scan_path(scan_root, path);
             let analysis_plan = registry.analysis_plan_for_path(*language, &relative_path);
-            if analysis_plan.ast_rules.is_empty() && analysis_plan.taint_specs.is_empty() {
+            let ast_rule_batch = AstRuleBatch::from_rules(&analysis_plan.ast_rules);
+            if ast_rule_batch.is_empty() && analysis_plan.taint_specs.is_empty() {
                 return FileScanOutcome {
                     findings: Vec::new(),
                     stats: file_stats,
@@ -1212,9 +1272,7 @@ fn scan_files(
                 ));
             }
 
-            for rule in analysis_plan.ast_rules {
-                file_findings.extend(rule.check_with_context(source, tree, &ctx));
-            }
+            file_findings.extend(ast_rule_batch.run(source, tree, &ctx));
 
             for finding in &mut file_findings {
                 finding.file = file_str.clone();
@@ -1294,6 +1352,51 @@ fn normalize_match_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    struct CountingRule {
+        id: &'static str,
+        requirement: AstAnalysisRequirement,
+        syntax_calls: Arc<AtomicUsize>,
+        context_calls: Arc<AtomicUsize>,
+    }
+
+    impl Rule for CountingRule {
+        fn id(&self) -> &str {
+            self.id
+        }
+        fn severity(&self) -> crate::Severity {
+            crate::Severity::Low
+        }
+        fn cwe(&self) -> Option<&str> {
+            None
+        }
+        fn description(&self) -> &str {
+            "test rule"
+        }
+        fn language(&self) -> Language {
+            Language::JavaScript
+        }
+        fn ast_analysis_requirement(&self) -> AstAnalysisRequirement {
+            self.requirement
+        }
+        fn check(&self, _source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
+            self.syntax_calls.fetch_add(1, Ordering::SeqCst);
+            Vec::new()
+        }
+        fn check_with_context(
+            &self,
+            _source: &str,
+            _tree: &tree_sitter::Tree,
+            _ctx: &FileContext<'_>,
+        ) -> Vec<Finding> {
+            self.context_calls.fetch_add(1, Ordering::SeqCst);
+            Vec::new()
+        }
+    }
 
     #[test]
     fn block_comment_ignore_js() {
@@ -1355,6 +1458,34 @@ mod tests {
 
         assert!(matcher.is_excluded(Path::new("generated/foo/bar.js")));
         assert!(!matcher.is_excluded(Path::new("generated/foo/bar.ts")));
+    }
+
+    #[test]
+    fn ast_rule_batch_dispatches_by_analysis_requirement() {
+        let syntax_calls = Arc::new(AtomicUsize::new(0));
+        let context_calls = Arc::new(AtomicUsize::new(0));
+        let syntax_rule = CountingRule {
+            id: "test/syntax",
+            requirement: AstAnalysisRequirement::SyntaxTree,
+            syntax_calls: Arc::clone(&syntax_calls),
+            context_calls: Arc::clone(&context_calls),
+        };
+        let context_rule = CountingRule {
+            id: "test/context",
+            requirement: AstAnalysisRequirement::FileContext,
+            syntax_calls: Arc::clone(&syntax_calls),
+            context_calls: Arc::clone(&context_calls),
+        };
+        let rules: Vec<&dyn Rule> = vec![&syntax_rule, &context_rule];
+        let batch = AstRuleBatch::from_rules(&rules);
+        let source = "const value = 1;\n";
+        let tree = super::super::parser::parse_file(source, Language::JavaScript).expect("parse");
+
+        let findings = batch.run(source, &tree, &FileContext::default());
+
+        assert!(findings.is_empty());
+        assert_eq!(syntax_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(context_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -43,6 +43,12 @@ pub struct AnalysisPlan<'a> {
     pub taint_specs: Vec<RegistryTaintSpec>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AstAnalysisRequirement {
+    SyntaxTree,
+    FileContext,
+}
+
 /// Macro to reduce boilerplate in `impl Rule for …` blocks.
 ///
 /// # Variant 1 — rules that only implement `check`:
@@ -146,6 +152,9 @@ macro_rules! impl_rule {
             fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
                 self.check_with_context(source, tree, &$crate::rules::FileContext::default())
             }
+            fn ast_analysis_requirement(&self) -> $crate::rules::AstAnalysisRequirement {
+                $crate::rules::AstAnalysisRequirement::FileContext
+            }
             fn check_with_context(
                 &self,
                 $src: &str,
@@ -178,6 +187,9 @@ macro_rules! impl_rule {
             fn cnsa2_deadline(&self) -> Option<&'static str> { Some($deadline) }
             fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
                 self.check_with_context(source, tree, &$crate::rules::FileContext::default())
+            }
+            fn ast_analysis_requirement(&self) -> $crate::rules::AstAnalysisRequirement {
+                $crate::rules::AstAnalysisRequirement::FileContext
             }
             fn check_with_context(
                 &self,
@@ -231,6 +243,10 @@ pub trait Rule: Send + Sync {
         true
     }
     fn check(&self, source: &str, tree: &tree_sitter::Tree) -> Vec<Finding>;
+
+    fn ast_analysis_requirement(&self) -> AstAnalysisRequirement {
+        AstAnalysisRequirement::SyntaxTree
+    }
 
     /// Context-aware variant. Defaults to calling `check` so every existing
     /// rule works unchanged. Rules that need the per-file context (e.g.

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -267,6 +267,10 @@ impl Rule for SemgrepTaintRule {
         self.check_with_context(source, tree, &FileContext::default())
     }
 
+    fn ast_analysis_requirement(&self) -> crate::rules::AstAnalysisRequirement {
+        crate::rules::AstAnalysisRequirement::FileContext
+    }
+
     fn check_with_context(
         &self,
         source: &str,

--- a/tests/ast_rule_batch_bench.rs
+++ b/tests/ast_rule_batch_bench.rs
@@ -1,0 +1,47 @@
+use foxguard::engine::parser::parse_file;
+use foxguard::rules::semgrep_compat::parse_semgrep_file;
+use foxguard::Language;
+use std::io::Write;
+use std::time::Instant;
+use tempfile::NamedTempFile;
+
+#[test]
+#[ignore = "benchmark harness; run with `cargo test --test ast_rule_batch_bench -- --ignored --nocapture`"]
+fn bench_ast_rule_count_scaling() {
+    let mut source = String::new();
+    for idx in 0..1_000 {
+        source.push_str(&format!("value_{idx} = safe_call({idx})\n"));
+    }
+    source.push_str("result = eval(user_input)\n");
+    let tree = parse_file(&source, Language::Python).expect("parse fixture");
+
+    for rule_count in [1usize, 25, 100, 250] {
+        let mut rules_yaml = String::from("rules:\n");
+        for idx in 0..rule_count {
+            rules_yaml.push_str(&format!(
+                "  - id: eval-{idx}\n    pattern: eval(...)\n    message: Avoid eval\n    severity: WARNING\n    languages: [python]\n"
+            ));
+        }
+
+        let mut rules_file = NamedTempFile::new().expect("temp rules file");
+        rules_file
+            .write_all(rules_yaml.as_bytes())
+            .expect("write rules");
+        let rules = parse_semgrep_file(rules_file.path()).expect("parse rules");
+
+        let started = Instant::now();
+        let findings: usize = rules
+            .iter()
+            .map(|rule| rule.check(&source, &tree).len())
+            .sum();
+        let elapsed = started.elapsed();
+
+        eprintln!(
+            "ast_rule_count_scaling rules={} findings={} scan_ms={}",
+            rules.len(),
+            findings,
+            elapsed.as_millis()
+        );
+        assert_eq!(findings, rule_count);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an explicit AST rule batch boundary in the scanner after each file is parsed and its per-file context is prepared.
- Let rules declare whether they need only the shared syntax tree or the full file context; macro-generated context rules and Semgrep taint rules declare context requirements.
- Add a dispatcher regression test and an ignored rule-count scaling benchmark.

Closes #316

## Validation
- cargo test ast_rule_batch --lib -- --nocapture
- cargo test --test ast_rule_batch_bench -- --nocapture
- cargo test --test ast_rule_batch_bench -- --ignored --nocapture
- cargo test
- cargo clippy -- -D warnings
- cargo fmt --check
- git diff --check

## Benchmark
- Local ignored harness: rules=1 scan_ms=13; rules=25 scan_ms=166; rules=100 scan_ms=614; rules=250 scan_ms=1552

## Notes
- This keeps finding behavior stable and creates the batching surface for deeper shared traversal work without rewriting every per-language rule visitor in one change.
