### PR TITLE
feat: add GitHub App check run annotations

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -6,7 +6,7 @@
 //!
 //! This binary receives webhook deliveries, verifies the signature,
 //! routes supported event types, and runs the Phase-1 GitHub App loop:
-//! `pull_request` → clone → scan → PR review comments.
+//! `pull_request` -> clone -> scan -> PR review comments + check run.
 //!
 //! Build:    `cargo build --release --features github-app --bin foxguard-github-app`
 //! Run:      `FOXGUARD_WEBHOOK_SECRET=xxx FOXGUARD_BIND=0.0.0.0:8080 foxguard-github-app`
@@ -272,7 +272,8 @@ async fn webhook(
                                     findings = result.findings.len(),
                                     posted_comments = result.posted_comments,
                                     deleted_comments = result.deleted_comments,
-                                    "pull_request scan complete and PR review updated"
+                                    posted_check_annotations = result.posted_check_annotations,
+                                    "pull_request scan complete and GitHub surfaces updated"
                                 );
                             }
                             Err(error) => {
@@ -375,6 +376,7 @@ struct PullRequestScanResult {
     findings: Vec<Finding>,
     posted_comments: usize,
     deleted_comments: usize,
+    posted_check_annotations: usize,
 }
 
 #[derive(Debug)]
@@ -418,6 +420,23 @@ async fn process_pull_request_delivery(
         .map_err(|error| error.to_string())?;
     result.posted_comments = review.posted_comments;
     result.deleted_comments = review.deleted_comments;
+    match state
+        .review
+        .post_check_run(&result.repo, &result.head_sha, &result.findings, &token)
+        .await
+    {
+        Ok(check_run) => {
+            result.posted_check_annotations = check_run.posted_annotations;
+        }
+        Err(error) => {
+            warn!(
+                repo = result.repo,
+                pr_number = result.pr_number,
+                %error,
+                "failed to post foxguard check run"
+            );
+        }
+    }
     Ok(result)
 }
 
@@ -457,6 +476,7 @@ fn run_pull_request_scan(
         findings,
         posted_comments: 0,
         deleted_comments: 0,
+        posted_check_annotations: 0,
     })
 }
 

--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -14,14 +14,14 @@ cargo build --release --features github-app --bin foxguard-github-app
 - `webhook.rs` — HMAC-SHA256 signature verification (`verify_signature`) and the `EventKind` router enum. 10 unit tests pin the verification contract: known-good vector, modified body, wrong secret, missing/empty/non-hex/short-length digest, trailing-whitespace tolerance, and the kind-routing map.
 - `auth.rs` — GitHub App JWT generation, installation-token exchange, and conservative in-memory token caching. It reads app credentials from `FOXGUARD_GITHUB_APP_ID` and either `FOXGUARD_GITHUB_PRIVATE_KEY` or an absolute `FOXGUARD_GITHUB_PRIVATE_KEY_PATH`, and keeps the outbound GitHub API base URL configurable for tests and allowlisted GitHub Enterprise hosts.
 - `installation_store.rs` — small JSON-backed installation registry. It records account metadata and selected repositories from `installation` / `installation_repositories` webhooks so self-hosted operators can recover install state across restarts without a database dependency.
-- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, persists installation metadata, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, posts foxguard PR review comments through the installation token, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds.
-- `review.rs` — installation-token GitHub REST client for PR review comments. It deletes prior foxguard review comments, lists changed PR files, filters findings to commentable diff lines, and posts inline comments using the shared CLI comment formatter.
+- `src/bin/foxguard_github_app.rs` — axum-based HTTP server with `/healthz` and `/webhook` endpoints. Verifies the signature, routes by `X-GitHub-Event`, extracts installation IDs from JSON payloads, persists installation metadata, prepares installation auth for `pull_request` deliveries, clones and scans pull-request heads in a bounded temp workspace, posts foxguard PR review comments and a check run through the installation token, clears cached tokens when installations are deleted, and returns `202 Accepted` for all known kinds.
+- `review.rs` — installation-token GitHub REST client for PR review comments and check runs. It deletes prior foxguard review comments, lists changed PR files, filters findings to commentable diff lines, posts inline comments using the shared CLI comment formatter, and creates a `foxguard` check run with up to 50 annotations.
 
 ## What's NOT here yet (Phase 2)
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **Check Runs API.** Inline annotations on the diff once the comment path is solid.
+- **App registration.** Create the production GitHub App, wire the real install URL into the landing page, and verify the requested permissions include pull request review comments plus check runs.
 
 ## Running locally
 
