### PR TITLE
fix(go): cover missing TLS cookie and random rules

### DIFF
--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -12,6 +12,64 @@ use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
 use regex::Regex;
 
+fn go_composite_literal_type_text<'a>(
+    node: tree_sitter::Node<'_>,
+    source: &'a str,
+) -> Option<&'a str> {
+    if node.kind() != "composite_literal" {
+        return None;
+    }
+    let type_node = node.child_by_field_name("type")?;
+    Some(&source[type_node.byte_range()])
+}
+
+fn go_import_locals_for_path(
+    source: &str,
+    tree: &tree_sitter::Tree,
+    import_path: &str,
+) -> Vec<String> {
+    let mut locals = Vec::new();
+
+    walk_tree(tree.root_node(), source, &mut |node, src| {
+        if node.kind() != "import_spec" {
+            return;
+        }
+
+        let Some(path_node) = node.child_by_field_name("path") else {
+            return;
+        };
+        let raw_path = &src[path_node.byte_range()];
+        let normalized_path = raw_path.trim_matches(|c: char| c == '"' || c == '`');
+        if normalized_path != import_path {
+            return;
+        }
+
+        let local = match node.child_by_field_name("name") {
+            Some(name_node) if name_node.kind() == "package_identifier" => {
+                Some(src[name_node.byte_range()].to_string())
+            }
+            Some(name_node)
+                if name_node.kind() == "dot" || name_node.kind() == "blank_identifier" =>
+            {
+                None
+            }
+            _ => Some(
+                import_path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(import_path)
+                    .to_string(),
+            ),
+        };
+
+        if let Some(local) = local {
+            locals.push(local);
+        }
+    });
+
+    locals
+}
+
 // ─── Rule 1: no-sql-injection ───────────────────────────────────────────────
 
 pub struct NoSqlInjection;
@@ -605,6 +663,235 @@ impl_rule! {
                 matched.end(),
             ));
         }
