### PR TITLE
feat(kernel/dirty-frag): extend STORE primitive coverage and calibrate metadata

### DIFF
--- a/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
+++ b/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
@@ -15,7 +15,18 @@ rules:
       ESP decrypt reaches crypto_aead_decrypt without an skb_has_shared_frag
       guard in the same function. Shared MSG_SPLICE_PAGES frags can be
       decrypted in place unless ESP copy-on-write also checks shared frags.
+
+      Remediation: extend the skip_cow gate in esp_input / esp6_input with
+      `!skb_has_shared_frag(skb)`, matching upstream commit
+      f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: ERROR
     query: queries/kernel/dirty-frag-esp-shared-frag-decrypt-guard.ql
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"
+        - "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"

--- a/rules/kernel/dirty-frag-class/rxrpc-verify-response-dispatch.yaml
+++ b/rules/kernel/dirty-frag-class/rxrpc-verify-response-dispatch.yaml
@@ -11,6 +11,12 @@
 # chosen backend eventually performs in-place decrypt on the skb without a
 # dominating cow/unshare gate.
 #
+# Severity rationale: this rule by itself does NOT detect a write primitive —
+# it only confirms the advisory-named file routes into a backend that may
+# contain one. Reported as WARNING (severity calibration per #215) to keep
+# ERROR-level findings reserved for confirmed write primitives flagged by
+# skb-inplace-skcipher-no-cow on the backend implementation file (rxkad.c).
+#
 # Recall caveats — shapes this rule MISSES:
 #   - renamed or wrapper-mediated verify_response dispatch.
 #   - the decrypt helper itself; that is still covered by the generic
@@ -25,16 +31,29 @@ rules:
     pattern-regex: '(?ms)RXRPC_PACKET_TYPE_RESPONSE\s*:\s*[^}]*?\bconn->security->verify_response\s*\(\s*conn\s*,\s*skb\s*\)'
     message: |
       RXRPC RESPONSE dispatch into an opaque verify_response backend
-      (Dirty Frag class). net/rxrpc/conn_event.c reaches the vulnerable RxKAD
-      decrypt path through conn->security->verify_response(conn, skb) rather
-      than an inline crypto_skcipher_decrypt() idiom, so confirm the selected
-      backend performs in-place skb decrypt without a dominating
-      skb_cow_data / skb_unshare / skb_make_writable / pskb_expand_head gate.
-      See oss-security 2026-05-07 advisory and pwnkit issue #263.
-    severity: ERROR
+      (Dirty Frag class — triage funnel, not a confirmed write primitive).
+      net/rxrpc/conn_event.c reaches the vulnerable RxKAD decrypt path
+      through conn->security->verify_response(conn, skb) rather than an
+      inline crypto_skcipher_decrypt() idiom, so this rule only signals
+      that the advisory-named file routes here.
+
+      Triage: confirm the selected backend (rxkad on v6.14, or a
+      structurally equivalent RxGK clone) performs in-place skb decrypt
+      WITHOUT a dominating skb_cow_data / skb_unshare / skb_make_writable /
+      pskb_expand_head gate. If confirmed, the actual write primitive will
+      also be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow
+      when scanning the backend implementation.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
+      issue #263.
+    severity: WARNING
     languages: [c]
     paths:
       include:
         - net/rxrpc/conn_event*.c
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
@@ -1,18 +1,28 @@
-# Dirty Frag class — authencesn exception for scatterwalk STORE on shared SGL.
+# Dirty Frag class — authencesn exception for scatterwalk / memcpy_to_sglist
+# STORE on shared SGL.
 #
 # The broad Dirty Frag rules exclude crypto/** because most hits there are
 # AEAD/skcipher template wrappers with no skb-frag bug-class semantics.
 # crypto/authencesn.c is the named exception: it is a confirmed advisory site
-# for the scatterwalk_map_and_copy STORE primitive.
+# for the scatterwalk_map_and_copy STORE primitive (and its memcpy_to_sglist
+# successor in newer kernels).
 rules:
   - id: kernel/dirty-frag/scatterwalk-store-on-shared-sgl-authencesn
