### PR TITLE
chore(github-app): refresh receiver references

### DIFF
--- a/Dockerfile.github-app
+++ b/Dockerfile.github-app
@@ -3,12 +3,12 @@
 # stays lean. See src/github_app/README.md and issue #246.
 #
 # Build:
-#   docker build -f Dockerfile.github-app -t foxguard/github-app:latest .
+#   docker build -f Dockerfile.github-app -t ghcr.io/0sec-labs/foxguard-github-app:latest .
 #
 # Run:
 #   docker run --rm -p 8080:8080 \
 #     -e FOXGUARD_WEBHOOK_SECRET=$(openssl rand -hex 32) \
-#     foxguard/github-app:latest
+#     ghcr.io/0sec-labs/foxguard-github-app:latest
 
 FROM rust:1.83-slim AS builder
 WORKDIR /usr/src/foxguard

--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -1,7 +1,7 @@
 //! foxguard-github-app — webhook receiver for the foxguard GitHub App.
 //!
 //! See `src/github_app/README.md` and the tracking issue at
-//! <https://github.com/PwnKit-Labs/foxguard/issues/246> for the design
+//! <https://github.com/0sec-labs/foxguard/issues/246> for the design
 //! discussion.
 //!
 //! This binary is intentionally scoped to the *Phase-1 foundation*
@@ -13,7 +13,7 @@
 //!
 //! Build:    `cargo build --release --features github-app --bin foxguard-github-app`
 //! Run:      `FOXGUARD_WEBHOOK_SECRET=xxx FOXGUARD_BIND=0.0.0.0:8080 foxguard-github-app`
-//! Docker:   `docker build -f Dockerfile.github-app -t foxguard/github-app .`
+//! Docker:   `docker build -f Dockerfile.github-app -t ghcr.io/0sec-labs/foxguard-github-app .`
 
 use std::net::SocketAddr;
 

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -1,6 +1,6 @@
 # foxguard GitHub App — Phase 1 foundation
 
-Tracking issue: [PwnKit-Labs/foxguard#246](https://github.com/PwnKit-Labs/foxguard/issues/246).
+Tracking issue: [0sec-labs/foxguard#246](https://github.com/0sec-labs/foxguard/issues/246).
 
 This directory hosts the in-tree pieces of the GitHub App webhook receiver. The receiver is built behind the `github-app` feature flag so the core scanner build stays lean for users who only want the CLI:
 
@@ -11,7 +11,7 @@ cargo build --release --features github-app --bin foxguard-github-app
 
 ## What's here today (Phase 1)
 
-- `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 9 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
+- `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
 - `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, and returns `202 Accepted` for all known kinds with the actual handler bodies stubbed and clearly marked TODO.
 
 ## What's NOT here yet (Phase 2)


### PR DESCRIPTION
## Summary
- update GitHub App receiver docs/comments from `PwnKit-Labs` to `0sec-labs`
- point Docker examples at `ghcr.io/0sec-labs/foxguard-github-app`
- correct the webhook unit-test count in the receiver README

Refs #246

## Validation
- `cargo build --features github-app --bin foxguard-github-app`
- `cargo test --features github-app --lib github_app::`
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
