### PR TITLE
feat(rules): reject reserved YAML namespaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ The Rust registry is the single source of truth for rule metadata. `www/src/data
 
 Use a YAML rule pack under `rules/<area>/<class>/` if the detection is Semgrep-shaped — `pattern-regex` / `pattern-not-regex` with `paths.include` / `paths.exclude`, scoped to a specific bug class or vendor corpus. Drop the YAML in place and rebuild; `include_dir!` snapshots `rules/` at compile time and `RuleRegistry::new()` registers it alongside the Rust core. See [`rules/README.md`](./rules/README.md) for the layout and calibration-test convention.
 
+YAML rule IDs must use a pack-specific namespace, for example `kernel/dirty-frag/<rule-name>` or `acme/security/<rule-name>`. Do not use reserved built-in namespaces: `py/`, `js/`, `go/`, `java/`, `php/`, `ruby/`, `cs/`, `csharp/`, `swift/`, `kotlin/`, `rs/`, `rust/`, `config/`, or `manifest/`.
+
 Add a Rust rule (per the steps above) when the detection needs cross-file taint, custom Rust types or traits, or non-trivial AST analysis that the Semgrep-compat surface can't express.
 
 ## Adding a language

--- a/rules/README.md
+++ b/rules/README.md
@@ -18,6 +18,8 @@ Plain `foxguard <target>` therefore runs the kernel/dirty-frag-class pack today 
 foxguard --rules /path/to/org-rules ./target/
 ```
 
