### PR TITLE
feat(github-app): wire auth into webhook handler state

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -16,6 +16,7 @@
 //! Docker:   `docker build -f Dockerfile.github-app -t ghcr.io/0sec-labs/foxguard-github-app .`
 
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 
 use axum::{
     extract::State,
@@ -23,7 +24,11 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use foxguard::github_app::auth::{
+    AppCredentials, AuthError, GitHubAppAuthClient, InstallationTokenCache,
+};
 use foxguard::github_app::webhook::{verify_signature, EventKind, SignatureError};
+use serde::Deserialize;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{info, warn};
@@ -37,6 +42,19 @@ const MAX_BODY_BYTES: usize = 1 << 20; // 1 MiB
 #[derive(Clone)]
 struct AppState {
     webhook_secret: Vec<u8>,
+    auth: GitHubAppAuthClient,
+    installation_tokens: Arc<Mutex<InstallationTokenCache>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubWebhookPayload {
+    action: Option<String>,
+    installation: Option<GitHubInstallation>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubInstallation {
+    id: u64,
 }
 
 #[tokio::main]
@@ -62,6 +80,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let state = AppState {
         webhook_secret: secret.into_bytes(),
+        auth: GitHubAppAuthClient::new(AppCredentials::from_env()?)?,
+        installation_tokens: Arc::new(Mutex::new(InstallationTokenCache::new())),
     };
 
     let app = Router::new()
@@ -77,10 +97,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(bind).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(async {
-            tokio::signal::ctrl_c()
-                .await
-                .expect("install Ctrl-C handler");
-            info!("shutdown signal received");
+            match tokio::signal::ctrl_c().await {
+                Ok(()) => {
+                    info!("shutdown signal received");
+                }
+                Err(error) => {
+                    warn!(%error, "failed to install Ctrl-C handler");
+                    std::future::pending::<()>().await;
+                }
+            }
         })
         .await?;
 
@@ -140,18 +165,61 @@ async fn webhook(
         EventKind::Ping => {
             info!(delivery, "ping received");
         }
-        EventKind::Installation => {
-            info!(
-                delivery,
-                "installation event — TODO: persist install metadata"
-            );
-        }
-        EventKind::PullRequest => {
-            info!(
-                delivery,
-                "pull_request event — TODO: clone, run foxguard, post --github-pr comment"
-            );
-        }
+        EventKind::Installation => match parse_webhook_payload(&body) {
+            Ok(payload) => {
+                if let Some(installation) = payload.installation {
+                    if payload.action.as_deref() == Some("deleted") {
+                        remove_cached_installation_token(&state, installation.id);
+                    }
+                    info!(
+                        delivery,
+                        installation_id = installation.id,
+                        action = payload.action.as_deref().unwrap_or("?"),
+                        "installation event — TODO: persist install metadata"
+                    );
+                } else {
+                    warn!(delivery, "installation event missing installation.id");
+                }
+            }
+            Err(error) => {
+                warn!(delivery, %error, "installation payload was not valid JSON");
+            }
+        },
+        EventKind::PullRequest => match parse_webhook_payload(&body) {
+            Ok(payload) => {
+                if let Some(installation) = payload.installation {
+                    let state_for_task = state.clone();
+                    let delivery = delivery.to_string();
+                    let action = payload.action.unwrap_or_else(|| "?".to_string());
+                    let installation_id = installation.id;
+                    std::mem::drop(tokio::spawn(async move {
+                        match installation_token_for(&state_for_task, installation_id).await {
+                            Ok(_) => {
+                                info!(
+                                    delivery,
+                                    installation_id,
+                                    action,
+                                    "pull_request auth ready — TODO: clone, run foxguard, post --github-pr comment"
+                                );
+                            }
+                            Err(error) => {
+                                warn!(
+                                    delivery,
+                                    installation_id,
+                                    %error,
+                                    "failed to prepare pull_request auth"
+                                );
+                            }
+                        }
+                    }));
+                } else {
+                    warn!(delivery, "pull_request event missing installation.id");
+                }
+            }
+            Err(error) => {
+                warn!(delivery, %error, "pull_request payload was not valid JSON");
+            }
+        },
         EventKind::Other => {
             // Acknowledge so GitHub doesn't retry. We log at debug
             // because a noisy install can subscribe us to events we
@@ -163,12 +231,80 @@ async fn webhook(
     StatusCode::ACCEPTED
 }
 
+fn parse_webhook_payload(body: &[u8]) -> Result<GitHubWebhookPayload, serde_json::Error> {
+    serde_json::from_slice(body)
+}
+
+async fn installation_token_for(
+    state: &AppState,
+    installation_id: u64,
+) -> Result<String, AuthError> {
+    if let Some(token) = cached_installation_token(state, installation_id) {
+        return Ok(token);
+    }
+
+    let token = state
+        .auth
+        .create_installation_token(installation_id)
+        .await?;
+    let value = token.token.clone();
+    match state.installation_tokens.lock() {
+        Ok(mut cache) => cache.remember(installation_id, token, std::time::SystemTime::now()),
+        Err(error) => {
+            warn!(%error, installation_id, "installation token cache lock poisoned");
+        }
+    }
+    Ok(value)
+}
+
+fn cached_installation_token(state: &AppState, installation_id: u64) -> Option<String> {
+    match state.installation_tokens.lock() {
+        Ok(cache) => cache
+            .lookup(installation_id, std::time::SystemTime::now())
+            .map(str::to_owned),
+        Err(error) => {
+            warn!(%error, installation_id, "installation token cache lock poisoned");
+            None
+        }
+    }
+}
+
+fn remove_cached_installation_token(state: &AppState, installation_id: u64) {
+    match state.installation_tokens.lock() {
+        Ok(mut cache) => cache.remove(installation_id),
+        Err(error) => {
+            warn!(%error, installation_id, "installation token cache lock poisoned");
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    // The signature verification logic itself is exhaustively tested
-    // in `src/github_app/webhook.rs`. Routing is exercised by the
-    // axum runtime in production; pulling it into unit tests would
-    // require spinning up a tokio runtime per test for low marginal
-    // value. When the pull_request handler lands it should ship with
-    // its own integration tests against a mocked GitHub API.
+    use super::*;
+
+    #[test]
+    fn parses_installation_id_from_pull_request_payload() {
+        let payload =
+            match parse_webhook_payload(br#"{"action":"opened","installation":{"id":12345}}"#) {
+                Ok(payload) => payload,
+                Err(error) => panic!("payload should parse: {error}"),
+            };
+
+        assert_eq!(payload.action.as_deref(), Some("opened"));
+        assert_eq!(
+            payload.installation.map(|installation| installation.id),
+            Some(12345)
+        );
+    }
+
+    #[test]
+    fn parses_payload_without_installation_id() {
+        let payload = match parse_webhook_payload(br#"{"action":"synchronize"}"#) {
+            Ok(payload) => payload,
+            Err(error) => panic!("payload should parse: {error}"),
+        };
+
+        assert_eq!(payload.action.as_deref(), Some("synchronize"));
+        assert!(payload.installation.is_none());
+    }
 }

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -13,13 +13,12 @@ cargo build --release --features github-app --bin foxguard-github-app
 
 - `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
 - `auth.rs` — GitHub App JWT generation, installation-token exchange, and conservative in-memory token caching. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
-- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, and returns `202 Accepted` for all known kinds with the actual handler bodies stubbed and clearly marked TODO.
+- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, prepares installation auth for `pull_request` deliveries, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds with scan/comment bodies still stubbed and clearly marked TODO.
 
 ## What's NOT here yet (Phase 2)
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **Auth handler wiring.** The auth client and token cache exist; the event handlers still need to call them.
 - **`pull_request` handler.** Clone the head ref into a sandboxed temp dir, run `foxguard scan` with a 60s timeout and a 1 GB repo cap, post the existing `--github-pr` output as a PR comment.
 - **`installation` handler.** Persist install metadata so we know which orgs we're serving. SQLite is fine for Phase 1; the data is small and operationally easy to back up.
 - **Check Runs API.** Inline annotations on the diff once the comment path is solid.


### PR DESCRIPTION
## Summary
- load GitHub App auth credentials and token cache into receiver state
- parse webhook JSON for installation IDs and action names
- prepare installation auth for pull_request deliveries without logging tokens or starting the scan/comment pipeline
- clear cached installation tokens on installation deletion

## Validation
- cargo test --features github-app --lib github_app::
- cargo test --features github-app --bin foxguard-github-app
- cargo build --features github-app --bin foxguard-github-app
- cargo clippy --features github-app --bin foxguard-github-app -- -D warnings
- cargo build --release
- ./target/release/foxguard --severity high src/
- git diff --check
- commit hook foxguard staged scan

Refs #246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub App authentication integration to webhook receiver
  * Implemented installation token caching for improved performance
  * Expanded webhook handling for installation and pull request events

* **Bug Fixes**
  * Improved error handling with graceful shutdown instead of panics

* **Documentation**
  * Updated documentation describing webhook verification and routing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->