### PR TITLE
docs(github-app): list exact permissions and webhook events needed for registration

### DIFF
--- a/src/github_app/README.md
+++ b/src/github_app/README.md
@@ -21,7 +21,20 @@ cargo build --release --features github-app --bin foxguard-github-app
 
 The intentional gap. Each of these is a follow-up PR so the architecture above can land cleanly first:
 
-- **App registration.** Create the production GitHub App, wire the real install URL into the landing page, and verify the requested permissions include pull request review comments plus check runs.
+- **App registration.** Create the production GitHub App under the `0sec-labs` org and wire the real install URL into the landing page (`www/src/pages/github.astro`, PR #299). The App must request exactly the permissions and webhook events the receiver consumes today — anything less will fail at runtime, anything more is over-scoped:
+
+  **Repository permissions**
+  - `contents: read` — used by `git clone --filter=blob:none` of the PR head (`src/bin/foxguard_github_app.rs`).
+  - `pull_requests: read` — used to list PR files and existing comments (`src/github_app/review.rs`, `GET /repos/{owner}/{repo}/pulls/{n}/files`, `GET /repos/{owner}/{repo}/pulls/{n}/comments`).
+  - `pull_requests: write` — used to post and delete foxguard review comments (`POST` / `DELETE /repos/{owner}/{repo}/pulls/comments/{id}`).
+  - `checks: write` — used to create the `foxguard` check run with annotations (`POST /repos/{owner}/{repo}/check-runs`).
+
+  **Subscribed events**
+  - `pull_request` — triggers the clone + scan + comment + check-run loop.
+  - `installation` — keeps `installation_store.rs` in sync when the App is installed, suspended, or uninstalled (also clears the cached installation token on deletion).
+  - `installation_repositories` — keeps the registry in sync when a user adds or removes repos from an existing installation.
+
+  `ping` is delivered automatically by GitHub at webhook setup; the receiver handles it but it is not a subscribable event.
 
 ## Running locally
 


### PR DESCRIPTION
## Summary
The Phase 2 \"App registration\" bullet in \`src/github_app/README.md\` only said the App needs \"pull request review comments plus check runs\" — anyone going to register the App in GitHub's UI had to read the receiver code to know the exact permissions and webhook subscriptions.

This expands the bullet to spell out:

**Repository permissions** (cited to the receiver code that needs each one)
- \`contents: read\` — \`git clone\` of the PR head
- \`pull_requests: read\` — list PR files + existing comments
- \`pull_requests: write\` — post and delete foxguard review comments
- \`checks: write\` — create the \`foxguard\` check run

**Subscribed events** (cited to the routing in \`webhook.rs\` / handlers in \`foxguard_github_app.rs\`)
- \`pull_request\`, \`installation\`, \`installation_repositories\`

Notes that \`ping\` is auto-delivered, not subscribable.

## Why now
- Unblocks #246 prep: when someone actually registers the App, the doc is the checklist.
- Audit trail: every permission is justified by a specific endpoint, so the doc and code can be re-verified later without re-reading both.

## Test plan
- [x] Cross-referenced each permission against the actual HTTP method/path in \`src/github_app/review.rs\` and \`src/bin/foxguard_github_app.rs\`.
- [x] Cross-referenced each event against the \`X-GitHub-Event\` match in \`src/github_app/webhook.rs\` and the handlers in \`foxguard_github_app.rs\`.
- [x] Doc-only change; no code paths touched.

Refs #246.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub App setup documentation with explicit production requirements, including required repository permissions and webhook event configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->