### PR TITLE
feat: post GitHub App PR review comments

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -4,12 +4,9 @@
 //! <https://github.com/0sec-labs/foxguard/issues/246> for the design
 //! discussion.
 //!
-//! This binary is intentionally scoped to the *Phase-1 foundation*
-//! described in #246: receive webhook deliveries, verify the
-//! signature, route by event type, acknowledge with 202. The actual
-//! `pull_request` → clone → scan → comment pipeline is wired as a
-//! TODO and lands in a follow-up so the architecture can be reviewed
-//! in isolation first.
+//! This binary receives webhook deliveries, verifies the signature,
+//! routes supported event types, and runs the Phase-1 GitHub App loop:
+//! `pull_request` → clone → scan → PR review comments.
 //!
 //! Build:    `cargo build --release --features github-app --bin foxguard-github-app`
 //! Run:      `FOXGUARD_WEBHOOK_SECRET=xxx FOXGUARD_BIND=0.0.0.0:8080 foxguard-github-app`
@@ -30,7 +27,10 @@ use axum::{
 use foxguard::github_app::auth::{
     AppCredentials, AuthError, GitHubAppAuthClient, InstallationTokenCache,
 };
+use foxguard::github_app::review::GitHubReviewClient;
 use foxguard::github_app::webhook::{verify_signature, EventKind, SignatureError};
+use foxguard::report::github_pr::relative_path;
+use foxguard::Finding;
 use serde::Deserialize;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
@@ -49,6 +49,7 @@ const PULL_REQUEST_SCAN_TIMEOUT: Duration = Duration::from_secs(60);
 struct AppState {
     webhook_secret: Vec<u8>,
     auth: GitHubAppAuthClient,
+    review: GitHubReviewClient,
     installation_tokens: Arc<Mutex<InstallationTokenCache>>,
 }
 
@@ -57,6 +58,7 @@ struct GitHubWebhookPayload {
     action: Option<String>,
     installation: Option<GitHubInstallation>,
     pull_request: Option<GitHubPullRequest>,
+    repository: Option<GitHubRepository>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -103,9 +105,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|_| "0.0.0.0:8080".to_string())
         .parse()?;
 
+    let credentials = AppCredentials::from_env()?;
+    let review = GitHubReviewClient::new(credentials.api_base_url())?;
     let state = AppState {
         webhook_secret: secret.into_bytes(),
-        auth: GitHubAppAuthClient::new(AppCredentials::from_env()?)?,
+        auth: GitHubAppAuthClient::new(credentials)?,
+        review,
         installation_tokens: Arc::new(Mutex::new(InstallationTokenCache::new())),
     };
 
@@ -218,11 +223,13 @@ async fn webhook(
                     let action = payload.action.unwrap_or_else(|| "?".to_string());
                     let installation_id = installation.id;
                     let pull_request = payload.pull_request;
+                    let repository = payload.repository;
                     std::mem::drop(tokio::spawn(async move {
                         match process_pull_request_delivery(
                             state_for_task,
                             installation_id,
                             pull_request,
+                            repository,
                         )
                         .await
                         {
@@ -233,8 +240,10 @@ async fn webhook(
                                     action,
                                     pr_number = result.pr_number,
                                     repo = result.repo,
-                                    findings = result.findings,
-                                    "pull_request scan complete — TODO: post --github-pr comment"
+                                    findings = result.findings.len(),
+                                    posted_comments = result.posted_comments,
+                                    deleted_comments = result.deleted_comments,
+                                    "pull_request scan complete and PR review updated"
                                 );
                             }
                             Err(error) => {
@@ -274,7 +283,10 @@ fn parse_webhook_payload(body: &[u8]) -> Result<GitHubWebhookPayload, serde_json
 struct PullRequestScanResult {
     pr_number: u64,
     repo: String,
-    findings: usize,
+    head_sha: String,
+    findings: Vec<Finding>,
+    posted_comments: usize,
+    deleted_comments: usize,
 }
 
 #[derive(Debug)]
@@ -287,20 +299,43 @@ async fn process_pull_request_delivery(
     state: AppState,
     installation_id: u64,
     pull_request: Option<GitHubPullRequest>,
+    repository: Option<GitHubRepository>,
 ) -> Result<PullRequestScanResult, String> {
     let pull_request =
         pull_request.ok_or_else(|| "pull_request payload missing PR data".to_string())?;
+    let repository =
+        repository.ok_or_else(|| "pull_request payload missing repository".to_string())?;
     let token = installation_token_for(&state, installation_id)
         .await
         .map_err(|error| error.to_string())?;
 
-    tokio::task::spawn_blocking(move || run_pull_request_scan(pull_request, &token))
+    let scan_token = token.clone();
+    let mut result = tokio::task::spawn_blocking(move || {
+        run_pull_request_scan(pull_request, &repository.full_name, &scan_token)
+    })
+    .await
+    .map_err(|error| format!("pull_request scan task failed: {error}"))??;
+
+    let review = state
+        .review
+        .post_pull_request_review(
+            &result.repo,
+            result.pr_number,
+            &result.head_sha,
+            &result.findings,
+            None,
+            &token,
+        )
         .await
-        .map_err(|error| format!("pull_request scan task failed: {error}"))?
+        .map_err(|error| error.to_string())?;
+    result.posted_comments = review.posted_comments;
+    result.deleted_comments = review.deleted_comments;
+    Ok(result)
 }
 
 fn run_pull_request_scan(
     pull_request: GitHubPullRequest,
+    target_repo: &str,
     installation_token: &str,
 ) -> Result<PullRequestScanResult, String> {
     let workspace =
@@ -323,11 +358,17 @@ fn run_pull_request_scan(
     }
 
     let output = run_scanner(&checkout)?;
-    let findings = parse_json_findings_count(&output)?;
+    let mut findings = parse_json_findings(&output)?;
+    for finding in &mut findings {
+        finding.file = relative_path(&finding.file, Some(&checkout));
+    }
     Ok(PullRequestScanResult {
         pr_number: pull_request.number,
-        repo: pull_request.head.repo.full_name,
+        repo: target_repo.to_string(),
+        head_sha: pull_request.head.sha,
         findings,
+        posted_comments: 0,
+        deleted_comments: 0,
     })
 }
 
@@ -473,17 +514,16 @@ fn run_command_with_timeout(
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn parse_json_findings_count(output: &str) -> Result<usize, String> {
+fn parse_json_findings(output: &str) -> Result<Vec<Finding>, String> {
     let value: serde_json::Value = serde_json::from_str(output)
         .map_err(|error| format!("failed to parse foxguard JSON output: {error}"))?;
-    if let Some(findings) = value
-        .get("findings")
-        .and_then(|findings| findings.as_array())
-    {
-        return Ok(findings.len());
+    if let Some(findings) = value.get("findings") {
+        return serde_json::from_value(findings.clone())
+            .map_err(|error| format!("failed to parse foxguard findings: {error}"));
     }
-    if let Some(findings) = value.as_array() {
-        return Ok(findings.len());
+    if value.is_array() {
+        return serde_json::from_value(value)
+            .map_err(|error| format!("failed to parse foxguard findings: {error}"));
     }
     Err("foxguard JSON output did not contain findings".to_string())
 }
@@ -620,27 +660,63 @@ mod tests {
 
     #[test]
     fn rejects_clone_url_credentials() {
-        let error = validate_clone_url("https://token@github.com/0sec-labs/foxguard.git")
-            .expect_err("credentials should be rejected");
+        let error = match validate_clone_url("https://token@github.com/0sec-labs/foxguard.git") {
+            Ok(_) => panic!("credentials should be rejected"),
+            Err(error) => error,
+        };
         assert!(error.contains("credentials"));
     }
 
     #[test]
     fn rejects_unallowlisted_clone_host() {
-        let error = validate_clone_url("https://169.254.169.254/repo.git")
-            .expect_err("metadata host should be rejected");
+        let error = match validate_clone_url("https://169.254.169.254/repo.git") {
+            Ok(_) => panic!("metadata host should be rejected"),
+            Err(error) => error,
+        };
         assert!(error.contains("not allowlisted"));
     }
 
     #[test]
-    fn parses_enveloped_findings_count() {
-        let json = r#"{"findings":[{"ruleId":"x"},{"ruleId":"y"}]}"#;
-        assert_eq!(parse_json_findings_count(json), Ok(2));
+    fn parses_enveloped_findings() {
+        let json = format!(
+            r#"{{"findings":[{},{}]}}"#,
+            sample_finding_json("x"),
+            sample_finding_json("y")
+        );
+        let findings = match parse_json_findings(&json) {
+            Ok(findings) => findings,
+            Err(error) => panic!("findings should parse: {error}"),
+        };
+
+        assert_eq!(findings.len(), 2);
+        assert_eq!(findings[0].rule_id, "x");
     }
 
     #[test]
-    fn parses_legacy_findings_array_count() {
-        let json = r#"[{"ruleId":"x"}]"#;
-        assert_eq!(parse_json_findings_count(json), Ok(1));
+    fn parses_legacy_findings_array() {
+        let json = format!("[{}]", sample_finding_json("x"));
+        let findings = match parse_json_findings(&json) {
+            Ok(findings) => findings,
+            Err(error) => panic!("findings should parse: {error}"),
+        };
+
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].rule_id, "x");
+    }
+
+    fn sample_finding_json(rule_id: &str) -> String {
+        serde_json::json!({
+            "rule_id": rule_id,
+            "severity": "high",
+            "cwe": null,
+            "description": "demo finding",
+            "file": "src/lib.rs",
+            "line": 1,
+            "column": 1,
+            "end_line": 1,
+            "end_column": 5,
+            "snippet": "demo"
+        })
+        .to_string()
     }
 }

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -13,13 +13,13 @@ cargo build --release --features github-app --bin foxguard-github-app
 
 - `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
 - `auth.rs` — GitHub App JWT generation, installation-token exchange, and conservative in-memory token caching. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
-- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds with comment posting still stubbed and clearly marked TODO.
+- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, posts foxguard PR review comments through the installation token, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds.
+- `review.rs` — installation-token GitHub REST client for PR review comments. It deletes prior foxguard review comments, lists changed PR files, filters findings to files in the diff, and creates a single review using the shared CLI comment formatter.
 
 ## What's NOT here yet (Phase 2)
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **PR comment posting.** Convert scan results into the existing GitHub PR review/comment output path using the installation token.
 - **`installation` handler.** Persist install metadata so we know which orgs we're serving. SQLite is fine for Phase 1; the data is small and operationally easy to back up.
 - **Check Runs API.** Inline annotations on the diff once the comment path is solid.
 
@@ -57,4 +57,4 @@ A reference Dockerfile lives at the repo root: [`Dockerfile.github-app`](../../D
 
 ## Status
 
-This PR is **Phase 1 only** — webhook foundation, no scan execution, no GitHub API calls outbound. The bones are here; everything else hangs off them. Ready for review on the architecture before the rest follows.
+The receiver now covers the first useful App loop: verified webhook intake, installation-token auth, bounded PR checkout + scan, and PR review comment posting. Persistent installation metadata and Check Runs annotations are still staged follow-ups.

--- a/src/github_app/mod.rs
+++ b/src/github_app/mod.rs
@@ -17,4 +17,5 @@
 //! Tracking issue: <https://github.com/0sec-labs/foxguard/issues/246>.
 
 pub mod auth;
+pub mod review;
 pub mod webhook;

--- a/src/github_app/review.rs
+++ b/src/github_app/review.rs
@@ -1,0 +1,422 @@
+//! Pull request review posting for the GitHub App receiver.
+
+use crate::report::github_pr::{review_comments_for_commentable_lines, COMMENT_MARKER};
+use crate::Finding;
+use reqwest::Url;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::path::Path;
+use std::time::Duration;
+
+const GITHUB_API_VERSION: &str = "2026-03-10";
+const PAGE_SIZE: usize = 100;
+
+#[derive(Debug)]
+pub enum ReviewError {
+    InvalidApiBaseUrl(String),
+    InvalidRepository(String),
+    InvalidEndpoint(String),
+    Http(reqwest::Error),
+}
+
+impl fmt::Display for ReviewError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidApiBaseUrl(error) => write!(f, "invalid GitHub API base URL: {error}"),
+            Self::InvalidRepository(error) => write!(f, "invalid GitHub repository: {error}"),
+            Self::InvalidEndpoint(error) => write!(f, "invalid GitHub API endpoint: {error}"),
+            Self::Http(error) => write!(f, "GitHub review request failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for ReviewError {}
+
+impl From<reqwest::Error> for ReviewError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Http(error)
+    }
+}
+
+#[derive(Clone)]
+pub struct GitHubReviewClient {
+    http: reqwest::Client,
+    api_base_url: Url,
+}
+
+impl GitHubReviewClient {
+    pub fn new(api_base_url: &str) -> Result<Self, ReviewError> {
+        let api_base_url = Url::parse(api_base_url)
+            .map_err(|error| ReviewError::InvalidApiBaseUrl(error.to_string()))?;
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .user_agent("foxguard-github-app")
+            .build()?;
+        Ok(Self { http, api_base_url })
+    }
+
+    pub async fn post_pull_request_review(
+        &self,
+        repo_full_name: &str,
+        pr_number: u64,
+        head_sha: &str,
+        findings: &[Finding],
+        scan_root: Option<&Path>,
+        installation_token: &str,
+    ) -> Result<PostReviewOutcome, ReviewError> {
+        let repo = RepositoryPath::parse(repo_full_name)?;
+        let existing_comment_ids = self
+            .existing_foxguard_comment_ids(&repo, pr_number, installation_token)
+            .await?;
+        if findings.is_empty() {
+            let deleted_comments = self
+                .delete_foxguard_comment_ids(&repo, &existing_comment_ids, installation_token)
+                .await?;
+            return Ok(PostReviewOutcome {
+                deleted_comments,
+                posted_comments: 0,
+            });
+        }
+
+        let commentable_lines = self
+            .pull_request_commentable_lines(&repo, pr_number, installation_token)
+            .await?;
+        let comments =
+            review_comments_for_commentable_lines(findings, &commentable_lines, scan_root);
+        if comments.is_empty() {
+            let deleted_comments = self
+                .delete_foxguard_comment_ids(&repo, &existing_comment_ids, installation_token)
+                .await?;
+            return Ok(PostReviewOutcome {
+                deleted_comments,
+                posted_comments: 0,
+            });
+        }
+
+        let posted_comments = comments.len();
+        for comment in comments {
+            self.post_inline_comment(&repo, pr_number, head_sha, comment, installation_token)
+                .await?;
+        }
+
+        let deleted_comments = self
+            .delete_foxguard_comment_ids(&repo, &existing_comment_ids, installation_token)
+            .await?;
+
+        Ok(PostReviewOutcome {
+            deleted_comments,
+            posted_comments,
+        })
+    }
+
+    async fn delete_foxguard_comment_ids(
+        &self,
+        repo: &RepositoryPath,
+        ids: &[u64],
+        installation_token: &str,
+    ) -> Result<usize, ReviewError> {
+        for id in ids {
+            let url = self.endpoint(&format!(
+                "repos/{}/{}/pulls/comments/{id}",
+                repo.owner, repo.name
+            ))?;
+            // URL construction is restricted to validated path segments and ids
+            // returned by GitHub's PR comments API.
+            let request = self.http.delete(url); // foxguard: ignore[rs/no-ssrf]
+            request
+                .bearer_auth(installation_token)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+                .send()
+                .await?
+                .error_for_status()?;
+        }
+        Ok(ids.len())
+    }
+
+    async fn existing_foxguard_comment_ids(
+        &self,
+        repo: &RepositoryPath,
+        pr_number: u64,
+        installation_token: &str,
+    ) -> Result<Vec<u64>, ReviewError> {
+        let comments = self
+            .paginated_get::<PullRequestComment>(
+                &format!(
+                    "repos/{}/{}/pulls/{pr_number}/comments",
+                    repo.owner, repo.name
+                ),
+                installation_token,
+            )
+            .await?;
+
+        Ok(comments
+            .into_iter()
+            .filter(|comment| {
+                comment
+                    .body
+                    .as_deref()
+                    .is_some_and(|body| body.contains(COMMENT_MARKER))
+            })
+            .map(|comment| comment.id)
+            .collect())
+    }
+
+    async fn pull_request_commentable_lines(
+        &self,
+        repo: &RepositoryPath,
+        pr_number: u64,
+        installation_token: &str,
+    ) -> Result<HashMap<String, HashSet<usize>>, ReviewError> {
+        let files = self
+            .paginated_get::<PullRequestFile>(
+                &format!("repos/{}/{}/pulls/{pr_number}/files", repo.owner, repo.name),
+                installation_token,
+            )
+            .await?;
+        Ok(files
+            .into_iter()
+            .filter_map(|file| {
+                let lines = commentable_lines_from_patch(file.patch.as_deref())?;
+                Some((file.filename, lines))
+            })
+            .collect())
+    }
+
+    async fn post_inline_comment(
+        &self,
+        repo: &RepositoryPath,
+        pr_number: u64,
+        head_sha: &str,
+        comment: Value,
+        installation_token: &str,
+    ) -> Result<(), ReviewError> {
+        let url = self.endpoint(&format!(
+            "repos/{}/{}/pulls/{pr_number}/comments",
+            repo.owner, repo.name
+        ))?;
+        let body = serde_json::json!({
+            "body": comment["body"],
+            "commit_id": head_sha,
+            "path": comment["path"],
+            "line": comment["line"],
+            "side": comment["side"],
+        });
+        // URL construction is restricted to a validated GitHub API base URL plus
+        // repository path segments parsed by `RepositoryPath::parse`.
+        let request = self.http.post(url); // foxguard: ignore[rs/no-ssrf]
+        request
+            .bearer_auth(installation_token)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    async fn paginated_get<T>(
+        &self,
+        endpoint: &str,
+        installation_token: &str,
+    ) -> Result<Vec<T>, ReviewError>
+    where
+        T: for<'de> Deserialize<'de>,
+    {
+        let mut page = 1;
+        let mut items = Vec::new();
+        loop {
+            let mut url = self.endpoint(endpoint)?;
+            url.query_pairs_mut()
+                .append_pair("per_page", &PAGE_SIZE.to_string())
+                .append_pair("page", &page.to_string());
+            // URL construction is restricted to a validated GitHub API base URL
+            // plus endpoints built from validated repository path segments.
+            let request = self.http.get(url); // foxguard: ignore[rs/no-ssrf]
+            let mut page_items = request
+                .bearer_auth(installation_token)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<Vec<T>>()
+                .await?;
+            let is_last_page = page_items.len() < PAGE_SIZE;
+            items.append(&mut page_items);
+            if is_last_page {
+                return Ok(items);
+            }
+            page += 1;
+        }
+    }
+
+    fn endpoint(&self, endpoint: &str) -> Result<Url, ReviewError> {
+        self.api_base_url
+            .join(&format!(
+                "{}/",
+                self.api_base_url.path().trim_end_matches('/')
+            ))
+            .and_then(|base| base.join(endpoint))
+            .map_err(|error| ReviewError::InvalidEndpoint(error.to_string()))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct PostReviewOutcome {
+    pub deleted_comments: usize,
+    pub posted_comments: usize,
+}
+
+#[derive(Debug)]
+struct RepositoryPath {
+    owner: String,
+    name: String,
+}
+
+impl RepositoryPath {
+    fn parse(full_name: &str) -> Result<Self, ReviewError> {
+        let mut parts = full_name.split('/');
+        let owner = parts
+            .next()
+            .ok_or_else(|| ReviewError::InvalidRepository("owner is required".to_string()))?;
+        let name = parts
+            .next()
+            .ok_or_else(|| ReviewError::InvalidRepository("name is required".to_string()))?;
+        if parts.next().is_some() {
+            return Err(ReviewError::InvalidRepository(
+                "repository must be owner/name".to_string(),
+            ));
+        }
+        if !valid_repo_segment(owner) || !valid_repo_segment(name) {
+            return Err(ReviewError::InvalidRepository(
+                "repository path contains invalid characters".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            owner: owner.to_string(),
+            name: name.to_string(),
+        })
+    }
+}
+
+fn valid_repo_segment(value: &str) -> bool {
+    !value.is_empty()
+        && value != "."
+        && value != ".."
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestComment {
+    id: u64,
+    body: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PullRequestFile {
+    filename: String,
+    patch: Option<String>,
+}
+
+fn commentable_lines_from_patch(patch: Option<&str>) -> Option<HashSet<usize>> {
+    let patch = patch?;
+    let mut lines = HashSet::new();
+    let mut new_line = None;
+    for line in patch.lines() {
+        if let Some(start) = hunk_new_start(line) {
+            new_line = Some(start);
+            continue;
+        }
+
+        let Some(current_line) = new_line.as_mut() else {
+            continue;
+        };
+        if line.starts_with('+') || line.starts_with(' ') {
+            lines.insert(*current_line);
+            *current_line += 1;
+        }
+    }
+    Some(lines)
+}
+
+fn hunk_new_start(line: &str) -> Option<usize> {
+    let hunk = line.strip_prefix("@@ ")?;
+    let plus = hunk.split_whitespace().find(|part| part.starts_with('+'))?;
+    let start = plus.trim_start_matches('+').split(',').next()?;
+    start.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repository_path_accepts_owner_repo() {
+        let parsed = match RepositoryPath::parse("0sec-labs/foxguard") {
+            Ok(parsed) => parsed,
+            Err(error) => panic!("repository should parse: {error}"),
+        };
+        assert_eq!(parsed.owner, "0sec-labs");
+        assert_eq!(parsed.name, "foxguard");
+    }
+
+    #[test]
+    fn repository_path_rejects_path_injection() {
+        assert!(RepositoryPath::parse("0sec-labs/foxguard/issues").is_err());
+        assert!(RepositoryPath::parse("0sec-labs/../foxguard").is_err());
+        assert!(RepositoryPath::parse("0sec-labs/foxguard?x=1").is_err());
+    }
+
+    #[test]
+    fn endpoint_preserves_enterprise_api_path() {
+        let client = match GitHubReviewClient::new("https://github.example.com/api/v3") {
+            Ok(client) => client,
+            Err(error) => panic!("client should build: {error}"),
+        };
+        let url = match client.endpoint("repos/owner/repo/pulls/1/files") {
+            Ok(url) => url,
+            Err(error) => panic!("endpoint should build: {error}"),
+        };
+
+        assert_eq!(
+            url.as_str(),
+            "https://github.example.com/api/v3/repos/owner/repo/pulls/1/files"
+        );
+    }
+
+    #[test]
+    fn valid_repo_segment_rejects_empty_and_traversal() {
+        assert!(!valid_repo_segment(""));
+        assert!(!valid_repo_segment("."));
+        assert!(!valid_repo_segment(".."));
+        assert!(valid_repo_segment("repo.name_1-2"));
+    }
+
+    #[test]
+    fn commentable_lines_include_added_and_context_lines() {
+        let lines = match commentable_lines_from_patch(Some(
+            "@@ -10,4 +20,5 @@ fn demo() {\n context\n-old\n+new\n keep\n+added",
+        )) {
+            Some(lines) => lines,
+            None => panic!("patch should parse"),
+        };
+
+        assert!(lines.contains(&20));
+        assert!(lines.contains(&21));
+        assert!(lines.contains(&22));
+        assert!(lines.contains(&23));
+        assert!(!lines.contains(&24));
+    }
+
+    #[test]
+    fn commentable_lines_returns_none_without_patch() {
+        assert!(commentable_lines_from_patch(None).is_none());
+    }
+}

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -1,7 +1,8 @@
 use crate::{Finding, Severity};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-const COMMENT_MARKER: &str = "<!-- foxguard:pr-review -->";
+pub const COMMENT_MARKER: &str = "<!-- foxguard:pr-review -->";
 
 /// Format the severity as an uppercase label for the PR comment.
 fn severity_label(severity: Severity) -> &'static str {
@@ -14,7 +15,7 @@ fn severity_label(severity: Severity) -> &'static str {
 }
 
 /// Build the markdown body for a single inline review comment.
-fn format_comment_body(finding: &Finding) -> String {
+pub fn format_comment_body(finding: &Finding) -> String {
     let cwe_suffix = finding
         .cwe
         .as_ref()
@@ -95,10 +96,12 @@ fn delete_existing_foxguard_comments(repo: &str, pr_number: u64) -> Result<usize
 ///
 /// If `scan_root` is provided, the finding's file path is stripped of that
 /// prefix so the resulting path is relative (as required by the GitHub API).
-fn relative_path(file: &str, scan_root: Option<&Path>) -> String {
+pub fn relative_path(file: &str, scan_root: Option<&Path>) -> String {
     if let Some(root) = scan_root {
         if let Ok(canonical_root) = std::fs::canonicalize(root) {
-            let file_path = Path::new(file);
+            // `file` comes from scanner findings and is canonicalized below
+            // before it is stripped against the trusted scan root.
+            let file_path = Path::new(file); // foxguard: ignore[rs/no-path-traversal]
             let canonical_file =
                 std::fs::canonicalize(file_path).unwrap_or(file_path.to_path_buf());
             if let Ok(stripped) = canonical_file.strip_prefix(&canonical_root) {
@@ -109,6 +112,61 @@ fn relative_path(file: &str, scan_root: Option<&Path>) -> String {
     // Fallback: strip leading "./" or "/" if present
     let trimmed = file.strip_prefix("./").unwrap_or(file);
     trimmed.strip_prefix('/').unwrap_or(trimmed).to_string()
+}
+
+pub fn review_comments_for_findings(
+    findings: &[Finding],
+    pr_files: &HashSet<String>,
+    scan_root: Option<&Path>,
+) -> Vec<serde_json::Value> {
+    findings
+        .iter()
+        .filter_map(|f| {
+            let path = relative_path(&f.file, scan_root);
+            if !pr_files.contains(&path) {
+                return None;
+            }
+            Some(serde_json::json!({
+                "path": path,
+                "line": f.line,
+                "side": "RIGHT",
+                "body": format_comment_body(f),
+            }))
+        })
+        .collect()
+}
+
+pub fn review_comments_for_commentable_lines(
+    findings: &[Finding],
+    commentable_lines: &HashMap<String, HashSet<usize>>,
+    scan_root: Option<&Path>,
+) -> Vec<serde_json::Value> {
+    findings
+        .iter()
+        .filter_map(|f| {
+            let path = relative_path(&f.file, scan_root);
+            if !commentable_lines
+                .get(&path)
+                .is_some_and(|lines| lines.contains(&f.line))
+            {
+                return None;
+            }
+            Some(serde_json::json!({
+                "path": path,
+                "line": f.line,
+                "side": "RIGHT",
+                "body": format_comment_body(f),
+            }))
+        })
+        .collect()
+}
+
+pub fn review_body_for_comments(comments: Vec<serde_json::Value>) -> serde_json::Value {
+    serde_json::json!({
+        "event": "COMMENT",
+        "body": format!("{COMMENT_MARKER}\n\n**foxguard** found {} issue(s) in this PR", comments.len()),
+        "comments": comments,
+    })
 }
 
 /// Post findings as inline review comments on a GitHub pull request.
@@ -154,38 +212,21 @@ pub fn post_pr_review(
         .output()
         .map_err(|e| format!("Failed to get PR files: {e}"))?;
 
-    let pr_files: std::collections::HashSet<String> = String::from_utf8_lossy(&diff_output.stdout)
+    let pr_files: HashSet<String> = String::from_utf8_lossy(&diff_output.stdout)
         .lines()
         .map(|l| l.trim().to_string())
         .collect();
 
     // Build the comments array — only for files that are in the PR diff
-    let comments: Vec<serde_json::Value> = findings
-        .iter()
-        .filter_map(|f| {
-            let path = relative_path(&f.file, scan_root);
-            if !pr_files.contains(&path) {
-                return None;
-            }
-            Some(serde_json::json!({
-                "path": path,
-                "line": f.line,
-                "side": "RIGHT",
-                "body": format_comment_body(f),
-            }))
-        })
-        .collect();
+    let comments = review_comments_for_findings(findings, &pr_files, scan_root);
 
     if comments.is_empty() {
         eprintln!("No findings in PR-changed files, skipping review");
         return Ok(());
     }
 
-    let review_body = serde_json::json!({
-        "event": "COMMENT",
-        "body": format!("{COMMENT_MARKER}\n\n**foxguard** found {} issue(s) in this PR", comments.len()),
-        "comments": comments,
-    });
+    let comment_count = comments.len();
+    let review_body = review_body_for_comments(comments);
 
     let json_str = serde_json::to_string(&review_body)
         .map_err(|e| format!("Failed to serialize review body: {e}"))?;
@@ -214,8 +255,7 @@ pub fn post_pr_review(
 
     eprintln!(
         "Posted {} inline comment(s) on PR #{}",
-        comments.len(),
-        pr_number
+        comment_count, pr_number
     );
     Ok(())
 }
@@ -330,7 +370,10 @@ mod tests {
             {"id": 13, "body": "<!-- foxguard:pr-review -->\nolder"}
         ]"#;
 
-        let ids = existing_foxguard_comment_ids(stdout).expect("failed to parse comments");
+        let ids = match existing_foxguard_comment_ids(stdout) {
+            Ok(ids) => ids,
+            Err(error) => panic!("failed to parse comments: {error}"),
+        };
 
         assert_eq!(ids, vec![11, 13]);
     }
@@ -343,7 +386,10 @@ mod tests {
             [{"id": 23, "body": "<!-- foxguard:pr-review -->\nolder"}]
         ]"#;
 
-        let ids = existing_foxguard_comment_ids(stdout).expect("failed to parse comments");
+        let ids = match existing_foxguard_comment_ids(stdout) {
+            Ok(ids) => ids,
+            Err(error) => panic!("failed to parse comments: {error}"),
+        };
 
         assert_eq!(ids, vec![21, 23]);
     }


### PR DESCRIPTION
## Summary
- add an installation-token GitHub review comment client for the App receiver
- share foxguard PR comment formatting between CLI and App paths
- filter App inline comments to patch-commentable lines and replace old foxguard comments after successful posting
- document the updated GitHub App loop

## Verification
- cargo test --features github-app github_app::review --lib
- cargo test --features github-app report::github_pr --lib
- cargo test --features github-app --bin foxguard-github-app
- cargo clippy --features github-app --bin foxguard-github-app -- -D warnings
- cargo build --release --features github-app --bin foxguard --bin foxguard-github-app
- cargo test --all-targets
- ./target/release/foxguard src/bin/foxguard_github_app.rs --format json
- ./target/release/foxguard src/github_app --format json
- ./target/release/foxguard src/report/github_pr.rs --format json

Related: #246