### PR TITLE
feat(parity): add Semgrep rule alias map

### DIFF
--- a/benchmarks/parity/README.md
+++ b/benchmarks/parity/README.md
@@ -67,14 +67,40 @@ The harness reports two numbers per repo:
 - **Site parity** = `|sites_both| / |sites_either|`, where a "site" is `(file, line)`.
   Did both tools flag the same code location at all? Ignores rule IDs entirely.
 - **Family parity** = `|matches_both| / |matches_either|`, where a "match" is
-  `(file, line, rule_family)`. `rule_family` is the rule_id with namespace
-  prefixes stripped — so foxguard's `py/no-eval` and Semgrep's
-  `python.lang.security.audit.eval-detected.eval-detected` both collapse to
-  their leaf token. In practice the leaves still don't always match (`no-eval`
-  vs `eval-detected`), so site parity is usually the more honest number.
+  `(file, line, rule_family)`. The harness first applies `aliases.toml`, then
+  falls back to namespace-stripped lexical families for unmapped rules. For
+  example, Semgrep's
+  `python.lang.security.audit.eval-detected.eval-detected` can map directly to
+  foxguard's `py/no-eval` even though their leaf tokens differ.
 
 Family parity is the stricter metric and is what we'd want to track over time.
 Site parity is the looser "do we even notice this code?" metric.
+
+### Alias map
+
+`aliases.toml` maps foxguard rule IDs to the full Semgrep registry IDs that
+detect the same defect class. The harness applies this map before computing
+family parity, while keeping the older lexical `rule_family` fallback for
+rules that are not mapped yet.
+
+Use it when Semgrep and foxguard agree semantically but use different rule IDs,
+for example `py/no-eval` vs
+`python.lang.security.audit.eval-detected.eval-detected`. Each alias entry
+should cite the Semgrep registry rule in `notes` and should only be added after
+reviewing that the two rules describe the same CWE/fix, not just a similar
+name.
+
+```toml
+[[alias]]
+foxguard = "py/no-eval"
+semgrep = [
+  "python.lang.security.audit.eval-detected.eval-detected",
+]
+notes = "Registry: https://semgrep.dev/r/python.lang.security.audit.eval-detected.eval-detected"
+```
+
+Pass `--aliases path/to/aliases.toml` to test an alternate map. If the file is
+missing, the harness falls back to lexical family parity only.
 
 ### Top 10 lists
 
