### PR TITLE
Fix Claude hook JSON parsing

### DIFF
--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -46,6 +46,9 @@ foxguard --format json --severity medium <edited-file>
 
 If findings are present, the hook exits `2` and prints a compact finding summary to stderr. Missing binaries, unreadable files, invalid hook input, and clean scans exit `0` so plugin machinery does not block Claude by itself.
 
+The hook uses `jq` to parse Claude Code's hook JSON. Run `/foxguard:setup` after
+loading the plugin to verify both `jq` and the active `foxguard` binary.
+
 Tune the threshold with:
 
 ```sh

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -35,7 +35,10 @@ That verifies the `foxguard` binary is available and explains the active hook se
 
 ## Hook Behavior
 
-The auto-scan hook reads the Claude Code hook JSON from stdin, extracts `tool_input.file_path` or `tool_input.path`, and runs:
+The auto-scan hook reads the Claude Code hook JSON from stdin, extracts the
+edited path from `tool_input.file_path`, `tool_input.path`,
+`tool_input.notebook_path`, `tool_response.filePath`, or
+`tool_response.file_path`, and runs:
 
 ```sh
 foxguard --format json --severity medium <edited-file>

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "foxguard",
-  "description": "Fast local security scanning in Claude Code: auto-scan edited files, slash commands for full scans, diff scans, post-quantum audits, and TUI triage. Powered by the foxguard Rust scanner — 170+ rules across 10 languages with cross-file taint tracking.",
+  "description": "Fast local security scanning in Claude Code: auto-scan edited files, slash commands for full scans, diff scans, post-quantum audits, and TUI triage. Powered by the foxguard Rust scanner with 170+ rules, cross-file taint tracking, and Semgrep-compatible rule support.",
   "version": "0.1.0",
   "author": {
     "name": "0sec Labs",
@@ -8,5 +8,5 @@
   },
   "homepage": "https://foxguard.dev",
   "repository": "https://github.com/0sec-labs/foxguard",
-  "license": "MIT"
+  "license": "MIT OR Apache-2.0"
 }

--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -77,6 +77,8 @@ Suggested demo checklist:
 The hook was validated directly with:
 
 ```sh
+jq --version
+
 printf '{"tool_input":{"file_path":"tests/fixtures/safe.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
 
@@ -98,6 +100,7 @@ printf '{"tool_input":{"file_path":"/does/not/exist.py"}}' \
 
 Expected results:
 
+- `jq --version` succeeds.
 - Clean supported files exit `0` and stay silent.
 - Missing files exit `0` and stay silent.
 - Finding input exits `2` and emits a compact finding summary to stderr.

--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -94,6 +94,9 @@ printf '{"tool_input":{"notebook_path":"tests/fixtures/safe.py"}}' \
 printf '{"tool_response":{"filePath":"tests/fixtures/safe.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
 
+printf '{"tool_response":{"file_path":"tests/fixtures/safe.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
 printf '{"tool_input":{"file_path":"/does/not/exist.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
 ```

--- a/plugins/claude-code/MARKETPLACE.md
+++ b/plugins/claude-code/MARKETPLACE.md
@@ -86,6 +86,12 @@ printf '{"tool_input":{"file_path":"tests/fixtures/vulnerable.py"}}' \
 printf '{"tool_input":{"path":"tests/fixtures/vulnerable.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
 