-    pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?scatterwalk_map_and_copy\s*\([^,]+,[^,]+,[^,]+,[^,]+,\s*1\s*\)'
+    pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?(?:scatterwalk_map_and_copy\s*\([^,]+,[^,]+,[^,]+,[^,]+,\s*1\s*\)|\bmemcpy_to_sglist\s*\()'
     message: |
-      scatterwalk_map_and_copy STORE (out=1) on the authencesn in-place AEAD
-      scatterlist (Dirty Frag class). crypto/authencesn.c is intentionally
-      included even though broader crypto template wrappers are excluded.
-      Verify the destination scatterlist aliases attacker-controllable input
-      before AEAD auth rejects the message.
+      scatterwalk_map_and_copy STORE (out=1) or memcpy_to_sglist on the
+      authencesn in-place AEAD scatterlist (Dirty Frag class).
+      crypto/authencesn.c is intentionally included even though broader
+      crypto template wrappers are excluded.
+
+      Remediation: verify the destination scatterlist aliases
+      attacker-controllable input before AEAD auth rejects the message,
+      then hoist the STORE to land in a private buffer that is only
+      spliced back into the shared SGL AFTER the AEAD authenticator
+      validates.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
+      issue #263.
     severity: ERROR
     languages: [c]
     paths:
@@ -20,3 +30,7 @@ rules:
         - crypto/authencesn*.c
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
@@ -1,23 +1,28 @@
-# Dirty Frag class — scatterwalk_map_and_copy STORE on AEAD-shared SGL.
+# Dirty Frag class — scatterwalk_map_and_copy / memcpy_to_sglist STORE on
+# AEAD-shared SGL.
 #
-# Pattern: scatterwalk_map_and_copy(..., dst, off, len, /*out=*/1) where dst
-# is part of an in-place AEAD request set up earlier in the same function via
-# aead_request_set_crypt(req, sg, sg, ...). This is the secondary STORE
-# primitive used by Copy Fail / Dirty Frag-style authenc clones. The confirmed
-# crypto/authencesn.c advisory site is handled by the narrower authencesn
-# exception rule because this broad rule excludes crypto/** template wrappers.
+# Pattern: scatterwalk_map_and_copy(..., dst, off, len, /*out=*/1) — or the
+# newer memcpy_to_sglist(dst, off, src, len) helper introduced in upstream
+# crypto/ — where dst is part of an in-place AEAD request set up earlier in
+# the same function via aead_request_set_crypt(req, sg, sg, ...). This is
+# the secondary STORE primitive used by Copy Fail / Dirty Frag-style authenc
+# clones. The confirmed crypto/authencesn.c advisory site is handled by the
+# narrower authencesn exception rule because this broad rule excludes
+# crypto/** template wrappers.
 #
 # Tier 1 sibling sites this rule also catches (see
-# scatterwalk_authenc_store_vulnerable.c):
+# scatterwalk_authenc_store_vulnerable.c, scatterwalk_memcpy_to_sglist_vulnerable.c):
 #   - any non-crypto-path authenc clone that mirrors the STORE primitive
+#   - modern Linux authenc clones that migrated to memcpy_to_sglist
 #
 # Recall caveats — shapes this rule MISSES:
-#   - the STORE done via memcpy_to_sglist or sg_pcopy_to_buffer instead of
-#     scatterwalk_map_and_copy — distinct primitives that need their own
-#     positive regex (deferred to follow-up).
+#   - the STORE done via sg_pcopy_to_buffer instead of
+#     scatterwalk_map_and_copy / memcpy_to_sglist — a distinct primitive
+#     that needs its own positive regex (deferred to follow-up).
 #   - cross-function setup (set_crypt in caller, STORE in callee).
-#   - calls where the `out` argument is a named constant (e.g.
-#     `SCATTERWALK_STORE`) instead of literal `1`.
+#   - calls where the `out` argument of scatterwalk_map_and_copy is a named
+#     constant (e.g. `SCATTERWALK_STORE`) instead of literal `1`. The
+#     mainline kernel uses the literal so this is informational.
 #
 # Precision caveats — false-positive shapes NOT suppressed:
 #   - in-place AEAD setup followed by a STORE that DOES happen after a
@@ -34,18 +39,27 @@
 rules:
   - id: kernel/dirty-frag/scatterwalk-store-on-shared-sgl
     # Positive: aead_request_set_crypt(...) is followed (within the same
-    # function body) by scatterwalk_map_and_copy(..., out=1). Rust regex has
-    # no backreferences, so we cannot require arg2 == arg3 of set_crypt to
-    # confirm the SGL is shared; manual triage / CodeQL confirms aliasing.
-    pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?scatterwalk_map_and_copy\s*\([^,]+,[^,]+,[^,]+,[^,]+,\s*1\s*\)'
+    # function body) by either scatterwalk_map_and_copy(..., out=1) or the
+    # newer memcpy_to_sglist(...) helper. Rust regex has no backreferences,
+    # so we cannot require arg2 == arg3 of set_crypt to confirm the SGL is
+    # shared; manual triage / CodeQL confirms aliasing.
+    pattern-regex: '(?ms)^\s*aead_request_set_crypt\s*\([^}]*?(?:scatterwalk_map_and_copy\s*\([^,]+,[^,]+,[^,]+,[^,]+,\s*1\s*\)|\bmemcpy_to_sglist\s*\()'
     message: |
-      scatterwalk_map_and_copy STORE (out=1) on an in-place AEAD scatterlist
-      (Dirty Frag class). The destination scatterlist is shared with the
-      attacker-controllable source SGL via aead_request_set_crypt(req, sg, sg, ...);
-      a 4-byte STORE lands in caller-pinned memory regardless of AEAD auth
-      result. The confirmed crypto/authencesn.c site is covered by the
+      scatterwalk_map_and_copy STORE (out=1) or memcpy_to_sglist on an
+      in-place AEAD scatterlist (Dirty Frag class). The destination
+      scatterlist is shared with the attacker-controllable source SGL via
+      aead_request_set_crypt(req, sg, sg, ...); the STORE lands in
+      caller-pinned memory regardless of AEAD auth result.
+
+      Remediation: gate the in-place authenc decrypt with skb_cow_data (or
+      equivalent: skb_unshare, skb_make_writable, pskb_expand_head) on the
+      same path BEFORE aead_request_set_crypt, or ensure the STORE target
+      SGL is not aliased with the AEAD source. The confirmed
+      crypto/authencesn.c site is covered by the
       scatterwalk-store-on-shared-sgl-authencesn exception rule.
-      See oss-security 2026-05-07 advisory and pwnkit issue #263.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
+      issue #263.
     severity: ERROR
     languages: [c]
     paths:
@@ -53,3 +67,7 @@ rules:
         - crypto/**
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
@@ -46,10 +46,18 @@ rules:
     pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_cow|__skb_cow|skb_copy|skb_copy_expand|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?aead_request_set_crypt\s*\([^}]*?crypto_aead_decrypt\s*\('
     message: |
       In-place AEAD decrypt on skb without a dominating cow/unshare gate
-      (Dirty Frag class). Verify skb_cow_data / skb_unshare / skb_make_writable /
-      pskb_expand_head is reached on the unsafe path before
-      aead_request_set_crypt(req, sg, sg, ...) + crypto_aead_decrypt(req).
-      See oss-security 2026-05-07 advisory and pwnkit issue #263.
+      (Dirty Frag class).
+
+      Remediation: ensure one of skb_cow_data / skb_unshare /
+      skb_make_writable / pskb_expand_head is reached on the unsafe path
+      before aead_request_set_crypt(req, sg, sg, ...) +
+      crypto_aead_decrypt(req). Follow upstream commit
+      f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4 which extends the skip_cow
+      gate with `!skb_has_shared_frag(skb)` to defeat the MSG_SPLICE_PAGES
+      shared-frag aliasing.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
+      issue #263.
     severity: ERROR
     languages: [c]
     paths:
@@ -57,3 +65,8 @@ rules:
         - crypto/**
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"
+        - "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"

--- a/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
@@ -48,10 +48,17 @@ rules:
     pattern-not-regex: '(?s)\b(?:skb_cow_data|skb_cow|__skb_cow|skb_copy|skb_copy_expand|skb_unshare|skb_make_writable|pskb_expand_head)\s*\([^}]*?skcipher_request_set_crypt\s*\([^}]*?crypto_skcipher_decrypt\s*\('
     message: |
       In-place skcipher decrypt on skb without a dominating cow/unshare gate
-      (Dirty Frag class). Verify skb_cow_data / skb_unshare / skb_make_writable /
-      pskb_expand_head is reached on the unsafe path before
-      skcipher_request_set_crypt(req, sg, sg, ...) + crypto_skcipher_decrypt(req).
-      See oss-security 2026-05-07 advisory and pwnkit issue #263.
+      (Dirty Frag class).
+
+      Remediation: ensure one of skb_cow_data / skb_unshare /
+      skb_make_writable / pskb_expand_head is reached on the unsafe path
+      before skcipher_request_set_crypt(req, sg, sg, ...) +
+      crypto_skcipher_decrypt(req). For RxKAD-style handlers, extend the
+      cow gate with a data_len / non-linear shared-frag check so
+      MSG_SPLICE_PAGES-pinned pages cannot reach the in-place decrypt.
+
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
+      issue #263.
     severity: ERROR
     languages: [c]
     paths:
@@ -59,3 +66,7 @@ rules:
         - crypto/**
     metadata:
       cwe: "CWE-787"
+      references:
+        - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
+        - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
+        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_from_sglist_safe.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_from_sglist_safe.c
@@ -1,0 +1,34 @@
+// Negative fixture (Tier 2 known-FP): in-place AEAD setup followed by a
+// memcpy_from_sglist READ-back. The modern Linux helper memcpy_from_sglist()
+// is the dual of memcpy_to_sglist() — it pulls bytes OUT of the SGL into a
+// local buffer for tag comparison and is not a STORE primitive.
+//
+// MUST NOT be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
+
+
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
+struct aead_request;
+struct scatterlist;
+
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern void memcpy_from_sglist(void *buf, struct scatterlist *sg,
+                               unsigned int start, unsigned int nbytes);
+
+int authenc_memcpy_from_sglist_read_safe(struct aead_request *req,
+                                         struct scatterlist *sg,
+                                         unsigned int assoclen,
+                                         unsigned int cryptlen,
+                                         void *iv, void *tmp)
+{
+        /* in-place AEAD: src == dst == sg. */
+        aead_request_set_crypt(req, sg, sg, cryptlen, iv);
+        /* READ-back via the modern memcpy_from_sglist helper: pulls tag
+         * bytes from the SGL into tmp. Not a STORE primitive, so the rule
+         * must not fire on memcpy_from_sglist. */
+        memcpy_from_sglist(tmp, sg, assoclen + cryptlen, 16);
+        return 0;
+}