@@ -83,8 +109,8 @@ Each per-repo report shows:
 - Top 10 foxguard-only findings — could be differentiation (foxguard catches
   something Semgrep doesn't) or could be false positives. Triage required.
 - Top 10 semgrep-only findings — straight-up coverage gaps to triage.
-- Per-rule-family counts — useful for spotting "I have a rule for X but Semgrep
-  is also flagging X with a different leaf token".
+- Per-rule-family counts after alias expansion — useful for spotting "I have a
+  rule for X but Semgrep is also flagging X with a different family".
 
 ## Snapshot tracking
 
@@ -125,11 +151,10 @@ are too slow + flaky to gate every push on. The intent is:
 
 ## Known limitations
 
-- **Rule-family normalization is heuristic.** Real-world rule IDs diverge
-  semantically more than lexically. `no-weak-crypto` vs
-  `insecure-hash-algorithm-sha1` is the same finding semantically but doesn't
-  collapse to the same family token. Site parity covers most of these cases;
-  for the rest, eyeballing the per-rule-family table is currently required.
+- **Rule-family normalization is still partial.** `aliases.toml` covers the
+  high-signal foxguard/Semgrep pairs known today, then falls back to the older
+  lexical heuristic. New Semgrep rules or foxguard rule IDs still need explicit
+  alias review before family parity fully reflects them.
 - **Semgrep version drift.** `repos.toml` declares an expected Semgrep version
   but the harness does not enforce it. We rely on the CI-side pin from #374.
 - **No Rust coverage yet.** `libssh-rs` is in the manifest but `skip = true`
@@ -139,10 +164,7 @@ are too slow + flaky to gate every push on. The intent is:
 
 1. **Nightly parity workflow.** GitHub Action that runs this on a cron,
    uploads reports as artifacts, and opens an issue on >5 pp parity drop.
-2. **Rule-family mapping table.** Maintain an explicit `foxguard_id -> semgrep_id`
-   alias map so semantically-equivalent rules collapse for parity even when
-   their lexical leaves diverge (`no-weak-crypto` vs `insecure-hash-algorithm-sha1`).
-3. **Rust corpus.** Once foxguard's Rust rule set is wider, unskip `libssh-rs`
+2. **Rust corpus.** Once foxguard's Rust rule set is wider, unskip `libssh-rs`
    and add a second Rust target.
-4. **`semgrep_version` enforcement.** Honor the version pin in `repos.toml` —
+3. **`semgrep_version` enforcement.** Honor the version pin in `repos.toml` —
    warn or skip when the local Semgrep is older/newer than expected.

--- a/benchmarks/parity/aliases.toml
+++ b/benchmarks/parity/aliases.toml
@@ -1,0 +1,642 @@
+# foxguard <-> Semgrep rule alias map.
+#
+# Each [[alias]] entry maps a single foxguard rule ID to one or more Semgrep
+# registry rule IDs that detect the same vulnerability class. The parity
+# harness (parity.py) uses this to compute family parity across scanners
+# whose rule IDs diverge lexically.
+#
+# Authoring rules:
+#   1. Only add an alias if the two scanners genuinely detect the same defect
+#      class (same CWE, same fix). Lexical similarity is not enough — review
+#      both rule sources before adding.
+#   2. Each Semgrep ID listed must be the FULL dotted registry ID exactly as
+#      Semgrep emits it (typically `<lang>.<framework>.security.<category>.<slug>.<slug>`).
+#      Semgrep duplicates the leaf token in some rules; keep the trailing dup.
+#   3. Cite the Semgrep registry source in `notes` (https://semgrep.dev/r/<id>).
+#      For multi-ID aliases (e.g. weak-crypto's MD5/SHA1 split) cite each rule.
+#   4. Do not invent aliases speculatively. If the harness has never surfaced
+#      a pairing and you can't point at a Semgrep registry rule that matches
+#      the foxguard rule's intent 1:1, leave it out. Inventing aliases
+#      pollutes the parity contract.
+#
+# See benchmarks/parity/README.md ("Alias map") for the full workflow.
+
+# ---------------------------------------------------------------------------
+# Python
+
+[[alias]]
+foxguard = "py/no-eval"
+semgrep = [
+  "python.lang.security.audit.eval-detected.eval-detected",
+  "python.lang.security.audit.exec-detected.exec-detected",
+]
+notes = """Both flag eval()/exec() with potentially-untrusted input.
+Registry: https://semgrep.dev/r/python.lang.security.audit.eval-detected.eval-detected
+Registry: https://semgrep.dev/r/python.lang.security.audit.exec-detected.exec-detected"""
+
+[[alias]]
+foxguard = "py/taint-eval"
+semgrep = [
+  "python.lang.security.audit.eval-detected.eval-detected",
+  "python.lang.security.audit.exec-detected.exec-detected",
+  "python.lang.security.audit.dangerous-system-call.dangerous-system-call-audit",
+]
+notes = """Taint-flow into eval/exec. Semgrep's eval/exec rules are syntactic-only
+but cover the same finding class. Confirmed by harness site match on
+flask/cli.py:1029.
+Registry: https://semgrep.dev/r/python.lang.security.audit.eval-detected.eval-detected"""
+
+[[alias]]
+foxguard = "py/no-weak-crypto"
+semgrep = [
+  "python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1",
+  "python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-md5",
+  "python.cryptography.security.insecure-hash-algorithm-sha1.insecure-hash-algorithm-sha1",
+  "python.cryptography.security.insecure-hash-algorithm-md5.insecure-hash-algorithm-md5",
+]
+notes = """Weak-hash detection. Harness site match on flask/sessions.py:295 confirms
+the p/python pairing. Both `lang.security` and `cryptography.security` namespaces
+ship in the Semgrep registry; we list both because different rulesets surface
+different variants. CWE-327.
+Registry: https://semgrep.dev/r/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-sha1
+Registry: https://semgrep.dev/r/python.lang.security.insecure-hash-algorithms.insecure-hash-algorithm-md5"""
+
+[[alias]]
+foxguard = "py/no-path-traversal"
+semgrep = [
+  "python.lang.security.audit.path-traversal.path-traversal-open.path-traversal-open",
+  "python.lang.security.audit.path-traversal.path-traversal-join.path-traversal-join",
+  "python.flask.security.audit.send-file-tainted.send-file-tainted",
+]
+notes = """Path-traversal via open()/os.path.join()/flask send_file with dynamic input.
+CWE-22.
+Registry: https://semgrep.dev/r/python.lang.security.audit.path-traversal.path-traversal-open.path-traversal-open
+Registry: https://semgrep.dev/r/python.lang.security.audit.path-traversal.path-traversal-join.path-traversal-join"""
+
+[[alias]]
+foxguard = "py/no-sql-injection"
+semgrep = [
+  "python.lang.security.audit.formatted-sql-query.formatted-sql-query",
+  "python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query",
+  "python.django.security.audit.raw-query.raw-query",
+]
+notes = """Dynamic SQL construction (f-string / % / +) reaching execute().
+CWE-89.
+Registry: https://semgrep.dev/r/python.lang.security.audit.formatted-sql-query.formatted-sql-query
+Registry: https://semgrep.dev/r/python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query"""
+
+[[alias]]
+foxguard = "py/taint-sql-injection"
+semgrep = [
+  "python.lang.security.audit.formatted-sql-query.formatted-sql-query",
+  "python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query",
+  "python.django.security.audit.raw-query.raw-query",
+]
+notes = """Taint-flow variant of the same defect class as py/no-sql-injection.
+Registry: https://semgrep.dev/r/python.lang.security.audit.formatted-sql-query.formatted-sql-query"""
+
+[[alias]]
+foxguard = "py/no-command-injection"
+semgrep = [
+  "python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use",
+  "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+  "python.lang.security.audit.dangerous-system-call.dangerous-system-call-audit",
+  "python.lang.security.audit.dangerous-os-exec.dangerous-os-exec",
+]
+notes = """subprocess(..., shell=True) / os.system / os.exec* with dynamic input.
+CWE-78.
+Registry: https://semgrep.dev/r/python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
+Registry: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true"""
+
+[[alias]]
+foxguard = "py/taint-command-injection"
+semgrep = [
+  "python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use",
+  "python.lang.security.audit.subprocess-shell-true.subprocess-shell-true",
+]
+notes = """Taint-flow variant of py/no-command-injection.
+Registry: https://semgrep.dev/r/python.lang.security.audit.subprocess-shell-true.subprocess-shell-true"""
+
+[[alias]]
+foxguard = "py/no-pickle"
+semgrep = [
+  "python.lang.security.deserialization.pickle.avoid-pickle",
+  "python.lang.security.audit.dangerous-pickle-use.dangerous-pickle-use",
+]
+notes = """pickle.load(s) on untrusted input → RCE. CWE-502.
+Registry: https://semgrep.dev/r/python.lang.security.deserialization.pickle.avoid-pickle"""
+
+[[alias]]
+foxguard = "py/taint-pickle-deserialization"
+semgrep = [
+  "python.lang.security.deserialization.pickle.avoid-pickle",
+]
+notes = """Taint-flow variant of py/no-pickle.
+Registry: https://semgrep.dev/r/python.lang.security.deserialization.pickle.avoid-pickle"""
+
+[[alias]]
+foxguard = "py/no-yaml-load"
+semgrep = [
+  "python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load",
+]
+notes = """yaml.load() without SafeLoader → arbitrary object instantiation.
+CWE-502.
+Registry: https://semgrep.dev/r/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load"""
+
+[[alias]]
+foxguard = "py/taint-yaml-load"
+semgrep = [
+  "python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load",
+]
+notes = """Taint-flow variant of py/no-yaml-load.
+Registry: https://semgrep.dev/r/python.lang.security.deserialization.avoid-pyyaml-load.avoid-pyyaml-load"""
+
+[[alias]]
+foxguard = "py/no-hardcoded-secret"
+semgrep = [
+  "generic.secrets.security.detected-generic-secret.detected-generic-secret",
+  "python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument",
+]
+notes = """Hardcoded credential / API token. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-generic-secret.detected-generic-secret"""
+
+[[alias]]
+foxguard = "py/no-ssrf"
+semgrep = [
+  "python.requests.security.disabled-cert-validation.disabled-cert-validation",
+  "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+]
+notes = """requests/urllib with attacker-controlled URL. CWE-918.
+Registry: https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"""
+
+[[alias]]
+foxguard = "py/taint-ssrf"
+semgrep = [
+  "python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected",
+]
+notes = """Taint-flow variant of py/no-ssrf.
+Registry: https://semgrep.dev/r/python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected"""
+
+[[alias]]
+foxguard = "py/no-open-redirect"
+semgrep = [
+  "python.flask.security.unescaped-template-extension.unescaped-template-extension",
+  "python.flask.security.open-redirect.open-redirect",
+]
+notes = """redirect() with attacker-controlled target. CWE-601.
+Registry: https://semgrep.dev/r/python.flask.security.open-redirect.open-redirect"""
+
+[[alias]]
+foxguard = "py/no-debug-true"
+semgrep = [
+  "python.flask.security.audit.app-run-param-config.avoid_app_run_with_bad_host",
+  "python.django.security.audit.django-debug-enabled.django-debug-enabled",
+]
+notes = """Web framework left in debug mode in production code.
+Registry: https://semgrep.dev/r/python.django.security.audit.django-debug-enabled.django-debug-enabled"""
+
+[[alias]]
+foxguard = "py/taint-ssti"
+semgrep = [
+  "python.flask.security.audit.render-template-string.render-template-string",
+  "python.jinja2.security.audit.autoescape-disabled.autoescape-disabled",
+]
+notes = """Template injection via Jinja2/render_template_string. CWE-1336.
+Registry: https://semgrep.dev/r/python.flask.security.audit.render-template-string.render-template-string"""
+
+[[alias]]
+foxguard = "py/taint-xxe"
+semgrep = [
+  "python.lang.security.audit.xxe.lxml-in-pyver-gt-py36.lxml-in-pyver-gt-py36",
+  "python.lang.security.audit.xxe.xmlsax-external-entity.xmlsax-external-entity",
+]
+notes = """XML external-entity expansion via lxml/xml.sax with default parser config. CWE-611.
+Registry: https://semgrep.dev/r/python.lang.security.audit.xxe.lxml-in-pyver-gt-py36.lxml-in-pyver-gt-py36"""
+
+# ---------------------------------------------------------------------------
+# JavaScript / TypeScript
+
+[[alias]]
+foxguard = "js/no-eval"
+semgrep = [
+  "javascript.lang.security.audit.eval-detected.eval-detected",
+  "javascript.lang.security.audit.code-string-concat.code-string-concat",
+]
+notes = """eval()/Function() with potentially-tainted input. Harness site match
+on juice-shop/userProfile.ts:62 confirms code-string-concat pairing.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.code-string-concat.code-string-concat"""
+
+[[alias]]
+foxguard = "js/taint-eval"
+semgrep = [
+  "javascript.lang.security.audit.eval-detected.eval-detected",
+  "javascript.lang.security.audit.code-string-concat.code-string-concat",
+]
+notes = """Taint-flow variant of js/no-eval. Harness site match on
+juice-shop/userProfile.ts:62 confirms.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.code-string-concat.code-string-concat"""
+
+[[alias]]
+foxguard = "js/no-path-traversal"
+semgrep = [
+  "javascript.express.security.audit.express-res-sendfile.express-res-sendfile",
+  "javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal",
+]
+notes = """sendFile()/readFile() with dynamic path. Harness site matches on
+juice-shop/{fileServer,keyServer,logfileServer,quarantineServer}.ts confirm
+the express-res-sendfile pairing. CWE-22 / CWE-73.
+Registry: https://semgrep.dev/r/javascript.express.security.audit.express-res-sendfile.express-res-sendfile"""
+
+[[alias]]
+foxguard = "js/no-sql-injection"
+semgrep = [
+  "javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection",
+  "javascript.lang.security.audit.tainted-sql-string.tainted-sql-string",
+]
+notes = """Template-literal / concatenated SQL reaching query(). Harness site matches
+on juice-shop/{login,search}.ts confirm sequelize-injection-express pairing. CWE-89.
+Registry: https://semgrep.dev/r/javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection"""
+
+[[alias]]
+foxguard = "js/taint-sql-injection"
+semgrep = [
+  "javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection",
+  "javascript.lang.security.audit.tainted-sql-string.tainted-sql-string",
+]
+notes = """Taint-flow variant of js/no-sql-injection. Harness site matches on
+juice-shop/{login,search}.ts confirm.
+Registry: https://semgrep.dev/r/javascript.sequelize.security.audit.sequelize-injection-express.express-sequelize-injection"""
+
+[[alias]]
+foxguard = "js/no-open-redirect"
+semgrep = [
+  "javascript.express.security.audit.express-open-redirect.express-open-redirect",
+]
+notes = """res.redirect() with attacker-controlled URL. CWE-601.
+Registry: https://semgrep.dev/r/javascript.express.security.audit.express-open-redirect.express-open-redirect"""
+
+[[alias]]
+foxguard = "js/no-xss-innerhtml"
+semgrep = [
+  "javascript.express.security.injection.raw-html-format.raw-html-format",
+  "javascript.browser.security.insecure-document-method.insecure-document-method",
+]
+notes = """innerHTML / document.write / raw HTML construction with dynamic input. CWE-79.
+Registry: https://semgrep.dev/r/javascript.express.security.injection.raw-html-format.raw-html-format"""
+
+[[alias]]
+foxguard = "js/taint-xss-innerhtml"
+semgrep = [
+  "javascript.express.security.injection.raw-html-format.raw-html-format",
+  "javascript.browser.security.insecure-document-method.insecure-document-method",
+]
+notes = """Taint-flow variant of js/no-xss-innerhtml.
+Registry: https://semgrep.dev/r/javascript.express.security.injection.raw-html-format.raw-html-format"""
+
+[[alias]]
+foxguard = "js/no-command-injection"
+semgrep = [
+  "javascript.lang.security.detect-child-process.detect-child-process",
+  "javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename",
+]
+notes = """child_process.exec() / spawn() with shell-true and dynamic input. CWE-78.
+Registry: https://semgrep.dev/r/javascript.lang.security.detect-child-process.detect-child-process"""
+
+[[alias]]
+foxguard = "js/taint-command-injection"
+semgrep = [
+  "javascript.lang.security.detect-child-process.detect-child-process",
+]
+notes = """Taint-flow variant of js/no-command-injection.
+Registry: https://semgrep.dev/r/javascript.lang.security.detect-child-process.detect-child-process"""
+
+[[alias]]
+foxguard = "js/no-weak-crypto"
+semgrep = [
+  "javascript.lang.security.audit.md5-used-as-password.md5-used-as-password",
+  "javascript.lang.security.audit.detect-crypto-randomness.detect-crypto-randomness",
+]
+notes = """MD5/SHA1 used for password hashing or Math.random() used for crypto. CWE-327 / CWE-338.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.md5-used-as-password.md5-used-as-password
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.detect-crypto-randomness.detect-crypto-randomness"""
+
+[[alias]]
+foxguard = "js/no-hardcoded-secret"
+semgrep = [
+  "generic.secrets.security.detected-generic-secret.detected-generic-secret",
+  "javascript.lang.security.audit.hardcoded-jwt-secret.hardcoded-jwt-secret",
+]
+notes = """Hardcoded credential / API key / JWT secret. CWE-798.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.hardcoded-jwt-secret.hardcoded-jwt-secret"""
+
+[[alias]]
+foxguard = "js/no-ssrf"
+semgrep = [
+  "javascript.lang.security.audit.detect-non-literal-fs-filename.detect-non-literal-fs-filename",
+  "javascript.express.security.audit.express-ssrf.express-ssrf",
+]
+notes = """fetch()/http.get() with attacker-controlled URL. CWE-918.
+Registry: https://semgrep.dev/r/javascript.express.security.audit.express-ssrf.express-ssrf"""
+
+[[alias]]
+foxguard = "js/taint-ssrf"
+semgrep = [
+  "javascript.express.security.audit.express-ssrf.express-ssrf",
+]
+notes = """Taint-flow variant of js/no-ssrf.
+Registry: https://semgrep.dev/r/javascript.express.security.audit.express-ssrf.express-ssrf"""
+
+[[alias]]
+foxguard = "js/no-unsafe-deserialization"
+semgrep = [
+  "javascript.lang.security.audit.prototype-pollution-loop.prototype-pollution-loop",
+  "javascript.lang.security.audit.unserialize-use.unserialize-use",
+]
+notes = """node-serialize / unserialize with untrusted JSON → RCE. CWE-502.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.unserialize-use.unserialize-use"""
+
+[[alias]]
+foxguard = "js/no-prototype-pollution"
+semgrep = [
+  "javascript.lang.security.audit.prototype-pollution-loop.prototype-pollution-loop",
+  "javascript.lang.security.audit.prototype-pollution-assignment.prototype-pollution-assignment",
+]
+notes = """Object.assign / merge / set on attacker-controlled key path. CWE-1321.
+Registry: https://semgrep.dev/r/javascript.lang.security.audit.prototype-pollution-loop.prototype-pollution-loop"""
+
+[[alias]]
+foxguard = "js/no-document-write"
+semgrep = [
+  "javascript.browser.security.insecure-document-method.insecure-document-method",
+]
+notes = """document.write() with dynamic content → DOM XSS. CWE-79.
+Registry: https://semgrep.dev/r/javascript.browser.security.insecure-document-method.insecure-document-method"""
+
+# ---------------------------------------------------------------------------
+# Go
+
+[[alias]]
+foxguard = "go/no-path-traversal"
+semgrep = [
+  "go.lang.security.audit.path-traversal.path-traversal-file-open.path-traversal-file-open",
+  "go.lang.security.audit.path-traversal.path-traversal-attr.path-traversal-attr",
+]
+notes = """os.Open / filepath.Join with tainted input. CWE-22.
+Registry: https://semgrep.dev/r/go.lang.security.audit.path-traversal.path-traversal-file-open.path-traversal-file-open
+Registry: https://semgrep.dev/r/go.lang.security.audit.path-traversal.path-traversal-attr.path-traversal-attr"""
+
+[[alias]]
+foxguard = "go/taint-path-traversal"
+semgrep = [
+  "go.lang.security.audit.path-traversal.path-traversal-file-open.path-traversal-file-open",
+  "go.lang.security.audit.path-traversal.path-traversal-attr.path-traversal-attr",
+]
+notes = """Taint-flow variant of go/no-path-traversal.
+Registry: https://semgrep.dev/r/go.lang.security.audit.path-traversal.path-traversal-attr.path-traversal-attr"""
+
+[[alias]]
+foxguard = "go/no-sql-injection"
+semgrep = [
+  "go.lang.security.audit.database.string-formatted-query.string-formatted-query",
+  "go.lang.security.audit.database.sqli.gorm-sqli.gorm-sqli",
+]
+notes = """fmt.Sprintf'd or +-concatenated SQL reaching db.Query/Exec. CWE-89.
+Registry: https://semgrep.dev/r/go.lang.security.audit.database.string-formatted-query.string-formatted-query"""
+
+[[alias]]
+foxguard = "go/taint-sql-injection"
+semgrep = [
+  "go.lang.security.audit.database.string-formatted-query.string-formatted-query",
+  "go.lang.security.audit.database.sqli.gorm-sqli.gorm-sqli",
+]
+notes = """Taint-flow variant of go/no-sql-injection.
+Registry: https://semgrep.dev/r/go.lang.security.audit.database.string-formatted-query.string-formatted-query"""
+
+[[alias]]
+foxguard = "go/no-command-injection"
+semgrep = [
+  "go.lang.security.audit.dangerous-exec-command.dangerous-exec-command",
+  "go.lang.security.audit.dangerous-syscall-exec.dangerous-syscall-exec",
+]
+notes = """exec.Command / syscall.Exec with tainted args. CWE-78.
+Registry: https://semgrep.dev/r/go.lang.security.audit.dangerous-exec-command.dangerous-exec-command"""
+
+[[alias]]
+foxguard = "go/taint-command-injection"
+semgrep = [
+  "go.lang.security.audit.dangerous-exec-command.dangerous-exec-command",
+  "go.lang.security.audit.dangerous-syscall-exec.dangerous-syscall-exec",
+]
+notes = """Taint-flow variant of go/no-command-injection.
+Registry: https://semgrep.dev/r/go.lang.security.audit.dangerous-exec-command.dangerous-exec-command"""
+
+[[alias]]
+foxguard = "go/no-ssrf"
+semgrep = [
+  "go.lang.security.audit.net.http-server-tainted-url-host.http-server-tainted-url-host",
+]
+notes = """http.Get / http.NewRequest with attacker-controlled URL. CWE-918.
+Registry: https://semgrep.dev/r/go.lang.security.audit.net.http-server-tainted-url-host.http-server-tainted-url-host"""
+
+[[alias]]
+foxguard = "go/taint-ssrf"
+semgrep = [
+  "go.lang.security.audit.net.http-server-tainted-url-host.http-server-tainted-url-host",
+]
+notes = """Taint-flow variant of go/no-ssrf.
+Registry: https://semgrep.dev/r/go.lang.security.audit.net.http-server-tainted-url-host.http-server-tainted-url-host"""
+
+[[alias]]
+foxguard = "go/no-weak-crypto"
+semgrep = [
+  "go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5",
+  "go.lang.security.audit.crypto.use_of_weak_crypto.use-of-sha1",
+  "go.lang.security.audit.crypto.math_random.math-random-used",
+]
+notes = """crypto/md5, crypto/sha1, math/rand used in security context. CWE-327 / CWE-338.
+Registry: https://semgrep.dev/r/go.lang.security.audit.crypto.use_of_weak_crypto.use-of-md5
+Registry: https://semgrep.dev/r/go.lang.security.audit.crypto.math_random.math-random-used"""
+
+[[alias]]
+foxguard = "go/no-hardcoded-secret"
+semgrep = [
+  "generic.secrets.security.detected-generic-secret.detected-generic-secret",
+  "go.lang.security.audit.hardcoded-credentials.hardcoded-credentials",
+]
+notes = """Hardcoded credential / API token. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-generic-secret.detected-generic-secret"""
+
+[[alias]]
+foxguard = "go/no-unsafe-deserialization"
+semgrep = [
+  "go.lang.security.audit.dangerous-gob-decoder.dangerous-gob-decoder",
+  "go.lang.security.audit.dangerous-decode-json.dangerous-decode-json",
+]
+notes = """encoding/gob and unbounded encoding/json reaching trusted code paths. CWE-502.
+Registry: https://semgrep.dev/r/go.lang.security.audit.dangerous-gob-decoder.dangerous-gob-decoder"""
+
+# ---------------------------------------------------------------------------
+# Java / Kotlin
+
+[[alias]]
+foxguard = "java/no-sql-injection"
+semgrep = [
+  "java.lang.security.audit.formatted-sql-string.formatted-sql-string",
+  "java.lang.security.audit.tainted-sql-from-http-request.tainted-sql-from-http-request",
+]
+notes = """JDBC Statement with concatenated SQL. CWE-89.
+Registry: https://semgrep.dev/r/java.lang.security.audit.formatted-sql-string.formatted-sql-string"""
+
+[[alias]]
+foxguard = "java/no-command-injection"
+semgrep = [
+  "java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call",
+  "java.lang.security.audit.dangerous-exec.dangerous-exec",
+]
+notes = """Runtime.exec() / ProcessBuilder with concatenated/tainted args. CWE-78.
+Registry: https://semgrep.dev/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call"""
+
+[[alias]]
+foxguard = "java/no-path-traversal"
+semgrep = [
+  "java.lang.security.audit.tainted-file-path.tainted-file-path",
+  "java.servlets.security.tainted-file-path.tainted-file-path",
+]
+notes = """new File(...) / FileInputStream with HTTP-tainted path. CWE-22.
+Registry: https://semgrep.dev/r/java.lang.security.audit.tainted-file-path.tainted-file-path"""
+
+[[alias]]
+foxguard = "java/no-weak-crypto"
+semgrep = [
+  "java.lang.security.audit.crypto.weak-hash.use-of-md5",
+  "java.lang.security.audit.crypto.weak-hash.use-of-sha1",
+  "java.lang.security.audit.crypto.des-is-deprecated.des-is-deprecated",
+]
+notes = """MessageDigest.getInstance("MD5") or DES cipher. CWE-327.
+Registry: https://semgrep.dev/r/java.lang.security.audit.crypto.weak-hash.use-of-md5
+Registry: https://semgrep.dev/r/java.lang.security.audit.crypto.des-is-deprecated.des-is-deprecated"""
+
+[[alias]]
+foxguard = "java/no-xxe"
+semgrep = [
+  "java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing",
+  "java.lang.security.audit.xxe.saxparserfactory-disallow-doctype-decl-missing.saxparserfactory-disallow-doctype-decl-missing",
+]
+notes = """XML parsers configured without disabling external entities. CWE-611.
+Registry: https://semgrep.dev/r/java.lang.security.audit.xxe.documentbuilderfactory-disallow-doctype-decl-missing.documentbuilderfactory-disallow-doctype-decl-missing"""
+
+[[alias]]
+foxguard = "java/no-xss"
+semgrep = [
+  "java.servlets.security.tainted-xss-from-http-servlet.tainted-xss-from-http-servlet",
+  "java.spring.security.audit.xss.spring-mvc-tainted-xss-from-http-servlet.spring-mvc-tainted-xss-from-http-servlet",
+]
+notes = """HttpServletResponse.getWriter().write(tainted). CWE-79.
+Registry: https://semgrep.dev/r/java.servlets.security.tainted-xss-from-http-servlet.tainted-xss-from-http-servlet"""
+
+[[alias]]
+foxguard = "java/no-unsafe-deserialization"
+semgrep = [
+  "java.lang.security.audit.object-deserialization.object-deserialization",
+]
+notes = """ObjectInputStream.readObject() on untrusted bytes. CWE-502.
+Registry: https://semgrep.dev/r/java.lang.security.audit.object-deserialization.object-deserialization"""
+
+[[alias]]
+foxguard = "java/no-hardcoded-secret"
+semgrep = [
+  "generic.secrets.security.detected-generic-secret.detected-generic-secret",
+  "java.lang.security.audit.hardcoded-jwt-key.hardcoded-jwt-key",
+]
+notes = """Hardcoded credential / JWT signing key. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-generic-secret.detected-generic-secret"""
+
+[[alias]]
+foxguard = "java/no-ssrf"
+semgrep = [
+  "java.lang.security.audit.ssrf.tainted-url-host.tainted-url-host",
+]
+notes = """URL/URI constructed from tainted input then fetched. CWE-918.
+Registry: https://semgrep.dev/r/java.lang.security.audit.ssrf.tainted-url-host.tainted-url-host"""
+
+[[alias]]
+foxguard = "kt/taint-sql-injection"
+semgrep = [
+  "java.lang.security.audit.formatted-sql-string.formatted-sql-string",
+  "java.lang.security.audit.tainted-sql-from-http-request.tainted-sql-from-http-request",
+]
+notes = """Kotlin runs on the JVM and Semgrep's p/kotlin reuses java.* rules for
+JDBC patterns. CWE-89.
+Registry: https://semgrep.dev/r/java.lang.security.audit.formatted-sql-string.formatted-sql-string"""
+
+[[alias]]
+foxguard = "kt/taint-command-injection"
+semgrep = [
+  "java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call",
+  "java.lang.security.audit.dangerous-exec.dangerous-exec",
+]
+notes = """Kotlin → JVM Runtime.exec / ProcessBuilder. CWE-78.
+Registry: https://semgrep.dev/r/java.lang.security.audit.command-injection-formatted-runtime-call.command-injection-formatted-runtime-call"""
+
+[[alias]]
+foxguard = "kt/taint-ssrf"
+semgrep = [
+  "java.lang.security.audit.ssrf.tainted-url-host.tainted-url-host",
+]
+notes = """Kotlin → JVM SSRF.
+Registry: https://semgrep.dev/r/java.lang.security.audit.ssrf.tainted-url-host.tainted-url-host"""
+
+# ---------------------------------------------------------------------------
+# Secrets (cross-language). Semgrep ships a single generic secret rule plus
+# provider-specific rules; we map each foxguard secret-* rule to the generic
+# one (highest-confidence overlap) plus the matching provider rule where one
+# exists in the registry.
+
+[[alias]]
+foxguard = "secret/aws-access-key-id"
+semgrep = [
+  "generic.secrets.security.detected-aws-account-id.detected-aws-account-id",
+  "generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value",
+]
+notes = """AWS access key ID in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-aws-access-key-id-value.detected-aws-access-key-id-value"""
+
+[[alias]]
+foxguard = "secret/aws-secret-access-key"
+semgrep = [
+  "generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key",
+]
+notes = """AWS secret access key in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-aws-secret-access-key.detected-aws-secret-access-key"""
+
+[[alias]]
+foxguard = "secret/github-token"
+semgrep = [
+  "generic.secrets.security.detected-github-token.detected-github-token",
+]
+notes = """GitHub personal/fine-grained access token in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-github-token.detected-github-token"""
+
+[[alias]]
+foxguard = "secret/slack-token"
+semgrep = [
+  "generic.secrets.security.detected-slack-token.detected-slack-token",
+]
+notes = """Slack bot/user/webhook token in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-slack-token.detected-slack-token"""
+
+[[alias]]
+foxguard = "secret/stripe-live-key"
+semgrep = [
+  "generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key",
+]
+notes = """Stripe live (sk_live_) API key in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-stripe-api-key.detected-stripe-api-key"""
+
+[[alias]]
+foxguard = "secret/private-key"
+semgrep = [
+  "generic.secrets.security.detected-private-key.detected-private-key",
+]
+notes = """Private key (PEM / OpenSSH) in source. CWE-798.
+Registry: https://semgrep.dev/r/generic.secrets.security.detected-private-key.detected-private-key"""

--- a/benchmarks/parity/parity.py
+++ b/benchmarks/parity/parity.py
@@ -44,6 +44,77 @@ from typing import Iterable
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PARITY_DIR = Path(__file__).resolve().parent
 DEFAULT_FOXGUARD = REPO_ROOT / "target" / "release" / "foxguard"
+DEFAULT_ALIASES = PARITY_DIR / "aliases.toml"
+
+
+# ---------------------------------------------------------------------------
+# alias map loading
+#
+# aliases.toml maps a foxguard rule_id to a set of equivalent Semgrep
+# registry rule IDs. The harness uses this to compute family parity across
+# scanners whose rule IDs diverge lexically — `py/no-eval` and Semgrep's
+# `python.lang.security.audit.eval-detected.eval-detected` would otherwise
+# never collapse to the same family key.
+
+
+@dataclass
+class AliasMap:
+    """foxguard rule_id <-> Semgrep rule_id equivalence map.
+
+    Built from `aliases.toml`. Stores both directions so we can normalize a
+    finding from either scanner into a canonical "family" set in O(1).
+    """
+
+    fox_to_sem: dict[str, frozenset[str]] = field(default_factory=dict)
+    sem_to_fox: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path) -> "AliasMap":
+        if not path.exists():
+            return cls()
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+        m = cls()
+        fox_acc: dict[str, set[str]] = {}
+        sem_acc: dict[str, set[str]] = {}
+        for entry in data.get("alias", []):
+            fox = entry.get("foxguard")
+            sem_ids = entry.get("semgrep", [])
+            if not fox or not sem_ids:
+                continue
+            fox_acc.setdefault(fox, set()).update(sem_ids)
+            for sem in sem_ids:
+                sem_acc.setdefault(sem, set()).add(fox)
+        m.fox_to_sem = {k: frozenset(v) for k, v in fox_acc.items()}
+        m.sem_to_fox = {k: frozenset(v) for k, v in sem_acc.items()}
+        return m
+
+    def __len__(self) -> int:
+        return len(self.fox_to_sem)
+
+    def has_foxguard(self, rule_id: str) -> bool:
+        return rule_id in self.fox_to_sem
+
+    def has_semgrep(self, rule_id: str) -> bool:
+        return rule_id in self.sem_to_fox
+
+    def family_keys_for(self, scanner: str, rule_id: str) -> frozenset[str]:
+        """Return the canonical alias family keys this rule belongs to.
+
+        For a foxguard rule the canonical key is its own rule_id; for a Semgrep
+        rule the canonical keys are the set of foxguard rule_ids it aliases to
+        (so the same Semgrep finding can satisfy multiple foxguard families).
+
+        If the rule has no entry in the alias map we return an empty set —
+        callers fall back to the lexical `rule_family` heuristic.
+        """
+        if scanner == "foxguard":
+            if rule_id in self.fox_to_sem:
+                return frozenset({rule_id})
+            return frozenset()
+        if scanner == "semgrep":
+            return self.sem_to_fox.get(rule_id, frozenset())
+        return frozenset()
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +226,21 @@ class Finding:
     def family_key(self) -> tuple[str, int, str]:
         return (self.file, self.line, self.rule_family)
 
+    def aliased_family_keys(self, aliases: "AliasMap") -> set[tuple[str, int, str]]:
+        """Family keys for this finding, expanded via the alias map.
+
+        For mapped foxguard findings the canonical family is the foxguard rule
+        ID. For mapped Semgrep findings the canonical families are the aliased
+        foxguard rule IDs. Unmapped findings fall back to the older lexical
+        `rule_family` heuristic.
+        """
+        if self.scanner == "foxguard":
+            if aliases.has_foxguard(self.rule_id):
+                return {(self.file, self.line, self.rule_id)}
+        elif fox_ids := aliases.family_keys_for("semgrep", self.rule_id):
+            return {(self.file, self.line, fox_id) for fox_id in fox_ids}
+        return {self.family_key()}
+
 
 def _normalize_path(path: str, repo_root: Path) -> str:
     p = Path(path)
@@ -167,6 +253,13 @@ def _normalize_path(path: str, repo_root: Path) -> str:
         return path.replace("\\", "/").lstrip("./")
     s = str(p).replace("\\", "/")
     return s[2:] if s.startswith("./") else s
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
 
 
 def parse_foxguard(output: bytes, repo_root: Path) -> list[Finding]:
@@ -228,9 +321,8 @@ class RepoResult:
     semgrep_error: str = ""
     skipped_reason: str = ""
 
-    def family_parity(self) -> dict:
-        fox_keys = {f.family_key() for f in self.foxguard}
-        sem_keys = {f.family_key() for f in self.semgrep}
+    def family_parity(self, aliases: AliasMap) -> dict:
+        fox_keys, sem_keys = self.family_key_sets(aliases)
         shared = fox_keys & sem_keys
         fox_only = fox_keys - sem_keys
         sem_only = sem_keys - fox_keys
@@ -243,6 +335,24 @@ class RepoResult:
             "union": len(union),
             "rate": rate,
         }
