### PR TITLE
feat(github-app): cache installation tokens

### DIFF
--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -12,14 +12,14 @@ cargo build --release --features github-app --bin foxguard-github-app
 ## What's here today (Phase 1)
 
 - `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
-- `auth.rs` — GitHub App JWT generation plus installation-token exchange. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
+- `auth.rs` — GitHub App JWT generation, installation-token exchange, and conservative in-memory token caching. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
 - `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, and returns `202 Accepted` for all known kinds with the actual handler bodies stubbed and clearly marked TODO.
 
 ## What's NOT here yet (Phase 2)
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **Auth wiring and token cache.** The auth client exists; the event handlers still need to call it and cache installation tokens until expiry.
+- **Auth handler wiring.** The auth client and token cache exist; the event handlers still need to call them.
 - **`pull_request` handler.** Clone the head ref into a sandboxed temp dir, run `foxguard scan` with a 60s timeout and a 1 GB repo cap, post the existing `--github-pr` output as a PR comment.
 - **`installation` handler.** Persist install metadata so we know which orgs we're serving. SQLite is fine for Phase 1; the data is small and operationally easy to back up.
 - **Check Runs API.** Inline annotations on the diff once the comment path is solid.

--- a/src/github_app/auth.rs
+++ b/src/github_app/auth.rs
@@ -6,6 +6,7 @@
 
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fmt;
 use std::path::{Component, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -15,6 +16,8 @@ const DEFAULT_API_HOST: &str = "api.github.com";
 const GITHUB_API_VERSION: &str = "2026-03-10";
 const JWT_BACKDATE_SECONDS: i64 = 60;
 const JWT_TTL_SECONDS: i64 = 9 * 60;
+const INSTALLATION_TOKEN_TTL: Duration = Duration::from_secs(60 * 60);
+const INSTALLATION_TOKEN_REFRESH_SKEW: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Debug)]
 pub enum AuthError {
@@ -235,6 +238,61 @@ pub struct InstallationToken {
     pub expires_at: String,
 }
 
+#[derive(Debug, Clone)]
+struct CachedInstallationToken {
+    token: String,
+    refresh_at: SystemTime,
+}
+
+impl CachedInstallationToken {
+    fn new(token: InstallationToken, received_at: SystemTime) -> Self {
+        Self {
+            token: token.token,
+            refresh_at: received_at + INSTALLATION_TOKEN_TTL - INSTALLATION_TOKEN_REFRESH_SKEW,
+        }
+    }
+
+    fn is_fresh(&self, now: SystemTime) -> bool {
+        now < self.refresh_at
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct InstallationTokenCache {
+    tokens: HashMap<u64, CachedInstallationToken>,
+}
+
+impl InstallationTokenCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn lookup(&self, installation_id: u64, now: SystemTime) -> Option<&str> {
+        let token = self
+            .tokens
+            .iter()
+            .find(|(cached_id, _)| **cached_id == installation_id)?
+            .1;
+        token.is_fresh(now).then_some(token.token.as_str())
+    }
+
+    pub fn remember(
+        &mut self,
+        installation_id: u64,
+        token: InstallationToken,
+        received_at: SystemTime,
+    ) {
+        self.tokens.insert(
+            installation_id,
+            CachedInstallationToken::new(token, received_at),
+        );
+    }
+
+    pub fn remove(&mut self, installation_id: u64) {
+        self.tokens.remove(&installation_id);
+    }
+}
+
 #[derive(Clone)]
 pub struct GitHubAppAuthClient {
     http: reqwest::Client,
@@ -270,6 +328,22 @@ impl GitHubAppAuthClient {
             .json::<InstallationToken>()
             .await?;
         Ok(token)
+    }
+
+    pub async fn installation_token(
+        &self,
+        cache: &mut InstallationTokenCache,
+        installation_id: u64,
+    ) -> Result<String, AuthError> {
+        let now = SystemTime::now();
+        if let Some(token) = cache.lookup(installation_id, now) {
+            return Ok(token.to_string());
+        }
+
+        let token = self.create_installation_token(installation_id).await?;
+        let value = token.token.clone();
+        cache.remember(installation_id, token, now);
+        Ok(value)
     }
 }
 
@@ -322,5 +396,60 @@ mod tests {
     fn invalid_private_key_is_reported_as_jwt_error() {
         let error = generate_app_jwt(12345, b"not a pem", 1_700_000_000).unwrap_err();
         assert!(matches!(error, AuthError::Jwt(_)));
+    }
+
+    #[test]
+    fn token_cache_reuses_fresh_installation_token() {
+        let mut cache = InstallationTokenCache::new();
+        let received_at = UNIX_EPOCH + Duration::from_secs(1_000);
+        cache.remember(
+            42,
+            InstallationToken {
+                token: "ghs_token".to_string(),
+                expires_at: "2026-05-17T15:00:00Z".to_string(),
+            },
+            received_at,
+        );
+
+        assert_eq!(
+            cache.lookup(42, received_at + Duration::from_secs(30 * 60)),
+            Some("ghs_token")
+        );
+    }
+
+    #[test]
+    fn token_cache_refreshes_before_github_expiry() {
+        let mut cache = InstallationTokenCache::new();
+        let received_at = UNIX_EPOCH + Duration::from_secs(1_000);
+        cache.remember(
+            42,
+            InstallationToken {
+                token: "ghs_token".to_string(),
+                expires_at: "2026-05-17T15:00:00Z".to_string(),
+            },
+            received_at,
+        );
+
+        assert_eq!(
+            cache.lookup(42, received_at + Duration::from_secs(56 * 60)),
+            None
+        );
+    }
+
+    #[test]
+    fn token_cache_can_remove_installation() {
+        let mut cache = InstallationTokenCache::new();
+        let received_at = UNIX_EPOCH + Duration::from_secs(1_000);
+        cache.remember(
+            42,
+            InstallationToken {
+                token: "ghs_token".to_string(),
+                expires_at: "2026-05-17T15:00:00Z".to_string(),
+            },
+            received_at,
+        );
+        cache.remove(42);
+
+        assert_eq!(cache.lookup(42, received_at), None);
     }
 }


### PR DESCRIPTION
## Summary
- add an in-memory installation-token cache for the GitHub App auth client
- refresh cached tokens five minutes before GitHub's one-hour token lifetime
- document that handler wiring is now the remaining auth step for #246

## Validation
- cargo test --features github-app --lib github_app::
- cargo build --features github-app --bin foxguard-github-app
- cargo clippy --features github-app --bin foxguard-github-app -- -D warnings
- cargo build --release
- ./target/release/foxguard --severity high src/
- git diff --check
- commit hook foxguard staged scan

Refs #246