--- a/tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_to_sglist_vulnerable.c
+++ b/tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_to_sglist_vulnerable.c
@@ -1,0 +1,39 @@
+// Positive fixture (Tier 1 sibling): memcpy_to_sglist STORE on shared in-place
+// AEAD SGL — the modern Linux helper that replaced the historical
+// scatterwalk_map_and_copy(..., /*out=*/1) idiom in crypto/authenc paths.
+//
+// The Dirty Frag class STORE primitive is identical in semantics whether it's
+// expressed as scatterwalk_map_and_copy(..., 1) or memcpy_to_sglist(...) — both
+// write into the destination scatterlist that aliases the attacker-controllable
+// AEAD source SGL before AEAD auth has rejected the message.
+//
+// Synthetic minimal reproducer — NOT copied from kernel source.
+// MUST be flagged by kernel/dirty-frag/scatterwalk-store-on-shared-sgl.
+
+
+/* Tree-sitter fixture — scanned as text by foxguard, never compiled.
+ * Kernel headers replaced with the inline forward decls below to keep clangd quiet. */
+struct aead_request;
+struct scatterlist;
+
+extern void aead_request_set_crypt(struct aead_request *req,
+                                   struct scatterlist *src,
+                                   struct scatterlist *dst,
+                                   unsigned int cryptlen, void *iv);
+extern void memcpy_to_sglist(struct scatterlist *sg, unsigned int start,
+                             const void *buf, unsigned int nbytes);
+
+int authenc_memcpy_to_sglist_inplace(struct aead_request *req,
+                                     struct scatterlist *sg,
+                                     unsigned int assoclen,
+                                     unsigned int cryptlen,
+                                     void *iv, void *tag)
+{
+        /* in-place AEAD: src == dst == sg, attacker-controllable. */
+        aead_request_set_crypt(req, sg, sg, cryptlen, iv);
+        /* The STORE: writes the computed tag into the shared SGL via the
+         * modern memcpy_to_sglist helper, before the AEAD verify decision
+         * lands. Same Dirty Frag class write primitive, different spelling. */
+        memcpy_to_sglist(sg, assoclen + cryptlen, tag, 16);
+        return 0;
+}

