### PR TITLE
test(ci): pin Semgrep version to stop parity drift (closes #374)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
           key: ubuntu-cargo-semgrep-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ubuntu-cargo-semgrep-
       - name: Install semgrep
-        run: pip install semgrep
+        # Pin Semgrep to a known version so parity-test drift comes from foxguard changes, not upstream behavior changes. Bump deliberately via PR + parity-test run.
+        run: pip install semgrep==1.163.0
       - name: Run Semgrep parity suite
         run: cargo test --test semgrep_parity
 


### PR DESCRIPTION
## Summary

Closes #374.

The Semgrep parity job in `.github/workflows/ci.yml` was installing Semgrep with an unpinned `pip install semgrep`, meaning every CI run would pull the latest published version. That makes the parity suite susceptible to drift driven by upstream Semgrep changes rather than foxguard changes — when the suite breaks, we can't tell whether foxguard regressed or Semgrep just changed its behavior.

This pins the version to **`semgrep==1.163.0`** and adds an inline comment explaining the intent: bumps should be deliberate, via PR, with a parity-test run.

## Version choice: 1.163.0

- Latest stable release on PyPI (released 2026-05-13): https://pypi.org/project/semgrep/1.163.0/
- GitHub releases: https://github.com/semgrep/semgrep/releases
- Changelog highlights for 1.163.0:
  - PHP parser updated for PHP 8.1–8.5 grammar
  - Startup-time improvements via parallel rule validation/parsing
  - Java/Kotlin/Scala name resolution improvements (may reduce false positives)
  - Memory usage optimizations for large rulesets
  - Fix for transitive reachability rule parsing perf (yaml→json suffix routing)
- No breaking changes called out in 1.161.0 → 1.163.0. The Java/Kotlin/Scala name-resolution change is the most likely source of parity diffs if any show up; if it does, that's exactly the kind of intentional bump signal we want.

## Test plan

- [ ] CI passes on this PR (the parity job itself exercises the pinned version)
- [ ] Confirm the comment renders above the `run:` line and the workflow YAML still parses