+
+    def family_key_sets(
+        self, aliases: AliasMap
+    ) -> tuple[set[tuple[str, int, str]], set[tuple[str, int, str]]]:
+        fox_keys = {
+            key for finding in self.foxguard for key in finding.aliased_family_keys(aliases)
+        }
+        sem_keys: set[tuple[str, int, str]] = set()
+        for finding in self.semgrep:
+            keys = finding.aliased_family_keys(aliases)
+            # Several foxguard rules may intentionally alias to the same
+            # Semgrep rule (e.g. syntactic and taint variants). If one of those
+            # families is present at the same site, count the Semgrep finding
+            # against the present family rather than also creating false
+            # semgrep-only rows for the sibling aliases.
+            matching_keys = keys & fox_keys
+            sem_keys.update(matching_keys or keys)
+        return fox_keys, sem_keys
 
     def site_parity(self) -> dict:
         # Looser: do both tools flag this (file, line) at all?
@@ -400,7 +510,29 @@ def _top_n_findings(findings: Iterable[Finding], n: int = 10) -> list[Finding]:
     return out
 
 
-def write_repo_report(result: RepoResult, out_path: Path) -> None:
+def _finding_key_map(
+    findings: Iterable[Finding], aliases: AliasMap
+) -> dict[tuple[str, int, str], Finding]:
+    out: dict[tuple[str, int, str], Finding] = {}
+    for finding in findings:
+        for key in finding.aliased_family_keys(aliases):
+            out.setdefault(key, finding)
+    return out
+
+
+def _semgrep_finding_key_map(
+    result: RepoResult, aliases: AliasMap
+) -> dict[tuple[str, int, str], Finding]:
+    fox_keys, _ = result.family_key_sets(aliases)
+    out: dict[tuple[str, int, str], Finding] = {}
+    for finding in result.semgrep:
+        keys = finding.aliased_family_keys(aliases)
+        for key in keys & fox_keys or keys:
+            out.setdefault(key, finding)
+    return out
+
+
+def write_repo_report(result: RepoResult, out_path: Path, aliases: AliasMap) -> None:
     e = result.entry
     lines: list[str] = []
     lines.append(f"# Parity report: {e.name}")
