### PR TITLE
refactor(taint): extract shared engine scaffolding

### DIFF
--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -38,16 +38,14 @@ use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
-    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
-    AnalysisContext, TaintLanguageAdapter, TaintState,
+    push_attributed_findings, summarize_function_return_generic, taint_finding_for_node, AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
     TaintSpec,
 };
-use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
+use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 
@@ -510,64 +508,16 @@ fn function_simple_name<'a>(func_node: Node<'_>, source: &'a str) -> Option<&'a 
         .map(|n| node_text(n, source))
 }
 
-/// Pass-1 walker: compute a function/method's return-taint summary.
-fn summarize_function(
-    func_node: Node<'_>,
-    ctx: &GoCtx<'_>,
-) -> (Option<String>, Option<String>) {
-    let name = function_simple_name(func_node, ctx.source).map(|s| s.to_string());
-
-    let mut state = TaintState::default();
-    if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
-    }
-    let Some(body) = func_node.child_by_field_name("body") else {
-        return (name, None);
-    };
-
-    let mut return_taint: Option<String> = None;
-    let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary_generic::<GoTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
-    (name, return_taint)
-}
-
 fn summarize_function_return(
     func_node: Node<'_>,
     ctx: &GoCtx<'_>,
 ) -> (Option<String>, ReturnTaintSummary) {
-    let (name, direct_source) = summarize_function(func_node, ctx);
-    let mut summary = ReturnTaintSummary {
-        direct_source,
-        params_to_return: Vec::new(),
-    };
-
-    let empty_summary = ReturnSummary::new();
-    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
-        .into_iter()
-        .enumerate()
-    {
-        let synthetic_spec = TaintSpec {
-            sources: vec![NodeMatcher::ParamName {
-                names: vec![param_name.clone()],
-                description: format!("parameter '{}'", param_name),
-            }],
-            sinks: vec![],
-            sanitizers: ctx.spec.sanitizers.clone(),
-        };
-        let param_ctx = AnalysisContext {
-            source: ctx.source,
-            spec: &synthetic_spec,
-            aliases: ctx.aliases,
-            summaries: &empty_summary,
-            cross_file: None,
-            sink_to_rules: None,
-        };
-        let (_, ret_taint) = summarize_function(func_node, &param_ctx);
-        if ret_taint.is_some() {
-            summary.params_to_return.push(param_idx);
-        }
-    }
-
+    let name = function_simple_name(func_node, ctx.source).map(|s| s.to_string());
+    let summary = summarize_function_return_generic::<GoTaintAdapter, _>(
+        func_node,
+        ctx,
+        collect_param_names,
+    );
     (name, summary)
 }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -37,9 +37,9 @@
 use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
-    cross_file_taint_finding, match_call_sink, node_text, push_attributed_findings,
-    taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext,
-    TaintLanguageAdapter, TaintState,
+    cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
+    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
+    AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -374,139 +374,19 @@ pub fn extract_cross_file_summaries(
             return;
         };
         let func_name = node_text(name_node, source).to_string();
-
         let param_names = collect_param_names(func_node, source);
-        if param_names.is_empty() {
-            return;
-        }
 
-        let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
-        let mut params_to_return: Vec<usize> = Vec::new();
-
-        // Partition rules: those without sanitizers can be batched into a
-        // single analyze_function call per parameter; rules with sanitizers
-        // must run individually to avoid incorrect taint clearing.
-        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
-        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
-        for (rule_id, rule_spec) in rule_specs {
-            if rule_spec.sanitizers.is_empty() {
-                for sink in &rule_spec.sinks {
-                    sink_desc_to_rule.insert(sink.description(), rule_id);
-                    batched_sinks.push(sink.clone());
-                }
-            } else {
-                sanitizer_rules.push((rule_id, rule_spec));
-            }
-        }
-
-        let empty_summary = ReturnSummary::new();
-
-        // Pre-build reusable specs outside the per-param loop. Only the
-        // `sources` field changes per parameter; sinks and sanitizers are
-        // constant. This avoids cloning the entire sink/sanitizer vecs on
-        // every iteration.
-        let placeholder_source = NodeMatcher::ParamName {
-            names: vec![],
-            description: String::new(),
-        };
-        let mut return_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: vec![],
-            sanitizers: vec![],
-        };
-        let mut batched_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: batched_sinks,
-            sanitizers: vec![],
-        };
-        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
-            .iter()
-            .map(|(_, rule_spec)| TaintSpec {
-                sources: vec![placeholder_source.clone()],
-                sinks: rule_spec.sinks.clone(),
-                sanitizers: rule_spec.sanitizers.clone(),
-            })
-            .collect();
-
-        for (param_idx, param_name) in param_names.iter().enumerate() {
-            let synthetic_source = NodeMatcher::ParamName {
-                names: vec![param_name.clone()],
-                description: format!("parameter '{}'", param_name),
-            };
-
-            // Check return-taint: does this parameter flow to a return value?
-            return_spec.sources[0] = synthetic_source.clone();
-            let return_ctx = AnalysisContext {
+        if let Some(summary) =
+            extract_cross_file_summary_for_function::<GoTaintAdapter, CrossFileInfo<'_>>(
+                func_node,
+                &func_name,
+                &param_names,
                 source,
-                spec: &return_spec,
                 aliases,
-                summaries: &empty_summary,
-                cross_file: None,
-                sink_to_rules: None,
-            };
-            let (_, ret_taint) = summarize_function(func_node, &return_ctx);
-            if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
-                params_to_return.push(param_idx);
-            }
-
-            let mut seen: HashSet<(usize, &str)> = HashSet::new();
-
-            // Batched pass: one call for all no-sanitizer rules.
-            if !batched_spec.sinks.is_empty() {
-                batched_spec.sources[0] = synthetic_source.clone();
-                let batched_ctx = AnalysisContext {
-                    source,
-                    spec: &batched_spec,
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &batched_ctx, &mut findings);
-                for f in &findings {
-                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
-                        if seen.insert((param_idx, rule_id)) {
-                            params_to_sink.push(ParamSinkFlow {
-                                param_index: param_idx,
-                                sink_rule_id: rule_id.to_string(),
-                                sink_description: f.sink_description.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Individual pass: rules with sanitizers run separately.
-            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
-                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
-                let sink_ctx = AnalysisContext {
-                    source,
-                    spec: &sanitizer_specs[idx],
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
-                    params_to_sink.push(ParamSinkFlow {
-                        param_index: param_idx,
-                        sink_rule_id: rule_id.to_string(),
-                        sink_description: findings[0].sink_description.clone(),
-                    });
-                }
-            }
-        }
-
-        if !params_to_sink.is_empty() || !params_to_return.is_empty() {
-            summaries.push(FunctionTaintSummary {
-                name: func_name,
-                params_to_return,
-                params_to_sink,
-            });
+                rule_specs,
+            )
+        {
+            summaries.push(summary);
         }
     });
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -36,9 +36,10 @@
 
 use super::common::AliasTable;
 use super::taint_engine::{
-    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
-    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node,
-    AnalysisContext, TaintState,
+    analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
+    cross_file_taint_finding, match_call_sink, node_text, push_attributed_findings,
+    taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext,
+    TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -539,6 +540,87 @@ where
     }
 }
 
+/// Zero-sized marker type for the Go taint language adapter.
+pub(super) struct GoTaintAdapter;
+
+impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for GoTaintAdapter {
+    fn is_nested_scope(kind: &str) -> bool {
+        kind == "func_literal"
+    }
+
+    fn dispatch_walk_node(
+        node: Node<'_>,
+        ctx: &GoCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+    ) {
+        match node.kind() {
+            "short_var_declaration" => {
+                handle_short_var_declaration(node, ctx, state);
+            }
+            "var_spec" => {
+                handle_var_spec(node, ctx, state);
+            }
+            "assignment_statement" => {
+                handle_assignment(node, ctx, state, findings);
+            }
+            "call_expression" => {
+                handle_call(node, ctx, state, findings);
+            }
+            _ => {}
+        }
+    }
+
+    fn dispatch_summary_node(
+        node: Node<'_>,
+        ctx: &GoCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+        return_taint: &mut Option<String>,
+    ) {
+        // Dispatch the same handlers as the main walk.
+        Self::dispatch_walk_node(node, ctx, state, findings);
+        // Additionally check return statements (Go wraps in expression_list).
+        if node.kind() == "return_statement" && return_taint.is_none() {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() == "expression_list" {
+                    let mut inner = child.walk();
+                    for expr in child.named_children(&mut inner) {
+                        if let Some((desc, _line)) = expression_taint(expr, ctx, state) {
+                            *return_taint = Some(desc);
+                            break;
+                        }
+                    }
+                } else if let Some((desc, _line)) = expression_taint(child, ctx, state) {
+                    *return_taint = Some(desc);
+                }
+                if return_taint.is_some() {
+                    break;
+                }
+            }
+        }
+    }
+
+    fn expression_taint(
+        expr: Node<'_>,
+        ctx: &GoCtx<'_>,
+        state: &TaintState,
+    ) -> Option<(String, usize)> {
+        expression_taint(expr, ctx, state)
+    }
+
+    fn seed_params(
+        func_node: Node<'_>,
+        ctx: &GoCtx<'_>,
+        state: &mut TaintState,
+    ) {
+        if let Some(params) = func_node.child_by_field_name("parameters") {
+            seed_param_sources(params, ctx.source, ctx.spec, state);
+        }
+    }
+}
+
 /// Extract a function / method simple name. For `method_declaration`
 /// the name is a `field_identifier`; for `function_declaration` it's
 /// an `identifier`.
