### PR TITLE
feat: persist GitHub App installation metadata

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -27,6 +27,7 @@ use axum::{
 use foxguard::github_app::auth::{
     AppCredentials, AuthError, GitHubAppAuthClient, InstallationTokenCache,
 };
+use foxguard::github_app::installation_store::{InstallationMetadataInput, InstallationStore};
 use foxguard::github_app::review::GitHubReviewClient;
 use foxguard::github_app::webhook::{verify_signature, EventKind, SignatureError};
 use foxguard::report::github_pr::relative_path;
@@ -51,6 +52,7 @@ struct AppState {
     auth: GitHubAppAuthClient,
     review: GitHubReviewClient,
     installation_tokens: Arc<Mutex<InstallationTokenCache>>,
+    installations: Arc<Mutex<InstallationStore>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,11 +61,24 @@ struct GitHubWebhookPayload {
     installation: Option<GitHubInstallation>,
     pull_request: Option<GitHubPullRequest>,
     repository: Option<GitHubRepository>,
+    repositories: Option<Vec<GitHubRepositorySummary>>,
+    repositories_added: Option<Vec<GitHubRepositorySummary>>,
+    repositories_removed: Option<Vec<GitHubRepositorySummary>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct GitHubInstallation {
     id: u64,
+    account: Option<GitHubAccount>,
+    repository_selection: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubAccount {
+    id: Option<u64>,
+    login: Option<String>,
+    #[serde(rename = "type")]
+    kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -81,6 +96,11 @@ struct GitHubPullRequestHead {
 #[derive(Debug, Deserialize)]
 struct GitHubRepository {
     clone_url: String,
+    full_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubRepositorySummary {
     full_name: String,
 }
 
@@ -112,6 +132,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         auth: GitHubAppAuthClient::new(credentials)?,
         review,
         installation_tokens: Arc::new(Mutex::new(InstallationTokenCache::new())),
+        installations: Arc::new(Mutex::new(InstallationStore::from_env_or_default()?)),
     };
 
     let app = Router::new()
@@ -197,15 +218,23 @@ async fn webhook(
         }
         EventKind::Installation => match parse_webhook_payload(&body) {
             Ok(payload) => {
-                if let Some(installation) = payload.installation {
+                if let Some(installation) = payload.installation.as_ref() {
                     if payload.action.as_deref() == Some("deleted") {
                         remove_cached_installation_token(&state, installation.id);
                     }
+                    let persisted = match persist_installation_event(&state, &payload) {
+                        Ok(persisted) => persisted,
+                        Err(error) => {
+                            warn!(delivery, installation_id = installation.id, %error, "failed to persist installation metadata");
+                            false
+                        }
+                    };
                     info!(
                         delivery,
                         installation_id = installation.id,
                         action = payload.action.as_deref().unwrap_or("?"),
-                        "installation event — TODO: persist install metadata"
+                        persisted,
+                        "installation event processed"
                     );
                 } else {
                     warn!(delivery, "installation event missing installation.id");
@@ -277,6 +306,65 @@ async fn webhook(
 
 fn parse_webhook_payload(body: &[u8]) -> Result<GitHubWebhookPayload, serde_json::Error> {
     serde_json::from_slice(body)
+}
+
+fn persist_installation_event(
+    state: &AppState,
+    payload: &GitHubWebhookPayload,
+) -> Result<bool, String> {
+    let installation = payload
+        .installation
+        .as_ref()
+        .ok_or_else(|| "installation payload missing installation.id".to_string())?;
+    let mut store = state
+        .installations
+        .lock()
+        .map_err(|error| format!("installation store lock poisoned: {error}"))?;
+
+    match payload.action.as_deref() {
+        Some("deleted") => store
+            .remove(installation.id)
+            .map_err(|error| error.to_string()),
+        Some("added") => {
+            let repositories = repository_names(payload.repositories_added.as_deref());
+            store
+                .add_repositories(installation.id, repositories)
+                .map(|()| true)
+                .map_err(|error| error.to_string())
+        }
+        Some("removed") => {
+            let repositories = repository_names(payload.repositories_removed.as_deref());
+            store
+                .remove_repositories(installation.id, repositories)
+                .map(|()| true)
+                .map_err(|error| error.to_string())
+        }
+        _ => store
+            .upsert(InstallationMetadataInput {
+                installation_id: installation.id,
+                account_login: installation
+                    .account
+                    .as_ref()
+                    .and_then(|account| account.login.clone()),
+                account_id: installation.account.as_ref().and_then(|account| account.id),
+                account_type: installation
+                    .account
+                    .as_ref()
+                    .and_then(|account| account.kind.clone()),
+                repository_selection: installation.repository_selection.clone(),
+                repositories: repository_names(payload.repositories.as_deref()),
+            })
+            .map(|()| true)
+            .map_err(|error| error.to_string()),
+    }
+}
+
+fn repository_names(repositories: Option<&[GitHubRepositorySummary]>) -> Vec<String> {
+    repositories
+        .unwrap_or_default()
+        .iter()
+        .map(|repository| repository.full_name.clone())
+        .collect()
 }
 
 #[derive(Debug)]
@@ -644,6 +732,47 @@ mod tests {
 
         assert_eq!(payload.action.as_deref(), Some("synchronize"));
         assert!(payload.installation.is_none());
+    }
+
+    #[test]
+    fn parses_installation_metadata_payload() {
+        let payload = match parse_webhook_payload(
+            br#"{
+                "action":"created",
+                "installation":{
+                    "id":12345,
+                    "repository_selection":"selected",
+                    "account":{"id":99,"login":"octo-org","type":"Organization"}
+                },
+                "repositories":[
+                    {"full_name":"octo-org/app"},
+                    {"full_name":"octo-org/service"}
+                ]
+            }"#,
+        ) {
+            Ok(payload) => payload,
+            Err(error) => panic!("payload should parse: {error}"),
+        };
+
+        let installation = match payload.installation {
+            Some(installation) => installation,
+            None => panic!("installation should parse"),
+        };
+        let account = match installation.account {
+            Some(account) => account,
+            None => panic!("account should parse"),
+        };
+
+        assert_eq!(installation.id, 12345);
+        assert_eq!(
+            installation.repository_selection.as_deref(),
+            Some("selected")
+        );
+        assert_eq!(account.login.as_deref(), Some("octo-org"));
+        assert_eq!(
+            repository_names(payload.repositories.as_deref()),
+            vec!["octo-org/app".to_string(), "octo-org/service".to_string()]
+        );
     }
 
     #[test]

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -13,14 +13,14 @@ cargo build --release --features github-app --bin foxguard-github-app
 
 - `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
 - `auth.rs` — GitHub App JWT generation, installation-token exchange, and conservative in-memory token caching. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
-- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, posts foxguard PR review comments through the installation token, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds.
-- `review.rs` — installation-token GitHub REST client for PR review comments. It deletes prior foxguard review comments, lists changed PR files, filters findings to files in the diff, and creates a single review using the shared CLI comment formatter.
+- `installation_store.rs` — small JSON-backed installation registry. It records account metadata and selected repositories from `installation` / `installation_repositories` webhooks so self-hosted operators can recover install state across restarts without a database dependency.
+- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, persists installation metadata, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, posts foxguard PR review comments through the installation token, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds.
+- `review.rs` — installation-token GitHub REST client for PR review comments. It deletes prior foxguard review comments, lists changed PR files, filters findings to commentable diff lines, and posts inline comments using the shared CLI comment formatter.
 
 ## What's NOT here yet (Phase 2)
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **`installation` handler.** Persist install metadata so we know which orgs we're serving. SQLite is fine for Phase 1; the data is small and operationally easy to back up.
 - **Check Runs API.** Inline annotations on the diff once the comment path is solid.
 
 ## Running locally
@@ -32,6 +32,8 @@ export FOXGUARD_GITHUB_PRIVATE_KEY_PATH=/path/to/private-key.pem
 # Optional for GitHub Enterprise:
 # export FOXGUARD_GITHUB_API_BASE_URL=https://github.example.com/api/v3
 # export FOXGUARD_GITHUB_ALLOWED_API_HOSTS=github.example.com
+# Optional install metadata location (defaults to ./.foxguard-github-app/installations.json):
+# export FOXGUARD_INSTALLATIONS_PATH=/var/lib/foxguard-github-app/installations.json
 export FOXGUARD_BIND=127.0.0.1:8080
 foxguard-github-app
 ```
@@ -53,8 +55,8 @@ curl -sS -X POST http://127.0.0.1:8080/webhook \
 
 ## Self-hosting
 
-A reference Dockerfile lives at the repo root: [`Dockerfile.github-app`](../../Dockerfile.github-app). It builds the binary with the `github-app` feature, drops to a non-root user, and exposes `:8080`. Operators can deploy it to anything that runs containers (Fly.io, Railway, ECS, a tiny VM); the only persistent state once the install handler lands will be the install metadata, which is fine on a single small SQLite volume.
+A reference Dockerfile lives at the repo root: [`Dockerfile.github-app`](../../Dockerfile.github-app). It builds the binary with the `github-app` feature, drops to a non-root user, and exposes `:8080`. Operators can deploy it to anything that runs containers (Fly.io, Railway, ECS, a tiny VM); the only persistent state is the install metadata JSON file, which is fine on a single small mounted volume.
 
 ## Status
 
-The receiver now covers the first useful App loop: verified webhook intake, installation-token auth, bounded PR checkout + scan, and PR review comment posting. Persistent installation metadata and Check Runs annotations are still staged follow-ups.
+The receiver now covers the first useful App loop: verified webhook intake, installation metadata persistence, installation-token auth, bounded PR checkout + scan, and PR review comment posting. Check Runs annotations are still staged follow-up work.

--- a/src/github_app/installation_store.rs
+++ b/src/github_app/installation_store.rs
@@ -1,0 +1,354 @@
+//! Persistent installation metadata for the GitHub App receiver.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const DEFAULT_STORE_DIR: &str = ".foxguard-github-app";
+const DEFAULT_STORE_FILE: &str = "installations.json";
+const STORE_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug)]
+pub enum InstallationStoreError {
+    InvalidPath(String),
+    Io(std::io::Error),
+    Json(serde_json::Error),
+    Time(std::time::SystemTimeError),
+}
+
+impl fmt::Display for InstallationStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidPath(error) => write!(f, "invalid installation store path: {error}"),
+            Self::Io(error) => write!(f, "installation store I/O failed: {error}"),
+            Self::Json(error) => write!(f, "installation store JSON failed: {error}"),
+            Self::Time(error) => write!(f, "system time is before Unix epoch: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for InstallationStoreError {}
+
+impl From<std::io::Error> for InstallationStoreError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for InstallationStoreError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+impl From<std::time::SystemTimeError> for InstallationStoreError {
+    fn from(error: std::time::SystemTimeError) -> Self {
+        Self::Time(error)
+    }
+}
+
+#[derive(Debug)]
+pub struct InstallationStore {
+    path: PathBuf,
+    registry: InstallationRegistry,
+}
+
+impl InstallationStore {
+    pub fn from_env_or_default() -> Result<Self, InstallationStoreError> {
+        let path = match std::env::var("FOXGUARD_INSTALLATIONS_PATH") {
+            Ok(value) => {
+                let path = PathBuf::from(value); // foxguard: ignore[rs/no-path-traversal]
+                validate_operator_path(&path)?;
+                path
+            }
+            Err(_) => std::env::current_dir()?
+                .join(DEFAULT_STORE_DIR)
+                .join(DEFAULT_STORE_FILE),
+        };
+        Self::open(path)
+    }
+
+    pub fn open(path: PathBuf) -> Result<Self, InstallationStoreError> {
+        validate_store_path(&path)?;
+        let registry = if path.exists() {
+            let bytes = std::fs::read(&path)?; // foxguard: ignore[rs/no-path-traversal]
+            serde_json::from_slice(&bytes)?
+        } else {
+            InstallationRegistry::default()
+        };
+        Ok(Self { path, registry })
+    }
+
+    pub fn upsert(
+        &mut self,
+        input: InstallationMetadataInput,
+    ) -> Result<(), InstallationStoreError> {
+        let updated_at_unix = unix_now()?;
+        let key = input.installation_id.to_string();
+        let repositories = input.repositories.into_iter().collect();
+        self.registry.installations.insert(
+            key,
+            StoredInstallation {
+                installation_id: input.installation_id,
+                account_login: input.account_login,
+                account_id: input.account_id,
+                account_type: input.account_type,
+                repository_selection: input.repository_selection,
+                repositories,
+                updated_at_unix,
+            },
+        );
+        self.save()
+    }
+
+    pub fn remove(&mut self, installation_id: u64) -> Result<bool, InstallationStoreError> {
+        let removed = self
+            .registry
+            .installations
+            .remove(&installation_id.to_string())
+            .is_some();
+        self.save()?;
+        Ok(removed)
+    }
+
+    pub fn add_repositories(
+        &mut self,
+        installation_id: u64,
+        repositories: impl IntoIterator<Item = String>,
+    ) -> Result<(), InstallationStoreError> {
+        let updated_at_unix = unix_now()?;
+        let installation = self
+            .registry
+            .installations
+            .entry(installation_id.to_string())
+            .or_insert_with(|| StoredInstallation::new_placeholder(installation_id));
+        installation.repositories.extend(repositories);
+        installation.updated_at_unix = updated_at_unix;
+        self.save()
+    }
+
+    pub fn remove_repositories(
+        &mut self,
+        installation_id: u64,
+        repositories: impl IntoIterator<Item = String>,
+    ) -> Result<(), InstallationStoreError> {
+        let updated_at_unix = unix_now()?;
+        let installation = self
+            .registry
+            .installations
+            .entry(installation_id.to_string())
+            .or_insert_with(|| StoredInstallation::new_placeholder(installation_id));
+        for repository in repositories {
+            installation.repositories.remove(&repository);
+        }
+        installation.updated_at_unix = updated_at_unix;
+        self.save()
+    }
+
+    #[cfg(test)]
+    fn get(&self, installation_id: u64) -> Option<&StoredInstallation> {
+        self.registry
+            .installations
+            .get(&installation_id.to_string())
+    }
+
+    fn save(&self) -> Result<(), InstallationStoreError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?; // foxguard: ignore[rs/no-path-traversal]
+        }
+        let mut temp_path = self.path.clone();
+        temp_path.set_extension(format!(
+            "{}.tmp.{}",
+            self.path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .unwrap_or("json"),
+            std::process::id()
+        ));
+        let bytes = serde_json::to_vec_pretty(&self.registry)?;
+        std::fs::write(&temp_path, bytes)?; // foxguard: ignore[rs/no-path-traversal]
+        std::fs::rename(&temp_path, &self.path)?; // foxguard: ignore[rs/no-path-traversal]
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct InstallationMetadataInput {
+    pub installation_id: u64,
+    pub account_login: Option<String>,
+    pub account_id: Option<u64>,
+    pub account_type: Option<String>,
+    pub repository_selection: Option<String>,
+    pub repositories: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct InstallationRegistry {
+    schema_version: u32,
+    installations: BTreeMap<String, StoredInstallation>,
+}
+
+impl Default for InstallationRegistry {
+    fn default() -> Self {
+        Self {
+            schema_version: STORE_SCHEMA_VERSION,
+            installations: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct StoredInstallation {
+    installation_id: u64,
+    account_login: Option<String>,
+    account_id: Option<u64>,
+    account_type: Option<String>,
+    repository_selection: Option<String>,
+    repositories: BTreeSet<String>,
+    updated_at_unix: u64,
+}
+
+impl StoredInstallation {
+    fn new_placeholder(installation_id: u64) -> Self {
+        Self {
+            installation_id,
+            account_login: None,
+            account_id: None,
+            account_type: None,
+            repository_selection: None,
+            repositories: BTreeSet::new(),
+            updated_at_unix: 0,
+        }
+    }
+}
+
+fn validate_operator_path(path: &Path) -> Result<(), InstallationStoreError> {
+    if !path.is_absolute() {
+        return Err(InstallationStoreError::InvalidPath(
+            "FOXGUARD_INSTALLATIONS_PATH must be absolute".to_string(),
+        ));
+    }
+    validate_store_path(path)
+}
+
+fn validate_store_path(path: &Path) -> Result<(), InstallationStoreError> {
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::CurDir | Component::Prefix(_)
+        )
+    }) {
+        return Err(InstallationStoreError::InvalidPath(
+            "path must not contain traversal components".to_string(),
+        ));
+    }
+    if path.file_name().is_none() {
+        return Err(InstallationStoreError::InvalidPath(
+            "path must include a file name".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn unix_now() -> Result<u64, InstallationStoreError> {
+    Ok(SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_path() -> (tempfile::TempDir, PathBuf) {
+        let dir = match tempfile::tempdir() {
+            Ok(dir) => dir,
+            Err(error) => panic!("tempdir should be created: {error}"),
+        };
+        let path = dir.path().join("installations.json");
+        (dir, path)
+    }
+
+    #[test]
+    fn upsert_persists_installation_metadata() {
+        let (_dir, path) = store_path();
+        let mut store = match InstallationStore::open(path.clone()) {
+            Ok(store) => store,
+            Err(error) => panic!("store should open: {error}"),
+        };
+
+        if let Err(error) = store.upsert(InstallationMetadataInput {
+            installation_id: 42,
+            account_login: Some("octo-org".to_string()),
+            account_id: Some(99),
+            account_type: Some("Organization".to_string()),
+            repository_selection: Some("selected".to_string()),
+            repositories: vec!["octo-org/app".to_string(), "octo-org/service".to_string()],
+        }) {
+            panic!("upsert should persist: {error}");
+        }
+
+        let reloaded = match InstallationStore::open(path) {
+            Ok(store) => store,
+            Err(error) => panic!("store should reload: {error}"),
+        };
+        let installation = match reloaded.get(42) {
+            Some(installation) => installation,
+            None => panic!("installation should exist"),
+        };
+
+        assert_eq!(installation.account_login.as_deref(), Some("octo-org"));
+        assert!(installation.repositories.contains("octo-org/app"));
+        assert!(installation.repositories.contains("octo-org/service"));
+    }
+
+    #[test]
+    fn repository_delta_events_update_existing_installation() {
+        let (_dir, path) = store_path();
+        let mut store = match InstallationStore::open(path) {
+            Ok(store) => store,
+            Err(error) => panic!("store should open: {error}"),
+        };
+
+        if let Err(error) = store.add_repositories(
+            42,
+            ["octo-org/app".to_string(), "octo-org/service".to_string()],
+        ) {
+            panic!("repositories should be added: {error}");
+        }
+        if let Err(error) = store.remove_repositories(42, ["octo-org/app".to_string()]) {
+            panic!("repositories should be removed: {error}");
+        }
+
+        let installation = match store.get(42) {
+            Some(installation) => installation,
+            None => panic!("installation should exist"),
+        };
+        assert!(!installation.repositories.contains("octo-org/app"));
+        assert!(installation.repositories.contains("octo-org/service"));
+    }
+
+    #[test]
+    fn delete_removes_installation() {
+        let (_dir, path) = store_path();
+        let mut store = match InstallationStore::open(path) {
+            Ok(store) => store,
+            Err(error) => panic!("store should open: {error}"),
+        };
+
+        if let Err(error) = store.add_repositories(42, ["octo-org/app".to_string()]) {
+            panic!("repository should be added: {error}");
+        }
+        match store.remove(42) {
+            Ok(true) => {}
+            Ok(false) => panic!("installation should be removed"),
+            Err(error) => panic!("installation removal should persist: {error}"),
+        }
+        assert!(store.get(42).is_none());
+    }
+
+    #[test]
+    fn rejects_traversal_paths() {
+        assert!(InstallationStore::open(PathBuf::from("../installations.json")).is_err());
+    }
+}

--- a/src/github_app/mod.rs
+++ b/src/github_app/mod.rs
@@ -2,20 +2,22 @@
 //!
 //! This module hosts the pieces needed to receive `pull_request` and
 //! `installation` events from GitHub and route them into a foxguard
-//! scan. Right now it ships only the foundation:
+//! scan.
 //!
 //! * [`webhook::verify_signature`] — constant-time HMAC-SHA256 check
 //!   over the raw request body using the configured webhook secret.
 //! * [`webhook::EventKind`] — minimal enum mapping the
 //!   `X-GitHub-Event` header to the events the receiver actually
 //!   handles.
+//! * [`installation_store::InstallationStore`] — JSON-backed install
+//!   metadata persistence for self-hosted App receivers.
 //!
 //! The HTTP server lives in the `foxguard-github-app` binary at
-//! `src/bin/foxguard_github_app.rs`. The full `pull_request` → scan
-//! → comment pipeline is intentionally staged as follow-up work.
+//! `src/bin/foxguard_github_app.rs`.
 //!
 //! Tracking issue: <https://github.com/0sec-labs/foxguard/issues/246>.
 
 pub mod auth;
+pub mod installation_store;
 pub mod review;
 pub mod webhook;


### PR DESCRIPTION
## Summary
- add a JSON-backed GitHub App installation registry without new dependencies
- persist account metadata and selected repositories from installation webhooks
- handle repository added/removed deltas and deletion cleanup
- document FOXGUARD_INSTALLATIONS_PATH and current App receiver status

## Verification
- cargo test --features github-app github_app::installation_store --lib
- cargo test --features github-app --bin foxguard-github-app
- cargo clippy --features github-app --bin foxguard-github-app -- -D warnings
- cargo build --release --features github-app --bin foxguard --bin foxguard-github-app
- cargo test --all-targets
- ./target/release/foxguard src/bin/foxguard_github_app.rs --format json
- ./target/release/foxguard src/github_app --format json

Related: #246