### PR TITLE
feat: add Dirty Frag ESP CodeQL guard calibration

### DIFF
--- a/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
+++ b/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
@@ -1,0 +1,21 @@
+# Dirty Frag class - ESP AEAD decrypt without shared-frag guard.
+#
+# This CodeQL companion rule calibrates the upstream Linux fix for
+# f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4. The vulnerable parent has
+# crypto_aead_decrypt() in esp_input()/esp6_input() without checking
+# skb_has_shared_frag(); the fixed commit extends the skip_cow gate with
+# !skb_has_shared_frag(skb).
+#
+# The query is intentionally narrow: it proves the real ESP regression shape
+# before broader MSG_SPLICE_PAGES taint modeling is added.
+rules:
+  - id: kernel/dirty-frag/esp-shared-frag-decrypt-guard-codeql
+    engine: codeql
+    message: |
+      ESP decrypt reaches crypto_aead_decrypt without an skb_has_shared_frag
+      guard in the same function. Shared MSG_SPLICE_PAGES frags can be
+      decrypted in place unless ESP copy-on-write also checks shared frags.
+    severity: ERROR
+    query: queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql
+    metadata:
+      cwe: "CWE-787"

--- a/rules/kernel/dirty-frag-class/queries/codeql-pack.lock.yml
+++ b/rules/kernel/dirty-frag-class/queries/codeql-pack.lock.yml
@@ -1,0 +1,28 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/controlflow:
+    version: 2.0.33
+  codeql/cpp-all:
+    version: 10.1.0
+  codeql/dataflow:
+    version: 2.1.5
+  codeql/mad:
+    version: 1.0.49
+  codeql/quantum:
+    version: 0.0.27
+  codeql/rangeanalysis:
+    version: 1.0.49
+  codeql/ssa:
+    version: 2.0.25
+  codeql/tutorial:
+    version: 1.0.49
+  codeql/typeflow:
+    version: 1.0.49
+  codeql/typetracking:
+    version: 2.0.33
+  codeql/util:
+    version: 2.0.36
+  codeql/xml:
+    version: 1.0.49
+compiled: false

--- a/rules/kernel/dirty-frag-class/queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql
+++ b/rules/kernel/dirty-frag-class/queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql
@@ -1,0 +1,34 @@
+/**
+ * @name ESP decrypt without shared-frag guard
+ * @description Finds Linux ESP decrypt handlers that call crypto_aead_decrypt
+ *              without an skb_has_shared_frag guard in the same function.
+ * @kind problem
+ * @problem.severity error
+ * @id cpp/kernel/dirty-frag/esp-shared-frag-decrypt-guard
+ * @tags security
+ *       external/cwe/cwe-787
+ */
+
+import cpp
+
+predicate isEspDecryptHandler(Function f) {
+  f.hasName("esp_input") or
+  f.hasName("esp6_input")
+}
+
+predicate callsFunction(Function f, string name) {
+  exists(FunctionCall call |
+    call.getEnclosingFunction() = f and
+    call.getTarget().hasName(name)
+  )
+}
+
+from FunctionCall decrypt, Function f
+where
+  isEspDecryptHandler(f) and
+  decrypt.getEnclosingFunction() = f and
+  decrypt.getTarget().hasName("crypto_aead_decrypt") and
+  not callsFunction(f, "skb_has_shared_frag")
+select decrypt,
+  "ESP decrypt calls crypto_aead_decrypt without checking skb_has_shared_frag in $@.",
+  f, f.getName()

--- a/rules/kernel/dirty-frag-class/queries/qlpack.yml
+++ b/rules/kernel/dirty-frag-class/queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: foxguard/kernel-dirty-frag-queries
+version: 0.0.0
+library: false
+dependencies:
+  codeql/cpp-all: "*"

--- a/tests/kernel_dirty_frag.rs
+++ b/tests/kernel_dirty_frag.rs
@@ -9,6 +9,7 @@
 //! - upstream ESP patch f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4
 //! - pwnkit issue #263 (foxguard-first integration approach)
 
+use foxguard::engine::codeql::parse_codeql_file;
 use foxguard::engine::parser::parse_file;
 use foxguard::rules::semgrep_compat::parse_semgrep_file;
 use foxguard::Language;
@@ -216,6 +217,24 @@ fn dirty_frag_rules_ignore_crypto_template_wrapper_fixture() {
             "expected {rule_yaml} to ignore crypto template-wrapper fixture, got {n} findings"
         );
     }
+}
+
+#[test]
+fn esp_shared_frag_decrypt_guard_codeql_rule_parses() {
+    let (rules, notices) =
+        parse_codeql_file(&Path::new(RULES_DIR).join("esp-shared-frag-decrypt-guard-codeql.yaml"))
+            .expect("CodeQL rule parses cleanly");
+
+    assert!(
+        notices.is_empty(),
+        "expected no CodeQL parse notices, got {notices:?}"
+    );
+    assert_eq!(rules.len(), 1, "expected one CodeQL rule");
+    assert_eq!(
+        rules[0].id,
+        "kernel/dirty-frag/esp-shared-frag-decrypt-guard-codeql"
+    );
+    assert_eq!(rules[0].cwe.as_deref(), Some("CWE-787"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add an in-tree CodeQL query pack for Dirty Frag kernel calibration
- add a narrow ESP shared-frag guard query and YAML rule
- add a regression test that the new CodeQL rule is loadable by foxguard

This is intentionally narrower than the full #296 MSG_SPLICE_PAGES source-to-sink taint query: it checks the endpoint invariant from upstream fix `f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4` (`esp_input`/`esp6_input` reaches `crypto_aead_decrypt` without `skb_has_shared_frag`). It should not close #296 by itself.

## Verification

- `cargo fmt --check`
- `cargo test`
- `/Users/peak/coding/tools/.local/codeql/codeql query compile rules/kernel/dirty-frag-class/queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql`
- synthetic CodeQL DB: vulnerable shape reports 2 SARIF results, fixed shape reports 0
- foxguard CodeQL scan on the same synthetic DBs: vulnerable reports 2 findings, fixed reports 0

## Real Linux DB attempt

I built a parent-commit Linux CodeQL DB in an amd64 Ubuntu container at `14acf9652e5690de3c7486c6db5fb8dafd0a32a3` using only:

- `net/ipv4/esp4.o`
- `net/ipv6/esp6.o`
- `net/ipv4/ip_output.o`
- `net/ipv6/ip6_output.o`

The build and DB creation completed after prebuilding `prepare scripts` outside CodeQL. However, the resulting GCC/QEMU extraction path produced file records but 0 function/call AST records; debug queries returned 21 files, 0 functions, 0 calls. So real parent/fix SARIF calibration remains blocked on a Linux CodeQL DB build whose extractor preserves kernel function/call ASTs.

Related: #296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CodeQL security rule to detect missing memory protection checks in Linux kernel ESP decryption handlers (CWE-787).

* **Tests**
  * Added test coverage for the new security detection rule.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->