@@ -438,22 +570,22 @@ def write_repo_report(result: RepoResult, out_path: Path) -> None:
         lines.append(f"> semgrep error: {result.semgrep_error}")
         lines.append("")
 
-    fam = result.family_parity()
+    fam = result.family_parity(aliases)
     site = result.site_parity()
     lines.append("## Parity")
     lines.append("")
     lines.append("| Metric | Shared | foxguard-only | semgrep-only | Union | Rate |")
     lines.append("|--------|-------:|--------------:|-------------:|------:|-----:|")
     lines.append(
-        f"| by `(file, line, rule_family)` | {fam['shared']} | {fam['foxguard_only']} | {fam['semgrep_only']} | {fam['union']} | {fam['rate']:.1%} |"
+        f"| by `(file, line, rule_family)` + aliases | {fam['shared']} | {fam['foxguard_only']} | {fam['semgrep_only']} | {fam['union']} | {fam['rate']:.1%} |"
     )
     lines.append(
         f"| by `(file, line)` | {site['shared']} | {site['foxguard_only']} | {site['semgrep_only']} | {site['union']} | {site['rate']:.1%} |"
     )
     lines.append("")
 
-    fox_keys = {f.family_key(): f for f in result.foxguard}
-    sem_keys = {f.family_key(): f for f in result.semgrep}
+    fox_keys = _finding_key_map(result.foxguard, aliases)
+    sem_keys = _semgrep_finding_key_map(result, aliases)
     fox_only_findings = [fox_keys[k] for k in fox_keys.keys() - sem_keys.keys()]
     sem_only_findings = [sem_keys[k] for k in sem_keys.keys() - fox_keys.keys()]
 
