### PR TITLE
test(parity): add Semgrep parity tests for JavaScript, Go, Java (closes #375)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,14 @@ jobs:
       - name: Install semgrep
         # Pin Semgrep to a known version so parity-test drift comes from foxguard changes, not upstream behavior changes. Bump deliberately via PR + parity-test run.
         run: pip install semgrep==1.163.0
-      - name: Run Semgrep parity suite
+      - name: Run Semgrep parity suite (Python)
         run: cargo test --test semgrep_parity
+      - name: Run Semgrep parity suite (JavaScript)
+        run: cargo test --test semgrep_parity_javascript
+      - name: Run Semgrep parity suite (Go)
+        run: cargo test --test semgrep_parity_go
+      - name: Run Semgrep parity suite (Java)
+        run: cargo test --test semgrep_parity_java
 
   website:
     name: Website Build

--- a/tests/semgrep_parity_go.rs
+++ b/tests/semgrep_parity_go.rs
@@ -1,0 +1,416 @@
+//! Go Semgrep parity micro-pattern suite.
+//!
+//! Mirrors the structure of `tests/semgrep_parity.rs` (Python) but uses
+//! Go-native sinks (`exec.Command`, `os.Exec`) and rule syntax. Each test
+//! runs both foxguard and `semgrep` against the same temp directory + YAML
+//! rule and asserts byte-identical normalized findings. Tests are skipped
+//! gracefully when `semgrep` is not on PATH so the suite remains green in
+//! restricted environments.
+//!
+//! ## Go-specific caveat
+//!
+//! tree-sitter-go rejects Semgrep micro-syntax (`$X`, `...`) at top level
+//! because Go requires a `package` clause before any other declaration.
+//! This produces parse-error nodes in foxguard's pattern AST, which the
+//! current matcher cannot drill into. As a result, three of the six
+//! micro-patterns (`pattern-inside`, `pattern-not-inside`,
+//! `metavariable-regex`) cannot be reliably parity-tested against Go
+//! today — their behavior diverges silently when the pattern AST fails
+//! to parse. Those tests are marked `#[ignore]` with explanatory comments
+//! and tracked in a follow-up issue.
+//!
+//! The three remaining tests (`pattern-either`, `pattern-regex` +
+//! `pattern-not-regex`, `paths.include/exclude`) work end-to-end via
+//! foxguard's pattern-regex path, which is language-agnostic and matches
+//! Semgrep byte-for-byte.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct NormalizedFinding {
+    path: String,
+    line: u64,
+    message: String,
+}
+
+fn foxguard_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_foxguard"))
+}
+
+fn semgrep_bin() -> String {
+    std::env::var("SEMGREP_BIN").unwrap_or_else(|_| "semgrep".to_string())
+}
+
+fn semgrep_available() -> bool {
+    Command::new(semgrep_bin())
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn write_file(dir: &Path, relative_path: &str, content: &str) -> PathBuf {
+    let path = dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create test directory");
+    }
+    fs::write(&path, content).expect("failed to write test file");
+    path
+}
+
+fn normalize_path(path: &str, repo: &Path) -> String {
+    let candidate = Path::new(path);
+    let normalized = candidate
+        .strip_prefix(repo)
+        .unwrap_or(candidate)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn parse_foxguard_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let report: Value = serde_json::from_slice(output).expect("invalid foxguard JSON output");
+    let findings = report["findings"]
+        .as_array()
+        .cloned()
+        .expect("foxguard JSON report missing findings array");
+    let mut normalized = findings
+        .into_iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["file"]
+                    .as_str()
+                    .expect("foxguard finding missing file"),
+                repo,
+            ),
+            line: finding["line"]
+                .as_u64()
+                .expect("foxguard finding missing line"),
+            message: finding["description"]
+                .as_str()
+                .expect("foxguard finding missing description")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn parse_semgrep_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let payload: Value = serde_json::from_slice(output).expect("invalid semgrep JSON output");
+    let results = payload["results"]
+        .as_array()
+        .expect("semgrep output missing results");
+
+    let mut normalized = results
+        .iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["path"]
+                    .as_str()
+                    .expect("semgrep finding missing path"),
+                repo,
+            ),
+            line: finding["start"]["line"]
+                .as_u64()
+                .expect("semgrep finding missing start line"),
+            message: finding["extra"]["message"]
+                .as_str()
+                .expect("semgrep finding missing message")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn foxguard_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = foxguard_cmd()
+        .current_dir(repo)
+        .args([
+            "--no-builtins",
+            "--rules",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            scan_target,
+            "-f",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success() || !output.stdout.is_empty(),
+        "foxguard failed without JSON output: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_foxguard_findings(&output.stdout, repo)
+}
+
+fn semgrep_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = Command::new(semgrep_bin())
+        .current_dir(repo)
+        .args([
+            "--config",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            "--json",
+            "--quiet",
+            scan_target,
+        ])
+        .output()
+        .expect("failed to execute semgrep");
+
+    assert!(
+        output.status.success(),
+        "semgrep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_semgrep_findings(&output.stdout, repo)
+}
+
+fn assert_parity(repo: &Path, rules_path: &Path, scan_target: &str) {
+    let foxguard = foxguard_findings(repo, rules_path, scan_target);
+    let semgrep = semgrep_findings(repo, rules_path, scan_target);
+
+    assert_eq!(foxguard, semgrep, "foxguard and semgrep results diverged");
+}
+
+fn skip_if_semgrep_missing() -> bool {
+    if semgrep_available() {
+        return false;
+    }
+
+    eprintln!("semgrep not installed; skipping parity test");
+    true
+}
+
+#[test]
+fn test_parity_pattern_either() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // `pattern-either` of regex sub-patterns is language-agnostic in
+    // foxguard and matches Semgrep on Go.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/exec.yaml",
+        r#"
+rules:
+  - id: dangerous-go-sink
+    pattern-either:
+      - pattern-regex: 'exec\.Command\('
+      - pattern-regex: 'os\.Exec\('
+    message: dangerous go call
+    severity: ERROR
+    languages: [go]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.go",
+        "package main\n\nimport \"os/exec\"\n\nfunc main() {\n    exec.Command(\"ls\")\n    safe()\n}\n\nfunc safe() {}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.go");
+}
+
+#[test]
+#[ignore = "foxguard cannot AST-match Go patterns; tree-sitter-go rejects Semgrep micro-syntax at top level (see issue tracking Go AST parity)"]
+fn test_parity_binary_operator_and_metavariable_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // `metavariable-regex` requires foxguard to AST-bind `$VAR`. For Go,
+    // the pattern parses with a `source_file -> ERROR` wrapper because
+    // tree-sitter-go demands a `package` clause first, so the binding
+    // never fires. Semgrep handles this case via its own AST engine,
+    // producing a divergence foxguard cannot reach without an upstream
+    // fix.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/tainted-exec.yaml",
+        r#"
+rules:
+  - id: tainted-exec-call
+    patterns:
+      - pattern: exec.Command($VAR)
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: ^userInput$
+    message: tainted exec call
+    severity: ERROR
+    languages: [go]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.go",
+        "package main\n\nimport \"os/exec\"\n\nfunc main() {\n    exec.Command(userInput)\n    exec.Command(\"ls\")\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.go");
+}
+
+#[test]
+#[ignore = "foxguard cannot AST-match Go patterns; see test_parity_binary_operator_and_metavariable_regex for context"]
+fn test_parity_pattern_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // `pattern-inside` requires foxguard to AST-match the enclosing Go
+    // function declaration; the pattern parses as ERROR (tree-sitter-go
+    // refuses bare declarations), so foxguard silently skips the inside
+    // filter and over-reports.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/inside.yaml",
+        r#"
+rules:
+  - id: exec-in-handle
+    patterns:
+      - pattern: exec.Command(...)
+      - pattern-inside: |
+          func handle(...) {
+            ...
+          }
+    message: exec inside handle()
+    severity: ERROR
+    languages: [go]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.go",
+        "package main\n\nimport \"os/exec\"\n\nfunc handle(s string) {\n    exec.Command(s)\n}\n\nfunc helper(s string) {\n    exec.Command(s)\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.go");
+}
+
+#[test]
+#[ignore = "foxguard cannot AST-match Go patterns; see test_parity_binary_operator_and_metavariable_regex for context"]
+fn test_parity_pattern_not_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // `pattern-not-inside` has the same AST-matching constraint as
+    // `pattern-inside`. Tracked in the Go AST parity follow-up.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/not-inside.yaml",
+        r#"
+rules:
+  - id: exec-outside-helper
+    patterns:
+      - pattern: exec.Command(...)
+      - pattern-not-inside: |
+          func safeExec(...) {
+            ...
+          }
+    message: exec outside safeExec()
+    severity: WARNING
+    languages: [go]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.go",
+        "package main\n\nimport \"os/exec\"\n\nfunc safeExec(s string) {\n    exec.Command(s)\n}\n\nfunc doExec(s string) {\n    exec.Command(s)\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.go");
+}
+
+#[test]
+fn test_parity_pattern_regex_and_not_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // Pure regex; language-agnostic in foxguard, matches Semgrep on Go.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/regex.yaml",
+        r#"
+rules:
+  - id: secret-assignment
+    pattern-regex: '(?m)^\s*(password|secret)\s*:?='
+    pattern-not-regex: '(?m)^\s*not_password\s*:?='
+    message: secret assignment
+    severity: ERROR
+    languages: [go]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.go",
+        "package main\n\nvar password = \"secret\"\nvar not_password = \"safe\"\nvar secret = \"abc\"\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.go");
+}
+
+#[test]
+fn test_parity_paths_include_exclude() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // Uses `pattern-regex` for the positive (avoids the Go-AST limitation)
+    // so that `paths.include`/`paths.exclude` scoping is the variable under
+    // test. Both tools see the same regex hits and apply identical path
+    // filters.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/paths.yaml",
+        r#"
+rules:
+  - id: path-scoped-exec
+    pattern-regex: 'exec\.Command\('
+    message: exec in app source
+    severity: ERROR
+    languages: [go]
+    paths:
+      include:
+        - src/**/*.go
+      exclude:
+        - src/generated/**
+"#,
+    );
+    write_file(
+        repo.path(),
+        "src/app/main.go",
+        "package main\nimport \"os/exec\"\nfunc main() { exec.Command(\"ls\") }\n",
+    );
+    write_file(
+        repo.path(),
+        "src/generated/main.go",
+        "package main\nimport \"os/exec\"\nfunc main() { exec.Command(\"ls\") }\n",
+    );
+    write_file(
+        repo.path(),
+        "tests/main.go",
+        "package main\nimport \"os/exec\"\nfunc main() { exec.Command(\"ls\") }\n",
+    );
+
+    assert_parity(repo.path(), &rules, ".");
+}

--- a/tests/semgrep_parity_java.rs
+++ b/tests/semgrep_parity_java.rs
@@ -1,0 +1,377 @@
+//! Java Semgrep parity micro-pattern suite.
+//!
+//! Mirrors the structure of `tests/semgrep_parity.rs` (Python) but uses
+//! Java-native sinks (`Runtime.getRuntime().exec`, `String.format`) and
+//! rule syntax. Each test runs both foxguard and `semgrep` against the
+//! same temp directory + YAML rule and asserts byte-identical normalized
+//! findings. Tests are skipped gracefully when `semgrep` is not on PATH
+//! so the suite remains green in restricted environments.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct NormalizedFinding {
+    path: String,
+    line: u64,
+    message: String,
+}
+
+fn foxguard_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_foxguard"))
+}
+
+fn semgrep_bin() -> String {
+    std::env::var("SEMGREP_BIN").unwrap_or_else(|_| "semgrep".to_string())
+}
+
+fn semgrep_available() -> bool {
+    Command::new(semgrep_bin())
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn write_file(dir: &Path, relative_path: &str, content: &str) -> PathBuf {
+    let path = dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create test directory");
+    }
+    fs::write(&path, content).expect("failed to write test file");
+    path
+}
+
+fn normalize_path(path: &str, repo: &Path) -> String {
+    let candidate = Path::new(path);
+    let normalized = candidate
+        .strip_prefix(repo)
+        .unwrap_or(candidate)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn parse_foxguard_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let report: Value = serde_json::from_slice(output).expect("invalid foxguard JSON output");
+    let findings = report["findings"]
+        .as_array()
+        .cloned()
+        .expect("foxguard JSON report missing findings array");
+    let mut normalized = findings
+        .into_iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["file"]
+                    .as_str()
+                    .expect("foxguard finding missing file"),
+                repo,
+            ),
+            line: finding["line"]
+                .as_u64()
+                .expect("foxguard finding missing line"),
+            message: finding["description"]
+                .as_str()
+                .expect("foxguard finding missing description")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn parse_semgrep_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let payload: Value = serde_json::from_slice(output).expect("invalid semgrep JSON output");
+    let results = payload["results"]
+        .as_array()
+        .expect("semgrep output missing results");
+
+    let mut normalized = results
+        .iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["path"]
+                    .as_str()
+                    .expect("semgrep finding missing path"),
+                repo,
+            ),
+            line: finding["start"]["line"]
+                .as_u64()
+                .expect("semgrep finding missing start line"),
+            message: finding["extra"]["message"]
+                .as_str()
+                .expect("semgrep finding missing message")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn foxguard_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = foxguard_cmd()
+        .current_dir(repo)
+        .args([
+            "--no-builtins",
+            "--rules",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            scan_target,
+            "-f",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success() || !output.stdout.is_empty(),
+        "foxguard failed without JSON output: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_foxguard_findings(&output.stdout, repo)
+}
+
+fn semgrep_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = Command::new(semgrep_bin())
+        .current_dir(repo)
+        .args([
+            "--config",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            "--json",
+            "--quiet",
+            scan_target,
+        ])
+        .output()
+        .expect("failed to execute semgrep");
+
+    assert!(
+        output.status.success(),
+        "semgrep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_semgrep_findings(&output.stdout, repo)
+}
+
+fn assert_parity(repo: &Path, rules_path: &Path, scan_target: &str) {
+    let foxguard = foxguard_findings(repo, rules_path, scan_target);
+    let semgrep = semgrep_findings(repo, rules_path, scan_target);
+
+    assert_eq!(foxguard, semgrep, "foxguard and semgrep results diverged");
+}
+
+fn skip_if_semgrep_missing() -> bool {
+    if semgrep_available() {
+        return false;
+    }
+
+    eprintln!("semgrep not installed; skipping parity test");
+    true
+}
+
+#[test]
+fn test_parity_pattern_either() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/exec.yaml",
+        r#"
+rules:
+  - id: dangerous-java-sink
+    pattern-either:
+      - pattern: Runtime.getRuntime().exec(...)
+      - pattern: String.format(...)
+    message: dangerous java call
+    severity: ERROR
+    languages: [java]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "A.java",
+        "public class A {\n    public static void main(String[] args) {\n        Runtime.getRuntime().exec(\"ls\");\n        String.format(\"%s\", args[0]);\n        System.out.println(\"safe\");\n    }\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "A.java");
+}
+
+#[test]
+fn test_parity_binary_operator_and_metavariable_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/format.yaml",
+        r#"
+rules:
+  - id: tainted-format
+    patterns:
+      - pattern: String.format($FMT, $VAR)
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: ^userInput$
+    message: tainted format call
+    severity: ERROR
+    languages: [java]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "A.java",
+        "public class A {\n    void m() {\n        String.format(\"%s\", userInput);\n        String.format(\"%s\", safeValue);\n    }\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "A.java");
+}
+
+#[test]
+fn test_parity_pattern_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/inside.yaml",
+        r#"
+rules:
+  - id: exec-in-handle
+    patterns:
+      - pattern: Runtime.getRuntime().exec(...)
+      - pattern-inside: |
+          void handle(...) {
+            ...
+          }
+    message: exec inside handle()
+    severity: ERROR
+    languages: [java]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "A.java",
+        "public class A {\n    void handle(String args) {\n        Runtime.getRuntime().exec(args);\n    }\n    void helper(String args) {\n        Runtime.getRuntime().exec(args);\n    }\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "A.java");
+}
+
+#[test]
+fn test_parity_pattern_not_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/not-inside.yaml",
+        r#"
+rules:
+  - id: exec-outside-helper
+    patterns:
+      - pattern: Runtime.getRuntime().exec(...)
+      - pattern-not-inside: |
+          void safeExec(...) {
+            ...
+          }
+    message: exec outside safeExec()
+    severity: WARNING
+    languages: [java]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "A.java",
+        "public class A {\n    void safeExec(String args) {\n        Runtime.getRuntime().exec(args);\n    }\n    void doExec(String args) {\n        Runtime.getRuntime().exec(args);\n    }\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "A.java");
+}
+
+#[test]
+fn test_parity_pattern_regex_and_not_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/regex.yaml",
+        r#"
+rules:
+  - id: secret-field
+    pattern-regex: '(?m)^\s*(String|final\s+String)\s+(password|secret)\s*='
+    pattern-not-regex: '(?m)^\s*String\s+not_password\s*='
+    message: secret field assignment
+    severity: ERROR
+    languages: [java]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "A.java",
+        "public class A {\n    String password = \"secret\";\n    String not_password = \"safe\";\n    final String secret = \"abc\";\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "A.java");
+}
+
+#[test]
+fn test_parity_paths_include_exclude() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/paths.yaml",
+        r#"
+rules:
+  - id: path-scoped-exec
+    pattern: Runtime.getRuntime().exec(...)
+    message: exec in app source
+    severity: ERROR
+    languages: [java]
+    paths:
+      include:
+        - src/**/*.java
+      exclude:
+        - src/generated/**
+"#,
+    );
+    write_file(
+        repo.path(),
+        "src/app/Main.java",
+        "public class Main { static { Runtime.getRuntime().exec(\"ls\"); } }\n",
+    );
+    write_file(
+        repo.path(),
+        "src/generated/Gen.java",
+        "public class Gen { static { Runtime.getRuntime().exec(\"ls\"); } }\n",
+    );
+    write_file(
+        repo.path(),
+        "tests/T.java",
+        "public class T { static { Runtime.getRuntime().exec(\"ls\"); } }\n",
+    );
+
+    assert_parity(repo.path(), &rules, ".");
+}

--- a/tests/semgrep_parity_javascript.rs
+++ b/tests/semgrep_parity_javascript.rs
@@ -1,0 +1,369 @@
+//! JavaScript Semgrep parity micro-pattern suite.
+//!
+//! Mirrors the structure of `tests/semgrep_parity.rs` (Python) but uses
+//! JavaScript-native sinks (`eval`, `document.write`, `child_process.exec`)
+//! and rule syntax. Each test runs both foxguard and `semgrep` against the
+//! same temp directory + YAML rule and asserts byte-identical normalized
+//! findings. Tests are skipped gracefully when `semgrep` is not on PATH so
+//! the suite remains green in restricted environments.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct NormalizedFinding {
+    path: String,
+    line: u64,
+    message: String,
+}
+
+fn foxguard_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_foxguard"))
+}
+
+fn semgrep_bin() -> String {
+    std::env::var("SEMGREP_BIN").unwrap_or_else(|_| "semgrep".to_string())
+}
+
+fn semgrep_available() -> bool {
+    Command::new(semgrep_bin())
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn write_file(dir: &Path, relative_path: &str, content: &str) -> PathBuf {
+    let path = dir.join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create test directory");
+    }
+    fs::write(&path, content).expect("failed to write test file");
+    path
+}
+
+fn normalize_path(path: &str, repo: &Path) -> String {
+    let candidate = Path::new(path);
+    let normalized = candidate
+        .strip_prefix(repo)
+        .unwrap_or(candidate)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .to_string()
+}
+
+fn parse_foxguard_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let report: Value = serde_json::from_slice(output).expect("invalid foxguard JSON output");
+    let findings = report["findings"]
+        .as_array()
+        .cloned()
+        .expect("foxguard JSON report missing findings array");
+    let mut normalized = findings
+        .into_iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["file"]
+                    .as_str()
+                    .expect("foxguard finding missing file"),
+                repo,
+            ),
+            line: finding["line"]
+                .as_u64()
+                .expect("foxguard finding missing line"),
+            message: finding["description"]
+                .as_str()
+                .expect("foxguard finding missing description")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn parse_semgrep_findings(output: &[u8], repo: &Path) -> Vec<NormalizedFinding> {
+    let payload: Value = serde_json::from_slice(output).expect("invalid semgrep JSON output");
+    let results = payload["results"]
+        .as_array()
+        .expect("semgrep output missing results");
+
+    let mut normalized = results
+        .iter()
+        .map(|finding| NormalizedFinding {
+            path: normalize_path(
+                finding["path"]
+                    .as_str()
+                    .expect("semgrep finding missing path"),
+                repo,
+            ),
+            line: finding["start"]["line"]
+                .as_u64()
+                .expect("semgrep finding missing start line"),
+            message: finding["extra"]["message"]
+                .as_str()
+                .expect("semgrep finding missing message")
+                .to_string(),
+        })
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized
+}
+
+fn foxguard_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = foxguard_cmd()
+        .current_dir(repo)
+        .args([
+            "--no-builtins",
+            "--rules",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            scan_target,
+            "-f",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute foxguard");
+
+    assert!(
+        output.status.success() || !output.stdout.is_empty(),
+        "foxguard failed without JSON output: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_foxguard_findings(&output.stdout, repo)
+}
+
+fn semgrep_findings(repo: &Path, rules_path: &Path, scan_target: &str) -> Vec<NormalizedFinding> {
+    let output = Command::new(semgrep_bin())
+        .current_dir(repo)
+        .args([
+            "--config",
+            rules_path.to_str().expect("non-utf8 rules path"),
+            "--json",
+            "--quiet",
+            scan_target,
+        ])
+        .output()
+        .expect("failed to execute semgrep");
+
+    assert!(
+        output.status.success(),
+        "semgrep failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    parse_semgrep_findings(&output.stdout, repo)
+}
+
+fn assert_parity(repo: &Path, rules_path: &Path, scan_target: &str) {
+    let foxguard = foxguard_findings(repo, rules_path, scan_target);
+    let semgrep = semgrep_findings(repo, rules_path, scan_target);
+
+    assert_eq!(foxguard, semgrep, "foxguard and semgrep results diverged");
+}
+
+fn skip_if_semgrep_missing() -> bool {
+    if semgrep_available() {
+        return false;
+    }
+
+    eprintln!("semgrep not installed; skipping parity test");
+    true
+}
+
+#[test]
+fn test_parity_pattern_either() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/eval.yaml",
+        r#"
+rules:
+  - id: dangerous-js-sink
+    pattern-either:
+      - pattern: eval(...)
+      - pattern: document.write(...)
+    message: eval or document.write usage
+    severity: ERROR
+    languages: [javascript]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.js",
+        "eval(userInput);\ndocument.write(payload);\nconsole.log(\"safe\");\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.js");
+}
+
+#[test]
+fn test_parity_binary_operator_and_metavariable_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/query.yaml",
+        r#"
+rules:
+  - id: tainted-string-concat
+    patterns:
+      - pattern: '"..." + $VAR'
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: ^userInput$
+    message: tainted string concatenation
+    severity: ERROR
+    languages: [javascript]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.js",
+        "var query = \"SELECT \" + userInput;\nvar query2 = \"SELECT \" + safeValue;\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.js");
+}
+
+#[test]
+fn test_parity_pattern_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    // Note: we use `$X` instead of `...` for the formal parameter list because
+    // tree-sitter-javascript rejects `function f(...)` as a syntactic ellipsis
+    // (it is a rest-param prefix in JS). `$X` is a regular identifier slot in
+    // both Semgrep and foxguard's pattern parsers.
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/inside.yaml",
+        r#"
+rules:
+  - id: eval-in-handler
+    patterns:
+      - pattern: eval(...)
+      - pattern-inside: |
+          function handler($X) {
+            ...
+          }
+    message: eval in handler
+    severity: ERROR
+    languages: [javascript]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.js",
+        "function handler(userInput) {\n    eval(userInput);\n}\n\nfunction helper(userInput) {\n    eval(userInput);\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.js");
+}
+
+#[test]
+fn test_parity_pattern_not_inside() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/not-inside.yaml",
+        r#"
+rules:
+  - id: redirect-outside-helper
+    patterns:
+      - pattern: redirect(...)
+      - pattern-not-inside: |
+          function safeRedirect($X) {
+            ...
+          }
+    message: redirect outside helper
+    severity: WARNING
+    languages: [javascript]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.js",
+        "function safeRedirect(url) {\n    return redirect(url);\n}\n\nfunction doRedirect(url) {\n    return redirect(url);\n}\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.js");
+}
+
+#[test]
+fn test_parity_pattern_regex_and_not_regex() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/regex.yaml",
+        r#"
+rules:
+  - id: secret-assignment
+    pattern-regex: '(?m)^(const|let|var)\s+(password|secret)\s*='
+    pattern-not-regex: '(?m)^(const|let|var)\s+not_password\s*='
+    message: secret assignment
+    severity: ERROR
+    languages: [javascript]
+"#,
+    );
+    write_file(
+        repo.path(),
+        "app.js",
+        "const password = \"secret\";\nconst not_password = \"safe\";\nlet secret = \"abc\";\n",
+    );
+
+    assert_parity(repo.path(), &rules, "app.js");
+}
+
+#[test]
+fn test_parity_paths_include_exclude() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/paths.yaml",
+        r#"
+rules:
+  - id: path-scoped-eval
+    pattern: eval(...)
+    message: eval in app source
+    severity: ERROR
+    languages: [javascript]
+    paths:
+      include:
+        - src/**/*.js
+      exclude:
+        - src/generated/**
+"#,
+    );
+    write_file(repo.path(), "src/app/main.js", "eval(userInput);\n");
+    write_file(repo.path(), "src/generated/main.js", "eval(userInput);\n");
+    write_file(repo.path(), "tests/main.js", "eval(userInput);\n");
+
+    assert_parity(repo.path(), &rules, ".");
+}


### PR DESCRIPTION
## Summary

Closes #375.

Extends Semgrep parity coverage beyond Python by mirroring the existing `tests/semgrep_parity.rs` 6-test micro-pattern suite for the three biggest production-user languages.

### Languages now covered (4/10)
- Python (existing — `tests/semgrep_parity.rs`)
- **JavaScript** — `tests/semgrep_parity_javascript.rs` (new, 6/6 passing)
- **Go** — `tests/semgrep_parity_go.rs` (new, 3/6 passing + 3 ignored, see below)
- **Java** — `tests/semgrep_parity_java.rs` (new, 6/6 passing)

### Languages still uncovered (6/10) — tracked in #390
Ruby, PHP, C#, Swift, Kotlin, Rust. Follow-up: https://github.com/0sec-labs/foxguard/issues/390

## Local results (Semgrep 1.157.0 on PATH)

| Test | Python | JavaScript | Go | Java |
| --- | --- | --- | --- | --- |
| `test_parity_pattern_either` | ok | ok | ok | ok |
| `test_parity_binary_operator_and_metavariable_regex` | ok | ok | **ignored** | ok |
| `test_parity_pattern_inside` | ok | ok | **ignored** | ok |
| `test_parity_pattern_not_inside` | ok | ok | **ignored** | ok |
| `test_parity_pattern_regex_and_not_regex` | ok | ok | ok | ok |
| `test_parity_paths_include_exclude` | ok | ok | ok | ok |
| **totals** | 6 pass | 6 pass | 3 pass / 3 ignore | 6 pass |

`cargo test --all` is green (0 failed across the full suite).

## Go AST caveat

`tree-sitter-go` rejects Semgrep micro-syntax (`$X`, `...`) at top level — Go requires a `package` clause first, so foxguard's pattern AST parses with an `ERROR` wrapper that `first_meaningful_node` can't descend into. Three Go tests (`pattern-inside`, `pattern-not-inside`, `metavariable-regex`) are marked `#[ignore]` with comments explaining the divergence; the remaining three use `pattern-regex` (language-agnostic, full parity). The gap is tracked in #390 with a concrete fix sketch — flipping the three ignored tests to active is the acceptance criterion.

## CI

`.github/workflows/ci.yml` now invokes each language as its own step under the existing `semgrep-parity` job:

```yaml
- name: Run Semgrep parity suite (Python)
  run: cargo test --test semgrep_parity
- name: Run Semgrep parity suite (JavaScript)
  run: cargo test --test semgrep_parity_javascript
- name: Run Semgrep parity suite (Go)
  run: cargo test --test semgrep_parity_go
- name: Run Semgrep parity suite (Java)
  run: cargo test --test semgrep_parity_java
```

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo test --test semgrep_parity` (Python baseline) — 6/6 pass
- [x] `cargo test --test semgrep_parity_javascript` — 6/6 pass
- [x] `cargo test --test semgrep_parity_go` — 3/6 pass + 3 ignored
- [x] `cargo test --test semgrep_parity_java` — 6/6 pass
- [x] `cargo test --all` — 0 failed
- [x] No new clippy errors (baseline already noisy, my new files are clean)
- [x] `tests/semgrep_parity.rs` (Python file) untouched
- [x] No changes under `src/`, `Cargo.toml`, or rule files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced language-specific Semgrep parity test suites for Go, Java, and JavaScript to validate tool behavior consistency.

* **Chores**
  * Restructured CI workflow to execute Semgrep parity checks as separate language-targeted runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->