### PR TITLE
docs(github-app): refresh module issue link

### DIFF
--- a/src/github_app/mod.rs
+++ b/src/github_app/mod.rs
@@ -17,6 +17,6 @@
 //! reviewed in isolation before the full `pull_request` handler
 //! lands.
 //!
-//! Tracking issue: <https://github.com/PwnKit-Labs/foxguard/issues/246>.
+//! Tracking issue: <https://github.com/0sec-labs/foxguard/issues/246>.
 
 pub mod webhook;


### PR DESCRIPTION
## Summary
- update the remaining GitHub App module doc link from `PwnKit-Labs` to `0sec-labs`
- confirm no stale org/image references remain in the repo

Refs #246

## Validation
- `rg -n "PwnKit-Labs|pwnkit-labs|foxguard/github-app" . -S`
- `cargo test --features github-app --lib github_app::`
- `cargo fmt --check`
- `git diff --check`
