### PR TITLE
chore(gitignore): ignore local togi mutation-test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ benchmarks/results*.md
 assets/terminalizer/
 assets/foxguard-terminalizer*.gif
 www/public/foxguard-logo.png
+
+# Local togi mutation-test artifacts
+.togi-cache/
+.togi.lock
+togi.toml


### PR DESCRIPTION
## Summary
- Adds `.togi-cache/`, `.togi.lock`, and `togi.toml` to `.gitignore` so local mutation-testing runs no longer pollute `git status`.
- Togi has no CI integration in this repo, so all three artifacts are local-only and should not be tracked.

Closes #409

## Test plan
- [ ] Run `togi` locally (if installed) and confirm `git status` stays clean afterward.
- [ ] Verify no existing tracked files are affected (`git ls-files` shows no togi entries).

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude testing-related artifacts from version control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->