### PR TITLE
chore: add Linux CodeQL Dirty Frag calibration workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
       - uses: actions/checkout@v6
       - run: bash -n action/entrypoint.sh
       - run: bash -n benchmarks/run.sh
+      - run: bash -n scripts/linux-codeql-dirty-frag.sh
       - run: bash -n scripts/release.sh
 
   readme-version-refs:

--- a/.github/workflows/linux-codeql-dirty-frag.yml
+++ b/.github/workflows/linux-codeql-dirty-frag.yml
@@ -1,0 +1,69 @@
+name: Linux CodeQL Dirty Frag Calibration
+
+on:
+  workflow_dispatch:
+    inputs:
+      linux_repo:
+        description: Linux repository URL
+        required: true
+        default: https://github.com/torvalds/linux.git
+      vulnerable_ref:
+        description: Vulnerable parent of the ESP shared-frag fix
+        required: true
+        default: 14acf9652e5690de3c7486c6db5fb8dafd0a32a3
+      fixed_ref:
+        description: ESP shared-frag fix commit
+        required: true
+        default: f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4
+
+jobs:
+  calibrate:
+    name: ${{ matrix.kind }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kind: vulnerable
+          - kind: fixed
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install kernel build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            bc \
+            bison \
+            build-essential \
+            flex \
+            libelf-dev \
+            libssl-dev \
+            python3 \
+            rsync
+
+      - name: Install CodeQL CLI
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/codeql-bundle.tar.gz" \
+            https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz
+          mkdir -p "$RUNNER_TEMP/codeql"
+          tar -xzf "$RUNNER_TEMP/codeql-bundle.tar.gz" -C "$RUNNER_TEMP/codeql" --strip-components=1
+          "$RUNNER_TEMP/codeql/codeql" version
+
+      - name: Build and analyze Linux CodeQL database
+        env:
+          CODEQL: ${{ runner.temp }}/codeql/codeql
+          KERNEL_REF: ${{ matrix.kind == 'vulnerable' && inputs.vulnerable_ref || inputs.fixed_ref }}
+          LINUX_REPO: ${{ inputs.linux_repo }}
+          OUT_DIR: ${{ runner.temp }}/dirty-frag-${{ matrix.kind }}
+          WORKDIR: ${{ runner.temp }}/linux-${{ matrix.kind }}
+        run: scripts/linux-codeql-dirty-frag.sh
+
+      - name: Upload calibration artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: linux-codeql-dirty-frag-${{ matrix.kind }}
+          path: ${{ runner.temp }}/dirty-frag-${{ matrix.kind }}
+          if-no-files-found: error

--- a/scripts/linux-codeql-dirty-frag.sh
+++ b/scripts/linux-codeql-dirty-frag.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kernel_ref="${KERNEL_REF:-14acf9652e5690de3c7486c6db5fb8dafd0a32a3}"
+linux_repo="${LINUX_REPO:-https://github.com/torvalds/linux.git}"
+workdir="${WORKDIR:-${RUNNER_TEMP:-/tmp}/foxguard-linux-codeql-${kernel_ref}}"
+out_dir="${OUT_DIR:-${repo_root}/.omx/codeql-linux-calibration/${kernel_ref}}"
+codeql_bin="${CODEQL:-codeql}"
+query_path="${FOXGUARD_QUERY:-${repo_root}/rules/kernel/dirty-frag-class/queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql}"
+targets="${TARGETS:-net/ipv4/esp4.o net/ipv6/esp6.o net/ipv4/ip_output.o net/ipv6/ip6_output.o}"
+jobs="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
+
+kernel_tree="${workdir}/linux"
+database_dir="${workdir}/linux-codeql-db"
+scratch_dir="${workdir}/scratch"
+sarif_path="${out_dir}/dirty-frag-${kernel_ref}.sarif"
+
+log() {
+  printf '[linux-codeql] %s\n' "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 127
+  fi
+}
+
+count_query_rows() {
+  local ql_file="$1"
+  local bqrs_file="$2"
+  local csv_file="$3"
+
+  "$codeql_bin" query run --database "$database_dir" --output "$bqrs_file" "$ql_file" >/dev/null
+  "$codeql_bin" bqrs decode --format=csv --output "$csv_file" "$bqrs_file" >/dev/null
+  tail -n +2 "$csv_file" | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]'
+}
+
+result_count() {
+  python3 - "$sarif_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+print(sum(len(run.get("results", [])) for run in data.get("runs", [])))
+PY
+}
+
+require_cmd git
+require_cmd make
+require_cmd python3
+require_cmd "$codeql_bin"
+
+mkdir -p "$workdir" "$out_dir" "$scratch_dir"
+
+if [ ! -d "$kernel_tree/.git" ]; then
+  log "cloning Linux into ${kernel_tree}"
+  git clone --filter=blob:none "$linux_repo" "$kernel_tree"
+else
+  log "reusing Linux tree ${kernel_tree}"
+fi
+
+log "checking out ${kernel_ref}"
+git -C "$kernel_tree" fetch --filter=blob:none origin "$kernel_ref"
+git -C "$kernel_tree" checkout --force FETCH_HEAD
+git -C "$kernel_tree" clean -ffdqx
+
+log "preparing minimal x86_64 kernel build state"
+make -C "$kernel_tree" ARCH=x86_64 defconfig
+make -C "$kernel_tree" ARCH=x86_64 -j"$jobs" prepare scripts
+
+rm -rf "$database_dir"
+
+log "creating CodeQL database for targets: ${targets}"
+"$codeql_bin" database create "$database_dir" \
+  --language=cpp \
+  --source-root "$kernel_tree" \
+  --command "make ARCH=x86_64 -j${jobs} ${targets}"
+
+cat >"${scratch_dir}/files.ql" <<'QL'
+import cpp
+
+from File f
+select f, f.getRelativePath()
+QL
+
+cat >"${scratch_dir}/functions.ql" <<'QL'
+import cpp
+
+from Function f
+select f, f.getName()
+QL
+
+cat >"${scratch_dir}/calls.ql" <<'QL'
+import cpp
+
+from FunctionCall c
+select c, c.toString()
+QL
+
+files_count="$(count_query_rows "${scratch_dir}/files.ql" "${scratch_dir}/files.bqrs" "${scratch_dir}/files.csv")"
+functions_count="$(count_query_rows "${scratch_dir}/functions.ql" "${scratch_dir}/functions.bqrs" "${scratch_dir}/functions.csv")"
+calls_count="$(count_query_rows "${scratch_dir}/calls.ql" "${scratch_dir}/calls.bqrs" "${scratch_dir}/calls.csv")"
+
+log "database inventory: files=${files_count} functions=${functions_count} calls=${calls_count}"
+
+if [ "$functions_count" -eq 0 ] || [ "$calls_count" -eq 0 ]; then
+  printf 'CodeQL database has no usable function/call AST records; refusing to calibrate.\n' >&2
+  exit 1
+fi
+
+log "analyzing ${query_path}"
+"$codeql_bin" database analyze "$database_dir" "$query_path" \
+  --format=sarif-latest \
+  --output "$sarif_path"
+
+findings="$(result_count)"
+log "SARIF findings: ${findings}"
+
+cat >"${out_dir}/summary.txt" <<EOF
+kernel_ref=${kernel_ref}
+linux_repo=${linux_repo}
+database=${database_dir}
+query=${query_path}
+sarif=${sarif_path}
+files=${files_count}
+functions=${functions_count}
+calls=${calls_count}
+findings=${findings}
+targets=${targets}
+EOF
+
+log "wrote ${out_dir}/summary.txt"
+
+if [ "${KEEP_WORKDIR:-0}" != "1" ]; then
+  log "removing workdir ${workdir}"
+  rm -rf "$workdir"
+fi


### PR DESCRIPTION
## Summary
- add a Linux-native Dirty Frag CodeQL calibration script
- add a manual workflow_dispatch job for vulnerable/fixed Linux refs on ubuntu-latest
- fail calibration when the generated CodeQL database has no function/call AST records

## Verification
- bash -n scripts/linux-codeql-dirty-frag.sh
- Ruby YAML parse for .github/workflows/ci.yml and .github/workflows/linux-codeql-dirty-frag.yml

## Notes
The full Linux workflow still needs to be dispatched on GitHub; local Docker/macOS extraction was the blocker this is meant to bypass.