### PR TITLE
fix(plugin): detect stale foxguard binaries during Claude setup

### DIFF
--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -97,9 +97,21 @@ Expected results:
 - Finding input exits `2` and emits a compact finding summary to stderr.
 - Both `tool_input.file_path` and `tool_input.path` are accepted.
 
-`claude plugin validate plugins/claude-code` was attempted with Claude Code
-`2.1.119`, but did not return and was stopped locally. Treat an in-session
-Claude Code smoke test as still required before submission.
+`claude plugin validate plugins/claude-code` passed with Claude Code `2.1.143`.
+
+Non-interactive Claude Code smoke tests using `claude -p --plugin-dir
+plugins/claude-code` passed for:
+
+- `/foxguard:setup`
+- `/foxguard:scan tests/fixtures/safe.py`
+- `/foxguard:diff-scan main`
+- `/foxguard:secrets tests/fixtures/safe.py`
+- `/foxguard:triage`
+
+`/foxguard:pq-audit tests/fixtures/safe.py` exposed an outdated local
+`foxguard 0.7.1` binary on `PATH` that lacks the `pqc` subcommand. The setup
+and PQ audit skills now explicitly detect that case and tell the user to
+upgrade rather than silently falling back to a generic scan.
 
 ## External Submission
 

--- a/plugins/claude-code/skills/pq-audit/SKILL.md
+++ b/plugins/claude-code/skills/pq-audit/SKILL.md
@@ -6,10 +6,15 @@ disable-model-invocation: true
 Run a post-quantum readiness audit.
 
 1. Take an optional path from `$ARGUMENTS`, default to `.`.
-2. Run via Bash: `foxguard pqc "$PATH_OR_DOT" --format json --severity medium`.
-3. Parse the JSON. Each finding may include a `cnsa2Deadline` field — surface that prominently. CNSA 2.0 mandates deprecation of classical asymmetric crypto in security-sensitive paths by specific dates; findings nearer those deadlines are higher priority.
-4. Report:
+2. Run `foxguard --help` first. If the active binary does not list the `pqc`
+   subcommand, stop and tell the user their foxguard binary is too old for
+   `/foxguard:pq-audit`; recommend upgrading foxguard, then rerunning
+   `/foxguard:setup`. Do not fall back to a generic scan and call it a PQ
+   audit.
+3. Run via Bash: `foxguard pqc "$PATH_OR_DOT" --format json --severity medium`.
+4. Parse the JSON. Each finding may include a `cnsa2Deadline` field — surface that prominently. CNSA 2.0 mandates deprecation of classical asymmetric crypto in security-sensitive paths by specific dates; findings nearer those deadlines are higher priority.
+5. Report:
    - Total PQ-vulnerable call sites
    - Breakdown by primitive (RSA, ECDSA, ECDH, etc.) — derive from `rule_id` or `description`
    - For each finding: `file:line`, the legacy primitive, the recommended PQ replacement (e.g., ML-KEM, ML-DSA, hybrid suites)
-5. Note that classical primitives may still be acceptable in non-security paths (test fixtures, signed-binary verification of trusted releases). Ask the user about context before recommending wholesale rewrites.
+6. Note that classical primitives may still be acceptable in non-security paths (test fixtures, signed-binary verification of trusted releases). Ask the user about context before recommending wholesale rewrites.

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -5,15 +5,24 @@ disable-model-invocation: true
 
 Walk the user through getting foxguard installed and the plugin working:
 
-1. Run `foxguard --version` via the Bash tool. If it succeeds, report the version and tell the user the plugin is ready — every Write/Edit will now be auto-scanned.
-2. If `foxguard` is not on PATH, offer the install options in this order:
+1. Run `foxguard --version` via the Bash tool. If it succeeds, also run
+   `foxguard --help` and verify the active binary exposes these subcommands:
+   `secrets`, `diff`, `tui`, and `pqc`.
+2. If `foxguard` is installed but any required subcommand is missing, report
+   that the binary is too old for the full Claude Code plugin. Recommend
+   upgrading with the install options below before calling the plugin ready.
+3. If `foxguard` is not on PATH, offer the install options in this order:
    - **Prebuilt binary (fastest)**: `curl -fsSL https://foxguard.dev/install.sh | sh`
    - **Homebrew** (macOS): `brew install 0sec-labs/foxguard/foxguard`
    - **npm**: `npm i -g foxguard` or zero-install via `npx foxguard`
    - **cargo**: `cargo install foxguard`
    Ask which the user prefers; do NOT install without confirmation.
-3. Recommend the user run `foxguard init` inside their repo to add a pre-commit hook so foxguard also catches issues outside Claude Code sessions.
-4. Mention the env vars they can tune:
+4. If all required subcommands are present, report the version and tell the
+   user the plugin is ready — every Write/Edit will now be auto-scanned.
+5. Recommend the user run `foxguard init` inside their repo to add a pre-commit hook so foxguard also catches issues outside Claude Code sessions.
+6. Mention the env vars they can tune:
    - `FOXGUARD_HOOK_SEVERITY` — minimum severity for auto-scan (default `medium`; values: `low|medium|high|critical`)
 
-Finish with a one-line confirmation of which version is active and which severity threshold the auto-scan is using.
+Finish with a one-line confirmation of which version is active, whether the
+full command surface is available, and which severity threshold the auto-scan
+is using.


### PR DESCRIPTION
## Summary
- make `/foxguard:setup` verify the installed foxguard command surface, including `pqc`
- make `/foxguard:pq-audit` stop with an upgrade instruction when `pqc` is unavailable
- update marketplace validation notes with the Claude Code 2.1.143 smoke results

## Verification
- `git diff --check`
- `claude plugin validate plugins/claude-code`
- `claude -p --plugin-dir plugins/claude-code --max-budget-usd 0.25 --permission-mode bypassPermissions '/foxguard:setup'`\n- `claude -p --plugin-dir plugins/claude-code --max-budget-usd 0.25 --permission-mode bypassPermissions '/foxguard:pq-audit tests/fixtures/safe.py'`\n\nRelated: #285