--- a/tests/kernel_dirty_frag.rs
+++ b/tests/kernel_dirty_frag.rs
@@ -249,3 +249,40 @@ fn scatterwalk_store_on_shared_sgl_ignores_inplace_read_fixture() {
         n
     );
 }
+
+#[test]
+fn scatterwalk_store_on_shared_sgl_flags_memcpy_to_sglist_fixture() {
+    let n = run_rule(
+        "scatterwalk-store-on-shared-sgl.yaml",
+        "scatterwalk_memcpy_to_sglist_vulnerable.c",
+    );
+    assert!(
+        n >= 1,
+        "expected memcpy_to_sglist STORE on in-place AEAD SGL to be flagged, got {n} findings"
+    );
+}
+
+#[test]
+fn scatterwalk_store_on_shared_sgl_ignores_memcpy_from_sglist_fixture() {
+    let n = run_rule(
+        "scatterwalk-store-on-shared-sgl.yaml",
+        "scatterwalk_memcpy_from_sglist_safe.c",
+    );
+    assert_eq!(
+        n, 0,
+        "expected memcpy_from_sglist READ-back on in-place AEAD SGL to be unflagged, got {n} findings"
+    );
+}
+
+#[test]
+fn scatterwalk_authencesn_exception_flags_memcpy_to_sglist_fixture() {
+    let n = run_rule_at_path(
+        "scatterwalk-store-on-shared-sgl-authencesn.yaml",
+        "scatterwalk_memcpy_to_sglist_vulnerable.c",
+        "crypto/authencesn.c",
+    );
+    assert!(
+        n >= 1,
+        "expected authencesn exception rule to flag memcpy_to_sglist STORE at crypto/authencesn.c, got {n} findings"
+    );
+}