@@ -59,4 +59,4 @@ A reference Dockerfile lives at the repo root: [`Dockerfile.github-app`](../../D
 
 ## Status
 
-The receiver now covers the first useful App loop: verified webhook intake, installation metadata persistence, installation-token auth, bounded PR checkout + scan, and PR review comment posting. Check Runs annotations are still staged follow-up work.
+The receiver now covers the first useful App loop: verified webhook intake, installation metadata persistence, installation-token auth, bounded PR checkout + scan, PR review comment posting, and check-run annotations.

--- a/src/github_app/review.rs
+++ b/src/github_app/review.rs
@@ -1,7 +1,7 @@
 //! Pull request review posting for the GitHub App receiver.
 
 use crate::report::github_pr::{review_comments_for_commentable_lines, COMMENT_MARKER};
-use crate::Finding;
+use crate::{Finding, Severity};
 use reqwest::Url;
 use serde::Deserialize;
 use serde_json::Value;
@@ -108,6 +108,45 @@ impl GitHubReviewClient {
         Ok(PostReviewOutcome {
             deleted_comments,
             posted_comments,
+        })
+    }
+
+    pub async fn post_check_run(
+        &self,
+        repo_full_name: &str,
+        head_sha: &str,
+        findings: &[Finding],
+        installation_token: &str,
+    ) -> Result<PostCheckRunOutcome, ReviewError> {
+        let repo = RepositoryPath::parse(repo_full_name)?;
+        let annotations = check_run_annotations(findings);
+        let annotation_count = annotations.len();
+        let url = self.endpoint(&format!("repos/{}/{}/check-runs", repo.owner, repo.name))?;
+        let body = serde_json::json!({
+            "name": "foxguard",
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": check_run_conclusion(findings),
+            "output": {
+                "title": check_run_title(findings),
+                "summary": check_run_summary(findings, annotation_count),
+                "annotations": annotations,
+            },
+        });
+        // URL construction is restricted to a validated GitHub API base URL plus
+        // repository path segments parsed by `RepositoryPath::parse`.
+        let request = self.http.post(url); // foxguard: ignore[rs/no-ssrf]
+        request
+            .bearer_auth(installation_token)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
+
+        Ok(PostCheckRunOutcome {
+            posted_annotations: annotation_count,
         })
     }
 
@@ -271,6 +310,11 @@ pub struct PostReviewOutcome {
     pub posted_comments: usize,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub struct PostCheckRunOutcome {
+    pub posted_annotations: usize,
+}
+
 #[derive(Debug)]
 struct RepositoryPath {
     owner: String,
@@ -353,6 +397,97 @@ fn hunk_new_start(line: &str) -> Option<usize> {
     start.parse().ok()
 }
 
+fn check_run_conclusion(findings: &[Finding]) -> &'static str {
+    if findings.is_empty() {
+        return "success";
+    }
+    if findings
+        .iter()
+        .any(|finding| matches!(finding.severity, Severity::High | Severity::Critical))
+    {
+        return "failure";
+    }
+    "neutral"
+}
+
+fn check_run_title(findings: &[Finding]) -> &'static str {
+    if findings.is_empty() {
+        "foxguard found no issues"
+    } else {
+        "foxguard found issues"
+    }
+}
+
+fn check_run_summary(findings: &[Finding], annotation_count: usize) -> String {
+    if findings.is_empty() {
+        return "foxguard scan completed with no findings.".to_string();
+    }
+
+    let mut low = 0;
+    let mut medium = 0;
+    let mut high = 0;
+    let mut critical = 0;
+    for finding in findings {
+        match finding.severity {
+            Severity::Low => low += 1,
+            Severity::Medium => medium += 1,
+            Severity::High => high += 1,
+            Severity::Critical => critical += 1,
+        }
+    }
+
+    let mut summary = format!(
+        "foxguard found {} issue(s): {critical} critical, {high} high, {medium} medium, {low} low.",
+        findings.len()
+    );
+    if annotation_count < findings.len() {
+        summary.push_str(&format!(
+            " Showing the first {annotation_count} as check annotations."
+        ));
+    }
+    summary
+}
+
+fn check_run_annotations(findings: &[Finding]) -> Vec<Value> {
+    findings
+        .iter()
+        .filter(|finding| finding.line > 0)
+        .take(50)
+        .map(|finding| {
+            let end_line = finding.end_line.max(finding.line);
+            serde_json::json!({
+                "path": finding.file,
+                "start_line": finding.line,
+                "end_line": end_line,
+                "annotation_level": annotation_level(finding.severity),
+                "title": truncate(&format!("{} ({})", finding.rule_id, finding.severity), 255),
+                "message": truncate(&finding.description, 64_000),
+                "raw_details": truncate(&finding.snippet, 64_000),
+            })
+        })
+        .collect()
+}
+
+fn annotation_level(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Low => "notice",
+        Severity::Medium => "warning",
+        Severity::High | Severity::Critical => "failure",
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+    let mut truncated: String = value.chars().take(max_chars - 3).collect();
+    truncated.push_str("...");
+    truncated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -418,5 +553,70 @@ mod tests {
     #[test]
     fn commentable_lines_returns_none_without_patch() {
         assert!(commentable_lines_from_patch(None).is_none());
+    }
+
+    fn finding(severity: Severity, line: usize) -> Finding {
+        Finding {
+            rule_id: "test/rule".to_string(),
+            severity,
+            cwe: Some("CWE-79".to_string()),
+            description: "finding description".to_string(),
+            file: "src/app.js".to_string(),
+            line,
+            column: 1,
+            end_line: line,
+            end_column: 2,
+            snippet: "bad()".to_string(),
+            source_line: None,
+            source_description: None,
+            sink_line: None,
+            sink_description: None,
+            fix_suggestion: None,
+            sink_start_byte: None,
+            sink_end_byte: None,
+            confidence: 1.0,
+            taint_hops: None,
+            tags: Vec::new(),
+            crypto_algorithm: None,
+            cnsa2_deadline: None,
+            dep_name: None,
+        }
+    }
+
+    #[test]
+    fn check_run_conclusion_matches_severity() {
+        assert_eq!(check_run_conclusion(&[]), "success");
+        assert_eq!(
+            check_run_conclusion(&[finding(Severity::Low, 1)]),
+            "neutral"
+        );
+        assert_eq!(
+            check_run_conclusion(&[finding(Severity::High, 1)]),
+            "failure"
+        );
+    }
+
+    #[test]
+    fn check_run_annotations_cap_at_github_limit() {
+        let findings: Vec<_> = (1..=60)
+            .map(|line| finding(Severity::Critical, line))
+            .collect();
+        let annotations = check_run_annotations(&findings);
+
+        assert_eq!(annotations.len(), 50);
+        assert_eq!(annotations[0]["path"], "src/app.js");
+        assert_eq!(annotations[0]["start_line"], 1);
+        assert_eq!(annotations[0]["annotation_level"], "failure");
+    }
+
+    #[test]
+    fn check_run_summary_mentions_truncated_annotations() {
+        let findings: Vec<_> = (1..=60)
+            .map(|line| finding(Severity::Medium, line))
+            .collect();
+        let summary = check_run_summary(&findings, 50);
+
+        assert!(summary.contains("60 issue(s)"));
+        assert!(summary.contains("Showing the first 50"));
     }
 }


### PR DESCRIPTION
## Summary
- create a completed `foxguard` check run for each PR scan
- summarize findings by severity and annotate up to GitHubs 50-annotation limit
- keep PR review comments in place, and make check-run posting fail-soft until production App permissions are verified
- update GitHub App docs/status to reflect check-run support

## Verification
- cargo fmt --check
- cargo test --features github-app
- cargo clippy --features github-app -- -D warnings

## Notes
Live check-run posting still needs validation after the production GitHub App is registered with Checks write permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request scans now post GitHub check runs alongside PR review comments, displaying findings as check-run annotations (up to 50 per scan).
  * Enhanced scan result tracking to monitor posted annotations.

* **Documentation**
  * Updated documentation to reflect expanded check-run functionality and current Phase 1 implementation status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->