@@ -565,7 +647,7 @@ fn summarize_function(
 
     let mut return_taint: Option<String> = None;
     let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
+    walk_body_for_summary_generic::<GoTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
 }
 
@@ -609,77 +691,12 @@ fn summarize_function_return(
     (name, summary)
 }
 
-fn walk_body_for_summary(
-    node: Node<'_>,
-    ctx: &GoCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-    return_taint: &mut Option<String>,
-) {
-    // Don't descend into nested function literals / closures — their
-    // own returns belong to their own summary. Each closure gets its
-    // own independent analysis via `collect_function_defs`.
-    if node.kind() == "func_literal" {
-        return;
-    }
-
-    match node.kind() {
-        "short_var_declaration" => {
-            handle_short_var_declaration(node, ctx, state);
-        }
-        "var_spec" => {
-            handle_var_spec(node, ctx, state);
-        }
-        "assignment_statement" => {
-            handle_assignment(node, ctx, state, findings);
-        }
-        "call_expression" => {
-            handle_call(node, ctx, state, findings);
-        }
-        "return_statement" if return_taint.is_none() => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                // return statement children are expression_list(s).
-                if child.kind() == "expression_list" {
-                    let mut inner = child.walk();
-                    for expr in child.named_children(&mut inner) {
-                        if let Some((desc, _line)) = expression_taint(expr, ctx, state) {
-                            *return_taint = Some(desc);
-                            break;
-                        }
-                    }
-                } else if let Some((desc, _line)) = expression_taint(child, ctx, state) {
-                    *return_taint = Some(desc);
-                }
-                if return_taint.is_some() {
-                    break;
-                }
-            }
-        }
-        _ => {}
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body_for_summary(child, ctx, state, findings, return_taint);
-    }
-}
-
 fn analyze_function(
     func_node: Node<'_>,
     ctx: &GoCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
-    let mut state = TaintState::default();
-
-    if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
-    }
-
-    let Some(body) = func_node.child_by_field_name("body") else {
-        return;
-    };
-    walk_body(body, ctx, &mut state, findings);
+    analyze_function_generic::<GoTaintAdapter, _>(func_node, ctx, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -710,41 +727,6 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
                 }
             }
         }
-    }
-}
-
-fn walk_body(
-    node: Node<'_>,
-    ctx: &GoCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-) {
-    // Nested function literal / closure — skip. Each closure gets its
-    // own independent analysis via `collect_function_defs`, so we must
-    // not walk into its body here (that would mix taint states).
-    if node.kind() == "func_literal" {
-        return;
-    }
-
-    match node.kind() {
-        "short_var_declaration" => {
-            handle_short_var_declaration(node, ctx, state);
-        }
-        "var_spec" => {
-            handle_var_spec(node, ctx, state);
-        }
-        "assignment_statement" => {
-            handle_assignment(node, ctx, state, findings);
-        }
-        "call_expression" => {
-            handle_call(node, ctx, state, findings);
-        }
-        _ => {}
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body(child, ctx, state, findings);
     }
 }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -37,7 +37,8 @@
 use super::common::AliasTable;
 use super::taint_engine::{
     attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
-    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
+    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node,
+    AnalysisContext, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -75,20 +76,8 @@ pub struct CrossFileInfo<'a> {
     pub rule_filter: RuleFilter<'a>,
 }
 
-/// Bundles the read-only context that every internal walker needs,
-/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
-struct AnalysisContext<'a> {
-    source: &'a str,
-    spec: &'a TaintSpec,
-    aliases: Option<&'a AliasTable>,
-    summaries: &'a ReturnSummary,
-    /// Cross-file info for resolving same-package function calls.
-    cross_file: Option<&'a CrossFileInfo<'a>>,
-    /// When the batched analyzer merges sinks from multiple rules into a
-    /// single `TaintSpec`, this map attributes each matched sink back to
-    /// its owning rule id. `None` in single-rule mode.
-    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
-}
+/// Type alias for the Go-specific analysis context.
+type GoCtx<'a> = AnalysisContext<'a, CrossFileInfo<'a>>;
 
 /// Run the taint engine over every function/method body inside `root`
 /// and return one `TaintFinding` per source→sink flow.