+
+        findings
+
+    }
+}
+
+// ─── Rule: missing-ssl-minversion ─────────────────────────────────────────
+
+pub struct MissingSslMinVersion;
+
+impl_rule! {
+    MissingSslMinVersion,
+    id = "go/missing-ssl-minversion",
+    severity = Severity::Medium,
+    cwe = Some("CWE-326"),
+    description = "tls.Config is missing an explicit MinVersion",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
+
+        let local_aliases: Option<AliasTable> = if ctx.go_aliases.is_none() {
+            Some(go_aliases_from_tree(source, tree))
+        } else {
+            None
+        };
+        let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
+        let min_version_re = Regex::new(r"\bMinVersion\s*:")
+            .expect("static Go TLS MinVersion regex should compile");
+
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            let Some(type_text) = go_composite_literal_type_text(node, src) else {
+                return;
+            };
+            let resolved_type = match aliases {
+                Some(a) => a.resolve(type_text),
+                None => std::borrow::Cow::Borrowed(type_text),
+            };
+            if resolved_type.as_ref() != "tls.Config" {
+                return;
+            }
+
+            let literal_text = &src[node.byte_range()];
+            if min_version_re.is_match(literal_text) {
+                return;
+            }
+
+            findings.push(make_finding(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "tls.Config without MinVersion permits legacy TLS versions — set MinVersion to tls.VersionTLS12 or higher",
+                node,
+                src,
+            ));
+        });
+
+        findings
+
+    }
+}
+
+// ─── Rule: cookie-missing-secure ──────────────────────────────────────────
+
+pub struct CookieMissingSecure;
+
+impl_rule! {
+    CookieMissingSecure,
+    id = "go/cookie-missing-secure",
+    severity = Severity::Medium,
+    cwe = Some("CWE-614"),
+    description = "http.Cookie missing Secure flag",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
+
+        let local_aliases: Option<AliasTable> = if ctx.go_aliases.is_none() {
+            Some(go_aliases_from_tree(source, tree))
+        } else {
+            None
+        };
+        let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
+        let secure_field_re = Regex::new(r"\bSecure\s*:")
+            .expect("static Go cookie Secure field regex should compile");
+        let secure_false_re = Regex::new(r"\bSecure\s*:\s*false\b")
+            .expect("static Go cookie Secure false regex should compile");
+
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            let Some(type_text) = go_composite_literal_type_text(node, src) else {
+                return;
+            };
+            let resolved_type = match aliases {
+                Some(a) => a.resolve(type_text),
+                None => std::borrow::Cow::Borrowed(type_text),
+            };
+            if resolved_type.as_ref() != "http.Cookie" {
+                return;
+            }
+
+            let literal_text = &src[node.byte_range()];
+            if secure_field_re.is_match(literal_text) && !secure_false_re.is_match(literal_text) {
+                return;
+            }
+
+            findings.push(make_finding(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "http.Cookie missing Secure: true — cookies may be sent over plaintext HTTP",
+                node,
+                src,
+            ));
+        });
+
+        findings
+
+    }
+}
+
+// ─── Rule: cookie-missing-httponly ────────────────────────────────────────
+
+pub struct CookieMissingHttpOnly;
+
+impl_rule! {
+    CookieMissingHttpOnly,
+    id = "go/cookie-missing-httponly",
+    severity = Severity::Medium,
+    cwe = Some("CWE-1004"),
+    description = "http.Cookie missing HttpOnly flag",
+    language = Language::Go,
+    fn check_with_context(_self, source, tree, ctx) {
+
+        let local_aliases: Option<AliasTable> = if ctx.go_aliases.is_none() {
+            Some(go_aliases_from_tree(source, tree))
+        } else {
+            None
+        };
+        let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
+        let http_only_field_re = Regex::new(r"\bHttpOnly\s*:")
+            .expect("static Go cookie HttpOnly field regex should compile");
+        let http_only_false_re = Regex::new(r"\bHttpOnly\s*:\s*false\b")
+            .expect("static Go cookie HttpOnly false regex should compile");
+
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            let Some(type_text) = go_composite_literal_type_text(node, src) else {
+                return;
+            };
+            let resolved_type = match aliases {
+                Some(a) => a.resolve(type_text),
+                None => std::borrow::Cow::Borrowed(type_text),
+            };
+            if resolved_type.as_ref() != "http.Cookie" {
+                return;
+            }
+
+            let literal_text = &src[node.byte_range()];
+            if http_only_field_re.is_match(literal_text)
+                && !http_only_false_re.is_match(literal_text)
+            {
+                return;
+            }
+
+            findings.push(make_finding(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "http.Cookie missing HttpOnly: true — client-side scripts can read the cookie",
+                node,
+                src,
+            ));
+        });
+
+        findings
+
+    }
+}
+
+// ─── Rule: math-random-used ───────────────────────────────────────────────
+
+pub struct MathRandomUsed;
+
+impl_rule! {
+    MathRandomUsed,
+    id = "go/math-random-used",
+    severity = Severity::Medium,
+    cwe = Some("CWE-338"),
+    description = "math/rand is not cryptographically secure",
+    language = Language::Go,
+    fn check(_self, source, tree) {
+
+        let math_rand_locals = go_import_locals_for_path(source, tree, "math/rand");
+        if math_rand_locals.is_empty() {
+            return Vec::new();
+        }
+
+        let mut findings = Vec::new();
+
+        walk_tree(tree.root_node(), source, &mut |node, src| {
+            if node.kind() != "call_expression" {
+                return;
+            }
+
+            let Some(func) = node.child_by_field_name("function") else {
+                return;
+            };
+            if func.kind() != "selector_expression" {
+                return;
+            }
+
+            let func_text = &src[func.byte_range()];
+            let Some((root, _)) = func_text.split_once('.') else {
+                return;
+            };
+            if !math_rand_locals.iter().any(|local| local == root) {
+                return;
+            }
+
+            findings.push(make_finding(
+                _self.id(),
+                _self.severity(),
+                _self.cwe(),
+                "math/rand is predictable — use crypto/rand for security-sensitive randomness",
+                node,
+                src,
+            ));
+        });
 
         findings
 

--- a/src/rules/kotlin_taint.rs
+++ b/src/rules/kotlin_taint.rs
@@ -494,7 +494,7 @@ fn collect_param_sources(
                             description: format!("@{} parameter '{}'", ann, name),
                             line: ch.start_position().row + 1,
                         });
-                    } else if bare_names.iter().any(|n| *n == name) {
+                    } else if bare_names.contains(&name) {
                         out.push(TaintSource {
                             var_name: Some(name.to_string()),
                             description: format!("parameter '{}'", name),
@@ -606,32 +606,26 @@ fn find_sinks(
         for matcher in &spec.sinks {
             match matcher {
                 NodeMatcher::MethodName {
-                    method: m,
+                    method: expected,
                     description,
-                } => {
-                    if let Some(name) = method {
-                        if name == m {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                description: description.clone(),
-                            });
-                            return;
-                        }
-                    }
+                } if method == Some(expected.as_str()) => {
+                    sinks.push(TaintSink {
+                        start_byte: n.start_byte(),
+                        end_byte: n.end_byte(),
+                        description: description.clone(),
+                    });
+                    return;
                 }
                 NodeMatcher::Call {
                     canonical,
                     description,
-                } => {
-                    if match_kotlin_sink_call(canonical, receiver, method, ctor) {
-                        sinks.push(TaintSink {
-                            start_byte: n.start_byte(),
-                            end_byte: n.end_byte(),
-                            description: description.clone(),
-                        });
-                        return;
-                    }
+                } if match_kotlin_sink_call(canonical, receiver, method, ctor) => {
+                    sinks.push(TaintSink {
+                        start_byte: n.start_byte(),
+                        end_byte: n.end_byte(),
+                        description: description.clone(),
+                    });
+                    return;
                 }
                 _ => {}
             }
@@ -746,12 +740,10 @@ fn extract_property_initializer(node: Node<'_>) -> Option<Node<'_>> {
 /// Body node of a `function_declaration` / `lambda_literal`, if any.
 fn find_function_body(func_node: Node<'_>) -> Option<Node<'_>> {
     let mut cursor = func_node.walk();
-    for child in func_node.children(&mut cursor) {
-        if child.kind() == "function_body" {
-            return Some(child);
-        }
-    }
-    None
+    let body = func_node
+        .children(&mut cursor)
+        .find(|child| child.kind() == "function_body");
+    body
 }
 
 /// Convert a byte offset into the source to a `(line, column)` pair,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -456,6 +456,10 @@ impl RuleRegistry {
         registry.register(Box::new(go::PqVulnerableCrypto));
         registry.register(Box::new(go::NoSsrf));
         registry.register(Box::new(go::InsecureTlsSkipVerify));
+        registry.register(Box::new(go::MissingSslMinVersion));
+        registry.register(Box::new(go::CookieMissingSecure));
+        registry.register(Box::new(go::CookieMissingHttpOnly));
+        registry.register(Box::new(go::MathRandomUsed));
         registry.register(Box::new(go::GinNoTrustedProxies));
         registry.register(Box::new(go::NetHttpNoTimeout));
         registry.register(Box::new(go::TaintCommandInjection));

--- a/tests/fixtures/safe.go
+++ b/tests/fixtures/safe.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"database/sql"
@@ -26,6 +27,14 @@ func safeOperations(db *sql.DB) {
 
 	// Safe: TLS verification remains enabled
 	_ = &tls.Config{MinVersion: tls.VersionTLS12}
+
+	// Safe: cookie has transport and script protections enabled
+	http.SetCookie(w, &http.Cookie{Name: "sid", Value: "ok", Secure: true, HttpOnly: true})
+
+	// Safe: cryptographic randomness
+	token := make([]byte, 16)
+	rand.Read(token)
+	_ = token
 
 	// Safe: environment variable for secrets
 	fmt.Println("Application started")

--- a/tests/fixtures/vulnerable.go
+++ b/tests/fixtures/vulnerable.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
+	mathrand "math/rand"
 	"net/http"
 	"os/exec"
 )
@@ -41,31 +42,41 @@ func vulnerable() {
 	// 8. go/net-http-no-timeout (Medium)
 	http.ListenAndServe(":8080", nil)
 
-	// 9. go/insecure-tls-skip-verify (High)
+	// 9. go/insecure-tls-skip-verify (High) + go/missing-ssl-minversion (Medium)
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	// 10. go/no-unsafe-deserialization — gob.NewDecoder (High)
+	// 10. go/cookie-missing-secure (Medium)
+	http.SetCookie(w, &http.Cookie{Name: "sid", Value: userInput, HttpOnly: true})
+
+	// 11. go/cookie-missing-httponly (Medium)
+	http.SetCookie(w, &http.Cookie{Name: "prefs", Value: userInput, Secure: true})
+
+	// 12. go/math-random-used (Medium)
+	insecureCode := mathrand.Intn(1000000)
+
+	// 13. go/no-unsafe-deserialization — gob.NewDecoder (High)
 	dec := gob.NewDecoder(conn)
 
-	// 11. go/no-unsafe-deserialization — yaml.Unmarshal into interface{} (High)
+	// 14. go/no-unsafe-deserialization — yaml.Unmarshal into interface{} (High)
 	var out interface{}
 	yaml.Unmarshal(data, new(interface{}))
 
-	// 12. go/jwt-no-verify — jwt.ParseUnverified (Critical)
+	// 15. go/jwt-no-verify — jwt.ParseUnverified (Critical)
 	jwt.ParseUnverified(tokenStr, &jwt.StandardClaims{})
 
-	// 13. go/jwt-no-verify — jwt.Parse with nil key function (Critical)
+	// 16. go/jwt-no-verify — jwt.Parse with nil key function (Critical)
 	jwt.Parse(tokenStr, nil)
 
-	// 14. go/jwt-hardcoded-secret (High)
+	// 17. go/jwt-hardcoded-secret (High)
 	jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) { return []byte("my-secret-key"), nil })
 
 	_ = query1
 	_ = query2
 	_ = apiKey
 	_ = transport
+	_ = insecureCode
 	_ = dec
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1009,8 +1009,8 @@ mod go {
 
         assert_eq!(
             findings.len(),
-            20,
-            "vulnerable.go should have 20 findings, got {}",
+            24,
+            "vulnerable.go should have 24 findings, got {}",
             findings.len()
         );
 
@@ -1026,6 +1026,10 @@ mod go {
             "go/no-weak-crypto",
             "go/no-ssrf",
             "go/insecure-tls-skip-verify",
+            "go/missing-ssl-minversion",
+            "go/cookie-missing-secure",
+            "go/cookie-missing-httponly",
+            "go/math-random-used",
             "go/net-http-no-timeout",
             "go/no-unsafe-deserialization",
             "go/jwt-no-verify",

--- a/www/src/data/rules.ts
+++ b/www/src/data/rules.ts
@@ -104,10 +104,14 @@ const pyRules: Rule[] = [
 ];
 
 const goRules: Rule[] = [
+  { id: 'go/cookie-missing-httponly', cwe: 'CWE-1004', desc: 'http.Cookie missing HttpOnly flag', severity: 'medium' },
+  { id: 'go/cookie-missing-secure', cwe: 'CWE-614', desc: 'http.Cookie missing Secure flag', severity: 'medium' },
   { id: 'go/gin-no-trusted-proxies', cwe: 'CWE-346', desc: 'Gin engine created without SetTrustedProxies configuration', severity: 'medium' },
   { id: 'go/insecure-tls-skip-verify', cwe: 'CWE-295', desc: 'TLS certificate verification disabled with InsecureSkipVerify', severity: 'high' },
   { id: 'go/jwt-hardcoded-secret', cwe: 'CWE-798', desc: 'JWT key function uses a hardcoded secret', severity: 'high' },
   { id: 'go/jwt-no-verify', cwe: 'CWE-347', desc: 'JWT parsed without signature verification', severity: 'critical' },
+  { id: 'go/math-random-used', cwe: 'CWE-338', desc: 'math/rand is not cryptographically secure', severity: 'medium' },
+  { id: 'go/missing-ssl-minversion', cwe: 'CWE-326', desc: 'tls.Config is missing an explicit MinVersion', severity: 'medium' },
   { id: 'go/net-http-no-timeout', cwe: 'CWE-400', desc: 'http.ListenAndServe without timeout configuration enables slowloris attacks', severity: 'medium' },
   { id: 'go/no-command-injection', cwe: 'CWE-78', desc: 'Potential command injection via exec.Command with dynamic input', severity: 'critical' },
   { id: 'go/no-hardcoded-secret', cwe: 'CWE-798', desc: 'Hardcoded secret or credential detected', severity: 'high' },


### PR DESCRIPTION
Closes #387.

Summary:
- add Go built-in checks for tls.Config without MinVersion, insecure http.Cookie Secure/HttpOnly settings, and math/rand calls
- register the new rules and regenerate the website rule inventory
- extend Go vulnerable/safe fixtures and integration expectations

Tests:
- cargo test --test integration go::
- cargo test --test rule_inventory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four Go security checks: missing TLS MinVersion, cookies missing Secure, cookies missing HttpOnly, and use of non-crypto math/rand.

* **Tests**
  * Extended safe/vulnerable fixtures and updated integration expectations to cover the new Go rules.

* **Refactor**
  * Simplified Kotlin taint rule matching internals for clearer and more maintainable logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->