+External rule IDs must use a pack-specific namespace, such as `acme/security/no-unsafe-call`. The built-in namespaces are reserved and rejected at load time: `py/`, `js/`, `go/`, `java/`, `php/`, `ruby/`, `cs/`, `csharp/`, `swift/`, `kotlin/`, `rs/`, `rust/`, `config/`, and `manifest/`.
+
 ## Layout convention
 
 ```
@@ -37,7 +39,8 @@ rules/<area>/<class>/
 ## Adding a new pack
 
 1. Pick a path under `rules/<area>/<class>/`. Reuse an existing `<area>` if one fits; otherwise add a new top-level folder.
-2. Write Semgrep-compat YAML (`pattern-regex`, `pattern-not-regex`, `paths.include` / `paths.exclude`, `languages`, `severity`, `metadata.cwe`, `metadata.references`). Any rule under `kernel/dirty-frag-class/` shows the shape the loader accepts.
-3. Add calibration tests in `tests/<area>_<class>.rs` that drive `parse_semgrep_file` against positive and negative fixtures. Use [`tests/kernel_dirty_frag.rs`](../tests/kernel_dirty_frag.rs) as the template — it loads each YAML, parses fixtures with tree-sitter-c, and asserts finding counts.
+2. Pick rule IDs under a pack-specific namespace, for example `kernel/dirty-frag/<rule-name>`. Do not use reserved built-in namespaces such as `py/`, `go/`, `rs/`, `config/`, or `manifest/`.
+3. Write Semgrep-compat YAML (`pattern-regex`, `pattern-not-regex`, `paths.include` / `paths.exclude`, `languages`, `severity`, `metadata.cwe`, `metadata.references`). Any rule under `kernel/dirty-frag-class/` shows the shape the loader accepts.
+4. Add calibration tests in `tests/<area>_<class>.rs` that drive `parse_semgrep_file` against positive and negative fixtures. Use [`tests/kernel_dirty_frag.rs`](../tests/kernel_dirty_frag.rs) as the template — it loads each YAML, parses fixtures with tree-sitter-c, and asserts finding counts.
 
 Files placed under `rules/` are picked up automatically on the next `cargo build` — `include_dir!` re-snapshots the tree at compile time. No edit to `RuleRegistry::new()` is required for new YAML packs.

--- a/src/rules/kotlin_taint.rs
+++ b/src/rules/kotlin_taint.rs
@@ -494,7 +494,7 @@ fn collect_param_sources(
                             description: format!("@{} parameter '{}'", ann, name),
                             line: ch.start_position().row + 1,
                         });
-                    } else if bare_names.iter().any(|n| *n == name) {
+                    } else if bare_names.contains(&name) {
                         out.push(TaintSource {
                             var_name: Some(name.to_string()),
                             description: format!("parameter '{}'", name),
@@ -606,32 +606,26 @@ fn find_sinks(
         for matcher in &spec.sinks {
             match matcher {
                 NodeMatcher::MethodName {
-                    method: m,
+                    method: expected,
                     description,
-                } => {
-                    if let Some(name) = method {
-                        if name == m {
-                            sinks.push(TaintSink {
-                                start_byte: n.start_byte(),
-                                end_byte: n.end_byte(),
-                                description: description.clone(),
-                            });
-                            return;
-                        }
-                    }
+                } if method == Some(expected.as_str()) => {
+                    sinks.push(TaintSink {
+                        start_byte: n.start_byte(),
+                        end_byte: n.end_byte(),
+                        description: description.clone(),
+                    });
+                    return;
                 }
                 NodeMatcher::Call {
                     canonical,
                     description,
-                } => {
-                    if match_kotlin_sink_call(canonical, receiver, method, ctor) {
-                        sinks.push(TaintSink {
-                            start_byte: n.start_byte(),
-                            end_byte: n.end_byte(),
-                            description: description.clone(),
-                        });
-                        return;
-                    }
+                } if match_kotlin_sink_call(canonical, receiver, method, ctor) => {
+                    sinks.push(TaintSink {
+                        start_byte: n.start_byte(),
+                        end_byte: n.end_byte(),
+                        description: description.clone(),
+                    });
+                    return;
                 }
                 _ => {}
             }
@@ -746,12 +740,10 @@ fn extract_property_initializer(node: Node<'_>) -> Option<Node<'_>> {
 /// Body node of a `function_declaration` / `lambda_literal`, if any.
 fn find_function_body(func_node: Node<'_>) -> Option<Node<'_>> {
     let mut cursor = func_node.walk();
-    for child in func_node.children(&mut cursor) {
-        if child.kind() == "function_body" {
-            return Some(child);
-        }
-    }
-    None
+    let body = func_node
+        .children(&mut cursor)
+        .find(|child| child.kind() == "function_body");
+    body
 }
 
 /// Convert a byte offset into the source to a `(line, column)` pair,

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -9,6 +9,11 @@ use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
+const RESERVED_RULE_ID_NAMESPACES: &[&str] = &[
+    "py", "js", "go", "java", "php", "ruby", "cs", "csharp", "swift", "kotlin", "rs", "rust",
+    "config", "manifest",
+];
+
 // ─── YAML Schema ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -1134,6 +1139,28 @@ fn extract_cwe(yaml: &SemgrepRuleYaml) -> Option<String> {
     }
 }
 
+fn reserved_rule_namespace(rule_id: &str) -> Option<&'static str> {
+    let (namespace, _) = rule_id.split_once('/')?;
+    RESERVED_RULE_ID_NAMESPACES
+        .iter()
+        .copied()
+        .find(|reserved| *reserved == namespace)
+}
+
+fn validate_semgrep_rule_id(rule_id: &str, source_label: &str) -> Result<(), String> {
+    let Some(namespace) = reserved_rule_namespace(rule_id) else {
+        return Ok(());
+    };
+
+    Err(format!(
+        "Rule id '{}' in {} uses reserved namespace '{}/'. YAML rule packs must use a pack-specific namespace such as 'kernel/dirty-frag/...' or 'acme/security/...'. Reserved namespaces: {}",
+        rule_id,
+        source_label,
+        namespace,
+        RESERVED_RULE_ID_NAMESPACES.join(", ")
+    ))
+}
+
 /// Parse a single Semgrep YAML file into foxguard rules.
 pub fn parse_semgrep_file(path: &Path) -> Result<Vec<Box<dyn Rule>>, String> {
     let content = std::fs::read_to_string(path)
@@ -1164,6 +1191,10 @@ pub fn parse_semgrep_str(content: &str, source_label: &str) -> Result<Vec<Box<dy
 
     if let Some(raw_rules) = raw_doc.get("rules").and_then(YamlValue::as_sequence) {
         for raw_rule in raw_rules {
+            if let Some(rule_id) = raw_rule.get("id").and_then(YamlValue::as_str) {
+                validate_semgrep_rule_id(rule_id, source_label)?;
+            }
+
             if raw_rule
                 .get("engine")
                 .and_then(YamlValue::as_str)
@@ -1334,6 +1365,34 @@ rules:
         assert_eq!(rules.len(), 1);
         assert_eq!(rules[0].id(), "semgrep/test-eval");
         assert_eq!(rules[0].severity(), Severity::Critical);
+    }
+
+    #[test]
+    fn test_reserved_rule_id_namespace_is_rejected() {
+        let yaml = r#"
+rules:
+  - id: py/custom-eval
+    pattern: eval(...)
+    message: Do not use eval
+    severity: ERROR
+    languages: [python]
+"#;
+
+        let err = match parse_semgrep_str(yaml, "org-pack.yml") {
+            Ok(_) => panic!("reserved rule namespace should be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.contains("py/custom-eval"));
+        assert!(err.contains("reserved namespace 'py/'"));
+        assert!(err.contains("org-pack.yml"));
+    }
+
+    #[test]
+    fn test_reserved_rule_id_alias_namespaces_are_rejected() {
+        for namespace in ["cs", "csharp", "rs", "rust"] {
+            let rule_id = format!("{namespace}/custom-rule");
+            assert_eq!(reserved_rule_namespace(&rule_id), Some(namespace));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #379.

Summary:
- reject Semgrep-compatible YAML rule IDs that use built-in namespaces such as py/, go/, rs/, config/, or manifest/
- document the namespace contract in CONTRIBUTING.md and rules/README.md
- include the current Kotlin taint Clippy cleanup needed for CI on main

Tests:
- cargo test test_reserved_rule_id
- cargo test --test semgrep_integration
- cargo clippy -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and README to clarify that rule IDs must use pack-specific namespaces and cannot use reserved built-in namespaces.

* **New Features**
  * Added validation to reject rules with reserved namespace identifiers at load time, ensuring compliance with namespace requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->