@@ -485,16 +617,15 @@ def write_repo_report(result: RepoResult, out_path: Path) -> None:
         lines.append("_None._")
     lines.append("")
 
-    # Per-rule-family parity
-    fams = set(f.rule_family for f in result.foxguard) | set(
-        f.rule_family for f in result.semgrep
-    )
+    # Per-rule-family parity after alias expansion.
+    fox_family_keys, sem_family_keys = result.family_key_sets(aliases)
+    fams = {key[2] for key in fox_family_keys} | {key[2] for key in sem_family_keys}
     fam_rows: list[tuple[str, int, int, float]] = []
     for fam_name in fams:
         if not fam_name:
             continue
-        fox_n = sum(1 for f in result.foxguard if f.rule_family == fam_name)
-        sem_n = sum(1 for f in result.semgrep if f.rule_family == fam_name)
+        fox_n = sum(1 for key in fox_family_keys if key[2] == fam_name)
+        sem_n = sum(1 for key in sem_family_keys if key[2] == fam_name)
         denom = max(fox_n, sem_n)
         rate = min(fox_n, sem_n) / denom if denom else 0.0
         fam_rows.append((fam_name, fox_n, sem_n, rate))
@@ -511,11 +642,11 @@ def write_repo_report(result: RepoResult, out_path: Path) -> None:
     out_path.write_text("\n".join(lines) + "\n")
 
 