+printf '{"tool_input":{"notebook_path":"tests/fixtures/safe.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
+printf '{"tool_response":{"filePath":"tests/fixtures/safe.py"}}' \
+  | plugins/claude-code/scripts/scan-edited-file.sh
+
 printf '{"tool_input":{"file_path":"/does/not/exist.py"}}' \
   | plugins/claude-code/scripts/scan-edited-file.sh
 ```
@@ -95,9 +101,15 @@ Expected results:
 - Clean supported files exit `0` and stay silent.
 - Missing files exit `0` and stay silent.
 - Finding input exits `2` and emits a compact finding summary to stderr.
-- Both `tool_input.file_path` and `tool_input.path` are accepted.
+- Edited path extraction accepts `tool_input.file_path`, `tool_input.path`,
+  `tool_input.notebook_path`, `tool_response.filePath`, and
+  `tool_response.file_path`.
+- Scanner JSON parsing accepts the current `schema_version` object with a
+  `findings` array.
 
 `claude plugin validate plugins/claude-code` passed with Claude Code `2.1.143`.
+Older local Claude Code builds have been observed hanging during validation;
+`2.1.143` is the known-good version for the current submission notes.
 
 Non-interactive Claude Code smoke tests using `claude -p --plugin-dir
 plugins/claude-code` passed with `foxguard 0.8.1` first on `PATH` for:

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -38,6 +38,9 @@ cargo install foxguard
 
 Verify with `foxguard --version`.
 
+The PostToolUse hook also needs `jq` to parse Claude Code's hook JSON. Run
+`jq --version` or use `/foxguard:setup` after loading the plugin to verify it.
+
 ### 2. Install the plugin
 
 Until the plugin is published to a marketplace, load it directly from this repo:
@@ -102,7 +105,7 @@ plugins/claude-code/
 ## Notes
 
 - The hook intentionally never blocks Claude on its own machinery: missing binary, parse errors, or unreadable inputs all exit `0`. Only real findings exit `2`.
-- The hook calls `foxguard` from `PATH` first, then falls back to `npx --yes foxguard`. If neither is available it stays silent — run `/foxguard:setup` to fix that.
+- The hook calls `foxguard` from `PATH` first, then falls back to `npx --yes foxguard`. It uses `jq` to parse Claude Code's hook JSON. If either dependency is unavailable it stays silent — run `/foxguard:setup` to fix that.
 - `--severity medium` is the default cutoff. Drop to `low` for stricter coverage; raise to `high` for noisier projects.
 - foxguard's exit codes: `0` clean, `1` findings, `2` error. The hook checks for findings via the JSON, not the exit code, so a piped error doesn't trigger a false alarm.
 - This package is scoped to Claude Code. Broader agent or editor integration

--- a/plugins/claude-code/scripts/scan-edited-file.sh
+++ b/plugins/claude-code/scripts/scan-edited-file.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # PostToolUse hook: scan the file Claude just wrote/edited and feed findings back.
 #
-# Reads the Claude Code hook input JSON from stdin, extracts tool_input.file_path,
-# runs `foxguard --format json` on it, and emits a compact summary on stderr with
-# exit 2 when medium+ findings exist so Claude treats it as actionable feedback.
+# Reads the Claude Code hook input JSON from stdin, extracts the edited path from
+# common Write/Edit/NotebookEdit schemas, runs `foxguard --format json` on it,
+# and emits a compact summary on stderr with exit 2 when medium+ findings exist
+# so Claude treats it as actionable feedback.
 # Stays silent (exit 0) on clean files, missing tools, or unreadable inputs — a
 # scanner hook should never block Claude on its own machinery.
 
@@ -11,7 +12,14 @@ set -uo pipefail
 
 input=$(cat)
 
-file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+file_path=$(printf '%s' "$input" | jq -r '
+  .tool_input.file_path
+  // .tool_input.path
+  // .tool_input.notebook_path
+  // .tool_response.filePath
+  // .tool_response.file_path
+  // empty
+' 2>/dev/null)
 
 [ -z "$file_path" ] && exit 0
 [ ! -f "$file_path" ] && exit 0
@@ -27,17 +35,37 @@ fi
 
 min_severity="${FOXGUARD_HOOK_SEVERITY:-medium}"
 
-findings=$("${fg[@]}" --format json --severity "$min_severity" "$file_path" 2>/dev/null) || true
+scan_output=$("${fg[@]}" --format json --severity "$min_severity" "$file_path" 2>/dev/null) || true
+
+[ -z "$scan_output" ] && exit 0
+
+findings=$(printf '%s' "$scan_output" | jq -c '
+  if type == "array" then
+    .
+  elif type == "object" and (.findings | type == "array") then
+    .findings
+  else
+    []
+  end
+' 2>/dev/null)
 
 [ -z "$findings" ] && exit 0
 [ "$findings" = "[]" ] && exit 0
 
 count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null)
-[ -z "$count" ] || [ "$count" = "0" ] && exit 0
+if [ -z "$count" ] || [ "$count" = "0" ]; then
+  exit 0
+fi
 
 {
   printf 'foxguard found %s issue(s) in %s (severity >= %s):\n\n' "$count" "$file_path" "$min_severity"
-  printf '%s' "$findings" | jq -r '.[] | "  [\(.severity | ascii_upcase)] \(.rule_id) at line \(.line)\n    \(.description)\n    \(.cwe // "")\n    > \(.snippet)\n"'
+  printf '%s' "$findings" | jq -r '
+    .[] |
+    "  [\(.severity // "unknown" | tostring | ascii_upcase)] \(.rule_id // "unknown-rule") at line \(.line // "?")\n" +
+    "    \(.description // "No description")\n" +
+    "    \(.cwe // "")\n" +
+    "    > \(.snippet // "" | tostring)\n"
+  '
   printf '\nFix these before continuing. Run `/foxguard:scan` for the full repo or `/foxguard:triage` for the interactive TUI.\n'
 } >&2
 

--- a/plugins/claude-code/scripts/scan-edited-file.sh
+++ b/plugins/claude-code/scripts/scan-edited-file.sh
@@ -35,7 +35,7 @@ fi
 
 min_severity="${FOXGUARD_HOOK_SEVERITY:-medium}"
 
-scan_output=$("${fg[@]}" --format json --severity "$min_severity" "$file_path" 2>/dev/null) || true
+scan_output=$("${fg[@]}" --format json --severity "$min_severity" -- "$file_path" 2>/dev/null) || true
 
 [ -z "$scan_output" ] && exit 0
 

--- a/plugins/claude-code/skills/setup/SKILL.md
+++ b/plugins/claude-code/skills/setup/SKILL.md
@@ -5,24 +5,32 @@ disable-model-invocation: true
 
 Walk the user through getting foxguard installed and the plugin working:
 
-1. Run `foxguard --version` via the Bash tool. If it succeeds, also run
+1. Run `command -v jq` and `jq --version` via the Bash tool. If `jq` is
+   missing, report that the plugin can load but the PostToolUse auto-scan
+   cannot parse Claude's hook JSON yet. Recommend installing `jq` with the
+   user's package manager (`brew install jq`, `sudo apt-get install jq`,
+   `sudo dnf install jq`, or `sudo apk add jq`) before calling the auto-scan
+   ready. Do not install without confirmation.
+2. Run `foxguard --version` via the Bash tool. If it succeeds, also run
    `foxguard --help` and verify the active binary exposes these subcommands:
    `secrets`, `diff`, `tui`, and `pqc`.
-2. If `foxguard` is installed but any required subcommand is missing, report
+3. If `foxguard` is installed but any required subcommand is missing, report
    that the binary is too old for the full Claude Code plugin. Recommend
    upgrading with the install options below before calling the plugin ready.
-3. If `foxguard` is not on PATH, offer the install options in this order:
+4. If `foxguard` is not on PATH, offer the install options in this order:
    - **Prebuilt binary (fastest)**: `curl -fsSL https://foxguard.dev/install.sh | sh`
    - **Homebrew** (macOS): `brew install 0sec-labs/foxguard/foxguard`
    - **npm**: `npm i -g foxguard` or zero-install via `npx foxguard`
    - **cargo**: `cargo install foxguard`
    Ask which the user prefers; do NOT install without confirmation.
