### PR TITLE
fix: preserve Linux CodeQL calibration diagnostics

### DIFF
--- a/.github/workflows/linux-codeql-dirty-frag.yml
+++ b/.github/workflows/linux-codeql-dirty-frag.yml
@@ -38,9 +38,12 @@ jobs:
             bc \
             bison \
             build-essential \
+            clang \
             flex \
             libelf-dev \
             libssl-dev \
+            lld \
+            llvm \
             python3 \
             rsync
 
@@ -62,6 +65,7 @@ jobs:
         run: scripts/linux-codeql-dirty-frag.sh
 
       - name: Upload calibration artifacts
+        if: always()
         uses: actions/upload-artifact@v5
         with:
           name: linux-codeql-dirty-frag-${{ matrix.kind }}

--- a/scripts/linux-codeql-dirty-frag.sh
+++ b/scripts/linux-codeql-dirty-frag.sh
@@ -10,7 +10,9 @@ out_dir="${OUT_DIR:-${repo_root}/.omx/codeql-linux-calibration/${kernel_ref}}"
 codeql_bin="${CODEQL:-codeql}"
 query_path="${FOXGUARD_QUERY:-${repo_root}/rules/kernel/dirty-frag-class/queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql}"
 targets="${TARGETS:-net/ipv4/esp4.o net/ipv6/esp6.o net/ipv4/ip_output.o net/ipv6/ip6_output.o}"
+make_args="${MAKE_ARGS:-ARCH=x86_64 LLVM=1}"
 jobs="${JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)}"
+read -r -a make_args_array <<<"$make_args"
 
 kernel_tree="${workdir}/linux"
 database_dir="${workdir}/linux-codeql-db"
@@ -51,6 +53,36 @@ print(sum(len(run.get("results", [])) for run in data.get("runs", [])))
 PY
 }
 
+collect_diagnostics() {
+  if [ -d "$database_dir/log" ]; then
+    mkdir -p "${out_dir}/database-log"
+    cp -R "$database_dir/log/." "${out_dir}/database-log/"
+  fi
+
+  if [ -d "$database_dir/diagnostic" ]; then
+    mkdir -p "${out_dir}/database-diagnostic"
+    cp -R "$database_dir/diagnostic/." "${out_dir}/database-diagnostic/"
+  fi
+}
+
+write_summary() {
+  local findings="${1:-unknown}"
+
+  cat >"${out_dir}/summary.txt" <<EOF
+kernel_ref=${kernel_ref}
+linux_repo=${linux_repo}
+database=${database_dir}
+query=${query_path}
+sarif=${sarif_path}
+files=${files_count:-unknown}
+functions=${functions_count:-unknown}
+calls=${calls_count:-unknown}
+findings=${findings}
+targets=${targets}
+make_args=${make_args}
+EOF
+}
+
 require_cmd git
 require_cmd make
 require_cmd python3
@@ -77,8 +109,8 @@ git -C "$kernel_tree" checkout --force FETCH_HEAD
 git -C "$kernel_tree" clean -ffdqx
 
 log "preparing minimal x86_64 kernel build state"
-make -C "$kernel_tree" ARCH=x86_64 defconfig
-make -C "$kernel_tree" ARCH=x86_64 -j"$jobs" prepare scripts
+make -C "$kernel_tree" "${make_args_array[@]}" defconfig
+make -C "$kernel_tree" "${make_args_array[@]}" -j"$jobs" prepare scripts
 
 rm -rf "$database_dir"
 
@@ -86,7 +118,7 @@ log "creating CodeQL database for targets: ${targets}"
 "$codeql_bin" database create "$database_dir" \
   --language=cpp \
   --source-root "$kernel_tree" \
-  --command "make ARCH=x86_64 -j${jobs} ${targets}"
+  --command "make ${make_args} -j${jobs} ${targets}"
 
 cat >"${scratch_dir}/files.ql" <<'QL'
 import cpp
@@ -116,6 +148,8 @@ calls_count="$(count_query_rows "${scratch_dir}/calls.ql" "${scratch_dir}/calls.
 log "database inventory: files=${files_count} functions=${functions_count} calls=${calls_count}"
 
 if [ "$functions_count" -eq 0 ] || [ "$calls_count" -eq 0 ]; then
+  collect_diagnostics
+  write_summary "not-run"
   printf 'CodeQL database has no usable function/call AST records; refusing to calibrate.\n' >&2
   exit 1
 fi
@@ -128,18 +162,8 @@ log "analyzing ${query_path}"
 findings="$(result_count)"
 log "SARIF findings: ${findings}"
 
-cat >"${out_dir}/summary.txt" <<EOF
-kernel_ref=${kernel_ref}
-linux_repo=${linux_repo}
-database=${database_dir}
-query=${query_path}
-sarif=${sarif_path}
-files=${files_count}
-functions=${functions_count}
-calls=${calls_count}
-findings=${findings}
-targets=${targets}
-EOF
+collect_diagnostics
+write_summary "$findings"
 
 log "wrote ${out_dir}/summary.txt"
 


### PR DESCRIPTION
## Summary
- switch the Linux calibration build to the kernel LLVM path by default (`MAKE_ARGS=ARCH=x86_64 LLVM=1`)
- install clang/lld/llvm in the manual workflow
- upload CodeQL database logs and diagnostics even when the AST inventory guard fails

## Verification
- bash -n scripts/linux-codeql-dirty-frag.sh
- Ruby YAML parse for CI and Linux CodeQL workflow

## Context
The native GitHub runner reproduced the real blocker: both vulnerable and fixed refs built target objects and created a CodeQL DB, but the database inventory was `files=21 functions=0 calls=0`.