-def write_summary(results: list[RepoResult], out_path: Path) -> dict:
+def write_summary(results: list[RepoResult], out_path: Path, aliases: AliasMap) -> dict:
     lines: list[str] = []
     lines.append("# Real-repo Semgrep parity — summary")
     lines.append("")
-    lines.append("Generated by `benchmarks/parity/run.sh` (issue #376).")
+    lines.append("Generated by `benchmarks/parity/run.sh` (issues #376, #386).")
     lines.append("")
     lines.append(
         "Each row aggregates findings from one pinned OSS repo. "
@@ -523,7 +654,11 @@ def write_summary(results: list[RepoResult], out_path: Path) -> dict:
     )
     lines.append("")
     lines.append(
-        "| Repo | Language | foxguard | semgrep | Shared (family) | foxguard-only | semgrep-only | Family parity | Site parity |"
+        f"Alias map: `{DEFAULT_ALIASES.relative_to(REPO_ROOT)}` ({len(aliases)} foxguard families)."
+    )
+    lines.append("")
+    lines.append(
+        "| Repo | Language | foxguard | semgrep | Shared (family+alias) | foxguard-only | semgrep-only | Family parity | Site parity |"
     )
     lines.append(
         "|------|----------|---------:|--------:|----------------:|--------------:|-------------:|--------------:|------------:|"
@@ -531,7 +666,7 @@ def write_summary(results: list[RepoResult], out_path: Path) -> dict:
 
     agg_shared = agg_fox_only = agg_sem_only = agg_union = 0
     agg_site_shared = agg_site_union = 0
-    snapshot: dict = {"repos": {}, "aggregate": {}}
+    snapshot: dict = {"repos": {}, "aggregate": {}, "aliases": {"foxguard_families": len(aliases)}}
 
     for r in results:
         if r.skipped_reason:
@@ -540,7 +675,7 @@ def write_summary(results: list[RepoResult], out_path: Path) -> dict:
             )
             snapshot["repos"][r.entry.name] = {"skipped": r.skipped_reason}
             continue
