### PR TITLE
fix(secrets): scan hidden files like .env in secrets mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -742,7 +742,7 @@ fn count_secret_files(scan_path: &Path) -> usize {
     }
 
     ignore::WalkBuilder::new(scan_path)
-        .hidden(true)
+        .hidden(false)
         .git_ignore(true)
         .build()
         .filter_map(|entry| entry.ok())

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -191,7 +191,7 @@ pub fn scan_directory_with_config_and_notices(
         vec![root_path.to_path_buf()]
     } else {
         WalkBuilder::new(root)
-            .hidden(true)
+            .hidden(false)
             .git_ignore(true)
             .build()
             .filter_map(|entry| entry.ok())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3865,6 +3865,35 @@ rules:
     }
 
     #[test]
+    fn test_secrets_mode_scans_hidden_files() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_secret_file(repo.path(), ".env");
+
+        let output = foxguard_cmd()
+            .args([
+                "secrets",
+                repo.path().to_str().expect("non-utf8 path"),
+                "-f",
+                "json",
+            ])
+            .output()
+            .expect("failed to execute foxguard secrets");
+
+        assert!(
+            !output.status.success(),
+            "secrets in hidden .env file should produce findings"
+        );
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f["file"].as_str().unwrap_or_default().ends_with(".env")),
+            "expected at least one finding from .env file, got: {findings:?}"
+        );
+    }
+
+    #[test]
     fn test_secrets_mode_ignore_rule_skips_specific_patterns() {
         let repo = TempDir::new().expect("failed to create temp dir");
         write_secrets_fixture(repo.path());


### PR DESCRIPTION
## Summary
- **Fixes** the directory walker in secrets mode which used `.hidden(true)`, causing it to skip hidden files like `.env` — one of the highest-value targets for secret scanning.
- Changed `.hidden(true)` to `.hidden(false)` in both `src/secrets.rs` (scanner walker) and `src/app.rs` (file counter) so hidden files are now included.
- `.gitignore` rules and explicit `--exclude-path` flags continue to be respected for noise control.
- Added integration test `test_secrets_mode_scans_hidden_files` that creates a `.env` file with a known secret and verifies it is detected.

Closes #401

## Test plan
- [x] New integration test `test_secrets_mode_scans_hidden_files` passes
- [x] Full test suite passes (`cargo test --all-features`)
- [ ] Manual: run `foxguard secrets` on a repo with a `.env` file and confirm findings are reported

none