### PR TITLE
refactor(rules/manifest): use impl_rule! macro for metadata consistency

### DIFF
--- a/src/rules/manifest.rs
+++ b/src/rules/manifest.rs
@@ -1,8 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::path::Path;
 
+use crate::impl_rule;
 use crate::rules::common::make_finding_from_offsets;
-use crate::rules::Rule;
 use crate::{Finding, Language, Severity};
 
 // ─── Shared seed entry ─────────────────────────────────────────────────────
@@ -195,31 +194,16 @@ const PIP_PACKAGES: &[SeedEntry] = &[
 
 pub struct CargoLockPqCrypto;
 
-impl Rule for CargoLockPqCrypto {
-    fn id(&self) -> &str {
-        "manifest/cargo-pq-vulnerable-dep"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some(MANIFEST_PQ_CWE)
-    }
-    fn description(&self) -> &str {
-        CARGO_PQ_DESC
-    }
-    fn language(&self) -> Language {
-        Language::Manifest
-    }
-    fn cnsa2_deadline(&self) -> Option<&'static str> {
-        Some(MANIFEST_PQ_DEADLINE)
-    }
-
-    fn applies_to_path(&self, path: &Path) -> bool {
-        path.file_name().and_then(|f| f.to_str()) == Some("Cargo.lock")
-    }
-
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
+impl_rule! {
+    CargoLockPqCrypto,
+    id = "manifest/cargo-pq-vulnerable-dep",
+    severity = Severity::High,
+    cwe = Some(MANIFEST_PQ_CWE),
+    description = CARGO_PQ_DESC,
+    language = Language::Manifest,
+    cnsa2_deadline = MANIFEST_PQ_DEADLINE,
+    applies_to_filename = "Cargo.lock",
+    fn check(_self, source, _tree) {
         let Ok(doc) = source.parse::<toml::Value>() else {
             return Vec::new();
         };
@@ -356,9 +340,9 @@ impl Rule for CargoLockPqCrypto {
             };
 
             let mut f = make_finding_from_offsets(
-                self.id(),
-                self.severity(),
-                self.cwe(),
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
                 &desc,
                 source,
                 offset,
@@ -376,31 +360,16 @@ impl Rule for CargoLockPqCrypto {
 
 pub struct RequirementsTxtPqCrypto;
 
-impl Rule for RequirementsTxtPqCrypto {
-    fn id(&self) -> &str {
-        "manifest/pip-pq-vulnerable-dep"
-    }
-    fn severity(&self) -> Severity {
-        Severity::High
-    }
-    fn cwe(&self) -> Option<&str> {
-        Some(MANIFEST_PQ_CWE)
-    }
-    fn description(&self) -> &str {
-        MANIFEST_PQ_DESC
-    }
-    fn language(&self) -> Language {
-        Language::Manifest
-    }
-    fn cnsa2_deadline(&self) -> Option<&'static str> {
-        Some(MANIFEST_PQ_DEADLINE)
-    }
-
-    fn applies_to_path(&self, path: &Path) -> bool {
-        path.file_name().and_then(|f| f.to_str()) == Some("requirements.txt")
-    }
-
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
+impl_rule! {
+    RequirementsTxtPqCrypto,
+    id = "manifest/pip-pq-vulnerable-dep",
+    severity = Severity::High,
+    cwe = Some(MANIFEST_PQ_CWE),
+    description = MANIFEST_PQ_DESC,
+    language = Language::Manifest,
+    cnsa2_deadline = MANIFEST_PQ_DEADLINE,
+    applies_to_filename = "requirements.txt",
+    fn check(_self, source, _tree) {
         let pip_map: HashMap<String, &SeedEntry> = PIP_PACKAGES
             .iter()
             .map(|e| (e.name.to_lowercase().replace(['_', '.'], "-"), e))
@@ -457,9 +426,9 @@ impl Rule for RequirementsTxtPqCrypto {
                 };
 
                 let mut f = make_finding_from_offsets(
-                    self.id(),
-                    self.severity(),
-                    self.cwe(),
+                    _self.id(),
+                    _self.severity(),
+                    _self.cwe(),
                     &desc,
                     source,
                     line_start,
@@ -514,6 +483,7 @@ fn extract_pip_package_name(s: &str) -> &str {
 mod tests {
     use super::*;
     use crate::engine::parser::parse_file;
+    use crate::rules::Rule;
 
     fn dummy_tree(source: &str) -> tree_sitter::Tree {
         parse_file(source, Language::Manifest).expect("parse")

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -94,6 +94,14 @@ pub enum AstAnalysisRequirement {
 ///     }
 /// }
 /// ```
+///
+/// Optional declarative metadata:
+///   * `cnsa2_deadline = "YYYY"` — sets [`Rule::cnsa2_deadline`] for
+///     quantum-related rules.
+///   * `applies_to_filename = "NAME"` — restricts the rule to files whose
+///     basename equals `NAME` (e.g. `"Cargo.lock"`, `"requirements.txt"`).
+///     Useful for manifest/lockfile rules that parse the source themselves
+///     rather than relying on tree-sitter.
 #[macro_export]
 macro_rules! impl_rule {
     // ── Variant 1: check only ──────────────────────────────────────────────
@@ -137,6 +145,42 @@ macro_rules! impl_rule {
             fn description(&self) -> &str { $desc }
             fn language(&self) -> $crate::Language { $lang }
             fn cnsa2_deadline(&self) -> Option<&'static str> { Some($deadline) }
+            fn check(&self, $src: &str, $tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
+                let $self_ = self;
+                $($check_body)*
+            }
+        }
+    };
+
+    // ── Variant 1c: check only, with cnsa2_deadline + applies_to_filename ──
+    //
+    // For rules that only fire on files with a specific basename (e.g.
+    // `Cargo.lock`, `requirements.txt`). The check body typically ignores
+    // the `tree` argument and parses `source` itself with a format-specific
+    // parser (TOML, line-oriented, …). Use this arm instead of writing the
+    // trait impl by hand so metadata (cwe, severity, cnsa2_deadline) stays
+    // declarative and consistent with every other rule.
+    (
+        $struct:ty,
+        id = $id:expr,
+        severity = $sev:expr,
+        cwe = $cwe:expr,
+        description = $desc:expr,
+        language = $lang:expr,
+        cnsa2_deadline = $deadline:expr,
+        applies_to_filename = $filename:expr,
+        fn check($self_:ident, $src:ident, $tree:ident) { $($check_body:tt)* }
+    ) => {
+        impl $crate::rules::Rule for $struct {
+            fn id(&self) -> &str { $id }
+            fn severity(&self) -> $crate::Severity { $sev }
+            fn cwe(&self) -> Option<&str> { $cwe }
+            fn description(&self) -> &str { $desc }
+            fn language(&self) -> $crate::Language { $lang }
+            fn cnsa2_deadline(&self) -> Option<&'static str> { Some($deadline) }
+            fn applies_to_path(&self, path: &std::path::Path) -> bool {
+                path.file_name().and_then(|f| f.to_str()) == Some($filename)
+            }
             fn check(&self, $src: &str, $tree: &tree_sitter::Tree) -> Vec<$crate::Finding> {
                 let $self_ = self;
                 $($check_body)*


### PR DESCRIPTION
## Summary

Addresses **audit item #4**: `CargoLockPqCrypto` and `RequirementsTxtPqCrypto` were the only ~/188 Rust-defined rules still bypassing `impl_rule!` with a hand-rolled `impl Rule for` block. They hardcoded `Some(MANIFEST_PQ_DEADLINE)` inside the trait method instead of declaring it via the macro's `cnsa2_deadline = "…"` arm, making them drift-prone outliers.

- Add **Variant 1c** to `impl_rule!` that accepts both `cnsa2_deadline` **and** `applies_to_filename` — the only piece the existing arms didn't cover (since manifest rules dispatch by filename rather than by tree-sitter language).
- Refactor `CargoLockPqCrypto` and `RequirementsTxtPqCrypto` to use the new arm. Net delta in `manifest.rs`: -28 lines of trait boilerplate.

`SemgrepRule` / `SemgrepTaintRule` keep their direct trait impl (per-instance dynamic dispatch from YAML — explicitly out of scope).

## Before / after

```diff
-impl Rule for CargoLockPqCrypto {
-    fn id(&self) -> &str { "manifest/cargo-pq-vulnerable-dep" }
-    fn severity(&self) -> Severity { Severity::High }
-    fn cwe(&self) -> Option<&str> { Some(MANIFEST_PQ_CWE) }
-    fn description(&self) -> &str { CARGO_PQ_DESC }
-    fn language(&self) -> Language { Language::Manifest }
-    fn cnsa2_deadline(&self) -> Option<&'static str> { Some(MANIFEST_PQ_DEADLINE) }
-    fn applies_to_path(&self, path: &Path) -> bool {
-        path.file_name().and_then(|f| f.to_str()) == Some("Cargo.lock")
-    }
-    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> { … }
-}
+impl_rule! {
+    CargoLockPqCrypto,
+    id = "manifest/cargo-pq-vulnerable-dep",
+    severity = Severity::High,
+    cwe = Some(MANIFEST_PQ_CWE),
+    description = CARGO_PQ_DESC,
+    language = Language::Manifest,
+    cnsa2_deadline = MANIFEST_PQ_DEADLINE,
+    applies_to_filename = "Cargo.lock",
+    fn check(_self, source, _tree) { … }
+}
```

## Test plan

- [x] `cargo build` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test manifest` — all **30** manifest tests pass (rule IDs, severities, CWEs, byte offsets, confidence values all unchanged)
- [x] `cargo test cbom` — all **8** CBOM tests pass (depends on `manifest/pip-pq-vulnerable-dep` rule id)
- [x] `cargo test cnsa2` — all tests pass, including `every_declared_pq_rule_reports_a_cnsa2_deadline` and `non_pq_rules_do_not_declare_a_cnsa2_deadline`
- [x] `cargo test --all` — 668 tests pass, 0 fail
- [x] `cargo clippy --all-targets` — no new warnings (399 → 399, all pre-existing `uninlined_format_args` in unrelated lines)

## Backwards compatibility

The new macro arm is additive — existing variants (1, 1b, 2, 2b) are untouched, so the other ~186 callers of `impl_rule!` are unaffected.