-4. If all required subcommands are present, report the version and tell the
-   user the plugin is ready — every Write/Edit will now be auto-scanned.
-5. Recommend the user run `foxguard init` inside their repo to add a pre-commit hook so foxguard also catches issues outside Claude Code sessions.
-6. Mention the env vars they can tune:
+5. If `jq` and all required foxguard subcommands are present, report the
+   version and tell the user the plugin is ready — every Write/Edit will now be
+   auto-scanned.
+6. Recommend the user run `foxguard init` inside their repo to add a pre-commit
+   hook so foxguard also catches issues outside Claude Code sessions.
+7. Mention the env vars they can tune:
    - `FOXGUARD_HOOK_SEVERITY` — minimum severity for auto-scan (default `medium`; values: `low|medium|high|critical`)
 
-Finish with a one-line confirmation of which version is active, whether the
-full command surface is available, and which severity threshold the auto-scan
-is using.
+Finish with a one-line confirmation of which `jq` version is active, which
+foxguard version is active, whether the full command surface is available, and
+which severity threshold the auto-scan is using.


### PR DESCRIPTION
## Summary

- Normalize `foxguard --format json` output so the Claude hook supports both legacy top-level arrays and the current schema object with a `findings` array.
- Extract edited paths from `tool_input.notebook_path`, `tool_response.filePath`, and `tool_response.file_path` in addition to the existing `tool_input.file_path` / `tool_input.path` fields.
- Align plugin submission metadata with the current repo copy: dual license string and scanner description without stale language-count wording.
- Make `/foxguard:setup` verify `jq`, since the PostToolUse hook depends on it for Claude hook JSON parsing.
- Refresh the Claude plugin integration docs and marketplace validation notes for #285.

## Validation

- `cargo build --release`
- `jq . plugins/claude-code/.claude-plugin/plugin.json`
- `bash -n plugins/claude-code/scripts/scan-edited-file.sh`
- Direct hook smoke tests with `target/release` first on PATH:
  - safe `tool_input.file_path`: exit 0, silent
  - vulnerable `tool_input.file_path`: exit 2, 37-finding stderr summary
  - vulnerable `tool_input.path`: exit 2, 37-finding stderr summary
  - safe `tool_input.notebook_path`: exit 0, silent
  - safe `tool_response.filePath`: exit 0, silent
  - safe `tool_response.file_path`: exit 0, silent
  - missing file: exit 0, silent
- `git diff --check`

## Notes

Refs #285.

Local `claude plugin validate plugins/claude-code` still hangs on this machine with Claude Code `2.1.126`; the issue notes already record Claude Code `2.1.143` as the known-good validator version for the current marketplace submission notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup instructions to explicitly require `jq` with installation and verification guidance
  * Enhanced marketplace and integration documentation with expanded validation scenarios
  * Clarified dependency requirements in README

* **Bug Fixes**
  * Improved file path extraction to handle multiple JSON field formats
  * Enhanced scan result normalization with better error tolerance for missing fields

* **Chores**
  * Updated plugin license to dual MIT OR Apache-2.0
  * Refined plugin manifest metadata and description

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->