### PR TITLE
docs: define shared agent editor integration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ claude --plugin-dir ./plugins/claude-code
 ```
 
 Run `/foxguard:setup` inside Claude Code to verify the scanner is available. See [Claude Code integration](docs/claude-code-integration.md) for local plugin loading, hook behavior, and marketplace status.
+Shared behavior for future agent/editor adapters is documented in [Agent and Editor Integration Contract](docs/agent-editor-integration.md).
 
 ## CI integration
 
@@ -141,7 +142,7 @@ jobs:
           upload-sarif: "true"
 ```
 
-Findings land in **Security → Code Scanning**. On any other CI: `npx foxguard@latest --format sarif . > out.sarif`. For Claude Code and other agent/editor hooks, see [docs/claude-code-integration.md](docs/claude-code-integration.md).
+Findings land in **Security → Code Scanning**. On any other CI: `npx foxguard@latest --format sarif . > out.sarif`. For Claude Code and other agent/editor hooks, see [docs/claude-code-integration.md](docs/claude-code-integration.md) and [docs/agent-editor-integration.md](docs/agent-editor-integration.md).
 
 **Pre-commit:**
 

--- a/docs/agent-editor-integration.md
+++ b/docs/agent-editor-integration.md
@@ -1,0 +1,117 @@
+# Agent and Editor Integration Contract
+
+foxguard integrations should share the same scanner behavior even when their host
+systems use different hook names, payloads, or UI surfaces. The Claude Code plugin
+is one implementation of this contract, not the contract itself.
+
+## Goals
+
+- Give agents and editors fast feedback on the file they just changed.
+- Keep failures in integration glue from blocking the host tool.
+- Preserve foxguard's normal CLI behavior for CI, pre-commit hooks, and humans.
+- Keep host-specific packaging, marketplace metadata, and command naming outside
+  the shared contract.
+
+## Shared Hook Shape
+
+An edit-time integration needs five inputs:
+
+| Field | Meaning |
+| --- | --- |
+| `path` | File path the host just wrote, edited, or saved. |
+| `workspace_root` | Optional root used to resolve relative paths and discover `.foxguard.yml`. |
+| `severity` | Minimum severity surfaced to the host. Default: `medium`. |
+| `mode` | Usually `scan-file`; integrations may expose `scan-workspace`, `diff`, `secrets`, and `pqc` as explicit commands. |
+| `format` | Machine format the adapter reads. Default: `json`. |
+
+The adapter normalizes the host payload into those fields, then runs:
+
+```sh
+foxguard --format json --severity "$severity" "$path"
+```
+
+If the host needs config isolation or a fixed working directory, the adapter may
+also pass `--config <path>` or set its current directory to `workspace_root`.
+
+## Exit Behavior
+
+Adapters should distinguish scanner findings from adapter failures:
+
+| Case | Adapter behavior |
+| --- | --- |
+| Clean scan | Exit success and stay silent. |
+| Findings at or above threshold | Surface a compact summary to the host and use the host's actionable-feedback convention. |
+| `foxguard` missing | Exit success with a setup hint only when the host has an appropriate setup command. |
+| Missing or unreadable edited file | Exit success and stay silent. |
+| Invalid host payload | Exit success and stay silent. |
+| Scanner execution error | Prefer a concise diagnostic; do not fail closed unless the integration is an explicit CI/pre-commit gate. |
+
+This fail-open rule is for live editor and agent loops. CI and pre-commit
+integrations should keep foxguard's normal nonzero exit behavior.
+
+## Output Summary
+
+Live integrations should avoid dumping full JSON. A useful summary includes:
+
+- total finding count at or above the threshold
+- file path
+- one line per finding: severity, rule id, line, description
+- a local rerun command, for example `foxguard --severity medium path/to/file`
+
+Adapters should parse the JSON report instead of relying only on process exit
+codes. foxguard exits `1` for findings and `2` for scanner errors, but JSON
+contents are the stable way to decide whether a host should receive feedback.
+
+## Command Surface
+
+Host integrations should expose the same conceptual commands even if naming
+syntax differs:
+
+| Command | CLI equivalent | Purpose |
+| --- | --- | --- |
+| `setup` | `foxguard --version` | Verify the scanner is installed and explain hook behavior. |
+| `scan` | `foxguard <path>` | Scan a file or workspace. |
+| `diff-scan` | `foxguard diff <base> <path>` | Review new findings relative to a base ref. |
+| `secrets` | `foxguard secrets <path>` | Run secret detection. |
+| `pq-audit` | `foxguard pqc <path>` | Run post-quantum crypto checks. |
+| `triage` | `foxguard triage <path>` | Launch the interactive triage UI when the host supports terminals. |
+
+## Non-Claude Example: Generic Editor Save Hook
+
+A generic editor or local agent wrapper can call a small adapter on save:
+
+```sh
+#!/usr/bin/env sh
+set -eu
+
+path="${1:-}"
+[ -n "$path" ] && [ -f "$path" ] || exit 0
+
+json="$(foxguard --format json --severity "${FOXGUARD_HOOK_SEVERITY:-medium}" "$path" 2>/dev/null || true)"
+count="$(printf '%s' "$json" | jq '.findings | length' 2>/dev/null || printf '0')"
+
+[ "$count" -gt 0 ] || exit 0
+
+printf 'foxguard found %s issue(s) in %s\n' "$count" "$path" >&2
+printf '%s' "$json" | jq -r '.findings[] | "\(.severity) \(.rule_id) line \(.line): \(.description)"' >&2
+exit 2
+```
+
+Host mapping:
+
+- Setup: install `foxguard` or use `npx --yes foxguard`.
+- Input: editor passes the saved file path as `$1`.
+- Output: stderr summary for the editor problem matcher or agent feedback loop.
+- Failure behavior: missing file, missing JSON parser, or scanner setup problems do
+  not block the save path. CI remains the blocking gate.
+
+## Implementation Boundaries
+
+- Claude Code-specific hook payloads, slash-command names, and marketplace copy
+  stay under `plugins/claude-code/`.
+- VS Code-specific diagnostics, decorations, and extension packaging stay in the
+  VS Code extension surface.
+- Shared behavior belongs in docs and small reusable scripts only when two or more
+  integrations need the same implementation.
+- New target integrations should get separate issues once their host payload,
+  setup path, and feedback conventions are known.

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -84,4 +84,7 @@ The plugin can be loaded locally today with `--plugin-dir`. Publishing to an off
 
 Track the publishing checklist in the GitHub issue linked from the README/PR queue rather than treating it as part of the scanner binary release. Marketplace copy, versioning notes, and local validation commands live in [`plugins/claude-code/MARKETPLACE.md`](../plugins/claude-code/MARKETPLACE.md).
 
-This integration is intentionally Claude Code-specific. Generalizing foxguard for other agent or editor hook systems should be handled as a separate design and implementation issue.
+This integration is intentionally Claude Code-specific. Shared behavior for other
+agent or editor hook systems is documented in
+[`agent-editor-integration.md`](agent-editor-integration.md) so Claude Code
+marketplace work can proceed independently.


### PR DESCRIPTION
## Summary
- add `docs/agent-editor-integration.md` with the shared edited-file hook contract, exit behavior, output summary, and command surface
- include a generic non-Claude editor save-hook sketch with setup/input/output/failure behavior
- link the shared contract from the README and Claude Code integration docs while keeping Claude marketplace work scoped to the plugin

Closes #290

## Validation
- `git diff --check`