-        fam = r.family_parity()
+        fam = r.family_parity(aliases)
         site = r.site_parity()
         lines.append(
             f"| {r.entry.name} | {r.entry.language} | {len(r.foxguard)} | {len(r.semgrep)} | "
@@ -576,10 +711,10 @@ def write_summary(results: list[RepoResult], out_path: Path) -> dict:
     )
     lines.append("")
     lines.append(
-        "Family parity collapses rule IDs to their last semantic token, so a "
-        "foxguard `py/no-eval` matches Semgrep `python.lang.security.audit.eval-detected.eval-detected`. "
+        "Family parity compares `(file, line, rule_family)` keys after applying "
+        "`benchmarks/parity/aliases.toml` plus the lexical fallback heuristic. "
         "Site parity ignores rule IDs entirely and just asks whether both scanners "
-        "flagged the same `(file, line)`. Site parity is always >= family parity."
+        "flagged the same `(file, line)`."
     )
     lines.append("")
 
@@ -629,6 +764,12 @@ def parse_args() -> argparse.Namespace:
         help="foxguard binary (default: target/release/foxguard)",
     )
     p.add_argument(
+        "--aliases",
+        type=Path,
+        default=DEFAULT_ALIASES,
+        help="foxguard<->Semgrep alias map (default: benchmarks/parity/aliases.toml)",
+    )
+    p.add_argument(
         "--semgrep",
         type=str,
         default=os.environ.get("SEMGREP", ""),
@@ -660,6 +801,7 @@ def main() -> int:
         return 2
 
     entries, _meta = load_manifest(args.manifest)
+    aliases = AliasMap.load(args.aliases)
     if args.only:
         wanted = {s.strip() for s in args.only.split(",") if s.strip()}
         entries = [e for e in entries if e.name in wanted]
@@ -690,6 +832,7 @@ def main() -> int:
     print(f"workdir: {workdir}")
     print(f"foxguard: {args.foxguard}")
     print(f"semgrep:  {semgrep_bin or '(missing)'}")
+    print(f"aliases:  {args.aliases} ({len(aliases)} foxguard families)")
     print("")
 
     results: list[RepoResult] = []
@@ -749,8 +892,8 @@ def main() -> int:
                 result.semgrep_error = "semgrep not installed"
 
             report_path = args.out / f"report-{entry.name}.md"
-            write_repo_report(result, report_path)
-            print(f"  wrote {report_path.relative_to(REPO_ROOT)}")
+            write_repo_report(result, report_path, aliases)
+            print(f"  wrote {_display_path(report_path)}")
             results.append(result)
     finally:
         if cleanup_workdir:
@@ -760,8 +903,8 @@ def main() -> int:
     # clobber the canonical multi-repo summary.md.
     summary_name = "summary.md" if not args.only else f"summary-{args.only.replace(',', '_')}.md"
     summary_path = args.out / summary_name
-    snapshot = write_summary(results, summary_path)
-    print(f"\nwrote {summary_path.relative_to(REPO_ROOT)}")
+    snapshot = write_summary(results, summary_path, aliases)
+    print(f"\nwrote {_display_path(summary_path)}")
 
     expected_path = PARITY_DIR / "expected.json"
     if args.update_snapshot:


### PR DESCRIPTION
## Summary
- add benchmarks/parity/aliases.toml with 65 foxguard -> Semgrep rule-family mappings
- wire the alias map into family parity, top-only lists, summary snapshots, and report per-family counts
- document alias-map authoring and add --aliases support for alternate maps

Closes #386.

## Tests
- python3 -m py_compile benchmarks/parity/parity.py
- python3 benchmarks/parity/parity.py --help
- python3 benchmarks/parity/parity.py --only flask --foxguard /Users/peak/coding/0sec/foxguard/target/debug/foxguard --workdir /tmp/foxguard-parity-alias-check --out /tmp/foxguard-parity-alias-results
- git diff --check origin/main..HEAD