### PR TITLE
docs(taint): explain engine language selection

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -35,6 +35,13 @@ use std::path::Path;
 /// See `rules/README.md` for the on-disk layout.
 static BUNDLED_RULES: include_dir::Dir<'_> = include_dir::include_dir!("$CARGO_MANIFEST_DIR/rules");
 
+/// Languages with built-in taint specs wired into the scanner.
+///
+/// Taint support is intentionally narrower than syntax-only AST rules: each
+/// language here has source/sink specs plus scanner dispatch in
+/// `builtin_taint_specs_for_language` and `engine/scanner.rs`. When adding a
+/// new taint-backed language, start with `docs/taint-tracking.md` so the
+/// engine choice, source model, and sanitizer behavior stay consistent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaintEngine {
     Go,


### PR DESCRIPTION
## Summary
- add an in-code comment near TaintEngine explaining why taint support is limited to the wired languages
- point future language additions at docs/taint-tracking.md and the scanner/spec dispatch points

Closes #378.

## Tests
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation regarding taint tracking capabilities and implementation guidelines for supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->