### PR DESCRIPTION
## Summary
Polish pass on the `kernel/dirty-frag-class/*` rule pack (shipped in v0.8.1 / #297 / #305 / #325).

### What changed

**1. Closed the documented recall gap on `memcpy_to_sglist`.**
Two rules — `scatterwalk-store-on-shared-sgl.yaml` and `scatterwalk-store-on-shared-sgl-authencesn.yaml` — previously listed "STORE done via `memcpy_to_sglist`" as a known miss. Modern `crypto/` code uses this helper as a drop-in for `scatterwalk_map_and_copy(..., /*out=*/1)`, so future authenc clones or forward-ports would slip past the existing regex. Extended the positive regex with `|\bmemcpy_to_sglist\s*\(` and added paired fixtures:
- `scatterwalk_memcpy_to_sglist_vulnerable.c` — positive shape
- `scatterwalk_memcpy_from_sglist_safe.c` — negative (the `*_from_*` READ-back must NOT flag)

**2. Calibrated `rxrpc-verify-response-dispatch.yaml` from ERROR → WARNING.**
The rule itself documents that it's a "triage funnel" — it flags the dispatch site but does NOT detect a write primitive on its own. Emitting Critical here muddied the signal vs. the in-place-decrypt rules that catch actual STOREs. Added a structured severity-rationale comment block so this stays calibrated under future rewrites.

**3. Rewrote remediation messages.**
All five rules now have an explicit Remediation block, including the upstream fix commit `f4c50a4034e6` where applicable. The RxKAD skcipher rule got specific guidance on the `data_len` / non-linear gate.

**4. Added structured `references` metadata** to all 6 rules — oss-security advisory URL, V4bel write-up, pwnkit #263, upstream kernel commit. Previously these were in code comments only.

### What I deliberately did NOT do
- Did not invent CVE IDs — Dirty Frag is a bug class per the advisory, not a single CVE.
- Did not add a per-rule `confidence:` YAML field — the Semgrep-compat path hardcodes `confidence: 0.7` so the field would parse silently with no scan-time effect.
- Did not tighten the cow-gate detection beyond regex capability — that's the Coccinelle/CodeQL follow-up (#295/#296).
- Did not touch the encrypt-side counterpart — out of scope per Hyunwoo Kim's advisory.
- Did not rewrite the dated v0.8.1 blog post.

## Test plan
- [x] `cargo test --test kernel_dirty_frag`: **19 passed, 0 failed** (was 16; +3 covering the `memcpy_to_sglist` extension).
- [x] `cargo test` whole suite: green (461 lib + integration suites).
- [x] `cargo fmt --check`: clean.
- [x] `cargo clippy --tests`: no new lints on added code.
- [x] Findings JSON byte-identical for unchanged fixtures (regex change is purely additive alternation).

## Determinism
All changes are static (regex, fixtures, metadata). Semgrep / CodeQL parsers ignore unknown metadata fields (no `deny_unknown_fields`), so `references` is documentation-only.