@@ -562,7 +551,7 @@ fn function_simple_name<'a>(func_node: Node<'_>, source: &'a str) -> Option<&'a 
 /// Pass-1 walker: compute a function/method's return-taint summary.
 fn summarize_function(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
 ) -> (Option<String>, Option<String>) {
     let name = function_simple_name(func_node, ctx.source).map(|s| s.to_string());
 
@@ -582,7 +571,7 @@ fn summarize_function(
 
 fn summarize_function_return(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
 ) -> (Option<String>, ReturnTaintSummary) {
     let (name, direct_source) = summarize_function(func_node, ctx);
     let mut summary = ReturnTaintSummary {
@@ -622,7 +611,7 @@ fn summarize_function_return(
 
 fn walk_body_for_summary(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
     return_taint: &mut Option<String>,
@@ -678,7 +667,7 @@ fn walk_body_for_summary(
 
 fn analyze_function(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
@@ -726,7 +715,7 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -785,7 +774,7 @@ fn collect_expression_list<'tree>(list: Node<'tree>) -> Vec<Node<'tree>> {
 }
 
 /// Handle `a := ...`, `a, b := ...`, `a, b := f()`.
-fn handle_short_var_declaration(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_short_var_declaration(node: Node<'_>, ctx: &GoCtx<'_>, state: &mut TaintState) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
         node.child_by_field_name("right"),
@@ -796,7 +785,7 @@ fn handle_short_var_declaration(node: Node<'_>, ctx: &AnalysisContext<'_>, state
 }
 
 /// Handle `var x = ...`, `var x, y = f()`, `var x T = ...`.
-fn handle_var_spec(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_var_spec(node: Node<'_>, ctx: &GoCtx<'_>, state: &mut TaintState) {
     // var_spec has multiple `name` fields and an optional `value`
     // expression_list.
     let Some(value) = node.child_by_field_name("value") else {
@@ -823,7 +812,7 @@ fn handle_var_spec(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintS
 /// Handle `x = ...`, `x, y = ...`, `x += ...`.
 fn handle_assignment(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
     _findings: &mut Vec<TaintFinding>,
 ) {
@@ -839,7 +828,7 @@ fn handle_assignment(
 fn propagate_multi_assign(
     left: Node<'_>,
     right: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
 ) {
     // Both sides are `expression_list`s in tree-sitter-go.
@@ -870,7 +859,7 @@ fn propagate_multi_assign(
 fn apply_multi_assign_semantics(
     lhs_names: &[&str],
     rhs_exprs: &[Node<'_>],
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
 ) {
     if lhs_names.len() == rhs_exprs.len() {
@@ -921,7 +910,7 @@ fn callee_text<'a>(call: Node<'_>, source: &'a str) -> Option<Cow<'a, str>> {
 
 fn handle_call(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -972,7 +961,7 @@ fn handle_call(
 fn handle_cross_file_call(
     node: Node<'_>,
     _callee_text: &str,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &TaintState,
     findings: &mut Vec<TaintFinding>,
     cross_file: &CrossFileInfo<'_>,
@@ -1037,7 +1026,7 @@ fn handle_cross_file_call(
 /// references) a tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &GoCtx<'_>,
     state: &TaintState,
 ) -> Option<(String, usize)> {
     let expr_line = expr.start_position().row + 1;

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -38,7 +38,8 @@ use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
-    push_attributed_findings, summarize_function_return_generic, taint_finding_for_node, AnalysisContext, TaintLanguageAdapter, TaintState,
+    push_attributed_findings, summarize_function_return_generic, taint_finding_for_node,
+    AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -488,11 +489,7 @@ impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for GoTaintAdapter {
         expression_taint(expr, ctx, state)
     }
 
-    fn seed_params(
-        func_node: Node<'_>,
-        ctx: &GoCtx<'_>,
-        state: &mut TaintState,
-    ) {
+    fn seed_params(func_node: Node<'_>, ctx: &GoCtx<'_>, state: &mut TaintState) {
         if let Some(params) = func_node.child_by_field_name("parameters") {
             seed_param_sources(params, ctx.source, ctx.spec, state);
         }
@@ -513,19 +510,12 @@ fn summarize_function_return(
     ctx: &GoCtx<'_>,
 ) -> (Option<String>, ReturnTaintSummary) {
     let name = function_simple_name(func_node, ctx.source).map(|s| s.to_string());
-    let summary = summarize_function_return_generic::<GoTaintAdapter, _>(
-        func_node,
-        ctx,
-        collect_param_names,
-    );
+    let summary =
+        summarize_function_return_generic::<GoTaintAdapter, _>(func_node, ctx, collect_param_names);
     (name, summary)
 }
 
-fn analyze_function(
-    func_node: Node<'_>,
-    ctx: &GoCtx<'_>,
-    findings: &mut Vec<TaintFinding>,
-) {
+fn analyze_function(func_node: Node<'_>, ctx: &GoCtx<'_>, findings: &mut Vec<TaintFinding>) {
     analyze_function_generic::<GoTaintAdapter, _>(func_node, ctx, findings);
 }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -27,9 +27,10 @@
 use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
-    cross_file_taint_finding, match_call_sink, match_member_assign_sink, node_text,
-    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
-    walk_body_generic, AnalysisContext, TaintLanguageAdapter, TaintState,
+    cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink,
+    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node,
+    walk_body_for_summary_generic, walk_body_generic, AnalysisContext, TaintLanguageAdapter,
+    TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -347,137 +348,18 @@ pub fn extract_cross_file_summaries(
 
     collect_exported_functions(root, source, &mut |func_name, func_node| {
         let param_names = collect_param_names(func_node, source);
-        if param_names.is_empty() {
-            return;
-        }
 
-        let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
-        let mut params_to_return: Vec<usize> = Vec::new();
-
-        // Partition rules: those without sanitizers can be batched into a
-        // single analyze_function call per parameter; rules with sanitizers
-        // must run individually to avoid incorrect taint clearing.
-        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
-        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
-        for (rule_id, rule_spec) in rule_specs {
-            if rule_spec.sanitizers.is_empty() {
-                for sink in &rule_spec.sinks {
-                    sink_desc_to_rule.insert(sink.description(), rule_id);
-                    batched_sinks.push(sink.clone());
-                }
-            } else {
-                sanitizer_rules.push((rule_id, rule_spec));
-            }
-        }
-
-        let empty_summary = ReturnSummary::new();
-
-        // Pre-build reusable specs outside the per-param loop. Only the
-        // `sources` field changes per parameter; sinks and sanitizers are
-        // constant. This avoids cloning the entire sink/sanitizer vecs on
-        // every iteration.
-        let placeholder_source = NodeMatcher::ParamName {
-            names: vec![],
-            description: String::new(),
-        };
-        let mut return_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: vec![],
-            sanitizers: vec![],
-        };
-        let mut batched_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: batched_sinks,
-            sanitizers: vec![],
-        };
-        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
-            .iter()
-            .map(|(_, rule_spec)| TaintSpec {
-                sources: vec![placeholder_source.clone()],
-                sinks: rule_spec.sinks.clone(),
-                sanitizers: rule_spec.sanitizers.clone(),
-            })
-            .collect();
-
-        for (param_idx, param_name) in param_names.iter().enumerate() {
-            let synthetic_source = NodeMatcher::ParamName {
-                names: vec![param_name.clone()],
-                description: format!("parameter '{}'", param_name),
-            };
-
-            // Check return-taint: does this parameter flow to a return value?
-            return_spec.sources[0] = synthetic_source.clone();
-            let return_ctx = AnalysisContext {
+        if let Some(summary) =
+            extract_cross_file_summary_for_function::<JsTaintAdapter, CrossFileInfo<'_>>(
+                func_node,
+                &func_name,
+                &param_names,
                 source,
-                spec: &return_spec,
                 aliases,
-                summaries: &empty_summary,
-                cross_file: None,
-                sink_to_rules: None,
-            };
-            let ret_taint = summarize_function(func_node, &return_ctx);
-            if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
-                params_to_return.push(param_idx);
-            }
-
-            let mut seen: HashSet<(usize, &str)> = HashSet::new();
-
-            // Batched pass: one call for all no-sanitizer rules.
-            if !batched_spec.sinks.is_empty() {
-                batched_spec.sources[0] = synthetic_source.clone();
-                let batched_ctx = AnalysisContext {
-                    source,
-                    spec: &batched_spec,
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &batched_ctx, &mut findings);
-                for f in &findings {
-                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
-                        if seen.insert((param_idx, rule_id)) {
-                            params_to_sink.push(ParamSinkFlow {
-                                param_index: param_idx,
-                                sink_rule_id: rule_id.to_string(),
-                                sink_description: f.sink_description.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Individual pass: rules with sanitizers run separately.
-            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
-                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
-                let sink_ctx = AnalysisContext {
-                    source,
-                    spec: &sanitizer_specs[idx],
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
-                    params_to_sink.push(ParamSinkFlow {
-                        param_index: param_idx,
-                        sink_rule_id: rule_id.to_string(),
-                        sink_description: findings[0].sink_description.clone(),
-                    });
-                }
-            }
-        }
-
-        if !params_to_sink.is_empty() || !params_to_return.is_empty() {
-            summaries.push(FunctionTaintSummary {
-                name: func_name,
-                params_to_return,
-                params_to_sink,
-            });
+                rule_specs,
+            )
+        {
+            summaries.push(summary);
         }
     });
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -28,7 +28,7 @@ use super::common::AliasTable;
 use super::taint_engine::{
     attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
     match_call_sink, match_member_assign_sink, node_text, push_attributed_findings,
-    taint_finding_for_node, TaintState,
+    taint_finding_for_node, AnalysisContext, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -64,20 +64,8 @@ pub struct CrossFileInfo<'a> {
     pub rule_filter: RuleFilter<'a>,
 }
 
-/// Bundles the read-only context that every internal walker needs,
-/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
-struct AnalysisContext<'a> {
-    source: &'a str,
-    spec: &'a TaintSpec,
-    aliases: Option<&'a AliasTable>,
-    summaries: &'a ReturnSummary,
-    /// Cross-file info for resolving imported function calls.
-    cross_file: Option<&'a CrossFileInfo<'a>>,
-    /// When the batched analyzer merges sinks from multiple rules into a
-    /// single `TaintSpec`, this map attributes each matched sink back to
-    /// its owning rule id. `None` in single-rule mode.
-    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
-}
+/// Type alias for the JS-specific analysis context.
+type JsCtx<'a> = AnalysisContext<'a, CrossFileInfo<'a>>;
 
 /// Run the taint engine over every function/method body inside `root` and
 /// return one `TaintFinding` per source→sink flow.
@@ -268,7 +256,7 @@ where
 /// Pass-1 walker: compute the return-taint summary for a single function
 /// scope. Walks the body with the normal state machinery but throws away
 /// sink findings and records the first tainted return expression it sees.
-fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<String> {
+fn summarize_function(func_node: Node<'_>, ctx: &JsCtx<'_>) -> Option<String> {
     let mut state = TaintState::default();
     if let Some(params) = func_node.child_by_field_name("parameters") {
         seed_param_sources(params, ctx.source, ctx.spec, &mut state);
@@ -303,7 +291,7 @@ fn summarize_function(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> Option<
     return_taint
 }
 
-fn summarize_function_return(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> ReturnTaintSummary {
+fn summarize_function_return(func_node: Node<'_>, ctx: &JsCtx<'_>) -> ReturnTaintSummary {
     let direct_source = summarize_function(func_node, ctx);
     let mut summary = ReturnTaintSummary {
         direct_source,
@@ -341,7 +329,7 @@ fn summarize_function_return(func_node: Node<'_>, ctx: &AnalysisContext<'_>) -> 
 
 fn walk_body_for_summary(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
     return_taint: &mut Option<String>,
@@ -1243,7 +1231,7 @@ where
 
 fn analyze_function(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
@@ -1324,7 +1312,7 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -1347,7 +1335,7 @@ fn walk_body(
     }
 }
 
-fn handle_variable_declarator(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_variable_declarator(node: Node<'_>, ctx: &JsCtx<'_>, state: &mut TaintState) {
     let Some(name) = node.child_by_field_name("name") else {
         return;
     };
@@ -1420,7 +1408,7 @@ fn collect_destructuring_targets(node: Node<'_>, source: &str) -> Vec<String> {
 
 fn handle_assignment(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -1480,7 +1468,7 @@ fn handle_assignment(
 
 fn handle_call(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -1534,7 +1522,7 @@ fn handle_cross_file_call(
     node: Node<'_>,
     func: Node<'_>,
     callee_text: &str,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &TaintState,
     findings: &mut Vec<TaintFinding>,
     cross_file: &CrossFileInfo<'_>,
@@ -1649,7 +1637,7 @@ fn resolve_cross_file_callee(
 
 fn expression_taint(
     expr: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &JsCtx<'_>,
     state: &TaintState,
 ) -> Option<(String, usize)> {
     let expr_line = expr.start_position().row + 1;

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -28,7 +28,8 @@ use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink,
-    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext, TaintLanguageAdapter, TaintState,
+    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node,
+    walk_body_for_summary_generic, AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -287,7 +288,13 @@ fn summarize_function(func_node: Node<'_>, ctx: &JsCtx<'_>) -> Option<String> {
 
     let mut scratch: Vec<TaintFinding> = Vec::new();
     let mut return_taint: Option<String> = None;
-    walk_body_for_summary_generic::<JsTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
+    walk_body_for_summary_generic::<JsTaintAdapter, _>(
+        body,
+        ctx,
+        &mut state,
+        &mut scratch,
+        &mut return_taint,
+    );
     return_taint
 }
 
@@ -1105,11 +1112,7 @@ impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for JsTaintAdapter {
         expression_taint(expr, ctx, state)
     }
 
-    fn seed_params(
-        func_node: Node<'_>,
-        ctx: &JsCtx<'_>,
-        state: &mut TaintState,
-    ) {
+    fn seed_params(func_node: Node<'_>, ctx: &JsCtx<'_>, state: &mut TaintState) {
         if let Some(params) = func_node.child_by_field_name("parameters") {
             seed_param_sources(params, ctx.source, ctx.spec, state);
         }
@@ -1157,11 +1160,7 @@ where
     }
 }
 
-fn analyze_function(
-    func_node: Node<'_>,
-    ctx: &JsCtx<'_>,
-    findings: &mut Vec<TaintFinding>,
-) {
+fn analyze_function(func_node: Node<'_>, ctx: &JsCtx<'_>, findings: &mut Vec<TaintFinding>) {
     analyze_function_generic::<JsTaintAdapter, _>(func_node, ctx, findings);
 }
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -28,17 +28,15 @@ use super::common::AliasTable;
 use super::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink,
-    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node,
-    walk_body_for_summary_generic, walk_body_generic, AnalysisContext, TaintLanguageAdapter,
-    TaintState,
+    match_member_assign_sink, node_text, push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
     TaintSpec,
 };
-use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
+use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tree_sitter::{Node, Tree};
 

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -26,9 +26,10 @@
 
 use super::common::AliasTable;
 use super::taint_engine::{
-    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
-    match_call_sink, match_member_assign_sink, node_text, push_attributed_findings,
-    taint_finding_for_node, AnalysisContext, TaintState,
+    analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
+    cross_file_taint_finding, match_call_sink, match_member_assign_sink, node_text,
+    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
+    walk_body_generic, AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use super::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -287,7 +288,7 @@ fn summarize_function(func_node: Node<'_>, ctx: &JsCtx<'_>) -> Option<String> {
 
     let mut scratch: Vec<TaintFinding> = Vec::new();
     let mut return_taint: Option<String> = None;
-    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
+    walk_body_for_summary_generic::<JsTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
     return_taint
 }
 
@@ -325,45 +326,6 @@ fn summarize_function_return(func_node: Node<'_>, ctx: &JsCtx<'_>) -> ReturnTain
     }
 
     summary
-}
-
-fn walk_body_for_summary(
-    node: Node<'_>,
-    ctx: &JsCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-    return_taint: &mut Option<String>,
-) {
-    if is_function_scope(node.kind()) {
-        return;
-    }
-
-    match node.kind() {
-        "variable_declarator" => {
-            handle_variable_declarator(node, ctx, state);
-        }
-        "assignment_expression" => {
-            handle_assignment(node, ctx, state, findings);
-        }
-        "call_expression" => {
-            handle_call(node, ctx, state, findings);
-        }
-        "return_statement" if return_taint.is_none() => {
-            let mut cursor = node.walk();
-            for child in node.named_children(&mut cursor) {
-                if let Some((desc, _line)) = expression_taint(child, ctx, state) {
-                    *return_taint = Some(desc);
-                    break;
-                }
-            }
-        }
-        _ => {}
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body_for_summary(child, ctx, state, findings, return_taint);
-    }
 }
 
 // ─── Cross-file summary extraction ───────────────────────────────────────
@@ -1203,6 +1165,92 @@ fn string_literal_text(node: Node<'_>, source: &str) -> String {
 
 // ─── Internals ────────────────────────────────────────────────────────────
 
+/// Zero-sized marker type for the JS taint language adapter.
+pub(super) struct JsTaintAdapter;
+
+impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for JsTaintAdapter {
+    fn is_nested_scope(kind: &str) -> bool {
+        is_function_scope(kind)
+    }
+
+    fn dispatch_walk_node(
+        node: Node<'_>,
+        ctx: &JsCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+    ) {
+        match node.kind() {
+            "variable_declarator" => handle_variable_declarator(node, ctx, state),
+            "assignment_expression" => handle_assignment(node, ctx, state, findings),
+            "call_expression" => handle_call(node, ctx, state, findings),
+            _ => {}
+        }
+    }
+
+    fn dispatch_summary_node(
+        node: Node<'_>,
+        ctx: &JsCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+        return_taint: &mut Option<String>,
+    ) {
+        match node.kind() {
+            "variable_declarator" => {
+                handle_variable_declarator(node, ctx, state);
+            }
+            "assignment_expression" => {
+                handle_assignment(node, ctx, state, findings);
+            }
+            "call_expression" => {
+                handle_call(node, ctx, state, findings);
+            }
+            "return_statement" if return_taint.is_none() => {
+                let mut cursor = node.walk();
+                for child in node.named_children(&mut cursor) {
+                    if let Some((desc, _line)) = expression_taint(child, ctx, state) {
+                        *return_taint = Some(desc);
+                        break;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn expression_taint(
+        expr: Node<'_>,
+        ctx: &JsCtx<'_>,
+        state: &TaintState,
+    ) -> Option<(String, usize)> {
+        expression_taint(expr, ctx, state)
+    }
+
+    fn seed_params(
+        func_node: Node<'_>,
+        ctx: &JsCtx<'_>,
+        state: &mut TaintState,
+    ) {
+        if let Some(params) = func_node.child_by_field_name("parameters") {
+            seed_param_sources(params, ctx.source, ctx.spec, state);
+        }
+        // Arrow functions with a single bare parameter.
+        if let Some(single) = func_node.child_by_field_name("parameter") {
+            if single.kind() == "identifier" {
+                let name = node_text(single, ctx.source);
+                let line = single.start_position().row + 1;
+                for matcher in &ctx.spec.sources {
+                    if let NodeMatcher::ParamName { names, description } = matcher {
+                        if names.iter().any(|n| n == name) {
+                            state.taint(name.to_string(), description.clone(), line);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Node kinds that introduce a fresh taint scope (a function body).
 fn is_function_scope(kind: &str) -> bool {
     matches!(
@@ -1234,34 +1282,7 @@ fn analyze_function(
     ctx: &JsCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
-    let mut state = TaintState::default();
-
-    if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
-    }
-    // Arrow functions with a single bare parameter have `parameter` instead
-    // of `parameters` (e.g. `x => x + 1`). tree-sitter-javascript actually
-    // wraps it in `formal_parameters` when there is a paren, but a bare
-    // identifier parameter is an `identifier` child field-named `parameter`.
-    if let Some(single) = func_node.child_by_field_name("parameter") {
-        if single.kind() == "identifier" {
-            let name = node_text(single, ctx.source);
-            let line = single.start_position().row + 1;
-            for matcher in &ctx.spec.sources {
-                if let NodeMatcher::ParamName { names, description } = matcher {
-                    if names.iter().any(|n| n == name) {
-                        state.taint(name.to_string(), description.clone(), line);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    let Some(body) = func_node.child_by_field_name("body") else {
-        return;
-    };
-    walk_body(body, ctx, &mut state, findings);
+    analyze_function_generic::<JsTaintAdapter, _>(func_node, ctx, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -1307,31 +1328,6 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
                 }
             }
         }
-    }
-}
-
-fn walk_body(
-    node: Node<'_>,
-    ctx: &JsCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-) {
-    // Nested function scopes have their own taint state — skip them; they'll
-    // be picked up independently by analyze_tree.
-    if is_function_scope(node.kind()) {
-        return;
-    }
-
-    match node.kind() {
-        "variable_declarator" => handle_variable_declarator(node, ctx, state),
-        "assignment_expression" => handle_assignment(node, ctx, state, findings),
-        "call_expression" => handle_call(node, ctx, state, findings),
-        _ => {}
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body(child, ctx, state, findings);
     }
 }
 

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -34,7 +34,8 @@ use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use crate::rules::taint_engine::{
     attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
-    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node, TaintState,
+    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node,
+    AnalysisContext, TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -68,20 +69,8 @@ pub struct CrossFileInfo<'a> {
 
 // ─── Public API ────────────────────────────────────────────────────────��──
 
-/// Bundles the read-only context that every internal walker needs,
-/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
-struct AnalysisContext<'a> {
-    source: &'a str,
-    spec: &'a TaintSpec,
-    aliases: Option<&'a AliasTable>,
-    summaries: &'a ReturnSummary,
-    /// Cross-file info for resolving imported function calls.
-    cross_file: Option<&'a CrossFileInfo<'a>>,
-    /// When the batched analyzer merges sinks from multiple rules into a
-    /// single `TaintSpec`, this map attributes each matched sink back to
-    /// its owning rule id. `None` in single-rule mode.
-    sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
-}
+/// Type alias for the Python-specific analysis context.
+type PyCtx<'a> = AnalysisContext<'a, CrossFileInfo<'a>>;
 
 /// Run the taint engine over every function definition inside `root` and
 /// return one [`TaintFinding`] per source→sink flow discovered.
@@ -457,7 +446,7 @@ fn call_summary_key(name: &str, args: Node<'_>) -> String {
 /// function bodies, which have their own summary).
 fn summarize_function(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
 ) -> (Option<String>, Option<String>) {
     let name = func_node
         .child_by_field_name("name")
@@ -481,7 +470,7 @@ fn summarize_function(
 
 fn summarize_function_return(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
 ) -> (Option<String>, ReturnTaintSummary) {
     let (name, direct_source) = summarize_function(func_node, ctx);
     let mut summary = ReturnTaintSummary {
@@ -523,7 +512,7 @@ fn summarize_function_return(
 
 fn walk_body_for_summary(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
     return_taint: &mut Option<String>,
@@ -578,7 +567,7 @@ where
 /// Taint metadata carried alongside a tainted variable: the human-readable
 fn analyze_function(
     func_node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
     let mut state = TaintState::default();
@@ -633,7 +622,7 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
 
 fn walk_body(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -684,7 +673,7 @@ fn walk_body(
     }
 }
 
-fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_assignment(node: Node<'_>, ctx: &PyCtx<'_>, state: &mut TaintState) {
     let (Some(left), Some(right)) = (
         node.child_by_field_name("left"),
         node.child_by_field_name("right"),
@@ -756,7 +745,7 @@ fn handle_assignment(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut Tain
 ///         as_pattern_target
 ///           identifier          (the alias)
 /// ```
-fn handle_with_statement(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_with_statement(node: Node<'_>, ctx: &PyCtx<'_>, state: &mut TaintState) {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() != "with_clause" {
@@ -782,7 +771,7 @@ fn handle_with_statement(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut 
 /// Process an `as_pattern` node: the first named child is the value
 /// expression and the `as_pattern_target` child contains the alias
 /// identifier. If the value is tainted, taint the alias.
-fn handle_as_pattern(node: Node<'_>, ctx: &AnalysisContext<'_>, state: &mut TaintState) {
+fn handle_as_pattern(node: Node<'_>, ctx: &PyCtx<'_>, state: &mut TaintState) {
     let mut cursor = node.walk();
     let named: Vec<Node<'_>> = node.named_children(&mut cursor).collect();
     // First named child = value expression, look for as_pattern_target among rest.
@@ -864,7 +853,7 @@ fn tuple_like_elements<'tree>(node: Node<'tree>) -> Option<Vec<Node<'tree>>> {
 
 fn handle_call(
     node: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     state: &mut TaintState,
     findings: &mut Vec<TaintFinding>,
 ) {
@@ -920,7 +909,7 @@ fn handle_cross_file_call(
     node: Node<'_>,
     func: Node<'_>,
     callee_text: &str,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     state: &TaintState,
     findings: &mut Vec<TaintFinding>,
     cross_file: &CrossFileInfo<'_>,
@@ -1019,7 +1008,7 @@ fn resolve_cross_file_callee(
 /// references) a tainted value, otherwise `None`.
 fn expression_taint(
     expr: Node<'_>,
-    ctx: &AnalysisContext<'_>,
+    ctx: &PyCtx<'_>,
     state: &TaintState,
 ) -> Option<(String, usize)> {
     let expr_line = expr.start_position().row + 1;

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -31,18 +31,19 @@
 //! Semgrep-compatible `mode: taint` YAML) will plug into the same API.
 
 use crate::rules::common::AliasTable;
-use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
+use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary};
 use crate::rules::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
-    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
-    AnalysisContext, TaintLanguageAdapter, TaintState,
+    push_attributed_findings, summarize_function_return_generic,
+    taint_finding_for_node, AnalysisContext, TaintLanguageAdapter,
+    TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
     TaintSpec,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use tree_sitter::Node;
 
@@ -320,71 +321,18 @@ fn call_summary_key(name: &str, args: Node<'_>) -> String {
     function_summary_key(name, args.named_children(&mut cursor).count())
 }
 
-/// Pass-1 walker: compute a function's return-taint summary by scanning
-/// its body with the same state machinery used in pass 2, then inspecting
-/// every `return_statement` that appears inside it (excluding nested
-/// function bodies, which have their own summary).
-fn summarize_function(
-    func_node: Node<'_>,
-    ctx: &PyCtx<'_>,
-) -> (Option<String>, Option<String>) {
-    let name = func_node
-        .child_by_field_name("name")
-        .map(|n| node_text(n, ctx.source).to_string());
-
-    let mut state = TaintState::default();
-    if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
-    }
-    let Some(body) = func_node.child_by_field_name("body") else {
-        return (name, None);
-    };
-
-    let mut return_taint: Option<String> = None;
-    // Reuse the normal walker but throw away sink findings — we only want
-    // to update the taint state and inspect return statements.
-    let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary_generic::<PyTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
-    (name, return_taint)
-}
-
 fn summarize_function_return(
     func_node: Node<'_>,
     ctx: &PyCtx<'_>,
 ) -> (Option<String>, ReturnTaintSummary) {
-    let (name, direct_source) = summarize_function(func_node, ctx);
-    let mut summary = ReturnTaintSummary {
-        direct_source,
-        params_to_return: Vec::new(),
-    };
-
-    let empty_summary = ReturnSummary::new();
-    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
-        .into_iter()
-        .enumerate()
-    {
-        let synthetic_spec = TaintSpec {
-            sources: vec![NodeMatcher::ParamName {
-                names: vec![param_name.clone()],
-                description: format!("parameter '{}'", param_name),
-            }],
-            sinks: vec![],
-            sanitizers: ctx.spec.sanitizers.clone(),
-        };
-        let param_ctx = AnalysisContext {
-            source: ctx.source,
-            spec: &synthetic_spec,
-            aliases: ctx.aliases,
-            summaries: &empty_summary,
-            cross_file: None,
-            sink_to_rules: None,
-        };
-        let (_, ret_taint) = summarize_function(func_node, &param_ctx);
-        if ret_taint.is_some() {
-            summary.params_to_return.push(param_idx);
-        }
-    }
-
+    let name = func_node
+        .child_by_field_name("name")
+        .map(|n| node_text(n, ctx.source).to_string());
+    let summary = summarize_function_return_generic::<PyTaintAdapter, _>(
+        func_node,
+        ctx,
+        collect_param_names,
+    );
     let name = name
         .map(|name| function_summary_key(&name, collect_param_names(func_node, ctx.source).len()));
     (name, summary)

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -33,9 +33,10 @@
 use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use crate::rules::taint_engine::{
-    attribution_hint_for_sink, build_batched_taint_groups, cross_file_taint_finding,
-    match_call_sink, node_text, push_attributed_findings, taint_finding_for_node,
-    AnalysisContext, TaintState,
+    analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
+    cross_file_taint_finding, match_call_sink, node_text, push_attributed_findings,
+    taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext,
+    TaintLanguageAdapter, TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -464,7 +465,7 @@ fn summarize_function(
     // Reuse the normal walker but throw away sink findings — we only want
     // to update the taint state and inspect return statements.
     let mut scratch: Vec<TaintFinding> = Vec::new();
-    walk_body_for_summary(body, ctx, &mut state, &mut scratch, &mut return_taint);
+    walk_body_for_summary_generic::<PyTaintAdapter, _>(body, ctx, &mut state, &mut scratch, &mut return_taint);
     (name, return_taint)
 }
 
@@ -510,46 +511,88 @@ fn summarize_function_return(
     (name, summary)
 }
 
-fn walk_body_for_summary(
-    node: Node<'_>,
-    ctx: &PyCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-    return_taint: &mut Option<String>,
-) {
-    // Don't descend into nested function definitions — their own returns
-    // belong to their own summary.
-    if node.kind() == "function_definition" {
-        return;
+// ─── Internals ────────────────────────────────────────────────────────────
+
+/// Zero-sized marker type for the Python taint language adapter.
+pub(super) struct PyTaintAdapter;
+
+impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for PyTaintAdapter {
+    fn is_nested_scope(kind: &str) -> bool {
+        kind == "function_definition"
     }
 
-    if node.kind() == "assignment" {
-        handle_assignment(node, ctx, state);
+    fn dispatch_walk_node(
+        node: Node<'_>,
+        ctx: &PyCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+    ) {
+        if node.kind() == "assignment" {
+            handle_assignment(node, ctx, state);
+        }
+        // Walrus operator: `name := value` (named_expression).
+        if node.kind() == "named_expression" {
+            if let (Some(name), Some(value)) = (
+                node.child_by_field_name("name"),
+                node.child_by_field_name("value"),
+            ) {
+                if name.kind() == "identifier" {
+                    let lhs = node_text(name, ctx.source).to_string();
+                    if let Some((desc, src_line)) = expression_taint(value, ctx, state) {
+                        state.taint(lhs, desc, src_line);
+                    } else {
+                        state.clear(&lhs);
+                    }
+                }
+            }
+        }
+        if node.kind() == "call" {
+            handle_call(node, ctx, state, findings);
+        }
+        if node.kind() == "with_statement" {
+            handle_with_statement(node, ctx, state);
+        }
     }
-    if node.kind() == "call" {
-        handle_call(node, ctx, state, findings);
-    }
-    if node.kind() == "with_statement" {
-        handle_with_statement(node, ctx, state);
-    }
-    if node.kind() == "return_statement" && return_taint.is_none() {
-        // The return's argument is the first named child, if any.
-        let mut cursor = node.walk();
-        for child in node.named_children(&mut cursor) {
-            if let Some((desc, _line)) = expression_taint(child, ctx, state) {
-                *return_taint = Some(desc);
-                break;
+
+    fn dispatch_summary_node(
+        node: Node<'_>,
+        ctx: &PyCtx<'_>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+        return_taint: &mut Option<String>,
+    ) {
+        // Dispatch the same handlers as the main walk.
+        Self::dispatch_walk_node(node, ctx, state, findings);
+        // Additionally check return statements.
+        if node.kind() == "return_statement" && return_taint.is_none() {
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if let Some((desc, _line)) = expression_taint(child, ctx, state) {
+                    *return_taint = Some(desc);
+                    break;
+                }
             }
         }
     }
 
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body_for_summary(child, ctx, state, findings, return_taint);
+    fn expression_taint(
+        expr: Node<'_>,
+        ctx: &PyCtx<'_>,
+        state: &TaintState,
+    ) -> Option<(String, usize)> {
+        expression_taint(expr, ctx, state)
+    }
+
+    fn seed_params(
+        func_node: Node<'_>,
+        ctx: &PyCtx<'_>,
+        state: &mut TaintState,
+    ) {
+        if let Some(params) = func_node.child_by_field_name("parameters") {
+            seed_param_sources(params, ctx.source, ctx.spec, state);
+        }
     }
 }
-
-// ─── Internals ────────────────────────────────────────────────────────────
 
 fn collect_function_defs<'tree, F>(node: Node<'tree>, visit: &mut F)
 where
@@ -564,25 +607,12 @@ where
     }
 }
 
-/// Taint metadata carried alongside a tainted variable: the human-readable
 fn analyze_function(
     func_node: Node<'_>,
     ctx: &PyCtx<'_>,
     findings: &mut Vec<TaintFinding>,
 ) {
-    let mut state = TaintState::default();
-
-    // Seed the state with any parameters marked as implicit sources.
-    if let Some(params) = func_node.child_by_field_name("parameters") {
-        seed_param_sources(params, ctx.source, ctx.spec, &mut state);
-    }
-
-    // Walk the body in source order, updating taint state at assignments
-    // and reporting flows at sink calls.
-    let Some(body) = func_node.child_by_field_name("body") else {
-        return;
-    };
-    walk_body(body, ctx, &mut state, findings);
+    analyze_function_generic::<PyTaintAdapter, _>(func_node, ctx, findings);
 }
 
 fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
@@ -617,59 +647,6 @@ fn seed_param_sources(params: Node<'_>, source: &str, spec: &TaintSpec, state: &
                 }
             }
         }
-    }
-}
-
-fn walk_body(
-    node: Node<'_>,
-    ctx: &PyCtx<'_>,
-    state: &mut TaintState,
-    findings: &mut Vec<TaintFinding>,
-) {
-    // Nested function definitions have their own scope. Skip them — they'll
-    // be picked up independently by analyze_tree.
-    if node.kind() == "function_definition" {
-        return;
-    }
-
-    if node.kind() == "assignment" {
-        handle_assignment(node, ctx, state);
-    }
-
-    // Walrus operator: `name := value` (named_expression). The `:=` both
-    // assigns and returns a value, so we need to track the binding.
-    if node.kind() == "named_expression" {
-        if let (Some(name), Some(value)) = (
-            node.child_by_field_name("name"),
-            node.child_by_field_name("value"),
-        ) {
-            if name.kind() == "identifier" {
-                let lhs = node_text(name, ctx.source).to_string();
-                if let Some((desc, src_line)) = expression_taint(value, ctx, state) {
-                    state.taint(lhs, desc, src_line);
-                } else {
-                    state.clear(&lhs);
-                }
-            }
-        }
-    }
-
-    if node.kind() == "call" {
-        handle_call(node, ctx, state, findings);
-    }
-
-    // `with` statement: `with expr as name: ...`
-    // If the context expression is tainted, the `as` target inherits taint.
-    if node.kind() == "with_statement" {
-        handle_with_statement(node, ctx, state);
-    }
-
-    // Tree-sitter's cursor walks in document order, which is exactly the
-    // "process statements in source order, unioning taint across branches"
-    // semantics the POC wants.
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_body(child, ctx, state, findings);
     }
 }
 

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -35,9 +35,8 @@ use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary};
 use crate::rules::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
     cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
-    push_attributed_findings, summarize_function_return_generic,
-    taint_finding_for_node, AnalysisContext, TaintLanguageAdapter,
-    TaintState,
+    push_attributed_findings, summarize_function_return_generic, taint_finding_for_node,
+    AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -328,11 +327,8 @@ fn summarize_function_return(
     let name = func_node
         .child_by_field_name("name")
         .map(|n| node_text(n, ctx.source).to_string());
-    let summary = summarize_function_return_generic::<PyTaintAdapter, _>(
-        func_node,
-        ctx,
-        collect_param_names,
-    );
+    let summary =
+        summarize_function_return_generic::<PyTaintAdapter, _>(func_node, ctx, collect_param_names);
     let name = name
         .map(|name| function_summary_key(&name, collect_param_names(func_node, ctx.source).len()));
     (name, summary)
@@ -410,11 +406,7 @@ impl<'a> TaintLanguageAdapter<CrossFileInfo<'a>> for PyTaintAdapter {
         expression_taint(expr, ctx, state)
     }
 
-    fn seed_params(
-        func_node: Node<'_>,
-        ctx: &PyCtx<'_>,
-        state: &mut TaintState,
-    ) {
+    fn seed_params(func_node: Node<'_>, ctx: &PyCtx<'_>, state: &mut TaintState) {
         if let Some(params) = func_node.child_by_field_name("parameters") {
             seed_param_sources(params, ctx.source, ctx.spec, state);
         }
@@ -434,11 +426,7 @@ where
     }
 }
 
-fn analyze_function(
-    func_node: Node<'_>,
-    ctx: &PyCtx<'_>,
-    findings: &mut Vec<TaintFinding>,
-) {
+fn analyze_function(func_node: Node<'_>, ctx: &PyCtx<'_>, findings: &mut Vec<TaintFinding>) {
     analyze_function_generic::<PyTaintAdapter, _>(func_node, ctx, findings);
 }
 

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -34,9 +34,9 @@ use crate::rules::common::AliasTable;
 use crate::rules::cross_file::{CrossFileSummaryMap, FunctionTaintSummary, ParamSinkFlow};
 use crate::rules::taint_engine::{
     analyze_function_generic, attribution_hint_for_sink, build_batched_taint_groups,
-    cross_file_taint_finding, match_call_sink, node_text, push_attributed_findings,
-    taint_finding_for_node, walk_body_for_summary_generic, AnalysisContext,
-    TaintLanguageAdapter, TaintState,
+    cross_file_taint_finding, extract_cross_file_summary_for_function, match_call_sink, node_text,
+    push_attributed_findings, taint_finding_for_node, walk_body_for_summary_generic,
+    AnalysisContext, TaintLanguageAdapter, TaintState,
 };
 pub use crate::rules::taint_engine::{
     BatchedRule, NodeMatcher, ReturnSummary, ReturnTaintSummary, RuleFilter, TaintFinding,
@@ -259,140 +259,19 @@ pub fn extract_cross_file_summaries(
             return;
         };
         let func_name = node_text(name_node, source).to_string();
-
-        // Collect parameter names in order.
         let param_names = collect_param_names(func_node, source);
-        if param_names.is_empty() {
-            return;
-        }
 
-        let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
-        let mut params_to_return: Vec<usize> = Vec::new();
-
-        // Partition rules: those without sanitizers can be batched into a
-        // single analyze_function call per parameter; rules with sanitizers
-        // must run individually to avoid incorrect taint clearing.
-        let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
-        let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
-        let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
-        for (rule_id, rule_spec) in rule_specs {
-            if rule_spec.sanitizers.is_empty() {
-                for sink in &rule_spec.sinks {
-                    sink_desc_to_rule.insert(sink.description(), rule_id);
-                    batched_sinks.push(sink.clone());
-                }
-            } else {
-                sanitizer_rules.push((rule_id, rule_spec));
-            }
-        }
-
-        let empty_summary = ReturnSummary::new();
-
-        // Pre-build reusable specs outside the per-param loop. Only the
-        // `sources` field changes per parameter; sinks and sanitizers are
-        // constant. This avoids cloning the entire sink/sanitizer vecs on
-        // every iteration.
-        let placeholder_source = NodeMatcher::ParamName {
-            names: vec![],
-            description: String::new(),
-        };
-        let mut return_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: vec![],
-            sanitizers: vec![],
-        };
-        let mut batched_spec = TaintSpec {
-            sources: vec![placeholder_source.clone()],
-            sinks: batched_sinks,
-            sanitizers: vec![],
-        };
-        let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
-            .iter()
-            .map(|(_, rule_spec)| TaintSpec {
-                sources: vec![placeholder_source.clone()],
-                sinks: rule_spec.sinks.clone(),
-                sanitizers: rule_spec.sanitizers.clone(),
-            })
-            .collect();
-
-        for (param_idx, param_name) in param_names.iter().enumerate() {
-            let synthetic_source = NodeMatcher::ParamName {
-                names: vec![param_name.clone()],
-                description: format!("parameter '{}'", param_name),
-            };
-
-            // Check return-taint: does this parameter flow to a return value?
-            return_spec.sources[0] = synthetic_source.clone();
-            let return_ctx = AnalysisContext {
+        if let Some(summary) =
+            extract_cross_file_summary_for_function::<PyTaintAdapter, CrossFileInfo<'_>>(
+                func_node,
+                &func_name,
+                &param_names,
                 source,
-                spec: &return_spec,
                 aliases,
-                summaries: &empty_summary,
-                cross_file: None,
-                sink_to_rules: None,
-            };
-            let (_, ret_taint) = summarize_function(func_node, &return_ctx);
-            if ret_taint.is_some() && !params_to_return.contains(&param_idx) {
-                params_to_return.push(param_idx);
-            }
-
-            let mut seen: HashSet<(usize, &str)> = HashSet::new();
-
-            // Batched pass: one call for all no-sanitizer rules.
-            if !batched_spec.sinks.is_empty() {
-                batched_spec.sources[0] = synthetic_source.clone();
-                let batched_ctx = AnalysisContext {
-                    source,
-                    spec: &batched_spec,
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &batched_ctx, &mut findings);
-                for f in &findings {
-                    if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
-                        if seen.insert((param_idx, rule_id)) {
-                            params_to_sink.push(ParamSinkFlow {
-                                param_index: param_idx,
-                                sink_rule_id: rule_id.to_string(),
-                                sink_description: f.sink_description.clone(),
-                            });
-                        }
-                    }
-                }
-            }
-
-            // Individual pass: rules with sanitizers run separately.
-            for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
-                sanitizer_specs[idx].sources[0] = synthetic_source.clone();
-                let sink_ctx = AnalysisContext {
-                    source,
-                    spec: &sanitizer_specs[idx],
-                    aliases,
-                    summaries: &empty_summary,
-                    cross_file: None,
-                    sink_to_rules: None,
-                };
-                let mut findings = Vec::new();
-                analyze_function(func_node, &sink_ctx, &mut findings);
-                if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
-                    params_to_sink.push(ParamSinkFlow {
-                        param_index: param_idx,
-                        sink_rule_id: rule_id.to_string(),
-                        sink_description: findings[0].sink_description.clone(),
-                    });
-                }
-            }
-        }
-
-        if !params_to_sink.is_empty() || !params_to_return.is_empty() {
-            summaries.push(FunctionTaintSummary {
-                name: func_name,
-                params_to_return,
-                params_to_sink,
-            });
+                rule_specs,
+            )
+        {
+            summaries.push(summary);
         }
     });
 

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -189,6 +189,119 @@ pub(super) struct AnalysisContext<'a, CF> {
     pub sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
 }
 
+// ─── Language adapter trait ──────────────────────────────────────────────
+
+/// Trait implemented by each language-specific taint engine.
+///
+/// Generic over `CF`, the language-specific cross-file info type.
+/// The generic walk/analyze functions call into this trait to dispatch to
+/// language-specific AST handling. Each language implements the trait on a
+/// zero-sized marker type (e.g. `JsTaintAdapter`, `PyTaintAdapter`,
+/// `GoTaintAdapter`) parameterized by its `CrossFileInfo`.
+pub(super) trait TaintLanguageAdapter<CF> {
+    /// Returns `true` if `kind` is a nested function scope that should be
+    /// skipped during the walk (each scope is analyzed independently).
+    fn is_nested_scope(kind: &str) -> bool;
+
+    /// Dispatch a single AST node to language-specific handlers during the
+    /// main analysis walk. Implementations should match on `node.kind()`
+    /// and call their assignment/declaration/call handlers as appropriate.
+    fn dispatch_walk_node(
+        node: Node<'_>,
+        ctx: &AnalysisContext<'_, CF>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+    );
+
+    /// Dispatch a single AST node during the summary walk (pass 1).
+    /// Same as `dispatch_walk_node` but also handles `return_statement`
+    /// for return-taint detection.
+    fn dispatch_summary_node(
+        node: Node<'_>,
+        ctx: &AnalysisContext<'_, CF>,
+        state: &mut TaintState,
+        findings: &mut Vec<TaintFinding>,
+        return_taint: &mut Option<String>,
+    );
+
+    /// Evaluate whether `expr` is tainted. Returns `(description, line)` or `None`.
+    fn expression_taint(
+        expr: Node<'_>,
+        ctx: &AnalysisContext<'_, CF>,
+        state: &TaintState,
+    ) -> Option<(String, usize)>;
+
+    /// Seed taint state from function parameters that match source matchers.
+    fn seed_params(
+        func_node: Node<'_>,
+        ctx: &AnalysisContext<'_, CF>,
+        state: &mut TaintState,
+    );
+
+    /// Get the function body node. Returns `None` if the function has no body.
+    fn get_body(func_node: Node<'_>) -> Option<Node<'_>> {
+        func_node.child_by_field_name("body")
+    }
+}
+
+// ─── Generic walk functions ─────────────────────────────────────────────
+
+/// Generic body walker for the main analysis pass (pass 2).
+///
+/// Skips nested scopes (as determined by `T::is_nested_scope`),
+/// dispatches to language-specific handlers, then recurses into children.
+pub(super) fn walk_body_generic<T: TaintLanguageAdapter<CF>, CF>(
+    node: Node<'_>,
+    ctx: &AnalysisContext<'_, CF>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+) {
+    if T::is_nested_scope(node.kind()) {
+        return;
+    }
+    T::dispatch_walk_node(node, ctx, state, findings);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_body_generic::<T, CF>(child, ctx, state, findings);
+    }
+}
+
+/// Generic body walker for the summary pass (pass 1).
+///
+/// Same as `walk_body_generic` but also detects return-taint.
+pub(super) fn walk_body_for_summary_generic<T: TaintLanguageAdapter<CF>, CF>(
+    node: Node<'_>,
+    ctx: &AnalysisContext<'_, CF>,
+    state: &mut TaintState,
+    findings: &mut Vec<TaintFinding>,
+    return_taint: &mut Option<String>,
+) {
+    if T::is_nested_scope(node.kind()) {
+        return;
+    }
+    T::dispatch_summary_node(node, ctx, state, findings, return_taint);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_body_for_summary_generic::<T, CF>(child, ctx, state, findings, return_taint);
+    }
+}
+
+/// Generic per-function analysis (pass 2).
+///
+/// Seeds parameter taint, gets the body, and walks it with the main walker.
+pub(super) fn analyze_function_generic<T: TaintLanguageAdapter<CF>, CF>(
+    func_node: Node<'_>,
+    ctx: &AnalysisContext<'_, CF>,
+    findings: &mut Vec<TaintFinding>,
+) {
+    let mut state = TaintState::default();
+    T::seed_params(func_node, ctx, &mut state);
+    let Some(body) = T::get_body(func_node) else {
+        return;
+    };
+    walk_body_generic::<T, CF>(body, ctx, &mut state, findings);
+}
+
 // ─── Utilities ───────────────────────────────────────────────────────────
 
 pub(super) fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -226,6 +226,7 @@ pub(super) trait TaintLanguageAdapter<CF> {
     );
 
     /// Evaluate whether `expr` is tainted. Returns `(description, line)` or `None`.
+    #[allow(dead_code)]
     fn expression_taint(
         expr: Node<'_>,
         ctx: &AnalysisContext<'_, CF>,
@@ -312,9 +313,7 @@ where
 {
     let mut state = TaintState::default();
     T::seed_params(func_node, ctx, &mut state);
-    let Some(body) = T::get_body(func_node) else {
-        return None;
-    };
+    let body = T::get_body(func_node)?;
     let mut scratch: Vec<TaintFinding> = Vec::new();
     let mut return_taint: Option<String> = None;
     walk_body_for_summary_generic::<T, CF>(body, ctx, &mut state, &mut scratch, &mut return_taint);

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -233,11 +233,7 @@ pub(super) trait TaintLanguageAdapter<CF> {
     ) -> Option<(String, usize)>;
 
     /// Seed taint state from function parameters that match source matchers.
-    fn seed_params(
-        func_node: Node<'_>,
-        ctx: &AnalysisContext<'_, CF>,
-        state: &mut TaintState,
-    );
+    fn seed_params(func_node: Node<'_>, ctx: &AnalysisContext<'_, CF>, state: &mut TaintState);
 
     /// Get the function body node. Returns `None` if the function has no body.
     fn get_body(func_node: Node<'_>) -> Option<Node<'_>> {

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -4,6 +4,7 @@
 //! `go_taint`) re-exports these types so existing consumers are
 //! unaffected.
 
+use crate::rules::cross_file::{FunctionTaintSummary, ParamSinkFlow};
 use std::collections::{HashMap, HashSet};
 use tree_sitter::Node;
 
@@ -300,6 +301,171 @@ pub(super) fn analyze_function_generic<T: TaintLanguageAdapter<CF>, CF>(
         return;
     };
     walk_body_generic::<T, CF>(body, ctx, &mut state, findings);
+}
+
+/// Extract cross-file taint summaries for a single function.
+///
+/// For each parameter, treat it as a synthetic taint source and test
+/// whether it flows to any sink (producing `ParamSinkFlow` entries) or
+/// to a return value (producing `params_to_return` entries).
+///
+/// This is the shared inner loop of `extract_cross_file_summaries` for
+/// JS, Python, and Go. Callers provide the function node, its name,
+/// its parameter names, rule specs, aliases, source, and the adapter type.
+pub(super) fn extract_cross_file_summary_for_function<T, CF>(
+    func_node: Node<'_>,
+    func_name: &str,
+    param_names: &[String],
+    source: &str,
+    aliases: Option<&super::common::AliasTable>,
+    rule_specs: &[(&str, TaintSpec)],
+) -> Option<FunctionTaintSummary>
+where
+    T: TaintLanguageAdapter<CF>,
+{
+    if param_names.is_empty() {
+        return None;
+    }
+
+    let mut params_to_sink: Vec<ParamSinkFlow> = Vec::new();
+    let mut params_to_return: Vec<usize> = Vec::new();
+
+    // Partition rules: those without sanitizers can be batched into a
+    // single analyze_function call per parameter; rules with sanitizers
+    // must run individually to avoid incorrect taint clearing.
+    let mut batched_sinks: Vec<NodeMatcher> = Vec::new();
+    let mut sink_desc_to_rule: HashMap<&str, &str> = HashMap::new();
+    let mut sanitizer_rules: Vec<(&str, &TaintSpec)> = Vec::new();
+    for (rule_id, rule_spec) in rule_specs {
+        if rule_spec.sanitizers.is_empty() {
+            for sink in &rule_spec.sinks {
+                sink_desc_to_rule.insert(sink.description(), rule_id);
+                batched_sinks.push(sink.clone());
+            }
+        } else {
+            sanitizer_rules.push((rule_id, rule_spec));
+        }
+    }
+
+    let empty_summary = ReturnSummary::new();
+
+    // Pre-build reusable specs outside the per-param loop.
+    let placeholder_source = NodeMatcher::ParamName {
+        names: vec![],
+        description: String::new(),
+    };
+    let mut return_spec = TaintSpec {
+        sources: vec![placeholder_source.clone()],
+        sinks: vec![],
+        sanitizers: vec![],
+    };
+    let mut batched_spec = TaintSpec {
+        sources: vec![placeholder_source.clone()],
+        sinks: batched_sinks,
+        sanitizers: vec![],
+    };
+    let mut sanitizer_specs: Vec<TaintSpec> = sanitizer_rules
+        .iter()
+        .map(|(_, rule_spec)| TaintSpec {
+            sources: vec![placeholder_source.clone()],
+            sinks: rule_spec.sinks.clone(),
+            sanitizers: rule_spec.sanitizers.clone(),
+        })
+        .collect();
+
+    for (param_idx, param_name) in param_names.iter().enumerate() {
+        let synthetic_source = NodeMatcher::ParamName {
+            names: vec![param_name.clone()],
+            description: format!("parameter '{}'", param_name),
+        };
+
+        // Check return-taint: does this parameter flow to a return value?
+        return_spec.sources[0] = synthetic_source.clone();
+        let return_ctx = AnalysisContext {
+            source,
+            spec: &return_spec,
+            aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rules: None,
+        };
+        let mut return_findings = Vec::new();
+        let mut return_state = TaintState::default();
+        T::seed_params(func_node, &return_ctx, &mut return_state);
+        if let Some(body) = T::get_body(func_node) {
+            let mut return_taint: Option<String> = None;
+            walk_body_for_summary_generic::<T, CF>(
+                body,
+                &return_ctx,
+                &mut return_state,
+                &mut return_findings,
+                &mut return_taint,
+            );
+            if return_taint.is_some() && !params_to_return.contains(&param_idx) {
+                params_to_return.push(param_idx);
+            }
+        }
+
+        let mut seen: HashSet<(usize, &str)> = HashSet::new();
+
+        // Batched pass: one call for all no-sanitizer rules.
+        if !batched_spec.sinks.is_empty() {
+            batched_spec.sources[0] = synthetic_source.clone();
+            let batched_ctx = AnalysisContext {
+                source,
+                spec: &batched_spec,
+                aliases,
+                summaries: &empty_summary,
+                cross_file: None,
+                sink_to_rules: None,
+            };
+            let mut findings = Vec::new();
+            analyze_function_generic::<T, CF>(func_node, &batched_ctx, &mut findings);
+            for f in &findings {
+                if let Some(&rule_id) = sink_desc_to_rule.get(f.sink_description.as_str()) {
+                    if seen.insert((param_idx, rule_id)) {
+                        params_to_sink.push(ParamSinkFlow {
+                            param_index: param_idx,
+                            sink_rule_id: rule_id.to_string(),
+                            sink_description: f.sink_description.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Individual pass: rules with sanitizers run separately.
+        for (idx, (rule_id, _)) in sanitizer_rules.iter().enumerate() {
+            sanitizer_specs[idx].sources[0] = synthetic_source.clone();
+            let sink_ctx = AnalysisContext {
+                source,
+                spec: &sanitizer_specs[idx],
+                aliases,
+                summaries: &empty_summary,
+                cross_file: None,
+                sink_to_rules: None,
+            };
+            let mut findings = Vec::new();
+            analyze_function_generic::<T, CF>(func_node, &sink_ctx, &mut findings);
+            if !findings.is_empty() && seen.insert((param_idx, rule_id)) {
+                params_to_sink.push(ParamSinkFlow {
+                    param_index: param_idx,
+                    sink_rule_id: rule_id.to_string(),
+                    sink_description: findings[0].sink_description.clone(),
+                });
+            }
+        }
+    }
+
+    if params_to_sink.is_empty() && params_to_return.is_empty() {
+        return None;
+    }
+
+    Some(FunctionTaintSummary {
+        name: func_name.to_string(),
+        params_to_return,
+        params_to_sink,
+    })
 }
 
 // ─── Utilities ───────────────────────────────────────────────────────────

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -303,6 +303,77 @@ pub(super) fn analyze_function_generic<T: TaintLanguageAdapter<CF>, CF>(
     walk_body_generic::<T, CF>(body, ctx, &mut state, findings);
 }
 
+/// Generic pass-1 summarizer: seed params, walk body, detect return taint.
+///
+/// Returns `Option<String>` -- the first tainted return expression's
+/// description, or `None` if the function returns clean.
+pub(super) fn summarize_function_generic<T, CF>(
+    func_node: Node<'_>,
+    ctx: &AnalysisContext<'_, CF>,
+) -> Option<String>
+where
+    T: TaintLanguageAdapter<CF>,
+{
+    let mut state = TaintState::default();
+    T::seed_params(func_node, ctx, &mut state);
+    let Some(body) = T::get_body(func_node) else {
+        return None;
+    };
+    let mut scratch: Vec<TaintFinding> = Vec::new();
+    let mut return_taint: Option<String> = None;
+    walk_body_for_summary_generic::<T, CF>(body, ctx, &mut state, &mut scratch, &mut return_taint);
+    return_taint
+}
+
+/// Generic return-taint summary builder.
+///
+/// Computes:
+/// 1. `direct_source`: does the function body contain a tainted return
+///    independent of caller arguments?
+/// 2. `params_to_return`: which parameter indices flow to a return value?
+pub(super) fn summarize_function_return_generic<T, CF>(
+    func_node: Node<'_>,
+    ctx: &AnalysisContext<'_, CF>,
+    collect_param_names: impl Fn(Node<'_>, &str) -> Vec<String>,
+) -> ReturnTaintSummary
+where
+    T: TaintLanguageAdapter<CF>,
+{
+    let direct_source = summarize_function_generic::<T, CF>(func_node, ctx);
+    let mut summary = ReturnTaintSummary {
+        direct_source,
+        params_to_return: Vec::new(),
+    };
+
+    let empty_summary = ReturnSummary::new();
+    for (param_idx, param_name) in collect_param_names(func_node, ctx.source)
+        .into_iter()
+        .enumerate()
+    {
+        let synthetic_spec = TaintSpec {
+            sources: vec![NodeMatcher::ParamName {
+                names: vec![param_name.clone()],
+                description: format!("parameter '{}'", param_name),
+            }],
+            sinks: vec![],
+            sanitizers: ctx.spec.sanitizers.clone(),
+        };
+        let param_ctx = AnalysisContext {
+            source: ctx.source,
+            spec: &synthetic_spec,
+            aliases: ctx.aliases,
+            summaries: &empty_summary,
+            cross_file: None,
+            sink_to_rules: None,
+        };
+        if summarize_function_generic::<T, CF>(func_node, &param_ctx).is_some() {
+            summary.params_to_return.push(param_idx);
+        }
+    }
+
+    summary
+}
+
 /// Extract cross-file taint summaries for a single function.
 ///
 /// For each parameter, treat it as a synthetic taint source and test

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -169,6 +169,26 @@ impl TaintState {
     }
 }
 
+/// Bundles the read-only context that every internal walker needs,
+/// replacing the repeated `(source, spec, aliases, summaries)` tuple.
+///
+/// Generic over `CF`, the language-specific cross-file info type:
+/// - JS/TS: `javascript_taint::CrossFileInfo`
+/// - Python: `python_taint::CrossFileInfo`
+/// - Go:    `go_taint::CrossFileInfo`
+pub(super) struct AnalysisContext<'a, CF> {
+    pub source: &'a str,
+    pub spec: &'a TaintSpec,
+    pub aliases: Option<&'a super::common::AliasTable>,
+    pub summaries: &'a ReturnSummary,
+    /// Cross-file info for resolving imported / same-package function calls.
+    pub cross_file: Option<&'a CF>,
+    /// When the batched analyzer merges sinks from multiple rules into a
+    /// single `TaintSpec`, this map attributes each matched sink back to
+    /// its owning rule id. `None` in single-rule mode.
+    pub sink_to_rules: Option<&'a HashMap<String, Vec<String>>>,
+}
+
 // ─── Utilities ───────────────────────────────────────────────────────────
 
 pub(super) fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {


### PR DESCRIPTION
## Summary
- Extracts shared taint engine loop into generic functions in `taint_engine.rs`
- Defines `TaintLanguageAdapter<CF>` trait with 6 methods that JS/Python/Go each implement
- Moves `AnalysisContext` to shared module with generic `CrossFileInfo` parameter
- Extracts `walk_body_generic`, `analyze_function_generic`, `summarize_function_generic`, `summarize_function_return_generic`, `walk_body_for_summary_generic`, `extract_cross_file_summary_for_function`
- Net -172 lines; bug fixes to the engine loop now land in one place
- Kotlin taint engine left unchanged (different architecture)

Closes #380

## Test plan
- [x] All 695 tests pass (473 unit + 222 integration)
- [ ] Verify Semgrep parity tests still pass
- [ ] Run a real scan on a test target to confirm behavioral equivalence

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated taint analysis engine implementations across Go, JavaScript/TypeScript, and Python by introducing a shared generic infrastructure layer, reducing code duplication and improving maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->