### PR TITLE
perf(rules): hoist static regexes to OnceLock statics

### DIFF
--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -8,112 +8,190 @@
       "line": 36
     },
     {
-      "fingerprint": "2a582db88f349f787141431679c6118920e5675ddafcfb543e119499899f77ab",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 71
+      "fingerprint": "019fc5cea1d33056d86f604fe21791816648da00392cacc2af37c92a6d19f012",
+      "rule_id": "py/no-command-injection",
+      "file": "./benchmarks/parity/parity.py",
+      "line": 386
     },
     {
-      "fingerprint": "529085b439fb25207175fe87b9d5035d28740e936bc285acdb454a62d3410a13",
+      "fingerprint": "53be29858a62396a2f4b3de998950bd3738aea5a5ddb60553d0b8b5330311576",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 78
+      "line": 74
     },
     {
-      "fingerprint": "a1f32ac359f47a7a1a756ef599761a2cff007ed607f514af12cb3f7d16b19011",
+      "fingerprint": "d9fd343536591d1c5b1d7d5b7fb74a74c487d9a3510770589d95e2277b672268",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 94
+      "line": 81
     },
     {
-      "fingerprint": "211d43675e5af86f6a802118eed2e4916cdbb27dc130d40bb98c2369001eba75",
+      "fingerprint": "719134e5400b669c776cec249587dfd2561b8d35fc12082d3cc864ea4531a28e",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 139
+      "line": 111
     },
     {
-      "fingerprint": "7431c5014318b158907f22e56d9bc5936ec810c35f0735b2938378e06954d2fd",
+      "fingerprint": "6f5d7ff55ae29f677d7f719aa91af4d31259f999ba0c0910794f4f60c122f59b",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 198
+      "line": 114
     },
     {
-      "fingerprint": "9e380ebf09a5be84b13d8705e1fe53ba395566266e3f498b9706c49f60442740",
+      "fingerprint": "8211afcb787bec135464d53a130c1c1f6b386afeab36953c9afea5b7f03bf0bc",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 203
+      "line": 123
     },
     {
-      "fingerprint": "8e7f34f79d045509a46aa2115632df621d8ba6ec76d751e7bbfc5888c763623c",
+      "fingerprint": "47e4937c89a8e5b9e16559fe67278cbae1a2fc5ca291cc6825029aca957da8cc",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 229
+      "line": 127
     },
     {
-      "fingerprint": "04c1f1f1e9ba96001d8a35776c8f3aacafd527ac79e857a1137f4afc172ad985",
+      "fingerprint": "eb327a4137d65f3c19d23f7d707788548547a8f017211d9c961e10c3661ba36d",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 260
+      "line": 182
     },
     {
-      "fingerprint": "f238a7c797b85ce16494165ed83d9c03b74749cf66520c07e0e974fc2f6e6f9e",
+      "fingerprint": "316cdb60585599a8850997d83df3922147130af0f0aca7e97e480ba32cf995b6",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 265
+      "line": 218
     },
     {
-      "fingerprint": "f9308fc18fef84a889b6d6ed0227d371ed0985c2ad7c388fc56bbe05c417cc4e",
+      "fingerprint": "43c24b7023a0e2a12409d6c5e8364b70612c133f4fb68851d5e431bf6e53a152",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 281
+      "line": 226
     },
     {
-      "fingerprint": "51f8508062a2b055a9c21216a61af6e8311130688110a4bcb0422c6c25fcb9ae",
+      "fingerprint": "35f3ac989962c8c99467e7049d25e330c9bd16afb8b2c510e4b4a3db2d0c7a01",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 467
+      "line": 248
     },
     {
-      "fingerprint": "9ed304f5a4ca5c5d3859acf005410e8ceefb7731f92c9b808104640f1400cb2b",
+      "fingerprint": "8d89e132f85ec9a4118e7e0ba393ea2ed7791641b09e6c3c709ab527c2c845c9",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 477
+      "line": 295
     },
     {
-      "fingerprint": "038c945c475524ecd7861409425472f0e05d20ec002adb9d3c5e037e82d15a3e",
+      "fingerprint": "bb30619cefea91460ed1ad8b4bca7a8d8a944f2360f0fe5586987a04bbe5f5ea",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 485
+      "line": 300
     },
     {
-      "fingerprint": "3a983db15edfeace37e99946d33cdf4e5d13d5174c8ff87906503165ca26988d",
+      "fingerprint": "ff2fed6862f21ee241e2c08cfefa1bf1b929b56be3da155d49c3e929b10a9633",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/app.rs",
-      "line": 506
+      "line": 333
     },
     {
-      "fingerprint": "4413510ce9a29f103d3a322bb5d4236c995ddc465accb59e683d3703b0d3874c",
+      "fingerprint": "f7eb077a2ec8f0a3650d65167d84647c7e8766e74c8e3201cbba218f9dace766",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 334
+    },
+    {
+      "fingerprint": "b11d72619c56700f37094728c2ef7c47a86bcdec5072bb58e71177266ed6ecc2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 337
+    },
+    {
+      "fingerprint": "638ff22d664033f5faa5dde62c13101676318ae5e353dff8101fa79e7c02a196",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 368
+    },
+    {
+      "fingerprint": "a2ba3d1c30b0a463e194b259c2324b286d12e48edff4d2e0fddeb6ec27c5deaa",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 373
+    },
+    {
+      "fingerprint": "e03218dee09a24e89589371d11e30d14cf8afce155c4a586e904fa810fca49be",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 389
+    },
+    {
+      "fingerprint": "0a9fa4ceb8b9454eeef2f2ec55e0cdc7bfcd3e46a02676bfea79575f93ab7d74",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 390
+    },
+    {
+      "fingerprint": "c699d1ff098b00f876ee1053358ee771aa708f618e7d2e4a4163923fe396974d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 407
+    },
+    {
+      "fingerprint": "5a20c48a2a229a6c0ba1b8066431ead348f217bffe63a693bb8516f07811db03",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 691
+    },
+    {
+      "fingerprint": "464b2a44e09f3c9b86a3d3ca1a45d9ae5912d023241f41d64ac78e9ebb1b35ac",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 701
+    },
+    {
+      "fingerprint": "aa5da5fbb6412d5c3cda9d9d343e176c56e0d71ca0c2870351eb4c1aaeb38aa5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 709
+    },
+    {
+      "fingerprint": "5c1c624463ca2b01f2d4a4f0b0ee7f8f068377b10345089950c05dedf41c55c6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/app.rs",
+      "line": 733
+    },
+    {
+      "fingerprint": "a6375cbdbd5cbba53415d3e770a783cde01bed49815174cd5043206f579285ae",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/baseline.rs",
-      "line": 185
+      "line": 283
     },
     {
-      "fingerprint": "a0fbaca8aaa31c3757d790d868bda125f68980ba4855aa736be219dc545af3d0",
+      "fingerprint": "29cc2e1fe4c490fa72200d67522d28e416f37a7c359e4b49935f9a1d36ce9fef",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/baseline.rs",
-      "line": 194
+      "line": 292
     },
     {
-      "fingerprint": "37f35720a97b3d6f968a4859db706b0ff3f9ce29d3bbab40745473bd86f6c0d4",
+      "fingerprint": "2a7ce3ec116c39712fffea815738fb702ffaf904f40cea403e229e90398ad897",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/baseline.rs",
-      "line": 194
+      "line": 292
     },
     {
-      "fingerprint": "5d72f04be86542e999521bff866403a140c4b24ac73c494dfece0714b0b84a33",
+      "fingerprint": "88455cee0fd75ad67d3853e90fcced358838a55b5633d73754a7c93e70351e8f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/baseline.rs",
-      "line": 219
+      "line": 317
+    },
+    {
+      "fingerprint": "c9c79d3aea84968de8434417f1ef2ba55a7dda79032960ae75859edc44bce086",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/bin/foxguard_github_app.rs",
+      "line": 1037
+    },
+    {
+      "fingerprint": "f4a983952a195ecc73b7edd86a5ee3c9b05eab89fc975cb50b083ee1aeaf6427",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/bin/foxguard_github_app.rs",
+      "line": 1081
     },
     {
       "fingerprint": "ba86c559eff463a1bfba7e82a8792af7f8bc70dca6c8f6fa692cc27bf771f002",
@@ -128,166 +206,190 @@
       "line": 168
     },
     {
-      "fingerprint": "bd6fd6b5a85ac5a912093c47881706394700c797a7b6f118c947f9233ab66a69",
+      "fingerprint": "6a8e9b5592e678759ab14934f0a1721ac626f3b306705be551bb2e08a6ef5b4b",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/config.rs",
-      "line": 457
+      "line": 463
     },
     {
-      "fingerprint": "22f6c124120e6598103c08206068f81118e803a44fdf21cf9a599e37f554b450",
+      "fingerprint": "cba5c7136b5b982c18ece49edb03741293120412dbbf5511e18c72b9b1aba391",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/config.rs",
-      "line": 474
+      "line": 911
     },
     {
-      "fingerprint": "c6c80340dcb431a71eecbf3f026a0c1c58404e82978f4ec9dbd0f6d2bd9ea06e",
+      "fingerprint": "6ce4ad2d8afc368e382b897e2a1183ece52511cafc809bdb74f2dbc8728bd755",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/config.rs",
-      "line": 908
+      "line": 948
     },
     {
-      "fingerprint": "69132d933ed844d58da3cc9d581c67b331ce587463096f1cf395e8e1e9cb69c4",
+      "fingerprint": "0621a3b8015655b666ea28849daaa10ac207fc0ca0f94fbd3123a94cca27a414",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/config.rs",
-      "line": 945
+      "line": 949
     },
     {
-      "fingerprint": "400ea6a6d4d8b0a99d4fb1dc92b648436c23b472f76b5a0053f9895ea6ed770a",
-      "rule_id": "rs/no-path-traversal",
+      "fingerprint": "f5854874b779735acd5376a8fa8499e3f84723b4ec7944c43bd70c1b213c21e5",
+      "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 946
+      "line": 990
     },
     {
-      "fingerprint": "48b4b81c4aecd319ea2bad382d32abff8af5cd0c64ba2dfb4a4d262c2214338a",
-      "rule_id": "rs/no-path-traversal",
+      "fingerprint": "5e83f6b5aaea585a7d98be0057eed08b0975d53f8763314b4ac6351b07280661",
+      "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1009
+      "line": 992
     },
     {
-      "fingerprint": "8212fa642d116798a52f8e726bff0362c28220a6e9c6d3ab430cddb80dcdec23",
+      "fingerprint": "ebb74ffa8b47a7805ecbf6bb0c275ee2c1aab1dbb7f185113166d65321acc507",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1026
+    },
+    {
+      "fingerprint": "f57ba72b98c8abebf4dd0bbf3d564e96c066796ed0e6aaf7cb863b29f350a96a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1044
+    },
+    {
+      "fingerprint": "097dffce2427b23ef430d4fc2d37a871fe724b6689d903b4428e590068ba7ec5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1045
+    },
+    {
+      "fingerprint": "9ddc75d3b90e826ae2f40b6c13b376bab15c138a6cac2d426001161029989feb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
       "line": 1047
     },
     {
-      "fingerprint": "b47537cf3266c89c02cf719ba5806786728e3bfce4392b79798a8d61e0997b60",
+      "fingerprint": "d61fe0876d1fe74fdd68b557592d4a2b193d44fafbb96d1c63ad72454bbdc660",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1049
+      "line": 1063
     },
     {
-      "fingerprint": "0e305919346214352f2cb10be6edc9f4511620e1abd7286ff8aa31124d2f9331",
+      "fingerprint": "3b7adec2b449c328dd5db1f70ae0f42a241f448602e254b11a82a5f48194125f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1055
+      "line": 1064
     },
     {
-      "fingerprint": "5fb59360233a4d875ce81164ba6a77d93cee70f315cd3c8e59808e673c0fc178",
+      "fingerprint": "07bf0e26da2b07738924777eb1bb96c6a904acbb19b34ff5324fac3758235da8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1073
+      "line": 1066
     },
     {
-      "fingerprint": "97c6fc3ed2b049f56150d8c74640d1a09b446cd32ae0796d569528d8af6c11e4",
+      "fingerprint": "439f2490efcf16e8794870129a3091adf0a5d72c64165e08bf3867348a2b7000",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1074
+      "line": 1067
     },
     {
-      "fingerprint": "aad257096dd0b8ba159641db1afd1a673b91a2153e1e7b59bb67ac012163195a",
+      "fingerprint": "88604b0835795c18c7d6f852733bf5940fcc879774c50fb40bbd4b72f0459ab2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1076
+      "line": 1083
     },
     {
-      "fingerprint": "83463432f569bf840b87603d39690756dc7054d5f9511ca861dac2625d1d1daa",
+      "fingerprint": "f9e092492e1ca8b6e4c4570dcb2d0bd239abee1b1125bd657ef046cf82904e14",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1092
+      "line": 1084
     },
     {
-      "fingerprint": "dd3f1741f1c67154725e61c8f1d3d25125fbe255595a6431add7c37fe4b28d7d",
+      "fingerprint": "3f366dc702cd44ecb6cd06b21878558748e72688d03def8bef9b37c4f7dfaca6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1093
+      "line": 1091
     },
     {
-      "fingerprint": "be77ae9fc8a7628087e6d2c4eee9cf72c748c2fe927b036192ff2234d70c83a9",
+      "fingerprint": "8bfea5e457ec20c96e5b9e6f8e9b16f3a9f0b45afaf6e2598f9363c81aff9176",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1095
+      "line": 1091
     },
     {
-      "fingerprint": "f426ef7d9c2dd1e91079cfad3dbdaa1744772935c7667366503f523eab39b862",
+      "fingerprint": "5ba5be7e7c71d477f644e492a4a4052b00ba103d80b5614bda41c2c0c7f99261",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1096
+      "line": 1091
     },
     {
-      "fingerprint": "685bd785f1603f7ca70f62f3e33d6ddcd9f6b4e44ed881027ae24929b432abfd",
+      "fingerprint": "5d0ef69c5f4cbe65286b0afcc4805a14be7b9cf43db18b4187eab5bace9414b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1105
+    },
+    {
+      "fingerprint": "a6be5cd52850cac5cd712c7686687d60fbb4738f1d60afa9fdbf7074ce3247db",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
       "line": 1112
     },
     {
-      "fingerprint": "1972a1c64c347c8d21aab0daacb272a69303f5950a5fd0360a1f9869dd34036f",
+      "fingerprint": "dd33e0999b25b98fbfa657097de45490f008117d37edabefb1422d7925c8c142",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1113
+      "line": 1112
     },
     {
-      "fingerprint": "1eb85b91bd04aa8bc8b1cae0e1556fbbd693ab65d0db29d1d99e8dceb3b460ed",
+      "fingerprint": "bc5aef0558da2ff0e8f2d4765d933a620cf811264ba5899ede2f611799c83ce4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1120
+      "line": 1125
     },
     {
-      "fingerprint": "93c3ca9da83d8631261942066016ea97a6ffffa1395254b5e32c2835691ceef0",
+      "fingerprint": "4d20f152a119ca341b44d587fbb6b53d5df47330643e29561955d601aecf9ad4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1120
+      "line": 1128
     },
     {
-      "fingerprint": "5f52af10d5fe55f01dc9a76335cfcc4dcec79f1e669b45979038bfabcab14473",
+      "fingerprint": "6167adea82c5a47fb5c51ce8a6af096498aea82a0294dc842d7de451cdf3b92e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1120
+      "line": 1128
     },
     {
-      "fingerprint": "ea2a2c762137d433c74ea859989a3e6cf9bc16e679e91c6f2589607b68d5d031",
+      "fingerprint": "3b3ffadaa406d177ef0ff6e15247838f9875450567ded290fa9ec1a37161f37e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1133
+      "line": 1141
     },
     {
-      "fingerprint": "135c4a02f2a8ad57730d783287f7ffae2b7d50dce2283d930823e997028073e6",
+      "fingerprint": "aba48a76a1a00b28c6f7fe6e7a090a3e88e85590d5a07121325b0843564935f9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1140
+      "line": 1148
     },
     {
-      "fingerprint": "ab877079ef292d891e54465bc19e2d6af7d4ec16aba0b87e543f3c22494e88f6",
+      "fingerprint": "71a9ed2e0c888958a8b5740abd388910330e9a426819e4215da2ff8b69f82ae6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1140
+      "line": 1148
     },
     {
-      "fingerprint": "63b3cb41c18cb59e827ba9bb771aa779e5a58ed004dbacfa42cbd51efd21aff8",
+      "fingerprint": "a78606ca8deca620139f259358c097790523aaf83ba35da2e4cb94a017920476",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1153
+      "line": 1157
     },
     {
-      "fingerprint": "c770843b5a5c83f2dab5576df195f8414edad72f619b0b2cf4da5148ec28f6a0",
+      "fingerprint": "7bd044602c90f223c76b078463de66f2dd2821cd97b91593d763a123c0f8f83e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1156
+      "line": 1160
     },
     {
-      "fingerprint": "383f70d1d26963669efe54974003c0e36466e92edc07367541f02e1f4c2bb20a",
+      "fingerprint": "4c7cd6350dce5edda52c9028d55d377d4117cde7acb7d7d7f7eef72615582875",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1156
+      "line": 1160
     },
     {
       "fingerprint": "08bff8d2c0a43cd014adfa786eef74e5d0e112c52323cf6141a3ecd592c212b4",
@@ -308,430 +410,436 @@
       "line": 1176
     },
     {
-      "fingerprint": "dfa4cedb98e4c82dda747e258580a6c7f0f748fb32c94973caaa8b1241b91cb7",
+      "fingerprint": "9c0ab59fd99da2a90092613c18f0a67befc6b058e71860486b3341bd44d5d34d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1185
+      "line": 1189
     },
     {
-      "fingerprint": "8f2e0d91daf11ac2065c26f5fa4a4de109a5401ca92477ce4bb0c347194bab62",
+      "fingerprint": "5d3371be89277723356e5c978a53f8d397340b66cf099fb8a005a3d045294b75",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1188
+      "line": 1193
     },
     {
-      "fingerprint": "b2c286bc5c71248d3bb873ec1b320a9268a60c71d7c1d26676113ce415453dcd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1188
-    },
-    {
-      "fingerprint": "1e7918a378668dd230d209ea66bc6c14a01390c01f982f20af5c53414afb592f",
+      "fingerprint": "a7b8855787b4a4c826ab916b2387c856649ac928c23a3b520fb39cbbd12bd640",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
       "line": 1197
     },
     {
-      "fingerprint": "50c5a4c83f5671281f34e5dab18146005fbedd5c84989864fab60d5c2ca63e03",
+      "fingerprint": "c2060b6ba5b99337076cc435d562c2f40bcb1d8f3682b045ead78f0a8c0a9363",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1204
+      "line": 1197
     },
     {
-      "fingerprint": "8620988f344a6c5348b3620473de14ade37eabab626e5b7fc6e3128ae94e70e5",
+      "fingerprint": "e4b386b089f140ce5db39bf03a2bc5f9f2c3b3943e3c7e44a9ca150d91465138",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1204
+      "line": 1207
     },
     {
-      "fingerprint": "17a69b3bd6ceae73cdfa68ee6ec1674b117cfb240bca2e579db62a79cdcc462c",
+      "fingerprint": "abfb20e10ce518c120516f8edcec0806de116cb081e932701e6fd391be70ecd7",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1217
+      "line": 1213
     },
     {
-      "fingerprint": "50da19348a7d049875df3f9328343ade97ae7ee32b63c3d0c780c442d29581c7",
+      "fingerprint": "b296594c5508876f7ef38bf8626766d4a812524978b02c6708451751f8fb7bba",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1245
+      "line": 1226
     },
     {
-      "fingerprint": "0b4eefd16713d9c03f9a08b76c38a852f8f924c8aa8d0635631624fe3c538891",
+      "fingerprint": "d7f7bcb8f13b7856941aade041fdfbf7de333bfea8d178f38113b6dfaaaa4772",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1249
+      "line": 1230
     },
     {
-      "fingerprint": "b41019a7558ab2792c6ac50df0824833fa65890ed8dd6d5e1833093891073d6a",
+      "fingerprint": "74e327340795b53d86777b19e5dace805a3895838aff276f5a179795df3a9ae1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1249
+      "line": 1231
     },
     {
-      "fingerprint": "fff034a4a4f2a18b35b6d88305c011a532b17f24e082f5ce9ed45c2565cc8227",
+      "fingerprint": "7dc8176b0b100e6bd16084cc4436dca8b4fa2ddce235f367311a8bee7e6cfad2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1232
+    },
+    {
+      "fingerprint": "31d3def95832a47b84ffa3700e7cf51c3e6020dace3c7b8a5083bdc4808e6739",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1242
+    },
+    {
+      "fingerprint": "c4fc2ed17046b86cb66ea6310d2cd059d4bea6520754e7fcc95c9f98ee5d259f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1256
+    },
+    {
+      "fingerprint": "a2b48faf389c2659f13de31f9c721481f5f72496d860225278faaf3716716136",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
       "line": 1259
     },
     {
-      "fingerprint": "dbbd2962524365d83ce3ccd140f0a9f4c66040c470652d222f39eee2283172fd",
+      "fingerprint": "30d2133c2ed42670df0f116a1519fc72e2afbdf18f5ff11b6a18e6aad790ea5d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1265
+      "line": 1264
     },
     {
-      "fingerprint": "a12c3c66c0805a5d48e96b53d9af403bfa0ddd1552919839a3fd590a2f1c699c",
+      "fingerprint": "ab4fa611b8d36302e2fb72ec94ecf2c6e4a6cd1b881916f3008b9ce1ff956231",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1268
+      "line": 1264
     },
     {
-      "fingerprint": "31d5b3c567af035fb54d374f862ea953a986e347ce6f7c0c03ee3a4e2b7cbfe3",
+      "fingerprint": "9d779e0ca1a65be9d7d39fd234fd61f919e0f7c2d5daf8daaaf6c3c31a4925f1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1273
+      "line": 1269
     },
     {
-      "fingerprint": "eb86725149359042b80120333b7cc3d8865e37e47685173dfd5c57c9178ffff2",
+      "fingerprint": "2b39fb31d7dc10c609eeb779ad61366d153a542ec6ac198711f201b305193979",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1273
+      "line": 1304
     },
     {
-      "fingerprint": "510d7506d27a32d2f834008b1c9945f9492e584d31451242bb16faafefd32aaf",
+      "fingerprint": "2456e2d3425d0d49d276ea5efbc2088ec63f2ba31391beb9d3d700493c8074fb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1278
+      "line": 1310
     },
     {
-      "fingerprint": "b5c364fa0d6b8d82d9e7d1dcb48ec34e23d94d1b07da88a06652e19d31dec2ac",
+      "fingerprint": "9e550c45c46c09e3a114e6a29ace646727bf21c9331a6e0ff02e4f81690b8c7e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1313
+      "line": 1310
     },
     {
-      "fingerprint": "722d79ac701d9b13e384eaf87a4b5dd5ce252c5c371a28d911eea3f7fd9a0d30",
+      "fingerprint": "96033cbbebd59cf03dfcfffeadcb29caef078b6e9349d6da70cbe7732ef7e624",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1319
+      "line": 1336
     },
     {
-      "fingerprint": "a122f780d64f74e2fbf7a91cf83fda4dbd8d49876b39a64a9c99c73e2f4f84d3",
+      "fingerprint": "8fbda6c13a9d8eae9f22f50e64667c4552e209df5426d30e797180aaf0be4e34",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1319
+      "line": 1342
     },
     {
-      "fingerprint": "3acfd28c3d19c15dae43a0876b8c43754a0eb403524093a8d3152d27aa706b7a",
+      "fingerprint": "eea683c7675bbcef882ef90954503e3c6493756b9716ba7461abf6721ce20208",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1345
+      "line": 1342
     },
     {
-      "fingerprint": "d7cd8bce57cfc8b58c05404462d291117d1ae20095fed51dd20d8ced906e34f1",
+      "fingerprint": "ef9c23d362516a8afb1a714afa10a21f8a219087fe10e8076911d094887a1ffb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1351
+      "line": 1365
     },
     {
-      "fingerprint": "eb7fb8135cc812767e5194ef1553364caec17cefe862c68813b2299464108cb6",
+      "fingerprint": "f7b37aaa520fd8fe7b661f07abe53a924b9a91470c09c484b56b5fa5fd65cb9c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1351
+      "line": 1371
     },
     {
-      "fingerprint": "bcd4c615f53d27ffd3671c917b0248b2e77411039283193eaaf6e9a339ceb2f0",
+      "fingerprint": "b9dce12a6658f69015af4aa4ebedc0a1a367a6d35512c46072210e34e2d5cd66",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1374
+      "line": 1371
     },
     {
-      "fingerprint": "948b487a2a72363ef4d57432ce3e3d1fffe80239f5728e1477a915636fc9b65a",
+      "fingerprint": "1165f57a77a7899c44fece95a78d3d9e8ed814affbc421614613cea66bcf3dce",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1380
+      "line": 1391
     },
     {
-      "fingerprint": "917d090c9899d7bed5108172c40ec396612eda7c012baf810ae436b63db725e5",
+      "fingerprint": "6d9b30011a7e51849b02e09905e0ebe672975ba7059651d957a8312b97e31de2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1380
+      "line": 1397
     },
     {
-      "fingerprint": "070462fb9f0ee41565e732a8dc6a6043eda3b63668091945eb8e930bee67974d",
+      "fingerprint": "b5ca8e7cb09f477a6773e335c22477202d46110ff24b4014099951b00471e4ec",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1400
+      "line": 1397
     },
     {
-      "fingerprint": "f113c5691652abc0eb4b2efc74a9574c3abd6ce75efe8617329621c8d751d4ae",
+      "fingerprint": "54b5b697ffae1daf095ad7c802708c54ec8486e7a842c56df77aaaaa0ce6d0f9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1406
+      "line": 1422
     },
     {
-      "fingerprint": "f98d8a2ba51994793fe88a3b500823c16b7dacbe7c52bd37d48ea4d3c6821b8b",
+      "fingerprint": "04d3804fec24e255508832606a169f698864826feddd6b3d665c697bfc4d34cf",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1406
+      "line": 1437
     },
     {
-      "fingerprint": "5b8952c322a6513f2cb581adb81c43c5ae74ca279bff2e4d7dc6834f40b78894",
+      "fingerprint": "cc131e39ce1dd4ec8bfd50c82e839d65ff946cba92549782719d75540253763d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1431
+      "line": 1439
     },
     {
-      "fingerprint": "5a3d36816bb44822fede7a4ebb1ece52de8d76ed2af61b25b18c09aec77cdcd1",
+      "fingerprint": "39c3f8915d458cf112bab04b3222ebd26d3867f7cc31f64cfe92a6f40c779595",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1446
+      "line": 1439
     },
     {
-      "fingerprint": "b5e669582e4c33cc9d6863f085be98f6f5ce8e77f12b1251734204535fe600ca",
+      "fingerprint": "7865f1da0f60224b569d4af5f07633949823537194a8001202810ae9b4feefde",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1448
+      "line": 1449
     },
     {
-      "fingerprint": "c0fc267ac89b31c7d68eab7d10f72a37a2d1b1c976b1cf5de84db975e108c9a7",
+      "fingerprint": "1d887512c28fccec5a8bcf27971b61e982c402d03c6e93673ce972ea213fe3f2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1448
+      "line": 1451
     },
     {
-      "fingerprint": "3b661d2b78583413ec64aac91702a6b967b2b0ce87df178c4a1759d33781236a",
+      "fingerprint": "7c201fa9d0ad522cbb3a9828ba31785ac1b011a0ca558f07dc8c57247eff4822",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1458
+      "line": 1451
     },
     {
-      "fingerprint": "b2ecc94f5f99d86967f972d3df97c297dae89375d688379df37d85875c7d5182",
+      "fingerprint": "40f6cbab2bfcd488a9bc2d463425bda2c069a294a0f552e96650c4f0f19a0510",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1460
+      "line": 1461
     },
     {
-      "fingerprint": "ea82362d0aef58973e6ecdafcae3c6b66d45a43a9441b1da70696904acca9e84",
+      "fingerprint": "607cb5e9ab11fed42325a8ad51720f899fd9081f2c34f7061210b0edc3562154",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1460
+      "line": 1467
     },
     {
-      "fingerprint": "2cb94d92f286cf0001fe93c3813d77e4030eeef46ca200f3f999d1f13c9ac265",
+      "fingerprint": "12b0f975a5bb1e246dd0cf457c7efcde23bec135624ee1934ff35a2749513f1e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1470
+      "line": 1467
     },
     {
-      "fingerprint": "3806a5f28d0974d9b373c88afc1e1d88c874bc7f7ce1732570605da46f87ca42",
+      "fingerprint": "18d209db7d59c8d0e9354b4a4a73dcd23db4aaded435519fcdaf5d1acb9116ae",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1476
+      "line": 1475
     },
     {
-      "fingerprint": "122397f148a26cf27cd8b6a9bc8bcbe5f67c499c9a826b32524899fc5af40d0b",
+      "fingerprint": "49c340715f083808c70e18cc79375fc3b794edd58c24620119e107d61d87f50e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1476
+      "line": 1481
     },
     {
-      "fingerprint": "f06f7e2b1956419ab6aef09cf64be53238209295b2a3f015c6d80d20c9c7e652",
+      "fingerprint": "09a3641c7e2b00b153c18ff3623dceb4fabbfa1b104b6a8fafc3a28cc6430ce1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1484
+      "line": 1481
     },
     {
-      "fingerprint": "416d1f2e262e1e5de95f0960b727e4e40e1b3f7b97c5063f3e17b6c61392e8a4",
+      "fingerprint": "983e3f4c90bcf33acb983c2adabfe96b251deb33022403878850f0e422f3bcdc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1490
+      "line": 1489
     },
     {
-      "fingerprint": "ef8a1e6b002e1113ceb4d5a76ddd8e1d40e7acff48dfc94357deb2192a3c6e59",
+      "fingerprint": "399801a1c8c6e49c2fd6cd7b067471bcdd928574b50f96afe8a538b8490b7619",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1490
+      "line": 1495
     },
     {
-      "fingerprint": "dbb587ea19d5156d107ae2ec066467c8968fb5a0af9b03d6c89cbd24bc9f665f",
+      "fingerprint": "ca3de25b7dcf5ff2c5b2144066c82a1d0917a7b085585b739dd09209c8bfdd12",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1498
+      "line": 1495
     },
     {
-      "fingerprint": "2d075aff545202f4560c36f2b55745f029fb95b6f532f6c245b7cd4c01eab407",
+      "fingerprint": "51fe4d38706559dff475f0333380ee6fa35ad9c57932d731643e088c8403a4ea",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1504
+      "line": 1503
     },
     {
-      "fingerprint": "4c8351d18d3684649603b8e5cd5464f8f8173352fc56dbb61235ffb21c7b449c",
+      "fingerprint": "3ad825cc7e7b605a5cfa3834bb25e1f7b9f521060e47f588fbc67327469b14a8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1504
+      "line": 1515
     },
     {
-      "fingerprint": "07c172285e76d22a721a11f928e9111475e13abea46b192ae06fd639a8f83623",
+      "fingerprint": "c6a8fed008841756a9ee8249503f2ea1f6ee15c9407b3b742a81946cc6c32cae",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1512
+      "line": 1527
     },
     {
-      "fingerprint": "b54d2345971200754275bf894d204b909b8a67049eed0db9bd04b02453c3d3d0",
+      "fingerprint": "af0ac191d3fcaae79578c4eb18dddb2d270f757be81ad01c6c9381aa426fe702",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1524
+      "line": 1541
     },
     {
-      "fingerprint": "fbee85e8e272db76475e804203728dd28479bafa09b224f59e7fe423a7113c01",
+      "fingerprint": "84d73e25bd4546166f6d65e58736dce323c3d688380773bca169df95f2ed1135",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1536
+      "line": 1563
     },
     {
-      "fingerprint": "167ca1682340405f4c026bf1e6baee50c9db8c87909bdd63ef9f56593c85051d",
+      "fingerprint": "652451dc979587e03705c6c80ba9b9f49d2ff72483eb4343c31a7d60834eaf8f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1550
+      "line": 1569
     },
     {
-      "fingerprint": "43bc4afc81bfd95ff50fd7f41ab546742a09dbcf4597339f153d3d61c9f22252",
+      "fingerprint": "b26e6733abc475214d208baac38cfc9f063705defddae8a600af46e7fa21ad25",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1572
+      "line": 1569
     },
     {
-      "fingerprint": "51b9d19cda1256c81b3d00ab6114c1332a1ee6a942312cab34d1247eae443b9e",
+      "fingerprint": "d7883f2956cc8b5ae4f885d41d8459d9aa54d4eb8d659406fb7bef3f262cc215",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1578
+      "line": 1577
     },
     {
-      "fingerprint": "53404af0f9b3feb7223f466dc73fed13670f514a63436a71dc6eae0d225c8dbc",
+      "fingerprint": "d4453a9f822f6141a8c3c75511e4e9912212a996747b12969f11155171a28e8d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1578
+      "line": 1583
     },
     {
-      "fingerprint": "11685bfc6e6c90f6f38d2dc07a70adc0a9e13e54665fab3506c6578cd60ef0c8",
+      "fingerprint": "9db6fa37f59794eba3eaf2fc51540eaf64710f74dcc6eea90e6547e9e11fa47c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1586
+      "line": 1583
     },
     {
-      "fingerprint": "580e48cdca058a5897a93048bce5f536d23509d67eba887e8e9f3510907867b3",
+      "fingerprint": "82c6cec03f3384f6ddd77b0689345893406c9c7f4274eea8c3b064d9b3b2bd02",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1592
+      "line": 1594
     },
     {
-      "fingerprint": "8ec05ed020163b8861b6a8c35e0c75a68326343bf1db7f867bf1259c5936118b",
+      "fingerprint": "fd956bbda061f067929a8d41e16351594d808dede2a0d9f21886e49ad7867c3c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1592
+      "line": 1597
     },
     {
-      "fingerprint": "82e57f7fad1e6bebcf6b2699d91dedfef0a0fee345d74cb4fb235ea1a1e8ea81",
+      "fingerprint": "52722e6870e3b41ff4757ac6272e8895956b95428da5d8eb75c011ad8c7ab07d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1603
+      "line": 1602
     },
     {
-      "fingerprint": "abc116641607d9af37e47683e5fdd2ef8a5ad37774e172a1502af2a9393aacfe",
+      "fingerprint": "d47de7e5618bef5ab6abafeaaeda315223b8d43e1d2d177e0c309f147164bc85",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1606
+      "line": 1602
     },
     {
-      "fingerprint": "1b3a2c1375274d7c0fe948d06f0c8d2ff21964f5100c5e058320e5fd6d8e44a4",
+      "fingerprint": "c4c474d4b47b945b960dd6c56757dc637d95f731e61ba0231b67d5f44d6d9d9d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1611
+      "line": 1612
     },
     {
-      "fingerprint": "458d2af3f72811474055fd2a535355de0623392337596f9e0358d79161893ba5",
+      "fingerprint": "a1767e432c1ce29ad9bbf4199626fe14873f37e04b79624672c327dcde0d48ee",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1611
+      "line": 1616
     },
     {
-      "fingerprint": "09b0593025048351639c834fcc28c607ba61c57c1c6fc3bf74cdbcd422dfb0df",
+      "fingerprint": "38a1879a3c771e18c15419017980bb4bf66bf01f9f34cc8d2763552a3b536d03",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1621
+      "line": 1616
     },
     {
-      "fingerprint": "969267b3c2ef819d55e2d2ff197a891270755be71c700e8e1e2cc0d62e096b27",
+      "fingerprint": "f6d9a6d6b6e172e3349c7b80a13c6a8aac4b0491510341d4186865972bed6fcf",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1625
+      "line": 1627
     },
     {
-      "fingerprint": "f067682d4d4aec95066523ca7bbcaea23789a1bdd69e330829f0a6f55beeb01e",
+      "fingerprint": "e0c4e885620b72a2d1b56c457bbed2cf9a698080599f3798d10bdd7be3996846",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1625
+      "line": 1628
     },
     {
-      "fingerprint": "d114f0cba5a64d6d94ced82976ace9a8a8497cea151ae97a2a70851b8dda92f4",
+      "fingerprint": "86988ffc7f1a6325f8b1fbdab5a627c5362e97161837ac55a29850d38c7c1a7f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1636
+      "line": 1632
     },
     {
-      "fingerprint": "2d1d4d0e23fddab626c465bfc43364f0fc3d5e237c2d87fcb69bf533f9942b7b",
+      "fingerprint": "5dbaf94700c487d9e0100b2909f3aa5d49954dce102e5b719f0b194e59066a45",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1637
+      "line": 1642
     },
     {
-      "fingerprint": "ab702d93c0e7d3541941e70cbdbab46481b450bcef88f69e378aeba65cbef145",
+      "fingerprint": "115aeb1830b26c657f60715a6c8171b7d6cd810241cf4713ee8fdf6aeb2fa4c8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1641
+      "line": 1663
     },
     {
-      "fingerprint": "e069deec1bcb7af6790d01854bdb18934a92ccee2c3c14006879c197342282e2",
+      "fingerprint": "b994d544d14bb64a7d0cf5417d78aab7d8bebbbbcd9dd8af3ad5e7eb452264fe",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1651
+      "line": 1666
     },
     {
-      "fingerprint": "f136b67bacfdff972cb216861ff6d3e93c5b2faf55b779c52dfcd1d9fa026a0d",
+      "fingerprint": "085aeef61a5f750565dc38594b6e7ab1b9c29542b416bdf4db4cc5da929706f5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1672
+      "line": 1670
     },
     {
-      "fingerprint": "1944153d0118b6a49e0aff7a30ad7050a56c646cee9ff14009af455086a310fc",
+      "fingerprint": "3f01cdff7ffbba012b8b475498c3c5fbc89d88e94677bb33d5d9fa9e5c0896e8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1675
+      "line": 1670
     },
     {
-      "fingerprint": "1cf533cc501a10d79dc09cd27cf0fe7fc21df5f3a708f3e7a40023e44fd4e416",
+      "fingerprint": "8c8009e5a30dbcae2fe3e3d8f7561efe1f4ca943650ffc3508d6f2ffee855d96",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1679
+      "line": 1677
     },
     {
-      "fingerprint": "c5e849768b8d7f163ad1234a1894db4be9125ec8851000433ff181737bd01608",
+      "fingerprint": "7f82a7d964c79d0bf25018892d30eb9f6cde2853e1edfde6bf3437cfd64cec20",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1679
+      "line": 1683
     },
     {
-      "fingerprint": "5c430c65a1a87663c220be12a856e8bc3c57de901bc23d96053ed7a956f00c9c",
+      "fingerprint": "528f594cb61519024af7b6e80814b91073003774e30e26733e619d8c2c7eedc9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1686
-    },
-    {
-      "fingerprint": "4e515ece185a9a6ddecdbccddb79643b9caaeaafc7c1066210491db13b8ae133",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1692
+      "line": 1700
     },
     {
       "fingerprint": "38bc857891b2aab8aeb43a07cd14c265b630596e52149f17624f9ba095db1129",
@@ -740,118 +848,418 @@
       "line": 1709
     },
     {
-      "fingerprint": "a3ae08196966a61e218728f43f7a7f2f394a762bc3722dac672604a42d0ea6e4",
+      "fingerprint": "e545d5f9ef20a4d1f1740e3ec63b1557c244f2577a4606f7f4713c422331caa5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1718
+      "line": 1715
     },
     {
-      "fingerprint": "995bc40e11bbbb02e4ae673b7f02024d4126f9bbcbb672a6ce3bb7640249cbeb",
+      "fingerprint": "3a9ad6ea19e7a8d3396cd9fa1cad2f6ecdf546f1d2bb33673e9e2221dd557032",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1724
+      "line": 1715
     },
     {
-      "fingerprint": "b57969899ff07a430edd9e3ffc370743e84124e6b14886623b566268185d8800",
+      "fingerprint": "da78f9308ea84d445ba518c82d2d2d1f1bcec42b39558f6b6eea4bd2b77c0401",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1724
+      "line": 1729
     },
     {
-      "fingerprint": "0b61603a5345c9b4610ab57b0675433c0df5d6e40554a08570af06c0ea77a1a9",
+      "fingerprint": "c80f84a558a63524310cfb422215d44db0c09b2b2d3b913cfac6bddbe2021de4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1738
+      "line": 1731
     },
     {
-      "fingerprint": "6e3cda0c18d93dcd402eafb994b54cd632226f1ea69d9a8a424b42e119314984",
+      "fingerprint": "51e4d0fcf81d7bf79653c354a98b20e8db0bd7e16bb7ba8cbf7b88082cbb3e71",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/config.rs",
-      "line": 1740
+      "line": 1731
     },
     {
-      "fingerprint": "09a3eb2923a0a33ffb5f9984dcd9620f7473f0cb58aebf33a69505e00b876f9f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1740
-    },
-    {
-      "fingerprint": "ca88ae016d2b058e624b5cb8e0d63acaca9ca2d87be8abf2c495edc994e0aa8b",
+      "fingerprint": "6d48181ec2ae6d943bcc158159927d90ef733eeab361627f79a9de04d8b398b1",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/diff.rs",
-      "line": 39
+      "line": 42
     },
     {
-      "fingerprint": "050ac6494b7d123296791a64a34e3779b23c94fa05cb143c4e54097cc2c78f3b",
+      "fingerprint": "3f553800635c144cf3989fbd06b6312547006cb8900e380297fb78585c2027f6",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/diff.rs",
-      "line": 186
+      "line": 217
     },
     {
-      "fingerprint": "d64b7f152860d61aa4709104fbcd3580f8f9c47cb11ace9afdcf96f5e0a8782f",
+      "fingerprint": "7d14dcb7d64feaea50eb5500a4cc386436216566f56e244dbdc9ae564a77c4c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 487
+    },
+    {
+      "fingerprint": "2449424a85be12a3f1ad2f920abc7bc960a45e100b90e47a8cd1575142086c72",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 492
+    },
+    {
+      "fingerprint": "04687d1ab8a35a03f9e2354cd90ad60b7bfca0cd0df2ebf966b17a910d424ff9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 511
+    },
+    {
+      "fingerprint": "84fb95b372befb7ac9c8f4d27102bcf9539ca290b281ece147075d804fcbef51",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 682
+    },
+    {
+      "fingerprint": "2b99addb7d4d492ce140a9d6e37560a0a106bcf0257ea5083095e4ce4872eb61",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 686
+    },
+    {
+      "fingerprint": "48f2bc40fbc5248d6aa084aa2617341a18987067bcb7fd1b01034c29bf07d02b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 719
+    },
+    {
+      "fingerprint": "f9957e0eed18e2a76b3c57d2d382aca7a79501fa3e85dfc8b8b9b42e155f7974",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 720
+    },
+    {
+      "fingerprint": "9959c40bccdb7bb00e2bd0d465a6d5532943b3b031a6e6d2aa0636af062dded2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 737
+    },
+    {
+      "fingerprint": "ce9530b71e4e9cb5adfd0323386ecbb5ddcd9fd9dac4d4c158f817bc23e0af72",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 747
+    },
+    {
+      "fingerprint": "3defc145327ae2e81d9698c27c3181728c6721140eb306bd699800afe9702505",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 748
+    },
+    {
+      "fingerprint": "609a40845f75fcc460ec98837c4f30c8da66b02ce991d64215cf86b0b66f246f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 776
+    },
+    {
+      "fingerprint": "6b015fc465856bd61e676b0075faa6d826edb0fc3daa50b8e9f31a0d67515bbe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 787
+    },
+    {
+      "fingerprint": "ac4277eaae31c54125152d7780207a406e08da74e1a646edc0a274895994b614",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 789
+    },
+    {
+      "fingerprint": "25cb230008b1aff0e3dad389443be800fceef1adbd8f6287a17f40bc0a687b08",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 809
+    },
+    {
+      "fingerprint": "2f490b999af03925d5fdc38afe67d4d9453cdc0b50fc2acf3abcac6398c08c3e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/coccinelle.rs",
+      "line": 811
+    },
+    {
+      "fingerprint": "9c4e3238e5ae54e0471a1c46795966590b3e67d45ad721964fde3121b41efdd6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 272
+    },
+    {
+      "fingerprint": "b4f7add89898fd79ebe2512d7efb287965a0c3fb483cd563fa08dd150da2591b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 304
+    },
+    {
+      "fingerprint": "cf9815b2675bf63c4a5e9706c24e17392f75d0ad231370832ffd8ebe58874e48",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/codeql.rs",
+      "line": 677
+    },
+    {
+      "fingerprint": "6555ba87a662f26007c672af75cdd78250b62a12c8b51e48863d12ec8d883bbc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/codeql.rs",
+      "line": 681
+    },
+    {
+      "fingerprint": "554380c0ca41efd3bba68644b4036be17cc49205632745e2bcb9fd9bdeacd1f8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 865
+    },
+    {
+      "fingerprint": "237a85a427ecaa45b7b190389fd7ccebdb9ba5c70b2ebd164b27833cc823c169",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 866
+    },
+    {
+      "fingerprint": "1160e68fe392fa26c53cd901c3ee6d3a1421d7c41c80b803562edd8a0a8ad6af",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 903
+    },
+    {
+      "fingerprint": "fdf3f74c146d6ab82189d1be53889818b972196ec214cc918087c384bc7f6cb5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 904
+    },
+    {
+      "fingerprint": "4782aea160e978c197229b657d83a37b704efe0c9c441a96fa359d067a9a8268",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 921
+    },
+    {
+      "fingerprint": "258fc44c52d49294d468f83e1728975da4d91b6e1826f76292dc0f06ee4addca",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 922
+    },
+    {
+      "fingerprint": "c00143365defd5913e299dcefd8628f9e355336dbc559df171caa9dae95dc788",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 930
+    },
+    {
+      "fingerprint": "30f760699079ea1ee4f0fb0a99e9794b944c1f2d9764136949ca5817c5208ba1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 931
+    },
+    {
+      "fingerprint": "aeca8dc2fa106c4d7ae02eeccfb2c06dc79073495d47deea0189c726b262016a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 932
+    },
+    {
+      "fingerprint": "994785d11730f283f50fd056e4565a0405200e15197a43589c1a577311ceba70",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 933
+    },
+    {
+      "fingerprint": "36658baa298ea2199d6630f7758fe7272ba56b96259fae0791d2002228a7cb2d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 949
+    },
+    {
+      "fingerprint": "5fea9229033eed2390d615b70aceca6a80acb7e7fa5b0c884d8c37e8e6e2d534",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 950
+    },
+    {
+      "fingerprint": "8ab9e5e62ae7a28254883944f2ec89f6d53ce4340fdf48631d8c530469641976",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 956
+    },
+    {
+      "fingerprint": "b71b35b1367c46d76fb15c15a52ff6ed3ea5799690023f8a5e387857a92dabee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/codeql.rs",
+      "line": 958
+    },
+    {
+      "fingerprint": "d626ba63206a27704b615f3dba2a165e4f527a4db405c243723252c443053e82",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/parser.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "f37e0c37709e26191e571b65d6d182b146d970e39aba5aa341115cc0586015c9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/parser.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "8fc5fad156acbd664d02df020b8ba019cf0c9c5cc2957b061a4e5fab9d88b23a",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/engine/scanner.rs",
-      "line": 49
+      "line": 226
     },
     {
-      "fingerprint": "b9fefbf2f85fdb848229b46c4feb67bf1de6eb9ae22c9abd1a168eecabea6347",
+      "fingerprint": "e0ad33bc921f61fafd3c2676c46a53c6a8ca1cfa97c2ef12e90a3ce6593a857a",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/engine/scanner.rs",
-      "line": 194
+      "line": 371
     },
     {
-      "fingerprint": "22f6980d0c5e39daf53e07e78e810fc30ff8d9de208abd8ad56a69db6552b20b",
+      "fingerprint": "2187d20ce4c0c82ad929fa420028727e3ab0133e19a0d7a7e24339b3d9ae7e8c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 332
+      "line": 553
     },
     {
-      "fingerprint": "bd90e88690e841180674abe8075a76800b9ec0e5f945c5228d2250085d1a5218",
+      "fingerprint": "7abbad0deacc2fdd963fe06da2d81e0b792e5ebfd66e7e6d1d4392d7d6f28d77",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 340
+      "line": 561
     },
     {
-      "fingerprint": "229fb04563cc22d25814055d81da6f21ad7e364802617fe7ccb0cddecb816e43",
+      "fingerprint": "c45f990c7345e601544c43eb851a86cfff153f704c2b2624aa3bfa4687655e18",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 347
+      "line": 568
     },
     {
-      "fingerprint": "383225eb67c109f5775c7ec1186aab0a386e21de833af5d04a32dcb1aa5e22a0",
+      "fingerprint": "a58b6ebc5cbb6e4f3bc8b4bea02165fe652ba9614c9df8e8db7875555624e63a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 751
+      "line": 1002
     },
     {
-      "fingerprint": "5d097fb5037819b2de7062df8b422912b3cc871b455f464d6fc5ce8215bc1b33",
+      "fingerprint": "cb7543fdd3a56842a5ecc57c16c12560d3370d6a5af6d1d7eef8c3d74a27b2ad",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 759
+      "line": 1010
     },
     {
-      "fingerprint": "359eff47d8a808fb9f47f5e047660c34d8c1804683b3e2f779d9f6613a167598",
+      "fingerprint": "d1a7166982dd6017aa45e6d78c53a91075f75f41e1a932b2ca4fd85e0d9f1f7a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 1066
+      "line": 1027
     },
     {
-      "fingerprint": "88acc1f658c1d045d4e1087bd11c8ef38d45059e5eaaacaa58db75784643193e",
+      "fingerprint": "cda66952259f0b9be2dcf6338cfb9bdf7cb4fefd3140e0845a806108446fc72d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 1100
+      "line": 1034
     },
     {
-      "fingerprint": "2ae6972ffa410d6b26f38a6b69b045166b96e61e535a02be9039eaeb7230d029",
+      "fingerprint": "e124c84fb196b01df9d8d4a90796fff106305b68c8aee1d37a5478ac1d396d9f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 1108
+      "line": 1056
     },
     {
-      "fingerprint": "c0e54a9f4339a3adafbf576989b04a92cd745142174e755fa7cca0c518741428",
+      "fingerprint": "1e55d65e309c4adad91a84f089db66e3b04c25ef6e013366d725da53624b04e3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/engine/scanner.rs",
-      "line": 1117
+      "line": 1065
+    },
+    {
+      "fingerprint": "16aa8ad9c75222eaa41e743f8f1efc55999835675edfb65479d14b2fa65712bd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1074
+    },
+    {
+      "fingerprint": "985a1766c68a3628289871a0b8b211476cad4251918393c75581c47f3378bfd7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1430
+    },
+    {
+      "fingerprint": "cd17f127021f0ce17919b66bfa31c0227bdff7d4e115d94f6d47a8e4f17ec2da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1464
+    },
+    {
+      "fingerprint": "150563578d03dfff5137ee5c2ba994aa231f48aadda5e4c8e7976c92f7ac7f02",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1472
+    },
+    {
+      "fingerprint": "ba4b123d9d7a121123ba1ce67b913779de7cd0e5bf6fa421fd32a73512abbc3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1481
+    },
+    {
+      "fingerprint": "5836fe14fd9f173590274b95f3cb4bd36964be4a5dc46bbea20f8a05a7ee14f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1507
+    },
+    {
+      "fingerprint": "f88351c0676e803bb60fb5e994406bb1456f585eae6d8030d7ba5552fc9863cf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1518
+    },
+    {
+      "fingerprint": "2347950730c1ca4dbef1e6baf71f16fbf95ff066370eb386e48b27c8d373fcfd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1519
+    },
+    {
+      "fingerprint": "7ede18a0b1bb7cdd5b07e755bd36747b194100cde32fb6c3ec14565b5f8922c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1521
+    },
+    {
+      "fingerprint": "199ecc3c5e07be69ac1f9ab2653113fa851a4c58bc177d7196d0c25526497d1a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1523
+    },
+    {
+      "fingerprint": "6286f96d3771805066bd899e37f1c5974b17f4f6a4db78179104a10bb2667af1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1527
+    },
+    {
+      "fingerprint": "0eeef7b8f254218ed40dcffbe791c9c2b18cb8c54a2285c85c4198b8123fd279",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1529
+    },
+    {
+      "fingerprint": "652aa932f03b1e0cc195ba5c06f1459a5fd7045c98bcf9dd9d7bd94ddd10bd65",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1546
+    },
+    {
+      "fingerprint": "a73f9a2f4608f4a8f0336033a2da1b0cb247b70c767ea0056b8fcac175321a1f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1547
+    },
+    {
+      "fingerprint": "20390813d44833ed233a8abe1e432f08595b04c1577dc977794c987d326d9ec7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1549
+    },
+    {
+      "fingerprint": "6ed2088751260dad5a1cef2425da9f0f968fd80bc336547966aad6e80b6cd101",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1553
     },
     {
       "fingerprint": "219a0836f42e060e80aad57d641de8560a8d44f9de16fb691b33dd2fab54ab69",
@@ -968,106 +1376,214 @@
       "line": 140
     },
     {
-      "fingerprint": "5eb20cf6ebaa65d640c2d2b128ff0c6a636f0b1247d389b80361dcdbd07df559",
+      "fingerprint": "46c6d713d6c5b06cddc9235bea1d00bdb8b7afb0f091428260f4351201384c5c",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/git.rs",
-      "line": 27
+      "line": 35
     },
     {
-      "fingerprint": "1d11bebb4c5efb624d60c3af9b1a13041b5e1cd5f99366c79ed8c3e9902ead82",
+      "fingerprint": "2a374954584f87965d64b37ba350f6d2699b9283b7038943ab2d19b5c0b44da8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/github_app/review.rs",
+      "line": 823
+    },
+    {
+      "fingerprint": "7689fad892785279654365885518d4f40cd2daa04ae02de4d9aa231195adf8f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/github_app/review.rs",
+      "line": 850
+    },
+    {
+      "fingerprint": "0531955a71fadf236b41c9c2650749b529bce1a1f5d92ac23472f35692bf70b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/github_app/review.rs",
+      "line": 879
+    },
+    {
+      "fingerprint": "decb4beafb728418d54bbbe2756aca05dd3edb94bdf976b90ae4b5db992f6d86",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/main.rs",
-      "line": 119
+      "line": 133
     },
     {
-      "fingerprint": "ce5bf5f9756c5e245d267b733882d5959d376f27f43bac0a4ff1329324a2c65a",
+      "fingerprint": "4fbff6f0946265958e65666370ce1dc5cff614640eb4334cbde055dad98e050a",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/main.rs",
-      "line": 211
+      "line": 141
     },
     {
-      "fingerprint": "93943d211221ebd8b38ed41ab5c62697de86accce48be658088d69a0b8d595b3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 285
-    },
-    {
-      "fingerprint": "43555dca89dce52d60273b59c305098358834ce6a834a6902b7569f14ad47226",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 419
-    },
-    {
-      "fingerprint": "fb52b9622825521cd2899d3633ed0f011b3229bbcd37ab3d5ad0be4d8911cd94",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 444
-    },
-    {
-      "fingerprint": "35a091320c20ec2c7fb0665d631ef0566364cbbaf8949e14ce01759ea78ea6c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 452
-    },
-    {
-      "fingerprint": "39cd3985750e4795bd061afcc0fff7a852f483fe44f9cf9397a3e90fba41420b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 455
-    },
-    {
-      "fingerprint": "e6bac8e284a44c4f3ff82d8993d7e9a7a0a97f42eadab438857591c437364d8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 458
-    },
-    {
-      "fingerprint": "16c4d01242e2104532d9f5f516474347580c45796cca308153a956086a0bd6cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 470
-    },
-    {
-      "fingerprint": "2abdfc56c2851a706daf5731a40bcd14eb3140e53e2f1a900237fb039e9ada85",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 474
-    },
-    {
-      "fingerprint": "97cce2b7ea9eb107d4e4c11eded9c861444f439bcc88d223baa724f630d81255",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 489
-    },
-    {
-      "fingerprint": "f744ddf4ba6b37fd2054a3906b712d8ccfff4120387adad5d6f8fe6eb18e4912",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 499
-    },
-    {
-      "fingerprint": "ce3f1c6d56920024c8184fc6a2e02aab077b1a2048bb32163a28cdec6799c586",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 512
-    },
-    {
-      "fingerprint": "ab833235d5a1f6f7206f91772b08bf398a12503322494cf18f86f4d737afd611",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 519
-    },
-    {
-      "fingerprint": "5f4cf6f5e9a841f947c7bfc69baa7e35197bf7648e23e09ac1a725bfa971c75d",
+      "fingerprint": "04097e2b99c7ea6913af7332e17d94a258945a79b486be2ae8522b5014fadcfa",
       "rule_id": "rs/no-path-traversal",
-      "file": "./src/report/github_pr.rs",
-      "line": 44
+      "file": "./src/main.rs",
+      "line": 146
     },
     {
-      "fingerprint": "80049cb66ce024fb90232d6c43b17ac9d09de03031a8cf7446f345a62618a45c",
+      "fingerprint": "c50cdb479b0d1325057c272e5edb423107711724e31eca7681292f677ca77bfc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/main.rs",
+      "line": 274
+    },
+    {
+      "fingerprint": "47a08326c2021b11bbb21dcb23e1a4fb9aa81587d741d114b05a1e0a0ccbddb7",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/output/mod.rs",
+      "line": 140
+    },
+    {
+      "fingerprint": "320640e419b0fd11a4a15160f978598ad68e09949ba2b2d4b0552e8666c308f6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/output/mod.rs",
+      "line": 181
+    },
+    {
+      "fingerprint": "f87a752e8b475c6be28af7b20ef52deaa1c166a1e416c7dfe3e617826ad761bf",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/output/mod.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "d9dcf7281be18630ffc5f58efccffdcd78818ed3307589979fe6f85d8d05f595",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/output/mod.rs",
+      "line": 230
+    },
+    {
+      "fingerprint": "f30a724b683367a30b47782d44ddb1c95fdadf2597c72f7b91a3233748e9e94b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/path_identity.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "9ae3305efaf2c5eb731c47f752da09a3887f19f0b48a6c16325430b73a79e908",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/path_identity.rs",
+      "line": 75
+    },
+    {
+      "fingerprint": "a8fa99c557a4c74d48e2436ef16b24b85b3960487922cbcd6e5966369b736bb2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/path_identity.rs",
+      "line": 112
+    },
+    {
+      "fingerprint": "598066b5176b9a4726b848934532af21667e2fe170bd16ccca03124a602b9caf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/path_identity.rs",
+      "line": 176
+    },
+    {
+      "fingerprint": "14ffe5d42103618471d434f50f995004c3028b758308c6d29c789194794dea23",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/path_identity.rs",
+      "line": 186
+    },
+    {
+      "fingerprint": "dc3c3e243e938327e1e1b8f35ca199fe198cefbfd2477a2066dcc2342bf8b863",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 271
+    },
+    {
+      "fingerprint": "0035f4e44b4a3af654f53cd0d06adf68db62311bbf93e8891ee1890c4d37fbba",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 471
+    },
+    {
+      "fingerprint": "f52e7b4642015a92b65dee8636569e49a249cebfc57cbd0b5582358080c9562d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 614
+    },
+    {
+      "fingerprint": "48b95b4b7e515958d21d26e790b50968a7262f02fd46fbe053b69ebcb9a39436",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 639
+    },
+    {
+      "fingerprint": "5e005b4c112eddb47bef857a3025122e2ac8281ba5fca9bf237f2fff74a71464",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 647
+    },
+    {
+      "fingerprint": "8df7d7972c0357ad88e2c94cf9e02ae432fb2e533a3139f9398b01fbf9baedbf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 650
+    },
+    {
+      "fingerprint": "ad68ec8435c20b775a3981bbd2969b9caef20682a22f01f3262d1214ac28e4d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 653
+    },
+    {
+      "fingerprint": "5c13205e7fe92b0a604bad1683d1b37c206c70617bde1bb9bd2298324fe0698f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 665
+    },
+    {
+      "fingerprint": "dc446739fc5a263d66466a8b329430002037d9a881944c5416910aa5be7d78d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 669
+    },
+    {
+      "fingerprint": "b5ee239ef18b8cfd5e68d8e473d91933ca7b9bb407457f052a879ff140a664be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 684
+    },
+    {
+      "fingerprint": "1bb6a3abfb814b93aadf5c272fe6af628ae86f07868dd6883d52e6cc40f0bca2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 694
+    },
+    {
+      "fingerprint": "6ddc77933ba3ac2b42514dd8cfefcdfe793217fd0e8cd92c869259ba51bed91e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 707
+    },
+    {
+      "fingerprint": "9088691f51dcb4ff2df8294900ef8d1c4cf99624401b6f854adc48fc0311f35a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 714
+    },
+    {
+      "fingerprint": "09a6d7c63a5a9662b9c40b479afcb2cf577f42a20103a9f9e3a74e4169330376",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 739
+    },
+    {
+      "fingerprint": "7849ad2ebafd7bfd058cddeea7b0cabd028576d558cf6979ca926ebd5a81185c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 758
+    },
+    {
+      "fingerprint": "91ea3b13543749ee87fc5db965193eb6b09c41b6ceb2af0fb2e9bb8fc39157ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 765
+    },
+    {
+      "fingerprint": "18ccb41e7b139b5938fd96c12c17ebdf823ee97bbd774d57588f930cf97e08b2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/report/json.rs",
-      "line": 4
+      "line": 114
+    },
+    {
+      "fingerprint": "20182102e5495e7042eccc37b55d1096ec0d40a7b6636aff23e1d10f020f0a56",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/sarif.rs",
+      "line": 341
     },
     {
       "fingerprint": "5f6d3c27f126c52bc227085d910aef9404833d8443b28715fed002a1600fe318",
@@ -1088,16 +1604,28 @@
       "line": 126
     },
     {
-      "fingerprint": "c9c4e5fdc9646709f55f5f8165fedf4adf5527c21726dc6137b0587886455117",
+      "fingerprint": "ebc99d48f661ce597a75c231fa245797aea11d0c89bb7c8335c599ec4a67e2f0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/common.rs",
-      "line": 387
+      "line": 72
     },
     {
-      "fingerprint": "f529b455a17ab78f1ed0fd85ef7ce52d5da9c07780b626f421004fb22e07788f",
+      "fingerprint": "381462dbf3c516654d35d305dafd9c11852f90a8dd7f46a5ed2a15b962de0edc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/common.rs",
-      "line": 388
+      "line": 80
+    },
+    {
+      "fingerprint": "109ed1859e2cced77cabfadb2b6a6014be25e466b418bcbb9982a3f442942478",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/common.rs",
+      "line": 407
+    },
+    {
+      "fingerprint": "78e839a06d5a2cb412c1c512f3a30a0dca41b75e85222a715bc6257d481b146b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/common.rs",
+      "line": 408
     },
     {
       "fingerprint": "c7c142467e1cfb8ea99f8962a87e158707fad7dda57d4a07c336a715ecd8979c",
@@ -1160,58 +1688,136 @@
       "line": 94
     },
     {
-      "fingerprint": "d5c46536705413b5a5565ea61dbc82edb4531ed7e4af63328277125f80b45327",
+      "fingerprint": "c0d7082e85c1c48f9df490a838fc92d71b7b27527a0b05848cb8257c6254b58a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/csharp.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "6bddb626b48038130f01122c8cfab2274da96b64627e6a38590cbd0f14eec21e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/go_taint.rs",
-      "line": 1425
+      "line": 1324
     },
     {
-      "fingerprint": "96126836713e4eada89a6d7a244ba5d34f8e1c935b28a3828c44dd5de0451cf5",
+      "fingerprint": "7f0d0d48a8609033ca68ad2d295daf5a76dabeb6e9ec9e23ff3ecf1e3d142a65",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/go_taint.rs",
-      "line": 1784
+      "line": 1702
     },
     {
-      "fingerprint": "4ed6ca0c3965bdfe86d90a726769ba374cc8093a678dbd9eeb99223d2c76713c",
+      "fingerprint": "23aeaf1a3580ee8dd092efb9ec5ea1950e68256c1793c3c7f6f6184514c8b741",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2154
+      "file": "./src/rules/java.rs",
+      "line": 17
     },
     {
-      "fingerprint": "47e8b3ec39cc8b38e2666ef6db34b9f793a316270fbaa2e3cc1b04fb1d33b6c1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2311
+      "fingerprint": "661d2383bee064a98159fc1807d0244c0b49969499626ade86069db41135facf",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./src/rules/java.rs",
+      "line": 25
     },
     {
-      "fingerprint": "fb548acd113f1f9f6a647afcfe62e2a96deebf0551f5ee7f269c7ea9a9156828",
+      "fingerprint": "906d4936ca242f9ca6bc911d9570661df50a97ee3e8f84f3c403722ec358ce34",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2333
+      "file": "./src/rules/java.rs",
+      "line": 25
     },
     {
-      "fingerprint": "a5b5050a34fc1cf5a2a77e7479ebcddf50f955af8724e2bac405d6012de3e000",
+      "fingerprint": "c578a8bba1d0779ee0402b641a1367d8460b2c7fae526de2679864cd5d040ba9",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2342
+      "file": "./src/rules/java.rs",
+      "line": 33
     },
     {
-      "fingerprint": "a40d04c7281c51f0aa7a0a324db36d6bffa471bd7863025790e972c1f2713293",
+      "fingerprint": "b0b3594f25948c53b98ebad97277f198749bb87b6ac43c020671770b2c01e045",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2351
+      "file": "./src/rules/java.rs",
+      "line": 41
     },
     {
-      "fingerprint": "e14ed58e3bedae73085b837aa23d21a2364690a404d86aee4e43aaa2afa944de",
+      "fingerprint": "224895a7e14317c657a602a6c106df39185aa89a5366222a4118992f91ddc49a",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2532
+      "file": "./src/rules/java.rs",
+      "line": 49
     },
     {
-      "fingerprint": "cf7b3610b3da042c927ee760248da24ef3b6b48a2653ccb52c5e0f3cd226b397",
+      "fingerprint": "90d96de49c43adb4b9a44c3646f2c6146454ef0d34383d11b54fcd98a1bc229d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/java.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "9db9a87fe6e5a248692b84e13b6fb87b683eadf66dad9a299ae9a9410b2719b1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "dbd1d2fa4afe6c0961264fc0154dfa07a4cd36825127e1371d0ab7655e7668db",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript.rs",
+      "line": 28
+    },
+    {
+      "fingerprint": "7cde115ad13f1453d314de353e97383d154d73c267e27eb64d4dfe559c894198",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript.rs",
+      "line": 36
+    },
+    {
+      "fingerprint": "ac8c31aeaff45a43595f820314dec47a94d38fa2fbaa9b8706542d9228f25dde",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "a83295abbbf267891e4000c5907f1dca02de49dd5ca1b51602c660cb51e292e8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2552
+      "line": 2121
+    },
+    {
+      "fingerprint": "0c59708c32e88c5a17fb9622d6fec9e798016632c56f3d1b0ca57e186b542b79",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2278
+    },
+    {
+      "fingerprint": "cddbb9333bfd6f320f508f2f902a294175bc3cdafa9c661b19ee624f1ff39e98",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2300
+    },
+    {
+      "fingerprint": "eaaa237072f768a5514771c7098b7b7258b62142f4abfe2879d94d59c307a3ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2309
+    },
+    {
+      "fingerprint": "a7df27fed900a8595f2bd564c48c929982e82e38285c87f28da4d2ebb0b59690",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2318
+    },
+    {
+      "fingerprint": "182a1e8c22ab4fbd81f04f11778ee83aec5507e56bd6f003e40dc2f508e7b0c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2514
+    },
+    {
+      "fingerprint": "03be16b312741ffdf3ce755c85210e3baaab3ee1734f8667743d33a05049c6bb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2534
+    },
+    {
+      "fingerprint": "a250d13cf7f19bdfa1fdb6dab7d77c2c0eea5e60a930b6c442a2b757f3fb03e6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2550
     },
     {
       "fingerprint": "c2d907ec76ca2de7b432213f9d93cab8c717a334f609e01653269e3c5c0db878",
@@ -1220,142 +1826,190 @@
       "line": 2568
     },
     {
-      "fingerprint": "652f725fb41859958a6f0d90413db589d2e21e4c96bdee7cbf76ad3c5e7ec928",
+      "fingerprint": "9b16e12241a576d65274ad9fc8ecc6f8bc83f4aceb89d362a0e7729916a6638c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2586
+      "line": 2584
     },
     {
-      "fingerprint": "a1941697fe494125b00f3c0e8029143968aff1dff2220193b14549f4a2737660",
+      "fingerprint": "9b387451eae2fa3d4a34552ae2e76909c5c31c921be9ff84f59de84da010cc16",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2602
+      "line": 2601
     },
     {
-      "fingerprint": "daf23977ff0acd20e37becca02b3ffca21ee63211b1d34d560f79c818da5d847",
+      "fingerprint": "c5d306313427906d220844426fda57faf7337088e47581a7eb4dc3446909693c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2619
+      "line": 2621
     },
     {
-      "fingerprint": "62fd7511cdc804fa3c2d6e3b0239eb99303cfcdfadae317706ab71073c5e690e",
+      "fingerprint": "db6b50e0939a1081fb30d76ff798ab96186f47750ece53209f708e22b5b97e15",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2639
+      "line": 2637
     },
     {
-      "fingerprint": "525f56f9f940c7f4adfccddfb0a78026678471659035e497f0da2bd22cb88f9d",
+      "fingerprint": "68c838bfec1c1b22938301e7662113dc51f4f03d92f361e278fc32d18b920af1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2655
+      "line": 2656
     },
     {
-      "fingerprint": "5351eb3c16ef3b9988df806945bef726ae20eb95dd079074535b1f423d8d0392",
+      "fingerprint": "b46ddb8e65eca9153fcc6f7099584d9dc25a6d654c67ec9697a5a9c2625576f8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2674
+      "line": 2681
     },
     {
-      "fingerprint": "ea0ef5c7173d35e8e72681f4aca54e90f8e6fc146efeff3b91b856d1e15b56c2",
+      "fingerprint": "f10dbdb3d07747981ceab5287b386cf455e51cfdb0fd60a684bc7adb2afda658",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2699
+      "line": 2700
     },
     {
-      "fingerprint": "c9932d7cadae05fdafaa785fa9857b73b7d7d5b7ebb16725a3277901c00a1e81",
+      "fingerprint": "8bd81c3109bc94c7dd84cd46ece7b836550b64bc9f92eb51573e3dc6b4d4c0bb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2718
+      "line": 2709
     },
     {
-      "fingerprint": "8c86ef163beaa6f3c6914132680dcac32614d887233e6d105b2c8d29829aea02",
+      "fingerprint": "c900f1a54bf4434b19674608817ccc6bb029c7b8150660ca4245b009d243d69a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2727
+      "line": 2729
     },
     {
-      "fingerprint": "5f36b61486bd23937759d491ad8f42e71b264475a2b0fc85e915de2706140ed5",
+      "fingerprint": "de9e18b10676daf40cd11bdbead52fa7bc28b2c7ee597114e49fa2ebb25f5595",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2747
+      "line": 2749
     },
     {
-      "fingerprint": "18de66c287bb19c288137c0453b3293e925a88afffaceecc65975d57762fb7e1",
+      "fingerprint": "9158d24e9f916f7278b0c99f8dee8ad68b87762f18c9ae8ae8b27dcfbff7dbf7",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2767
+      "line": 2766
     },
     {
-      "fingerprint": "36c13fc7c90bd219e465da161b3692e1a29fc1d2d0f600418d61519c4b96852e",
+      "fingerprint": "60b4e5d7594008015783bd8c2039693354c0b77cfa2dc5358c88347cb5935476",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2784
+      "line": 2787
     },
     {
-      "fingerprint": "876fbc0a5f356d7f3cb92698cc402aeba1e9b45355e9551a09be63ff8925e5ab",
+      "fingerprint": "5e592d9f2ad2611aec8cc9bed5524359efaf507a47cad1f9731db549a84a7968",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2805
+      "line": 2811
     },
     {
-      "fingerprint": "bb2c6f9aea79794f40984b6cc95deac563bd314f6d2a4ac8d4f21c4eaac2a9a0",
+      "fingerprint": "2f48e1ff6e61e56d730c7d7536decd7114f6c10d664cca43d8fe25dc5b538c1c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2829
+      "line": 2837
     },
     {
-      "fingerprint": "8f9db2d88474d3962e0ac8bf2acf3d8fcc5b6879a698009c6ef477a687e8f1bf",
+      "fingerprint": "cecf4d756198c7803b891133c0436af7ec800a3cb9b34b49eec3c2e32ba0d3f3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/javascript_taint.rs",
-      "line": 2855
+      "line": 2856
     },
     {
-      "fingerprint": "98189480328e04b84eba4a7e0e8f167634158f196793fd8b9e1e20566532f392",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2874
-    },
-    {
-      "fingerprint": "20d2fc779fa278699161dd057447746795f9d6f879e9c1d43c75eee18220b293",
+      "fingerprint": "3f1cf078e348f67cc395c0123c44b8504a1f4f83bf6b91287d4e3a729cb13f5b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/kotlin.rs",
-      "line": 1450
+      "line": 17
     },
     {
-      "fingerprint": "665b09682d4baf680c183482c0aa3ea07dc882ae2fd1c39de79e207dcbc8a215",
+      "fingerprint": "258571289adc9f12c07840d9b6d098c04dd3b4abc6bc7f08c842cdb01da839ad",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./src/rules/kotlin.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "137eedfaa8903838fa0a8fffa2390c6d1571425800df0b020f2c50caea3148c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "0584cbd5029fc225030c56eda19d82819583173dcfec900ef59b2cc97b0cd4a0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "a0161a584645792846932a038e665d590bca0c5b70930c52f0736c24227d28f7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 41
+    },
+    {
+      "fingerprint": "915d7b6dd549cb9debcdddabcbe4d6f397b4ab12207be7021d4d1fb2c8a044b8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "38991c253723ca46d8165ecd51b17a9dd81c77d69595b4a7bb497e9057063729",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 1031
+    },
+    {
+      "fingerprint": "4978b57909641c62821d3cf60238cf5ff94f2ceff7b43f7c7a021f95b3aa3009",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin_taint.rs",
+      "line": 766
+    },
+    {
+      "fingerprint": "bb562e6bd569d8a4a4b4f203138104c4ebd124b35dc2783de45b22da0c95d995",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/manifest.rs",
-      "line": 519
+      "line": 489
     },
     {
-      "fingerprint": "27aed9ddb0f708fdf6a20e716ea85a9ddbad7cdc9e6f123250f1f490700ad782",
+      "fingerprint": "59ce4fe823c738fdc1cd1db6c4faddecf8d45261eaf66ee678a5de277980ffc4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/manifest.rs",
-      "line": 563
+      "line": 533
     },
     {
-      "fingerprint": "18a02eca89255bec65c684f5d575550cfb9aa98657f248c6d2bd1e5e83c3da01",
+      "fingerprint": "7b154cc5237ec9b3170fe58afeeebc0e7cef4c450f6e500db63301776e95f5b9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/manifest.rs",
-      "line": 785
+      "line": 755
     },
     {
-      "fingerprint": "933de5e652a715e168a3199ed686c7d4d9bf527b17c287b22fd65ab177190afb",
+      "fingerprint": "94546272e664eb626ab31042c41b2fcc35f5e9f08dbaeba4c7d9830faab1c0ce",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/mod.rs",
-      "line": 667
+      "line": 976
     },
     {
-      "fingerprint": "405110dfc92e9f67fce7cd3a08089c0d2c5062fb215733343030039f6d1cf740",
+      "fingerprint": "abecf3bbbb68c6c98c11e61a727a817b8a2fbcc379db6066ac77e1c5dd982c2b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/mod.rs",
-      "line": 677
+      "line": 986
     },
     {
-      "fingerprint": "a2a5163b61f7d13fdef6a316b9daf89f1d222c6648f2e933a9ed52ac6afe0dd1",
+      "fingerprint": "034fe7f5541e45fdb3c716084728abcb8bad48fc07de39f74cba80bcdccc5083",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/mod.rs",
-      "line": 685
+      "line": 994
+    },
+    {
+      "fingerprint": "3442fc2ee763d5213f008e493a8c39d1a317ae607011f2b42a8f9800be53ca3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/php.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "ba287edfdb414f3a39018546f11f3774e2cd73368f8f37980e5de09043f97a56",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/python.rs",
+      "line": 19
     },
     {
       "fingerprint": "5f6662f4717da5fcb3674901505bc993aca6b350e7668fe4eff11e30d22ec7c4",
@@ -1364,280 +2018,376 @@
       "line": 316
     },
     {
-      "fingerprint": "e33971ccaf4eb42a77eddef9a30e18b9cb65e32d391501cc11dda6647d4143fe",
+      "fingerprint": "cdcb2b999f7272c358f83911942d9b9a6515d6f7b33cd16f235e2d6f3374ab94",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/python_taint.rs",
-      "line": 1626
+      "line": 1495
     },
     {
-      "fingerprint": "d11b2916c674424589de2d7aaadab3c9d71f0b4edc58c31e1be24c25a68a7543",
+      "fingerprint": "add03796c534a27767975a3b95af65d9abc2d817a2b4c9f63a913fca4da81fce",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/python_taint.rs",
-      "line": 1816
+      "line": 1685
     },
     {
-      "fingerprint": "092f8c432395dc299543b9639d4fda80183dacd7ce369d9dcfa09921c24b99dc",
+      "fingerprint": "c0b40c5fd90b926e5977fee798ebea348aec18c5ce5d44f37e8e894319bf3917",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/ruby.rs",
+      "line": 836
+    },
+    {
+      "fingerprint": "fd7f41c8e17e2cdb0217b3577721b8071b0aa3f08091349be93c837605fc5f67",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/ruby.rs",
       "line": 839
     },
     {
-      "fingerprint": "9874e20f2c2ad7389f8b72d2fe9adb9e415c3e2f368bb7e7ca463e9f3875f50b",
+      "fingerprint": "637fac132cd3d2616daf5836e5947dbb28ba9b0d8b963fcac4f225221fe1b598",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/ruby.rs",
+      "file": "./src/rules/rust_lang.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "7615674b9a0002fa246b1421b14dae7d01462aeabeae3a99a2c3d1770cf0dc7a",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./src/rules/rust_lang.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "676ade54160679929bc3ba6bc0b9d06b4ec7552588b5ddf37f4e5779ed2a5f73",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/rust_lang.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "3f4bcde0ed7c4527e0465a249838e40b00157d47dda9617ec5bb56ab5764c97e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 347
+    },
+    {
+      "fingerprint": "3742a4e9950972a8bd8a54aee9544d05d1124d2bfd2d4856af6cb2f3772d8c47",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 353
+    },
+    {
+      "fingerprint": "c220c1a76c6efc2a0e44fd152b4ded06094408f253460d07eebdc769855c9ea2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1060
+    },
+    {
+      "fingerprint": "9e24a9d6b6943c2ac491bf6e37eddfc3f922146fb2fb5fba93d09f878edd7ef4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1348
+    },
+    {
+      "fingerprint": "1c05a7181b60adad6250ac49036854d1fe52392228b86ef502f808be3dfeaf1e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1349
+    },
+    {
+      "fingerprint": "9ad32cf893790458b8d7749b2f270d003340bc456f98e7d21c4254a494a895ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1364
+    },
+    {
+      "fingerprint": "86b81c6c7572f12d3e63f4d29a66739a6f46adafe93e88c11cd76f975a346c4c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1408
+    },
+    {
+      "fingerprint": "4279ac09d6d8fa6552fd036fc3fbe91ebfeef18ca67c244660c46e275993157f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1409
+    },
+    {
+      "fingerprint": "3b86e843dc57a3dc05414170e35f8865766a69aad288de0643e2b3ccfe2e8421",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1433
+    },
+    {
+      "fingerprint": "6f58029432c01495dc42bfbb471a15da14bd6b71ccbcc0ba7d01f3be60616f8f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1448
+    },
+    {
+      "fingerprint": "a434f6056ef9554264dcaa29a952a5acebd7d6fef838e5bb01bf20f8247ecec3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1474
+    },
+    {
+      "fingerprint": "6e4d3cf0dcb8de954bbb58dda698c873dc2e92af517d8d39df8499b07702b50a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1477
+    },
+    {
+      "fingerprint": "19a7bd9a5c0973750a67c02c69c05e7a4926ba100ddec9195cf730eec2e187ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1497
+    },
+    {
+      "fingerprint": "0049b3bd8ab37bfc464ed7e1ecd79c3b6a76abe003c5722835eb11ead1f9f3ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1500
+    },
+    {
+      "fingerprint": "1a50759342b0a29295c7aeaf13b28cd486a7441d82b8d307ad4696f164a38714",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1517
+    },
+    {
+      "fingerprint": "d274f199d7aaf7fbc46fe3abf36b6e4f5a59597e88b3752159c5535e4c4f165f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1520
+    },
+    {
+      "fingerprint": "19473493c11dddf262440d7bc095b3ced1ff813cf1a3ce40d8c416a10506e79a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1537
+    },
+    {
+      "fingerprint": "4bf4f269653c21fe70992bb986be366254a3033109b466a45d4ddc8965e89dd4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1540
+    },
+    {
+      "fingerprint": "8cadfcb00d3c77a2de3de7dec8569d18083ebed94a6f295f0721fc5803f1b7a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1557
+    },
+    {
+      "fingerprint": "45467e078e8e969e9c7287b0d66608ae53401fa146207641ce86ccd8fe2db25e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1560
+    },
+    {
+      "fingerprint": "562da2e8ceb8f39b25dc3c842f293d0a7d54120b5e720de6c399aed0372e5f48",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1579
+    },
+    {
+      "fingerprint": "aeca5cf26f7969c5881ef499fd66650fa5a933225ee8546bcfabd878ab13db96",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1582
+    },
+    {
+      "fingerprint": "1413fca54f0a6f5388fcd0cb85df0ff8be87bdce8ae2c481040536765a50889c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1603
+    },
+    {
+      "fingerprint": "6e2a01616bf8eb49cee49c7cab00df577d073e25e100addd3ca2b1e9b61b4540",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1606
+    },
+    {
+      "fingerprint": "f0a627c3441242f214961e956fa06850b362944a408d1fd3f6aee660009c571c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1627
+    },
+    {
+      "fingerprint": "7b3a44d6840cc5a49ffc6ba7bba517d96eb9af53211188ed35b025324820e279",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1630
+    },
+    {
+      "fingerprint": "38aaf8680ae46a00eed92771c777e85e1df7fc9286517bf6abd42728046d0e04",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 548
+    },
+    {
+      "fingerprint": "61dfd6858b20545616e6d82b1dff47e2d63860eb6a0df6f33e298fcd9a4a0bc8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 648
+    },
+    {
+      "fingerprint": "76b8f7eb3675ca03beb4690ebfd151117f9426d9e795848c7e548f6e73d597ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 731
+    },
+    {
+      "fingerprint": "725f5caddc515a29f3aa54ff9242a53ed8b59f355475d1ae10070eab5d8964aa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 743
+    },
+    {
+      "fingerprint": "49a8d5e0a567976d2a78bf966d4097163034e339159c162efc6d67cb714f940b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 755
+    },
+    {
+      "fingerprint": "3612d852e62ea8af07ca77f5ba43d41ebce179fbe388658ecb90e2f131b33397",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 764
+    },
+    {
+      "fingerprint": "1c2670f2f4b8241bda6aa7edde7cbadaa85abc4cba13952f28aaab9f92c32e1f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 773
+    },
+    {
+      "fingerprint": "dfabdccaeda351e8c6506a1111e3ed94f043e8a3026407b47d093b6abb38e650",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 782
+    },
+    {
+      "fingerprint": "1267cdb32e45836e0026abc58c2c030b4fadf6ede2d0eeea921bcdffedd222b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 819
+    },
+    {
+      "fingerprint": "f8249bad1fbdbb3f06507843cd0bb8d89ae24307c35706e3707616244d7aafb9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
       "line": 842
     },
     {
-      "fingerprint": "4b1551e6b90efef862119d3b8f16290ed6ce836a3f61e57b89d56e3ecd4c997c",
+      "fingerprint": "4283f0f61af6e7bbdee0bfa9ac8626dbb5d3dec03d56b884e6ab3078e19bfeb0",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 893
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 857
     },
     {
-      "fingerprint": "0b4407c68967f3c6e81ed81bdc48d3821ac67c9c36779cbc0c0c5a2e72796c3d",
+      "fingerprint": "c5a8b7869f3e314ac6ec111435fd4971829b1701c9ad9d9b666f572b63cd0c0b",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1074
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 872
     },
     {
-      "fingerprint": "4ee54ceba3b3d030af08dbbd2acaa3a40dba364b1f46cb88014a90484b2c392f",
+      "fingerprint": "303bd6904d2719f1b6e9203a86e84a07814a0b77d4d1854bc76cc7370c9a2551",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1075
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 895
     },
     {
-      "fingerprint": "5ad40f27868b5c4878612bd488043f211c77bf38e25265101b5d2f5aa879d81d",
+      "fingerprint": "6dbd206c8deaa2adf3df85a3756553e6295494c79673d4b90d794582eb3f20d5",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1090
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 914
     },
     {
-      "fingerprint": "903a9bec70203ec7ef033f2289ad597aa0bfd6a8791e9cd17ddfcfc56ef733c8",
+      "fingerprint": "d6b7b9e6c39c59e83118271bf98325104a1ea19aa981d272880baadb7ff8db72",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 927
+    },
+    {
+      "fingerprint": "85bb3803dc4446b4d5e28bc785a36265f4cc53b0dfab117b98d7ad7c36ab961a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 1060
+    },
+    {
+      "fingerprint": "2b11eac46c1b74270aea7a005bf3ba6f532bd4430fde2aded9dfda6bf5172e73",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
       "line": 1109
     },
     {
-      "fingerprint": "adf0546439b77897d35bcfabfb7f1e77aca11e15e1c345d5d3a4e0b012ab145d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1124
-    },
-    {
-      "fingerprint": "8a6dd190b54355c65d3977dfcd70fdb6c9ac66623a1e9bc40c8c59629dc537ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1150
-    },
-    {
-      "fingerprint": "2027193b2b891df35ec0bbc138659bd2e40c2d53c8db50c6fce4f836f54968cf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1153
-    },
-    {
-      "fingerprint": "a7399c31bed5b5c40455563fc0cec0e3881569c6e6f8027b6e000a74b5f3a7ed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1173
-    },
-    {
-      "fingerprint": "1b6d13c09eae616ea28b4cbc5d78c198064fe0ee9ad3faa8d70a3635147a655b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1176
-    },
-    {
-      "fingerprint": "dd786eda3089a29298ced62a322fd68ce2a088f4d6c8027fa9a4f89f6617eb72",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1193
-    },
-    {
-      "fingerprint": "82220d9a4536076a8ec1c9aba7f70236f4d188f75b12ab07e4e79624fd101e8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1196
-    },
-    {
-      "fingerprint": "2dbce23fad803768da1ecb84ba796ddd6688c1b721b32e0c027a84bb8045bd82",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1213
-    },
-    {
-      "fingerprint": "06d39fc5ccf42f92c91199e44bd6ce53aae80dfa913758ad9d77098721c41a5f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1216
-    },
-    {
-      "fingerprint": "885e6784eb81d323e8e7cfb555d63ac89b932262964fa359c4039a793d82cb63",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1233
-    },
-    {
-      "fingerprint": "33d3339c8c85d1ca626d1278390a042ebf3f2120312182bf377517fb77052bb0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1236
-    },
-    {
-      "fingerprint": "914be65a35c1e22ea10299ea4c3fadeedd42f6bbbf3a4789ef150f337603ac2a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1255
-    },
-    {
-      "fingerprint": "ef1e9c7a525e6dfab9907d4a4285838ea94bfa04dd1bfbd729cbaee5f44525e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1258
-    },
-    {
-      "fingerprint": "aacc394eb5c8c1a2b98f1400eb36d7dd2d8485d71aa1af9b486c1d1496a30677",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1279
-    },
-    {
-      "fingerprint": "0fd3c8d21101c38a7c7d0f86fd8c90c3319356b689cb7cd8789a7b9e8c012bba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1282
-    },
-    {
-      "fingerprint": "c827a033c2b77f48ee309db28f6d8b2f34b66b2d8b1cd5bb3a47ac0410dde5d4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1303
-    },
-    {
-      "fingerprint": "f745823b985b414a24386052dab15d46ea7e894ef0dd605142da6ac223aab341",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1306
-    },
-    {
-      "fingerprint": "02cbb3844fc6dc00821863cc03db6d58208ae028306c1387298c7dd7988e86df",
+      "fingerprint": "acfa49d62f48d69c2f01e6f3fe745d38a0909ca6b578f6e5899410c53060cabc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/semgrep_taint.rs",
-      "line": 544
+      "line": 1126
     },
     {
-      "fingerprint": "a8c9b201e6f67e15812b587c1136795a27e3c0d6df6cc74d16296a17efd37adb",
+      "fingerprint": "ac3bb3687277b4880789a5741167360f041b19722675145b0144f7a695874409",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./src/rules/swift.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "0945f5c890be7de33946cf68b7c65066d35525b561cdd5a8327a90ca46b6d511",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 644
+      "file": "./src/rules/swift.rs",
+      "line": 17
     },
     {
-      "fingerprint": "4dae15c54a5000a9aa96a4118a6c45c28fc1aebd5f3fada41e188ec0712ddc05",
+      "fingerprint": "7a6528d216c0b12d01d0b91fe6ac80e4bedd180c1975395754baddcc8494f17d",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 727
+      "file": "./src/rules/swift.rs",
+      "line": 25
     },
     {
-      "fingerprint": "43c2edefae60a455292a3ab0c21707861683ba23f605e6b76c5c0c730ec58a15",
+      "fingerprint": "440450b487f36c09b028540ea87848478437a2f7b5aa4c5a08ac7ca57e717ddc",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 739
+      "file": "./src/rules/swift.rs",
+      "line": 33
     },
     {
-      "fingerprint": "6b8664702af7a85ad06c1ec4c6cc5719780668919a3824b94a92154dc9b7bbfb",
+      "fingerprint": "608f4d44cc902b8e0ce9c0d5a9d2451ea4748108a72a13ff8b5214c000284622",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 751
+      "file": "./src/rules/swift.rs",
+      "line": 41
     },
     {
-      "fingerprint": "cd3195baae90e2ae3c1196ece4afa266c7d269fb690a48e15ebba2bcbd1bad2d",
+      "fingerprint": "84218aabdaa35021816f2d05ff35f8fd3cde7e3fb656141bafd60080bfcd231f",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 760
+      "file": "./src/rules/swift.rs",
+      "line": 51
     },
     {
-      "fingerprint": "6987a3c347e29b3f8e5906eeba82837805a1ed8c25c3335ac358852eaeee3e2b",
+      "fingerprint": "2240b65f4c5365d111833ed3f57f02958b9f17aa7a6ccbc16caa7c00237ff4ed",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 769
+      "file": "./src/rules/swift.rs",
+      "line": 59
     },
     {
-      "fingerprint": "b4ceeaef38735d01c53ee6c492a9d61857faed3aa98e71c65cf65edfb0b17830",
+      "fingerprint": "1294407a2d1ecce062332fc3a09a8145bbb1964c13e91ac11b7ca80ce1bd62b6",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 778
+      "file": "./src/rules/swift.rs",
+      "line": 67
     },
     {
-      "fingerprint": "bf45e9556aa2f629ab41ca87f1e8241446e9507fb55bb9cd629400f42cbfc785",
+      "fingerprint": "fefc4623c5698cd8baf3dfc3e4a3e15583c7a34edcb789fb55cee800b70be7be",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 815
+      "file": "./src/rules/swift.rs",
+      "line": 74
     },
     {
-      "fingerprint": "769dc396a81d756f397a1fde3b7c1a6cf1a54e7a3779c9457ce37a7d955de9c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 838
-    },
-    {
-      "fingerprint": "aa14ff6e5c737523ac91af344a58db2c1d5f5a67d9a87b44b8f002ed0d7eec4d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 853
-    },
-    {
-      "fingerprint": "52769fd75ec81f94df04c934b252796af268548258c8cf22aaea33466b8f28af",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 868
-    },
-    {
-      "fingerprint": "a8be1eaaf73c5e4a13e95d64b0898e6f1aa18f24a0a7c180d0822810881e3230",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 891
-    },
-    {
-      "fingerprint": "9430ebd7293fb4c7d37591af6789e29aa36532e5a3948e61b79f497ab3552bd1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 910
-    },
-    {
-      "fingerprint": "13474c02cea276dcfecc955f435488897bae0d4a3fbc40845906249631eeb3a1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 923
-    },
-    {
-      "fingerprint": "1e9274b42b5d3d085d9ee7ecb445d2692d564bc498277986fd91707d240e9338",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1056
-    },
-    {
-      "fingerprint": "bb7a5e244aa0176ffa5896ac1cc5cf0a49b1035a99656c26e6fd504ca0ab4cb3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1105
-    },
-    {
-      "fingerprint": "276ae2e21bd29e749efb48e94a511202fd771f092f848ec2012ea05581b8b4b0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1122
-    },
-    {
-      "fingerprint": "5c962278a8a9d6e849a1e7401fb0fbc0e651f64d49b69c493bd83ed7499b288b",
+      "fingerprint": "85c62a5896cbd9a5de228e47eaf1d468c1aeff032be9dcf2d36bd7759f63e662",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/taint_engine.rs",
-      "line": 439
+      "line": 814
     },
     {
-      "fingerprint": "8428c9fafa1167380a09380037c06fade3d47320885c363f56a7749d905b4f5e",
+      "fingerprint": "707377de73b3e48499863e79a2a79f467b9d312e8f648c22f2973be1b56f5159",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/rules/taint_engine.rs",
-      "line": 464
+      "line": 839
     },
     {
       "fingerprint": "00c010f9d5b52be7b7f62eb7aa83821675698e70068300b44cf3a35eb02c0183",
@@ -1646,64 +2396,76 @@
       "line": 189
     },
     {
-      "fingerprint": "a9c8fcec7e0f8d2ed00f97c62c3c262049fa6a0be84d890fe2c6573b8ffbc072",
+      "fingerprint": "d820b72d039fb9582b8433ed84ae2161203c47d6e5be90fa786d81fe3672a1bb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/tui/input.rs",
-      "line": 353
+      "line": 354
     },
     {
-      "fingerprint": "a4bf62c0839404811dfd72a830af96cfbc69c811efd8277c23f0ad6159b61b3f",
+      "fingerprint": "aedf3a8c627c9f5fcbce2e3ac5eed2537516cafa1163232e95b801c509a38060",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/tui/input.rs",
-      "line": 356
+      "line": 357
     },
     {
-      "fingerprint": "c3c766a778d00195b9bcb8b211363f7a8380a1e98da9edea8ad4856802a7b545",
+      "fingerprint": "1b359a274b077cc3fa694b4cfd98c09ca18bf570d4d311aad3d2368e02e37708",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./src/tui/input.rs",
-      "line": 360
+      "line": 361
     },
     {
-      "fingerprint": "cd8bd547cf6841c1dc4f18c01205132ecb681912c90e6903ee05f7ece412cb24",
+      "fingerprint": "04ccfd4304fb80250f02504fa200395a07064c35b237163e5f3ac0eb612ab31e",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 433
+      "line": 434
     },
     {
-      "fingerprint": "bdb849dcc83f2a2fdc3b28a9c286bbc11ec07a2dfa55ff0e73fbc3ff7cb0d8dc",
+      "fingerprint": "0c0107b4296fe5bb170cac10cf8174dfeac179bc4363c0916afa38f674cce2c2",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 460
+      "line": 461
     },
     {
-      "fingerprint": "b2776b1da84156ab53abcd9a4e84ae5209a51a43c88e9f3a5ac9612436bf1e9f",
+      "fingerprint": "d7bc0a95b149f5c538fa651f38e0f873c99a74078670f8a51c65f670c7a98ad4",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 656
+      "line": 642
     },
     {
-      "fingerprint": "cb99565883a3e9b6f43e9dad53786a7dcd4238be4c8073513b6092fbd13c83e7",
+      "fingerprint": "c5feb22afca62581c9c88efbbdfd1e12bafe51a9e688ed22fa21432365138e86",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 677
+      "line": 646
     },
     {
-      "fingerprint": "98d0aea83d0b8d9b2bb64a724e26d0bce9b446c82b21253ec88c8c26cfcb67c8",
+      "fingerprint": "67a755197f33eb90773e475c4abdb5242c2b50460c1557255263668d8276ebf6",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 706
+      "line": 666
     },
     {
-      "fingerprint": "a6014c3a16fe2301bc47d705b18a5b2a4d013dd0227d8a5087e3cb66d6d581b5",
+      "fingerprint": "24e3d312875fbde397c0b4c03bd6d6486b1f5712379f942a59a3e1a8bb510688",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 742
+      "line": 687
     },
     {
-      "fingerprint": "1f8fe66ea5c95be0cca097d650ee1eeb23b3924ef52a5286276db6f8ab3d78ef",
+      "fingerprint": "bb9070dcd4aaad87d6f113bc74c3d77404647b72ea8d2b08785a8eb9d9395032",
       "rule_id": "rs/no-path-traversal",
       "file": "./src/tui/input.rs",
-      "line": 818
+      "line": 716
+    },
+    {
+      "fingerprint": "e3e3954227ec06076e34c36ef394610b53a8f4a50a162b7fc4e7485a0feb0125",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 752
+    },
+    {
+      "fingerprint": "28ef043cfcb11f076e0304620e56e9e02eba73899b818acbdc2ed2877e4fa10d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 828
     },
     {
       "fingerprint": "8057ec702926ff34e8d01850067c450254093fa31f85f82a2d9c24dc028e02d3",
@@ -2042,6 +2804,30 @@
       "line": 1123
     },
     {
+      "fingerprint": "021a59a8d6ae0ac58287cf6c364f36fcbe3e87df25183e72857e9ee241459c5f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/ast_rule_batch_bench.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "a0028135f49795103ab8253beb1ed824842ab16767694bd1913962e0f9c565ba",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/ast_rule_batch_bench.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "1ec2fdc22d140e8577e2eeb783d775980348191d89a76c65ab28c9b14e655892",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/ast_rule_batch_bench.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "92655c580fc99f7fee01caa43151595d68f75569798393801a32b12b25a8f038",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/ast_rule_batch_bench.rs",
+      "line": 30
+    },
+    {
       "fingerprint": "446854433cfd47fcdb01e1b2806729e420401f89c4091709dcae23ac126c67eb",
       "rule_id": "rs/no-command-injection",
       "file": "./tests/cnsa2_compliance.rs",
@@ -2060,40 +2846,250 @@
       "line": 21
     },
     {
-      "fingerprint": "cb27ed7e543c44e9c0a4aa561346b24873d75592a2f890dfad9ca7a19f423f2a",
+      "fingerprint": "9ef5e49846e219e2652c152d1374c06eb7198294daac55b176a043b8185836cd",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 91
+      "line": 30
     },
     {
-      "fingerprint": "b6771aa52172ae0858f17d19dbd41ffd426fdaf73aa505105c299928ac1c2430",
+      "fingerprint": "23ebe41662cffe2f56a7b690bed49665c49531adcd7b142ae7893984f552625f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 99
+      "line": 106
     },
     {
-      "fingerprint": "ac9f239eb36a78b60a69b0b1d29e225c9b030cb0c9f9242d3a37f74ca94a5236",
+      "fingerprint": "41144be0527977afc369182ef3df71b4dd36b515a73ee9231e21ddccedd6e119",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 163
+      "line": 168
     },
     {
-      "fingerprint": "c90ed31c9121eb955ad787f5141a44a64adeccf9dc2b6a2877f4fc436b9522d7",
+      "fingerprint": "60495d629546af9551ead15bb7f65be67cd81a5bb2b49bfca3e7f52adc5caaef",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 190
+      "line": 195
     },
     {
-      "fingerprint": "6160ac6b4b1ad90a594db5c2ffd6469d0d98cc723d5dd899ed7f7127595d2cac",
+      "fingerprint": "1f0fd2687febe70a864be829c103bcb0bdf9a71706e7a4feeae85543e266ebf3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 221
+      "line": 226
     },
     {
-      "fingerprint": "aab65138cae5c724cb5b38c2b31c7f96d32eba42042440dbcf65e988e7f293b6",
+      "fingerprint": "bbb638193c7a03d49c2be87d5a86f2ff4d400107a3d1e2244ef999dfc7b42e34",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/cnsa2_compliance.rs",
-      "line": 239
+      "line": 244
+    },
+    {
+      "fingerprint": "e0fd39f99f662aca1eb02cb7f111e3f01c6a78ee2b3f8945213befab9967bbfd",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 10
+    },
+    {
+      "fingerprint": "f063feab00bf40d5a2371209175bde440350ab6c526c6bc034173a1871376924",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "24a9a1031cc248b4c9a50555d6fa9dd9b07889ed0913d4dbc1d37315f3cdbc91",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "65f80f63c90678f4dea3cbdfcab519595a53fddd5509b4744b2f649f8197100c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "b14a447431c44b4fe625b3f471b581aabfc8261322d283ee7fce39f54ff87213",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "bdf383e70fd4aa3fd773981ac298f85d4ef4b7aac0e60c48691ef808de6cd4c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 46
+    },
+    {
+      "fingerprint": "04e6ba737f3c5322f05f6d576f508b62e11442cd3a4c2c22614ec1037556a35b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 51
+    },
+    {
+      "fingerprint": "d0d5ab8dce98522d3820eb080ca04881b3ea22805b399c6e084d7994cbc77068",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 52
+    },
+    {
+      "fingerprint": "b5a7a098c07768e038f19b878833e3e245839a8a3b116b11153916e7e2dcfae3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "1a428d7708caea27cf9a3d1ed59d2d2d3b96d9e9345601b3773e3d16f307c4d3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "bfdd0d0fe67402c1192d3343e25232c9b085613ef2fccd4b263e9374c86d94e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 74
+    },
+    {
+      "fingerprint": "ab441a0e9ae2ac754eb7530932a56c7f678750e91db25b345b9db2d8612f45e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 78
+    },
+    {
+      "fingerprint": "f5d1f9a61c716c5fbbf33efa6a98fbcc0bcdfe3234c8102f2c010aba9ee7e7c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "fc2731f2c2e0dec7ea582865d118eb47a78985c154717c13680b24e9c81c721a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 129
+    },
+    {
+      "fingerprint": "62597eecf44ce129db9fe409b88629359bad8cfce1df54715cbbb31e3418e521",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/coccinelle_integration.rs",
+      "line": 138
+    },
+    {
+      "fingerprint": "14b486fde8157ff6090b43e1026054122fbd765d581878ed165204d7d271b186",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "9fef00879031a1151ae09fa3948c280bf5178976d4cb0f34d176d254a7b363c1",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 235
+    },
+    {
+      "fingerprint": "1a7ba04cf57c32d9fb674b63b2a5391b4517dc4c3838a55bdfcb9eb69de2023b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 235
+    },
+    {
+      "fingerprint": "39f6d5ae5a64d1409a33a857e1df75f2ef028b1314b40e7b04045482d9d4ac7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 295
+    },
+    {
+      "fingerprint": "3ffaead40e10cde753444ac8e6592b4b8e7372933ed50dfe2cee409c24bf1ee4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 301
+    },
+    {
+      "fingerprint": "76bf3b6f577c9aad6d75b746d0c5be27b4c7bb613603c3087e145f91a5f075e3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 310
+    },
+    {
+      "fingerprint": "57e64d3bc31a8c818046a109a8c8fe9359f0e61aabd077b81ef6680361094160",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 317
+    },
+    {
+      "fingerprint": "842205b094237fe061f2351381585261bad391a31a6abd9bc4c52a19f1d3c9f8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 348
+    },
+    {
+      "fingerprint": "59fcb8606eae721a11f57bd46e4813e82f84d8b94a91e8cdc071fff698ec993d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 440
+    },
+    {
+      "fingerprint": "a8606921676ce0fcb6b034148f170f3c17ca049352d5c65244beecba146d9072",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 442
+    },
+    {
+      "fingerprint": "1a025802b570094d40f474029284f9ca2597d30636ffe3ac030ff29267a5a535",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 505
+    },
+    {
+      "fingerprint": "a710c2a8c13d55bf1223f631d447458cefd5c9ee63204ab9a6fd467c3a3a2a74",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 508
+    },
+    {
+      "fingerprint": "e7665b295cbd96162f25e7969cda48890cb45490c758d7ba7e4015e8c31a9640",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 511
+    },
+    {
+      "fingerprint": "44dccbf753d1da60c94c26148998bb1797ac52da75fdf9a955d9b96d3305eefe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 514
+    },
+    {
+      "fingerprint": "b46dd1c974603e40e2316f97d22db81b46685e10d23ce19fa9bf8a650b14e3fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 516
+    },
+    {
+      "fingerprint": "7376a46590d3b2cf1c10004ff01ecaa379cf65d41e96b8f6fcc956f8f38cd5f3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 547
+    },
+    {
+      "fingerprint": "28caf2644977f809ad0b4b9e3c5c96e85ec89a84a41f8d0825e820ddf33dea62",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 550
+    },
+    {
+      "fingerprint": "63ede03332e86b21c11ca51603c6c42a3698d68349bf3bba9b66884fe6162f4e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 571
+    },
+    {
+      "fingerprint": "7a1051438ee0e86ed1f8493d45f5552d66b18df65b5c73af215df85abeb567de",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 575
+    },
+    {
+      "fingerprint": "4a20a63bd7ce34e4080e63e6423e9794217ae6fdb2ae95375a6ae7e79ae37b5e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cross_language_matrix.rs",
+      "line": 617
     },
     {
       "fingerprint": "4a209776a3e7761ab74111288af55ee22e648562b71cd1de503b72f66abeb137",
@@ -3248,88 +4244,88 @@
       "line": 8
     },
     {
-      "fingerprint": "74465c45c1b76a7770cb659fed433179b37b73925e16c29ba5865e034e3d1c5e",
+      "fingerprint": "c2d5af79edd7908572c6b03b759bb873f558248f8421cdbe3e1c3438e510aa6a",
       "rule_id": "go/no-sql-injection",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 21
+      "line": 22
     },
     {
-      "fingerprint": "434e9394ba4af425c9e9d719e28ed821b843acee3fca39edc00830e1c2f655bb",
+      "fingerprint": "fb35ec2d5ddb2bc197812688882372ec0752993a1d9e97e39a06ebdf3e2eb0d7",
       "rule_id": "go/no-sql-injection",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 24
+      "line": 25
     },
     {
-      "fingerprint": "277485f44e9a94770d41166b3aac2cb9fbc1a1681ac1ccb6c51b188cc3720c44",
+      "fingerprint": "4043ca72a392ac65be8437de09de401d5f34ee8cd140af7669fec087c584bc30",
       "rule_id": "go/no-command-injection",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 27
+      "line": 28
     },
     {
-      "fingerprint": "e53bafc73d0f8ba1e5ebfccddf5d5792995e46864b47d22c0632144baaf93312",
+      "fingerprint": "71ee7d46b3502a9ade3137bff6d1fd66217957833cfb979123cca09706f3b857",
       "rule_id": "go/no-hardcoded-secret",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 30
+      "line": 31
     },
     {
-      "fingerprint": "dc33c63fa7585987fb4fcd980d2528940794316bbc4c48721a1818e88b416f3d",
+      "fingerprint": "ade056cabb35cb3484e860229cec4cec6f7c57b683001fc8216432a2eed2badb",
       "rule_id": "go/no-weak-crypto",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 33
+      "line": 34
     },
     {
-      "fingerprint": "d947b1daaf0207748f2bd7ce5f5618528d91478c4555de4d331455e748a8cadf",
+      "fingerprint": "f2af9ae23084eefb6b3c063af170738a4ed4ba893954477ba22aee9d5d4818ed",
       "rule_id": "go/no-ssrf",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 36
+      "line": 37
     },
     {
-      "fingerprint": "c10cf2fd2cc1e813f2bf7e4836bcee846475cd6b1845bdd6eb1cc967685db102",
+      "fingerprint": "9977d9afc10f750b67bb911c1004f53486d5d03019a34f17aba0d99d4960729c",
       "rule_id": "go/no-ssrf",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 39
+      "line": 40
     },
     {
-      "fingerprint": "b2fabfb2533a76784f40a76c30b0b79c408f89bfa16cb1562cf545f9dfbfd0f6",
+      "fingerprint": "1d557a90238594cb75a3c9689d5bc507817653eff54f6d2140e65109aae3ff1a",
       "rule_id": "go/net-http-no-timeout",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 42
+      "line": 43
     },
     {
-      "fingerprint": "101061eedb77c49e3ae4852d11f7de48e59e3d1a460876153be8a46d418649ab",
+      "fingerprint": "4bc336d7d30621af4881b29af5d89e7fbdbbfc12801eba23737f6ec9fefaff27",
       "rule_id": "go/insecure-tls-skip-verify",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 46
+      "line": 47
     },
     {
-      "fingerprint": "fa1b8c49a43927639a6e3acc33d17ec4d07d0cade6c7b24d6ad9693b14581b31",
+      "fingerprint": "12c6b9f4afd48d4f696d34b7117677528ab370a9bb5e35e812c845eb59f8c82e",
       "rule_id": "go/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 50
-    },
-    {
-      "fingerprint": "5405b945f1b7e6e9f043953b8452af773246cb84aa8fab3c92a53586c962eee9",
-      "rule_id": "go/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 54
-    },
-    {
-      "fingerprint": "1ae32b0236cff87744b5796a1cd67483f263462b742fc3a4198b21fbb4eef5c7",
-      "rule_id": "go/jwt-no-verify",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "5642df1510f823a3104a4bba7f56f54ced55544503436aaa4ecf30ccaec8baf2",
-      "rule_id": "go/jwt-no-verify",
       "file": "./tests/fixtures/vulnerable.go",
       "line": 60
     },
     {
-      "fingerprint": "52dabf3c89bb926790f117104e269b612c6f4e8b504e2a81e70419019bfd2922",
+      "fingerprint": "ecb8464262a2912f597a022b4af17ecd4eb1398fe8fe165ae31d0f35e426b834",
+      "rule_id": "go/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 64
+    },
+    {
+      "fingerprint": "b6ea1c741925ab17341b4f54e2779cc0fa5feaac0542f24206c64039a8c6df63",
+      "rule_id": "go/jwt-no-verify",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 67
+    },
+    {
+      "fingerprint": "91b5bf7d47dd23e9dfee7588dc4b0ac70063f257a9e92b39c20b4ef5df24da61",
+      "rule_id": "go/jwt-no-verify",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 70
+    },
+    {
+      "fingerprint": "563c1c447e4d4f97373ea8b655c1d8abdd8c1ee0d9df72f8e417f395d61a8f33",
       "rule_id": "go/jwt-hardcoded-secret",
       "file": "./tests/fixtures/vulnerable.go",
-      "line": 63
+      "line": 73
     },
     {
       "fingerprint": "b38dd555b3b949c5166cfc66656a965bdaf47384e96c4fbe2cd2c45493668381",
@@ -3654,6 +4650,78 @@
       "rule_id": "js/no-unsafe-deserialization",
       "file": "./tests/fixtures/vulnerable.js",
       "line": 100
+    },
+    {
+      "fingerprint": "5e045bf4d14eb91903ea7c64d44277237573c7eac5ba86c3f52f564fd026754d",
+      "rule_id": "kt/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 7
+    },
+    {
+      "fingerprint": "9546631540531fd5966676c5fa14668d7930754e6b877348cbf1c7e6c78c52e7",
+      "rule_id": "kt/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 11
+    },
+    {
+      "fingerprint": "ca7c818abc6b601e1791badbe89a2186b583de3775e127da0d774f4b8dd18337",
+      "rule_id": "kt/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 12
+    },
+    {
+      "fingerprint": "3bd3f312e9280a1ab0603230daa1171e40ca96423be09ecbf187fd4265498303",
+      "rule_id": "kt/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 17
+    },
+    {
+      "fingerprint": "961522c93064601cd1b6315ba50e25865fd5f8c078ecbaa71b24ba0637aff77d",
+      "rule_id": "kt/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 21
+    },
+    {
+      "fingerprint": "8d164219679484edc9d6b88a9cbf60b1928055c5f732c24ccb6c738e0a382ba3",
+      "rule_id": "kt/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 25
+    },
+    {
+      "fingerprint": "3ea363e54f7831afa51fc05cc81c20f4e4b00a4c798892a8b7c57a9d513b6035",
+      "rule_id": "kt/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 33
+    },
+    {
+      "fingerprint": "22af00a5b95673d45e051e3fd838e569e66e68851e5e62395e787d9b32606e2b",
+      "rule_id": "kt/no-xxe",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 38
+    },
+    {
+      "fingerprint": "e45b9b64b44c2d3b337f14e091c3af054bcb485be62a7afc06ec3108a71e564e",
+      "rule_id": "kt/no-cors-star",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 44
+    },
+    {
+      "fingerprint": "03290c914e8c9f3661a983c3a3d36dc00cdbb684a7f9584d95beedfdeb6580c2",
+      "rule_id": "kt/no-eval",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 48
+    },
+    {
+      "fingerprint": "30124d5b33f337a0932be9ba10be01ea33188736b9bdc538aed5aad741ca5980",
+      "rule_id": "kt/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 53
+    },
+    {
+      "fingerprint": "96fb44f931d97a858576f2b1cf962fb6162b3f7e8d3295ad000e685f5ed721ce",
+      "rule_id": "kt/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable.kt",
+      "line": 53
     },
     {
       "fingerprint": "5f44d08fac3ea97e8d080ee932dcebd59c6e629c9b2ada0afcfeeb9d400f94d7",
@@ -5372,454 +6440,274 @@
       "line": 247
     },
     {
-      "fingerprint": "e497082d69e4e6981c56929e79a6a97f515f6cd9dde212fd79df058b879fa04a",
+      "fingerprint": "d84099aec001886ec3df5c83d5adb4b6818a5056e4b0b7c591920996e16e0204",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/vulnerable_tsx.tsx",
+      "line": 6
+    },
+    {
+      "fingerprint": "7c3ea0dd7f616c615fa72809209bebab94b3513ec00566e7d0b984da4239b23d",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/vulnerable_typescript.ts",
+      "line": 6
+    },
+    {
+      "fingerprint": "bc90f5aa427a302e745274d93b3be7777f06a3288de04614f4f06a2ceb7035e0",
       "rule_id": "rs/no-command-injection",
       "file": "./tests/integration.rs",
-      "line": 7
+      "line": 42
     },
     {
-      "fingerprint": "eba0076130649dfbfdcb55929928d284379365b01967ef861dab28133e666416",
+      "fingerprint": "95df077c0c1bedc808babcaa9c536f76010f3efefa6eb0a651a8e79074c21230",
       "rule_id": "rs/no-path-traversal",
       "file": "./tests/integration.rs",
-      "line": 11
+      "line": 62
     },
     {
-      "fingerprint": "44f56c40eb8aa3144e74a06c4fb69cc60e80a1831fe2ec9a4ef80c5a653ddea1",
+      "fingerprint": "0e9eb77a577dbe76ad5687daf355026450f2b47d9432f0dad7e3d1c223fcdadf",
       "rule_id": "rs/no-path-traversal",
       "file": "./tests/integration.rs",
-      "line": 11
+      "line": 62
     },
     {
-      "fingerprint": "96625d420933d7e71b01a8862aaf0c48c2861a27bfa2ac7e06b8ef676ef2048f",
+      "fingerprint": "2c7aff86903ac0bc4aa8a32bbe95334e0b182329badb1329d95b786eab4db4a5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 32
+      "line": 83
     },
     {
-      "fingerprint": "2279f3ccf706007cfadd9f74e986759a93b84eebe61fd06a6620d75101ea9a97",
+      "fingerprint": "90b694a33960ce615cfe2307fc7c32431afc9e0d5eaaa2291534574e64592450",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 41
+      "line": 92
     },
     {
-      "fingerprint": "802f09e5510bc22b071858f4e3684be96bddb451404d6fcda00c6a7feb474943",
+      "fingerprint": "f27fbaa3a098f9411e97a0ed7cb2c60dde47c54f13765bd4f641257d201f49fe",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 49
+      "line": 100
     },
     {
-      "fingerprint": "b08dd553c50973f9e90853924316fad44eaef9443c15419c57ba87303b78e9d9",
+      "fingerprint": "6e60b7e0b87c0f05b649cd4f8b849f4e98355b7bad49030c541f004fd2868b94",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 51
+      "line": 102
     },
     {
-      "fingerprint": "9e1ca5639334e07b9d8aabf33d6c4f96a0b04da87f2257c3f05eb7619c9158a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 56
-    },
-    {
-      "fingerprint": "39ab6f3e5a9c27563a2a6497359a32e64268a87b920816073a1f8681d207e1cb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 58
-    },
-    {
-      "fingerprint": "0d95f74b3a8efe1908c348ae0b69108e98e71de7f40c2492a41ed0f021e3b642",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 67
-    },
-    {
-      "fingerprint": "7be0adb8f28ec4a03f3f65bf5384009c47a8383a7b9749cde3d67e965132e6a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 76
-    },
-    {
-      "fingerprint": "85f70baafaa4ceef33a55b98237c44db7f7437c8ff4ef574a801fa9625b2761c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 78
-    },
-    {
-      "fingerprint": "57605c0a005c748111449834412b74a672fddf2e13bd66e1df07d7d6a6df4d05",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 86
-    },
-    {
-      "fingerprint": "3fda8137364c71876cc84929e6987e70f8bdf7abaf02d53c869d58b16f380cb1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "108c4678e646a9e550d5a8cc8fa86699a928481978ccbd3883ef900924af52d4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 99
-    },
-    {
-      "fingerprint": "20f790288961648aeb8a27c5c5945d93c14bbbe3dfacec2dd0f8353769bf68ae",
+      "fingerprint": "17c9d0d7226850d5c08041a7993c2d9c0a174ed33464959bfcfe408b3176c58d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 107
     },
     {
-      "fingerprint": "d0fa914616aa5f0adbbdb7c4d7285096098e54bbd91dbfc68783fb6ea0fa1966",
+      "fingerprint": "ec4995de741c90095be06e9537cd41f9c68920c658b1fa6af35be632e0694b98",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 169
+      "line": 109
     },
     {
-      "fingerprint": "f95537b328c225a2386c7a932633f3d16747df5b1577a28b8dfe28cbacd28ee9",
+      "fingerprint": "b238a2805c993d45d7435b08c4759ed5ef7c00b371348b482d62cb72b98a648a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 177
+      "line": 118
     },
     {
-      "fingerprint": "cb56c3a453945b5517dd410f7a2b7daea812918464a2810f98765216aa288276",
+      "fingerprint": "2b22f8efba0d3ef360e49fe7559b4875d8b93dee0d1efa628b5bc81cd6a4cf45",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "e32cc12e60ab8cfed51fd43312641fc089cc989e89f21a121bbe8b593965959b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 129
+    },
+    {
+      "fingerprint": "1c83512bbc17b697a596d90b760f07833e72393ebb03d6bca73f6656a22a5b35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "ced0be284e22c20893d1829004a6e10e3db4cc3af7cf7e48aacf6828557c8d63",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 139
+    },
+    {
+      "fingerprint": "f425f50be1fd20f80decf58b39da5920b36a5edcb25d55414f4ac7dc1aab20e0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "6d37eeccfd284e57eb54dd9dbee3cf46565870bf4bf6095761fa2233f7cef9b8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "aa7d572f0230073d6791221ae5bcccc39069c5a7bc51f3dcab41f76da6a2904f",
       "rule_id": "rs/no-ssrf",
       "file": "./tests/integration.rs",
-      "line": 205
+      "line": 254
     },
     {
-      "fingerprint": "1f4aa10013d792548b60e73362b0640920ea13a7c6d2a69a65c0d4e66491a33c",
+      "fingerprint": "2ab1074d6f247c1e1072e3547adccfa2feabb0fb5722c6b69b6270209aa23a10",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 221
+      "line": 270
     },
     {
-      "fingerprint": "f3b0990b86891fe353f11dc9b0c226071cf4327f0965d67ea7a559fb31467867",
+      "fingerprint": "866af0177c239120cbd953896faee84256b608abf44052c68fb9e18ae8fcb9c8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 229
+      "line": 364
     },
     {
-      "fingerprint": "fbbbe342fe1fa22420416b77b50598ad0da3638637b0fa4c777ecc050008a9f6",
+      "fingerprint": "0c6f255a0290d5e95c9f8f80a3aed591a17e87c965b1845deee2f0e74c61c564",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 316
+      "line": 402
     },
     {
-      "fingerprint": "017a7ec825efa13ce9315b489448eb955f71ce904ce40f9e46192ac46908335a",
+      "fingerprint": "419fdd8279a7364b127168006685ee6cd5736dab471016f294dfe6ecee6179a8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 322
+      "line": 439
     },
     {
-      "fingerprint": "9befda8b2e3b72d9113c1009425520c2d01fced57a0e157e38c1e8f232c1e9d7",
+      "fingerprint": "3ee028825510bfb9862675864be7b065ffe5ff243d4ae7d1fccaf0fdca89f124",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 355
+      "line": 471
     },
     {
-      "fingerprint": "7da0522d42d6f5f6a27de7d1d9657e42bddf0771cc0f584814d15fd613d26edb",
+      "fingerprint": "03ea6cdd56bb875542651bf547de514f1d50c757b98450888897c5bc917d5fe8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 363
+      "line": 505
     },
     {
-      "fingerprint": "4ead2a1911333c69bc385a715e81d781dec82bf75e20dcf95e4a8c571ed34dcd",
+      "fingerprint": "9f317da3114ef837c9c6d52b64209172e2de5f0a10b487ac2f2241b420626710",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 393
+      "line": 539
     },
     {
-      "fingerprint": "22ec07fcc12417ab645630ed2065559af255f029d05df80109bf480acd5c188b",
+      "fingerprint": "ecb66c3e02e681b77c24e3ed7d9e4a930625ba1cf535fe633562d2ec7a4e610b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 399
+      "line": 572
     },
     {
-      "fingerprint": "f68d69d25c380357f08c1f747560fdba0caf4f35f306cfabe40305db08ee1d88",
+      "fingerprint": "b1e79987cc390071818805d70ecd8cfd9f9d2ccf13750f03b3c06ce2ab03a6e1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 426
+      "line": 605
     },
     {
-      "fingerprint": "ba79a9aadf8bf519c9479e2b50a465441473a4709ee162fb601e8172d533d7da",
+      "fingerprint": "7932ebba7cbe8362b474597f872e563a3b0b6e7c789ac709a0b03baa2e9ab984",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 434
+      "line": 627
     },
     {
-      "fingerprint": "8202a0ae0b1c4a12bb2e1cce0bc1d1217a7cecf008e4de9dc7cb734e071d61aa",
+      "fingerprint": "21a3da8e3712d92b1b3c12aac5500bbf5555f840fffe987447fe60c0b5fde1b6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 461
+      "line": 647
     },
     {
-      "fingerprint": "c06e51832f7621cabfce6de82be31c839e648d9f0766a73b3a51c4052f640e86",
+      "fingerprint": "9c49e172e279c4f78a02aef465403718891bab358852abc62d0c6daacf16fc8b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 467
+      "line": 714
     },
     {
-      "fingerprint": "2e1324d8d98f2994f0e69f16155b03bb4e8c210d224c98f961ea214b1fdef77f",
+      "fingerprint": "269c0a519b02a56719bc79f09c79dee336f584b840df5989e588d943ea302f12",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 496
+      "line": 769
     },
     {
-      "fingerprint": "5c23313a655eabe21085bb4997d66000ea0dbd56a189a66309c57332a19c2bd0",
+      "fingerprint": "82d0727f2767f3624d9a614b7a4af93e1a38c71649a9acc13db66e6969838701",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 504
+      "line": 800
     },
     {
-      "fingerprint": "ba4bbbe50356e0129434da4dde6090365219adc440a31c297a5efd2c2b430840",
+      "fingerprint": "b57ef8f6fe143a41acd357205b348a4748ed1edea604f434e27b7480c23af2df",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 530
+      "line": 822
     },
     {
-      "fingerprint": "76e7de0212b7aae5cc69413db3430716becee02fb6bff01e9c6ec50cce359f45",
+      "fingerprint": "36b0737d4f990108c5ce7bccfa1777aef8ca393c97d8600ce65e2ee9210d0663",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 536
+      "line": 848
     },
     {
-      "fingerprint": "1b6a00207a08e25990709cf77eec95e66f9576b5e33aec607c095f1d60496f3e",
+      "fingerprint": "7b2109f2e91e17fa21b25a6263ec35edb4a0a80d34e8cfa148270d14dbb5161a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 564
+      "line": 871
     },
     {
-      "fingerprint": "e2f5406796ba20348b9f3fd1f61e32c4ad5e82da5e3095b764e26bdef4c1f6d4",
+      "fingerprint": "0739fb3a0d29304af6209c1e88902040b2e2b9f19c51fd37c771b6b7257e9082",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 575
+      "line": 894
     },
     {
-      "fingerprint": "3357c11175836c2ca195415da056daec851e666d78e9a391a0e419ccb63ad266",
+      "fingerprint": "da1049afabfa8e105e51377c19999fe43042acd010fd2eae649e05260b2c521f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 587
+      "line": 916
     },
     {
-      "fingerprint": "971fdcf303600602c663b12a6ea4d6f209322c47e844b8c3553c46f94f82d13f",
+      "fingerprint": "c6e7ae54a0eec50fb577ba8f89249f5a7c77a4887351b7ae171fe86f2f1d687c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 595
+      "line": 939
     },
     {
-      "fingerprint": "ef4421238db6fa208149274aa8a80ff719622f9dbb9cf21e872ed473f302f9cb",
+      "fingerprint": "cbc54e74ddaf5edc7f19367620f8cd8f7c8efdf46914002e8567613ffb0cb4b4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 608
+      "line": 961
     },
     {
-      "fingerprint": "d438d503160df6ad76a7dbd531e96e3a52736345cf7b8358b0547dcf669a3b14",
+      "fingerprint": "4f7a527e7378db03b20fd7438772fdee013e211c622eaa7db3f4bb2055f82409",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 619
+      "line": 981
     },
     {
-      "fingerprint": "a09866b4f6e0c635f65093470a51d3318fe00306e603fb668902d58979f056a2",
+      "fingerprint": "993c306af4d72e89b8332628258d7d68503e6c5c08b6b5aa5e416c0b92ec0055",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 676
+      "line": 1001
     },
     {
-      "fingerprint": "d82bd0f3fb91ad23077f89e4da8909d4acf1929eac0e88500aafc4c5362c91ac",
+      "fingerprint": "580110671d092fcfced7c6d963651d66569f1f344b694f7754d73626e4208bcc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 684
+      "line": 1052
     },
     {
-      "fingerprint": "819b519afcea25d5c9a37e95b79ece920d7eff58d4a96f8b288c734e394a70b5",
+      "fingerprint": "a947ee7247c4d13cfe5d6e67ad0dcb76a299c709c9cce8a14dc8e681395e69f6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 732
+      "line": 1122
     },
     {
-      "fingerprint": "87134c37d40718c60b7b35b49d03de53764c686aff62ad2a9b3f0c9a0307aee4",
+      "fingerprint": "7dba6ea15dabd29e3ee7d0988bc390545217ccefd9fb7982bd27df11cb09e51a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 738
-    },
-    {
-      "fingerprint": "689c34feb04f94542d8a856690d04648d461bf46528d95d49f554a994548c949",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 764
-    },
-    {
-      "fingerprint": "8cb3c98d249d42a257d02d6ccc4eaea082602b6894b7ee13a92252d4c5806367",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 772
-    },
-    {
-      "fingerprint": "4ebd9d05a7f7aba85345dad9a94af1d0a1192da13cc190388ee2ad922ee80a4f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 787
-    },
-    {
-      "fingerprint": "8cffeda86fc9115deeda2a12980aea4e232367be183b4faf57300ab3a1b0a1f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 793
-    },
-    {
-      "fingerprint": "578c334c77357f798f863755943eaf5fba67f68fdf352d4448aa1aa4727badb0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 811
-    },
-    {
-      "fingerprint": "e57e494d0db1e627409fabce5cad7cbca09c84f0b239f25d9dadfee836abeffa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 819
-    },
-    {
-      "fingerprint": "ae0333eb3d4b3cdd30f3e01b2e907e38b9f9f67cca75af63ec7d6b959583393b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 834
-    },
-    {
-      "fingerprint": "96a9bbd30dd5883729e433b6dedcddf4535b99d4fa1dbb34f1bccdc40f87bc2f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 840
-    },
-    {
-      "fingerprint": "170d16fde3584cffd0ff6ee0030b6916f340f0d9a6521c0c45225dfd08d43d2f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 858
-    },
-    {
-      "fingerprint": "7aa73a02413fcfd523aa5906983b2cdf9e9dccd25faefd5921792578384b6075",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 866
-    },
-    {
-      "fingerprint": "511c2d596820d2ec3f18df8acc32e808f5e2c3b1c9ad1c4acbde545b41fc7cdd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 881
-    },
-    {
-      "fingerprint": "c5c2a0b790c155965e86ddfdabdc03631c605394dd6f2464baef5841a2db6e46",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 887
-    },
-    {
-      "fingerprint": "cdd5ef457e82f380dd17e4e3f0aad33f56baa5e24efdeeb8d5dfd5a97078b6c1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 902
-    },
-    {
-      "fingerprint": "503643e7540562f7d59945392d4af04fb748dd53ee6dfea50f98634e8492e63b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 910
-    },
-    {
-      "fingerprint": "311f91872819317f8ade870833e3a7aa8e7ba43f07e130d49c02d9a8ef08a465",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 923
-    },
-    {
-      "fingerprint": "0a1cffea9ba86950bb8952077458b89514bc658b5f1be7394b1093df4a3128f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 931
-    },
-    {
-      "fingerprint": "c83227a68e49c0689805f84c9850b4c4e7e83b56b8b676b586c581f6c6e17fcf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 971
-    },
-    {
-      "fingerprint": "a2ae5ed5e8611e7974368caf6c6e3b673500d47813c043c7341c64fa2b7a94ee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 979
-    },
-    {
-      "fingerprint": "e3f40b80a93879a7fdeadaa711aa0ed761e86c5c5eb27daf4bb1356b2ae8facf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1042
-    },
-    {
-      "fingerprint": "e759ffb15b021681e74a89807e8a78a714748b0f14bb6dde5e0553ddd5f864da",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1048
-    },
-    {
-      "fingerprint": "b4d205b03ed4b9ace062c2af95083aac16088567026e1eed12bbd4156d8dc547",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1075
-    },
-    {
-      "fingerprint": "5a674d03c81491b702f1cff14b83c07efde69746f27a0d355930c7255b7e50a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1083
-    },
-    {
-      "fingerprint": "48575e6fcaa8a54ca0fed9d65d5a077f503c552e3fe041852b1a03ade22d7695",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1096
-    },
-    {
-      "fingerprint": "c06fd0a0ab0f9d78befa785631254a57d3111e5bda9a9d00bdf93d26e2e4d757",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1104
-    },
-    {
-      "fingerprint": "cb0fecf62464cdff9314662c30e36713adf0139466f63d89b01caf45e064219c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1140
-    },
-    {
-      "fingerprint": "9e168ae113c8a144df028a29a404d3cff61aa4df97b64dc4039fe20fd9677c86",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1162
-    },
-    {
-      "fingerprint": "bb67e77961cf94a62c6aaadacadc0403930c95c527250d2d9af434d943262a18",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1164
-    },
-    {
-      "fingerprint": "860452d2ed29dd3fe7b62149fb3b8d1c6e5c6ef16fc5ec4c0aebcce4ba7b4cac",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 1170
-    },
-    {
-      "fingerprint": "f5329f0b137afe8fa61cf79e31e6b058c2e9e793ac69c34cc6506b28718cf127",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1171
-    },
-    {
-      "fingerprint": "7553496015df48b54ed6631aeb2e3a59397f30ba2f0ae1b382c876b8297182f7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1172
+      "line": 1154
     },
     {
       "fingerprint": "73436d268dc120e33c44563235b4104288b1d306c09a740761bb3f852c0ab418",
@@ -5828,1360 +6716,1744 @@
       "line": 1174
     },
     {
-      "fingerprint": "76c872a3561da87c7a6b848b6176b97274fc794e476e67c03bac59b1d49d8447",
+      "fingerprint": "10ad8c707d09b5db71ff80379ab5db7aa576abc8a3aef5e4f90608db17c255f1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1175
+      "line": 1217
     },
     {
-      "fingerprint": "348ae9aa0a49e7d1acf974c7d092fecd934dfc95391ea565ef0b7b09f6dd8bae",
+      "fingerprint": "b7dab2ed0bc0d913ee5583284686d8a6c24ac421c596c2abe6793f36bb6e48aa",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1240
+      "line": 1239
     },
     {
-      "fingerprint": "417b4578f67d0c585e44004ea5ca0074e00d049d3a445bab1769cd0693446056",
+      "fingerprint": "5b4325917ee3964bec723fd69b4906b07258c11777e4ccfbdf6049a5bd0279f3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1241
+    },
+    {
+      "fingerprint": "5dad17ed053ab5b2e883c540d9359c10b7a75990f3081453f9da12c129a8ebae",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 1247
+    },
+    {
+      "fingerprint": "bb45748960a0da6900779d79ecba4283a026bcebcd1232fa8bebfcebb24af94d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 1248
     },
     {
-      "fingerprint": "52ebf1365467ccc32c992cd854c270585a8d85351899ce7335ad0d2c00f843db",
+      "fingerprint": "b933a46b64bc6bffb81288862a5604b8c96660cd2c62ffcedb8f0ad163c2ac23",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1288
+      "line": 1249
     },
     {
-      "fingerprint": "9e9754f71c6bf09d5974458dca9342facf43c006d0bd99f038e7fa8bb7686c85",
+      "fingerprint": "bb898278b6c4cc97c11918a576f29c6120145a820d17f5c46e6d3d962384e190",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1296
+      "line": 1251
     },
     {
-      "fingerprint": "c0bf4760937e317bb8e909308fafb68d9ca877aa2de263cc38651270799c2a42",
+      "fingerprint": "8b133d144e3dd77d0cc42d5ad5a72909ca3c6f2e11fddc51846279985ca7f982",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1332
+      "line": 1252
     },
     {
-      "fingerprint": "ca073c6fb8771f1ca8d68a03dde1281cdfd7f4569a4aed474307ba995ad30c95",
+      "fingerprint": "56c3f5564e784ec88174dce53c99030b46b0b79fb1400676eaa313d7da35a42b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1360
+      "line": 1317
     },
     {
-      "fingerprint": "a4f7203cee0d452935a6090fb8e56c9163c9c2415e7e3df5f31c1717a588cd38",
+      "fingerprint": "dcfa2124f4476f966cc59d98d3a5e24f98e0778d854c5c3099655f3ea57b72fd",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1368
+      "line": 1364
     },
     {
-      "fingerprint": "f671773c8a6e5d5ed7cd8a72f431e3fc278a3856d71926a9b318f732fc09fe86",
+      "fingerprint": "51b280b1f382a0fdf82cbdcf17ef47403dad00a31e48d128c5022d3b83d145c0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1408
+      "line": 1407
     },
     {
-      "fingerprint": "bd7f0726a0d946c998fd61362db673ff29d0b5d70a73aa3e3918ef06bdb7ce95",
+      "fingerprint": "005e3f9d75bd01760262f1f69047a98ee646ac28fb04eb5723aeb0da86a3d304",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1416
+      "line": 1435
     },
     {
-      "fingerprint": "0afcd0917d676d3f05c24063af6f0f0f7793c885df8ca610f390ac6cd4ccb5d9",
+      "fingerprint": "d6976c5f294e651725ee3960af209aa5fda14bdab183651755d4b2c21bd05a55",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1456
+      "line": 1482
     },
     {
-      "fingerprint": "5f4b87084c0b6fc6b1807093e97b08a6871aeccfea587067e8af70c76f608562",
+      "fingerprint": "84c57520f95a7dc67b1ad3df2b8230e6f1b07c052c21dba34cad12ff528e94de",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1464
+      "line": 1529
     },
     {
-      "fingerprint": "42d6bc646c5233b03d741d9809ccf4b6d6ca23a59ab53b0de8c5ea43abd2dc3a",
+      "fingerprint": "ad18ff3d3d239c7aad072bbdd4fe5acf410bbd75842b45ecd6c80565a2299569",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1508
+      "line": 1580
     },
     {
-      "fingerprint": "4f151277c08bcc19ba5c85e7c8a4e9a8506b3022515b523238b6acefe85e293e",
+      "fingerprint": "de81287a0e0bcf7e3d3f1b80336e17b85864a29705aad3fd82e6758f2c0cf147",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1516
+      "line": 1616
     },
     {
-      "fingerprint": "2f39d14fc611e1419c6244589cded61cbde428ec025ea6320b73b173377f5663",
+      "fingerprint": "6c131d2c7f0f16903097a5e91e95d088bada1f33afa008619a10bb7a4ca9e19a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1545
+      "line": 1657
     },
     {
-      "fingerprint": "9facf80601436f22b30ac16dbbb2c1b02517a0dcbe4d7d758c85a91a57b5556f",
+      "fingerprint": "e2a83cb443a4b8310ff7aa7144aabb07c3734a2a6667913b8dea01b34fd014e2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1558
+      "line": 1690
     },
     {
-      "fingerprint": "326a60a97a142a42c3aab9beca6a9272e061339e2bdc431f34dccbac36d91cc2",
+      "fingerprint": "21ad1ba8ee586ac86a8860193a9c31ac836b51577070be8a31017d8a7ffe6ab3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1587
+      "line": 1721
     },
     {
-      "fingerprint": "488d2368f5d9ab6f31adef9c47b3a63e350e2c0c6b9b9ad303604d9c72e29fe5",
+      "fingerprint": "60c221b082aca844b8ac560ddb5619e72f7c314d3cdeb2fa0c15ef387708a2b4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1600
+      "line": 1752
     },
     {
-      "fingerprint": "dba2dfde8073af359ab0c3064ff002d2087edbaf3924a717e39c52dd6471bbfa",
+      "fingerprint": "5b8cd46da7bd04fc0b721406edd5f76304733a05c68c5044cccbd000395081ca",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1621
+      "line": 1783
     },
     {
-      "fingerprint": "066901e51f7929890eb0087295a70ae78244d727cca89a228233a50724654ff6",
+      "fingerprint": "4c03c869478011f034f7ffbe53caf5b1359c5bd788efddb0c7d11d7882ba0880",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1634
+      "line": 1814
     },
     {
-      "fingerprint": "37eb3f99ae51bf1ac69d7ca645d2d861eb8b0c4a57226b961d9524c4c7e401cd",
+      "fingerprint": "60fc46169cbd4f98cd3271d9d788775550c2fbb2617f6bc0cd078fbd5036e834",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1653
+      "line": 1845
     },
     {
-      "fingerprint": "956815821e733b6dde65c9018776826c6b0faa9db9d0e13276b8cb44620bd34a",
+      "fingerprint": "ee692466e2ab3b23ef22f2a1d5d802c265e23d5b5fc8e606314c7972de85e604",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1666
+      "line": 1879
     },
     {
-      "fingerprint": "8a71be9fc50a95fb1f11fab1fa588938761741b4acdffeba918efc80fda97d91",
+      "fingerprint": "436b3a7e74b57585e0c9485ce14e517800508f2f64064d499de3fc6a6515aeee",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1685
+      "line": 1885
     },
     {
-      "fingerprint": "ba7eb9bb3e2ac45edea6dd06ea895f09ddf0ff7df0e00ed6054b7c65cd801568",
+      "fingerprint": "a6038d607b83af13a03dc4f97d9283cc4b35044325910fd708c61326b279fdb5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1698
+      "line": 1925
     },
     {
-      "fingerprint": "dffebf546b82856418b830a4a15445927795f36543378b7346026105a43015c3",
+      "fingerprint": "5cfb29f36347ced482dfa34335179ba1d137af51e1a7849503b982bb9ced81c4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1717
+      "line": 1928
     },
     {
-      "fingerprint": "a6d00b9a32bf9e925d900cfbb44e1ccde17fb56f0de1a9ec31dfd2e3cf986147",
+      "fingerprint": "ceb1f4e79390d953a70b65997a72324ce5eb488dfe8a8240da139c29efd0e0c7",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1730
+      "line": 1934
     },
     {
-      "fingerprint": "b187cdd08f1b7de7d463fd4ab041e7899bc15d04b9c7070d193f583163f60a1f",
+      "fingerprint": "55857625660dc19d0b68e51424e7f175cba2db465c8e2be1fa9da1f62c8195dc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1749
+      "line": 1949
     },
     {
-      "fingerprint": "f1ec013a3610d5b3df24e4d1b11c39ce6179dfb00d32bd10b638c1c72adcf64f",
+      "fingerprint": "74fb956bf38011e148c882719e1b4c4327521b8a3f264985d0ba6e01af40a3bc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1762
+      "line": 1962
     },
     {
-      "fingerprint": "d747043303e5791d1f5ed550a5679e3236a9cda2f1d5eb5e6bef9aacf5ae3a7e",
+      "fingerprint": "6f4fa0151e12e86e8e461b75e8e5b484f0caaff6640fdfe1dd8847a7ff01c05e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1781
+      "line": 1965
     },
     {
-      "fingerprint": "e0c62397c39fc4c42b99cee5b781185e053573f81e63312966ad657bf68257e6",
+      "fingerprint": "a3302c0fcc8f5e050c4ae32b612447dff60327dd2a2688a430ae04a2f85a5620",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1794
+      "line": 1971
     },
     {
-      "fingerprint": "3be52beaf921263d0cc8044a96da745cad410b83fdee7cabe0411b90335a171b",
+      "fingerprint": "ca3ca195ae9e4184fd3c86fa99219cc0f82565e7c7a5428d23547c14357bf51e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1816
+      "line": 1985
     },
     {
-      "fingerprint": "bcd09c83fd3598921fce4b9b59eb004242b9e49013719be343bb6a299341e9a1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1822
-    },
-    {
-      "fingerprint": "c05bc9f986f4a0cc7b792499c7b921ce308271fd73701929b7e4f4a60fe46098",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1842
-    },
-    {
-      "fingerprint": "600e1daa026f8961aced9196c7ed699eb334d048e9a3b94daffd853d0c2e3175",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1848
-    },
-    {
-      "fingerprint": "eb0ff5e5cf7275a4177323363d611bb5118c73a824169b6e366c27c6261c17de",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1854
-    },
-    {
-      "fingerprint": "97d3f09c9e14d481102290d28f5c35daecd66f6842fefe248f1ad22df079e1a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1868
-    },
-    {
-      "fingerprint": "f8baf22ef313cb49ec6b55637e7d27f0ef9ed3a730e69fbe86084d0eb5e44f6c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1888
-    },
-    {
-      "fingerprint": "6d523ae67a3c73e46de38e44b9a39d1b8fce15c1181da3624115fb2dc46827f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1904
-    },
-    {
-      "fingerprint": "6803111737c87d6b8f77b5debf530c24680ffdc28ec7981f596759cd79a2adec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1911
-    },
-    {
-      "fingerprint": "4bfe59307db674513064fa6c755c5a47fcf249a195c2c4ae18eb0c0d92b9223a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1929
-    },
-    {
-      "fingerprint": "d7ad816c3e10299ddda2b6dac61458e9f6b63766bbc3d5947bb803fc1644d3e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1939
-    },
-    {
-      "fingerprint": "e8902ff2e3c42f38fec150bab3ce261ee9da4555c9ee0e25b6309f04bf964302",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1944
-    },
-    {
-      "fingerprint": "2c0ed37dcc7f7dd9b611f8caeffdf3b401f17748db20ae1f9fc9dd75e720db55",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1945
-    },
-    {
-      "fingerprint": "a855f92525d87aa1161f1ee27b1c2de0328ab3599e65dbbb1b435d9cc93fe82c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1961
-    },
-    {
-      "fingerprint": "725d0db73ac2feca0c5e07f904c0f632325e79c19da94f4f40ed047827d175f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1973
-    },
-    {
-      "fingerprint": "062d1c7bb062c3aee0b0c9f602c9e854e3b2c6ffd09890fba7459448c0d6dfe5",
+      "fingerprint": "e70abdf8fe9268cd84525029505e51e4c0be0608c1093e6aaf435487fd1d5743",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 1986
     },
     {
-      "fingerprint": "e436c525820c3dd6f86431823fa988955c2b191929dd987140376fadf42509ac",
+      "fingerprint": "1c0a535faf9e887efb2480884dc60ec324684ee1dbdc103d87c4af229d105b20",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1989
+      "line": 2000
     },
     {
-      "fingerprint": "6728a43b739f32b36db617570191c4907c8f8a3a427ee1af0fac7f707f675f35",
+      "fingerprint": "0d0b3aadaccf64e1943811a0255cb9c61e18644c26d200f5d2a72478a8fffb24",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 1992
+      "line": 2003
     },
     {
-      "fingerprint": "ca449472d928aa4aaa09757df4ab037e58aa4fdb7c7368742e477f3a26e59d4a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1994
-    },
-    {
-      "fingerprint": "4e7dc12c09095e29ed024ea7749848ab880d618b94a2b77ba7edbe57664be0c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1998
-    },
-    {
-      "fingerprint": "e0deae22f2baa25d7646ef9b4aec411598e9c6a84508aa97619ab2c11b482ce2",
+      "fingerprint": "251658636980ec11b5d2352beac0ecba12564fdb6a213a521d6f5948aefaa2ff",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2009
     },
     {
-      "fingerprint": "200d5b78bd00f5fceb291a46003051d911869d779ba06f33727b67d6b2e2e506",
+      "fingerprint": "e493591f29b5ef6d6f1024f107d235ebb21137a3eba4506ec12ae3c096b510b5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2011
+      "line": 2023
     },
     {
-      "fingerprint": "80e29fbbb08d706e20d6f6612787075d093186627c2dff198b7625c01e23781a",
+      "fingerprint": "b5f2510ea7ccf8ba2c0144c91e01a2e130a569c3b830ec2d0e041b1423aed4fb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2015
+      "line": 2024
     },
     {
-      "fingerprint": "c0a92b3efc16cdcc60a748ba018798ec203562af328f644ccbf6946fd3e052e5",
+      "fingerprint": "d26b46af3c7696341f34d07e78efba18383c6524b9db23a7f79a19894686993e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2026
+      "line": 2038
     },
     {
-      "fingerprint": "df95223e644f43d926718d663243098298fdae464fb16066331e29ff09feaf71",
+      "fingerprint": "e906d7f2a5b2078fc62dff3f6932ea1deaa7b92e531930c8720159306fb9e31a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2032
+      "line": 2042
     },
     {
-      "fingerprint": "4803054674c5409931a4c7380b2463b1620dc8e38d8056fb20ad52a7bac88a89",
+      "fingerprint": "011eba29f96bd012475fe4d7d28982388aacefe09f30a6cfbc9186e9d7538164",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2033
+      "line": 2045
     },
     {
-      "fingerprint": "08b99e6dc636d7e6c55400158567b96c8e80cf54db643392406a4355d68725ff",
+      "fingerprint": "4070ae273ab8367c820b715befe22f1f1fda98b6405e1ee54e0c4bb5665ed0b4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2040
+      "line": 2049
     },
     {
-      "fingerprint": "d959aebc546a59529bd5323a5148ea05595636c20c8e564596926e94d23fa3df",
+      "fingerprint": "376b74e6aaefd9c737a2056dcba5628e6f996e0371b5f53a61a1151a73d5e55a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2040
+      "line": 2064
     },
     {
-      "fingerprint": "049f5929566562c32e562264921d0bd179abd4583c9cdbc35e2a979d9a4cf2a1",
+      "fingerprint": "c35fb10121c6c6847f37d0194aea88db9e74b384017e4e0b081f4bd262fd646a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2043
+      "line": 2077
     },
     {
-      "fingerprint": "96bdd420cf1c253526c013c241f39e8a6a1f9c25ea55346c894000e79b82609d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2050
-    },
-    {
-      "fingerprint": "76b5a89c9171a38e4c9d9657a85377833aa1a23d0ba06e0ff81599a0ffa52e7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2066
-    },
-    {
-      "fingerprint": "764b2d45686236b9e490a06ce33bbaf15d94af6116ad1d08d866e0323d5f5e5a",
+      "fingerprint": "a85563aef154c81d56ce12df2d35a36b2db9cb8f40942d598d9a16a0d29c30e3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2078
     },
     {
-      "fingerprint": "e095ae7c96f825dd67a93eab502c86765e30b572fdaa4b54ef49c9b19190b654",
+      "fingerprint": "410b6781a39a1da08347583ab46c6295ff2a1e9fa24b442140e27219caacaa01",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2088
+      "line": 2083
     },
     {
-      "fingerprint": "706c6134de793addd0c95c96b8355eea3910965f42089451aa248ff1270d104a",
+      "fingerprint": "12a51cba6e0aa44aa109b5c354f269574d8d7143fda0ed53657c6d1bd53450a0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2096
+      "line": 2085
     },
     {
-      "fingerprint": "5b6461d7e5db4f343b6b4e2780507d926e3484f09e4c4cd8e203f82e36828c83",
+      "fingerprint": "7d9717cab5c2dad1ab6bb894e9ea2e725551afbadecc349b084e42e585a24e0e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2090
+    },
+    {
+      "fingerprint": "b38242344d061106dea36e8749df0b358e7ac79fc816e7b0ea108680c8817b07",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2103
     },
     {
-      "fingerprint": "2ecb90fa7ddb63402d9b70c066cd8ec4e02f5983865cfd17195512df4816b018",
+      "fingerprint": "901ce45a52223a98c2f1b92cdb5efa3cc8eedd98426c03b988d40e17a9a2747a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2122
+      "line": 2110
     },
     {
-      "fingerprint": "bf1522afaaad8d19637b5ed3c6a2c849db26451896712d693ae1ceab8f8fdd06",
+      "fingerprint": "70e47ce52d3c3570f2c35ee12b0ee135086a4509301a9f2d93717d43737a7eae",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2126
+      "line": 2119
     },
     {
-      "fingerprint": "a36b311b707c791b68ffa54804827f477e48b804b8a7b28960203d9baade57f9",
+      "fingerprint": "389ce240f0d0fe6313f95493cde38489ed621915869ccb0d50139257f2b4451f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2132
+      "line": 2134
     },
     {
-      "fingerprint": "03e702878349bfbe89f7d8db147980581bdc0dff2e4134f6ff99fdfa989fb0fa",
+      "fingerprint": "92eeef747818ea17d4bac57df6d8eecb554d1d6a5c0970ed4f5f2784c5e370d4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2146
+      "line": 2148
     },
     {
-      "fingerprint": "676ead43ab2c48527b3838e34ec226a489175332f7d42ba7102842337c31c5b9",
+      "fingerprint": "74eebff52327445146926bb6fe9583c2f4600ebbf13e10c7df3d1289f20dbcd4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2153
     },
     {
-      "fingerprint": "4e8c2dfd4d860ee8f2643263813c0f698caced47e513a36c9d6ac2f2bb230189",
+      "fingerprint": "bdbf59e92efb0168506b4b7658a43247e03330097553b0e757d71dc0c25348b6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2168
+      "line": 2157
     },
     {
-      "fingerprint": "c6eb75d65d4ce1b6dd78bb096f1818016b22b8b4f5e339c4e5a0d482b902806a",
+      "fingerprint": "d45a30656d28c64229f8804eb252b9f3732c77d68c3c13303f2717fd0b65b460",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2178
+      "line": 2166
     },
     {
-      "fingerprint": "1727e2f165bbefa0f6f0beece00d8d8ab072d24c170ab24db62dbde4dea9ea6b",
+      "fingerprint": "4d8d8aa5e68ecef57f51c7d24f899ecb2cd86185cf1a9d35c13f6cb97ed99950",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2185
+      "line": 2169
     },
     {
-      "fingerprint": "a67fdefa3c36a679d7d11f60f9d1ae78e5486d93d11ee776892160f14bd496b1",
+      "fingerprint": "617f8df8b3b1b8f28ebc777b5efe3b11c4f3604c0c30dc090de64d13bf6c9806",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2171
+    },
+    {
+      "fingerprint": "ee4d077702f59571585ca5193241916d173a3041146c17a25dc6fe3a0b9e945f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2182
+    },
+    {
+      "fingerprint": "349a089f130d68b590e24da6a03bc43c03a65dc850fa72c35ac079819ba6a3d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2183
+    },
+    {
+      "fingerprint": "42e385d86c6e95382178196b01df6f53f1267575475134e82c6af0d3450b5caa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2188
+    },
+    {
+      "fingerprint": "8239bb936ab1b4caeb8b6fb9953518a1b3505c3d532bb54c1f30cb5b18b6294d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2190
+    },
+    {
+      "fingerprint": "e3eb51205fed2d02aa02da82cdfd6e77dd9575f5059f358e19a37110f4fdf173",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2195
+    },
+    {
+      "fingerprint": "b157a59dfb69ef4e06d4c83aa695c6efc4e443b508ad316efc9587101c991bd2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2208
     },
     {
-      "fingerprint": "aa770e8863c68cfc32ddd992fd79502a01839ba07473da0095ee7df24ae5c08e",
+      "fingerprint": "8be1913088b20d1781190473ea19c883ce708f09d2841c773a2e4c5b9114d8ba",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2216
+      "line": 2215
     },
     {
-      "fingerprint": "98d430d3be617d87ba3d9f0e6c813813bf30b0fed06d129a9ed8a367654f57ef",
+      "fingerprint": "5414b4024d28ef898b5a8dc0331bcafda4e071f5374ac17f41e13d2b3ff308ea",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2238
+      "line": 2222
     },
     {
-      "fingerprint": "926700ce25b63be73b7351067b395c3cdf9b36fd03f336552872c79ec758b724",
+      "fingerprint": "d584bc53a3619e0dbef516504dbec23988bcec5302c35e6870237ac88509a679",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2249
+      "line": 2234
     },
     {
-      "fingerprint": "b540a166e4f318323ec4cbee9a262db042499bdc1ecfbef751e3c898cf82fe14",
+      "fingerprint": "048aafe647068d18ea783bee6e8592dea2a15be1cf98bac4261828cfaefafd1d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2250
+      "line": 2240
     },
     {
-      "fingerprint": "da8dc12c14c1bee5ab0935ab32144509d453b390c1f9317029212ce85716d595",
+      "fingerprint": "aea5213c5c7f7a2fc3c6540b5255ca2d59a6ea7396da706ef1f3ace654670a7e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2252
+      "line": 2246
     },
     {
-      "fingerprint": "fee256a0f12e11685eea2e49fec2827839bd4c894f3006e252da93fc1591d7df",
+      "fingerprint": "c9d47788d463549852261211816a79655c2ca6ae2ff2f9cc1be4069fde650a26",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2259
+      "line": 2251
     },
     {
-      "fingerprint": "589033dd849f0fd408945481942d95cba8eeead758d83182ce291d2906087b25",
+      "fingerprint": "b31423c5bf39fba2af77a7152ceac959ffddae741badc6174556bd636cbbc940",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2285
+      "line": 2257
     },
     {
-      "fingerprint": "2439c743587590ddf3a5af240bad0ffca68f4115917ca1127bf3ba820f2c253a",
+      "fingerprint": "96084e4d60d2c5211c4f41fcdd56f3bb8c5d2c15737fd976db1ee47c999f2f09",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2286
+      "line": 2265
     },
     {
-      "fingerprint": "4cd9fc4ec57cdfb286af8961da5425af6a781993f920003a55f2a846bb518e4a",
+      "fingerprint": "b05d3a5d49c5f2396e0d86c1dcb6a40ed21b2aa817fa9562607f6e6778f763c5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2287
+      "line": 2293
     },
     {
-      "fingerprint": "e551a57d90c48058a7b7755e9e3cb05da71044cb67e4c98590a2845f396db57f",
+      "fingerprint": "3a4cc46385ae6db281f8621b78a61ee8c7abc129f31f049e1d8851f673fa724b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2288
+      "line": 2294
     },
     {
-      "fingerprint": "2b2d6779958cc68dc708b6c88bd2b9885f415d998e13d63b0e887aae28ff0a94",
+      "fingerprint": "ab19125ae6f46a256c9c61f5a612590b461d5449c86a072611abd414705e6963",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2290
+      "line": 2299
     },
     {
-      "fingerprint": "dfc7a8b1d15077ac5af7696dc59486d29a8644aa644f9bbb8b475bc8a3a740bf",
+      "fingerprint": "2bbd87dc88431e647de8082bf4c97216559a034bc42448c4856a1f9671033ff8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2296
+      "line": 2301
     },
     {
-      "fingerprint": "b9e022ed9b459bec46319410a97ec0e83a4900dd8904b36fdb9e88523d171383",
+      "fingerprint": "b53441a772f2df9c35fb8a3ac548c624219883848f924ecf51c6c927d609df71",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2308
+      "line": 2306
     },
     {
-      "fingerprint": "53a4e886aa53444dc0c6dbab82f2568fda863ff84a93c53b6ee28cd1595bdc35",
+      "fingerprint": "3d3c5ba11dcf213da555ddcbe0078a41e3a7a9df6b06420f3420c85f0dcd53b2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2324
+      "line": 2319
     },
     {
-      "fingerprint": "24fec50094d1f13ba7a3c24ef9dcb1a7b94d81432907befbfa16e8a5bc4a0b05",
+      "fingerprint": "afdd856ec3aad16269817fd7f9b9c7be0a4b15cc75c992569f231de3dc1e6983",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2325
+      "line": 2328
     },
     {
-      "fingerprint": "0e7be4ad15c5fa1c0b1482f9aefc8393a7bed0d8b9a43d3e20c4e59e1d9fc921",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2327
-    },
-    {
-      "fingerprint": "e323f9bfcfb69f320f0bf9d40c989ea678ce91443db29ef28a58ae01046c2357",
+      "fingerprint": "e819d4ab21cc5511cef15e099e14e66afc3288aabe8929b77af1f671817dc707",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2329
     },
     {
-      "fingerprint": "05ac11d2dd290525fa71b412aff35653829a96e2a5d70d8c20615a97863e5aea",
+      "fingerprint": "8b078a8654e42403030add9319a23596b3f098e5f4eae4e8cc78421e2c6b14ba",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2335
     },
     {
-      "fingerprint": "57c814e68ae7561337228caf741be235faf1989741c9bf17d338d544ca263104",
+      "fingerprint": "0c79d7af476475b58b52b0b86d9fe17f6eb85476d2cbe97f39827f4a80f53eae",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2341
+      "line": 2337
     },
     {
-      "fingerprint": "23f40e8f53d569932d305fa91d6a5c8d6498a1e8f84b27e0a0f511b9164d8e13",
+      "fingerprint": "869b0a33edf735b9aa922e017ae5a1a490075f4422658c0a3f15d0f5fee0a998",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2360
+      "line": 2342
     },
     {
-      "fingerprint": "5727f3a80fc3beb74d95b9de01ea9bb595fb2583781a72fd75d5641fbf52bcab",
+      "fingerprint": "2e30e3f078bdbe9c8dd7c8a630845bde140bbadb0248c028581249d8f1e391d6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2378
+      "line": 2356
     },
     {
-      "fingerprint": "350cc728e6391241eebe701b346078fd701a1f6d76342a9a5dbccda8119b41b5",
+      "fingerprint": "7ff9763c94c0eff614d693fcd6b289923c4c208830283697c316e826ce4d29b9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2379
+      "line": 2358
     },
     {
-      "fingerprint": "9c254404df01765057fbbb13953e8e6bfabed51e56ffaa11b67a92e906847dd4",
+      "fingerprint": "a6b80d8c51902f5f4c95b43b0599ee6fe99526105c855d6048bf8199b7c11a41",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2381
+      "line": 2364
     },
     {
-      "fingerprint": "900a54640c149af187671ada70996076e2406a2f2437571e757752db364eca69",
+      "fingerprint": "f0c15be388e107d6999346ecaebbab3641c899e7936258a8e6194bc208c765b7",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2382
+      "line": 2366
     },
     {
-      "fingerprint": "9ba3233f8f9566ef70d5971ad643a40a8b35ba601f1ee4ca6d7b43535c4a55d9",
+      "fingerprint": "ff173ba0ce8320567a50880cb46106ce74c2bcaa1483dcd35684cd14f7f3585b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 2373
+    },
+    {
+      "fingerprint": "b21762bf9cfcf1762612309830b3fad293f7e8d1779dda07e4a671735d83ab84",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 2376
+    },
+    {
+      "fingerprint": "f72f3b9a953aa04996ab19a5014998cdc38c9c7d7081a9b21d9e86dba5cfc605",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2390
+      "line": 2383
     },
     {
-      "fingerprint": "ce339041f0490161e7b27f234ea8ef49b90d5a4d0cfaf69aff18f16f178837c3",
+      "fingerprint": "0ab28077aef34b412dcb509ef40e20b7ea785f434ccde8f29797e4671bba116a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2416
+      "line": 2403
     },
     {
-      "fingerprint": "0cffb8e60f9daea6248dc5030bbcd7d36edee77daaddb8be2341f6a4caa433d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2418
-    },
-    {
-      "fingerprint": "56b8fd59ff9448a924470842ff35d3567bfded00f48f3f77163b7943a11a88e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2424
-    },
-    {
-      "fingerprint": "782389b05195dd05878ae9327f3704b3202a4403836f8fe1d02b72d98fe88c78",
+      "fingerprint": "87277a8fde63b4effcf0ea3fd2f913b46e1c4abe091a4b40c88728d04c58883d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2425
     },
     {
-      "fingerprint": "610b3e332d164595818c1532181364109729a308624a126e7a87c4bf8b777ddb",
+      "fingerprint": "7d068d594e569a47f8c678431da15ac31b7407ff585883d38adcf3a9d27ec29b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2435
+      "line": 2452
     },
     {
-      "fingerprint": "aa9d5d9e683636fceb74ea2114b613f3ace2bb4e8a3a598ba462d29f77c3e1f4",
+      "fingerprint": "41c0bdacb08d8eb876d93af3d5262dcf80c9f3003cffb60bf75a2096c7c703d5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2444
+      "line": 2457
     },
     {
-      "fingerprint": "ce200629df76cd5cf1ea4a5a0e6b3ea7883e9741df34067cb5bf7afe28d0ccad",
+      "fingerprint": "62f3eda42653580be6022e5503ab847445e2003d81c7882375c2e4c65d3a8955",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2446
+      "line": 2458
     },
     {
-      "fingerprint": "6e163f4be253311db2da087592067ff2d8a395a2d27b3d5e05cb7154728b693b",
+      "fingerprint": "6bedeb57394dc969be0a4e5c4da50a8bf9fed50e9497b98296ae7250823a78e8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2449
+      "line": 2474
     },
     {
-      "fingerprint": "968a5938b2ab7be9b3fe19cbe82a1503150cc4f9378220ff41e4e4b70cfe4f77",
+      "fingerprint": "e6abfcd23ad2fe3733bb29853cc646e1e81c1a9e7ebff80b96bccee96c977e84",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2450
+      "line": 2498
     },
     {
-      "fingerprint": "c3d09b4c18213346a80c09b6aceb3923e9d523fbeae97360a7e8c9311f7cbabe",
+      "fingerprint": "11090a23c006c6339dc42c9631b00979223ee7977a8f778f46c619d8792bc787",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2460
+      "line": 2501
     },
     {
-      "fingerprint": "3d5addcaf9241844a4f0b45281676a59b0b540d80f0a525898623e5fe964bce2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2469
-    },
-    {
-      "fingerprint": "4734b4fcabed4d33e8a3bd85806a29245a4c411f29808586a1a14da6a1f9ea5c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2471
-    },
-    {
-      "fingerprint": "25d1b384169ce1f495693061aa01cd1381b6d6aeeaf4863ab6d36e483461ae80",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2477
-    },
-    {
-      "fingerprint": "ef0a999c3b7d5405e30ae1bdb724c78af75e260ad10c3ac427ce58b8b3abd376",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2478
-    },
-    {
-      "fingerprint": "4dd8719b185ee246c6f22cdec6835152acb60e252adcd01561c56f31f24f4669",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2488
-    },
-    {
-      "fingerprint": "c996494ae0ff41014b43ed7d5f4b5d86358324694d0097c31da4b3e82958d44f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2495
-    },
-    {
-      "fingerprint": "9a26a68c36d1eb8f438089578a88633732b508d253a4fec4aa96a58ad453dd34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2497
-    },
-    {
-      "fingerprint": "5d3e177fffffc25c7e949e4632f80937a1363366a5f70bc6906e99db3e79630c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2503
-    },
-    {
-      "fingerprint": "dfc380d0f1a0cffdd4d93e08cc29b27c27bac453d683c304fc0bf1a01584bf43",
+      "fingerprint": "478ce3d69fa97afb81616ca4716b90e98834d706095e0f185ee4c0f40331970b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2504
     },
     {
-      "fingerprint": "27b4b14d9e045e60ec3a1b8c2dd3d732f8237eef05af6a8067c7ffd40b1483fa",
+      "fingerprint": "074137fb27807428eee104d0b856e9a94ec1aa624571f564dc8cb70d92c0e03f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2514
+      "line": 2506
     },
     {
-      "fingerprint": "77ed62063282aef350fa4ae331704940b82066c3ded782cef0747a19832e1f6e",
+      "fingerprint": "64fdf9b4b8b82c6a902f56c8e39e84458197363ababbf523110886fe9a05a372",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2520
+      "line": 2510
     },
     {
-      "fingerprint": "decc0d600615311c869facca3120cd85a8bc621b14391a2dc51ad09fafb39f37",
+      "fingerprint": "27989d38dc8208ae8cc2d0587ecf055333bd8a000af3c512f9c6bab4ec3a48cd",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2522
+      "line": 2521
     },
     {
-      "fingerprint": "01c54ec16f75eaceb7a3a484b5561858198e9f844222f2b2dcbaa9b43639f489",
+      "fingerprint": "aefe8736ee5d8ddcde3d77f528cb5a8234b2a3900b81ae43f6772de894311c51",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2528
+      "line": 2523
     },
     {
-      "fingerprint": "c37f70299eaff1ba64f338370628066adb5d30c98ed260a1941cbcc81001d785",
+      "fingerprint": "44536e316be1e8333a6b13fb14ac57b3dd82ef6e27c9924d04c37962439edb46",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2529
+      "line": 2527
     },
     {
-      "fingerprint": "34bcba7c41a449056d5b19ced5a7a5d02f3fb214c9cc2bbd418db99f9f2b3fcf",
+      "fingerprint": "b88cd2565a6d12be857775543050e5e688a53d77817dee2d737616801aeec03e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2539
+      "line": 2543
     },
     {
-      "fingerprint": "77bcbb7d448557d54dd760e4eb0d53a557716bcff97994714085b1c1009f78e4",
+      "fingerprint": "3052d7bf948584a7ef78705c64f3c18c16e13c907d7ea28d01920d79d762175f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2550
+      "line": 2544
     },
     {
-      "fingerprint": "d3e48602ca58e27a1ab872a35e27d3612601db2fcd263d5fcaf96fcc3ed9b8ae",
+      "fingerprint": "037a8d6ec603ede0853a82eb991dedc85a768bf1bc6475ad4e31eeef4ae2709a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2556
+      "line": 2551
     },
     {
-      "fingerprint": "2c2c30796ad64ef61003033c60b65bdcff06d32dbf8bed6287f7064fc07c39ea",
+      "fingerprint": "18dc1b64e62632e28aefe20315883a868054479f2db1c7337fc7641ff2e6f4c0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2568
+      "line": 2551
     },
     {
-      "fingerprint": "aa80aaa84597337146f30cd082e318876c1d819463c8c3de55960f5c6013676c",
+      "fingerprint": "b85a22cc3c3651b977e507ad750d75b0fb3b75bc93bbf377b3ba6743e6b89b91",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2582
+      "line": 2554
     },
     {
-      "fingerprint": "58aa8099a3b21f0a9f24415cc67b45332c852d331782a444f4800f57dc0d70d3",
+      "fingerprint": "5e1432d952b5ab63afd7958d01a069b1241440712036fa47dfda0c89d0c7ae12",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2561
+    },
+    {
+      "fingerprint": "860d1d603556bd1a810922860280fb748fcaa18b211a68195f2d778c2b323acb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2577
+    },
+    {
+      "fingerprint": "fb5363b4c0f299f678b4004a24a733bc30ee6824978850e21e1c756cf942ec5a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2598
+    },
+    {
+      "fingerprint": "f3b3ce818feb419694b37f9b6fb8bc601b683732d23453da8b119f03fcca89cd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2599
+    },
+    {
+      "fingerprint": "86dbf3fd2b0b9a3be145a0b6500c2da70b31517f08258ed8881d340f813dfe7d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2606
     },
     {
-      "fingerprint": "2b045342d387769ebb811e0d99bb8a0c462fc89cfea32dda99806f96acba784c",
+      "fingerprint": "42daf2bccf0ee3e8473af6406ba50672d5cc4ed450e2d998e26bd7b1eb2425a6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2617
+      "line": 2607
     },
     {
-      "fingerprint": "e090a1adb93fc289c09c3bf570d60bf2703f75f7aab3a746ac3041a23934c136",
+      "fingerprint": "e9b7453de440c0a3dc6af668a233eb1eec24aa4aabeeff83800d4de8b97a2a56",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2638
+      "line": 2613
     },
     {
-      "fingerprint": "85685971d8750254f5d0c4db9a1e7623fb0558701c833502e8fb4bf8bca752f1",
+      "fingerprint": "f0e7e5d4be384d1040a4b6c7b7265b5a7f7e6490e1985769bf432110780b2c3a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2646
+      "line": 2620
     },
     {
-      "fingerprint": "18568b009e72415e058db3be2b512e56675eaf426879ee774e3db01e589614f8",
+      "fingerprint": "101ed17f81c19eedea180696463955b9bc239a030d4f842a69582dc289cc7c92",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2661
+      "line": 2636
     },
     {
-      "fingerprint": "67d407677a6d5a713411ec9a3e27b4eb77cb3f714cba661d237c6710ecf3dde4",
+      "fingerprint": "58ec3e150404727a36cc801b7ea969af5ffe7eb48750420692f4377adc1afc6d",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2671
+      "line": 2654
     },
     {
-      "fingerprint": "0e01eeffdded6f6558188b8fe332bf6b4738e5d8ae0639c0d27fb29f4c7b58d1",
+      "fingerprint": "82714c7293be7065692da84841e6646cbb300644ba9fac81c2443f84d97f7dba",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2679
+      "line": 2660
     },
     {
-      "fingerprint": "5e93b93c66252ff75a1eab4fb281bc4fa5c0b3395f50502ca5cbb806be790d63",
+      "fingerprint": "aacbe721c77b963156b26b12acecbcb749278683d06008e671b2e49960f41646",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2691
+      "line": 2674
     },
     {
-      "fingerprint": "10b3a9b0906c837b8deb64e182157825f67fab21d163129748a5c38bf15a376b",
+      "fingerprint": "6d5c92880eb3d86dc006cafd8bcdaab67b73fc9245624e5d4283a85f043057a3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2674
+    },
+    {
+      "fingerprint": "7f7d5d8ffeea52b245a7e90fa982fb4a9dedf30ef0d3b695a809725bc17820eb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2675
+    },
+    {
+      "fingerprint": "78b024945156ec53074de5e5fbfe16d427c52af5482ee347ff5a64bb4a533c18",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2682
+    },
+    {
+      "fingerprint": "12b5fb9fcae32feb98b315e4208c1ce7dfd8baaa990df8302f1444a0c811b7cb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2682
+    },
+    {
+      "fingerprint": "2ad61b4b11f519cc0a858ac5d28f8e6b68c48f2dd980b6a0e622fc8d9ff48beb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2683
+    },
+    {
+      "fingerprint": "fadfc3b4a759e455bc8bc55ddaeb4743a74ee2efeb87c17f881c3d91b184f1b0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2702
     },
     {
-      "fingerprint": "9261bb6b8e20c00d6dcbe5808d3cfc1f7b6604b9e6a89c2469f3abde4c3fbab7",
+      "fingerprint": "ad75fd12c03fdc11580e77d6a1fb38eb152693c2f7246e783ab88c5ea5871f30",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2716
+      "line": 2703
     },
     {
-      "fingerprint": "c3d256d2ce4e9d0bca9092a1e4a10965fb4a1904b8261ec7729991cddffb3c6e",
+      "fingerprint": "4d2f667eebd16d34e251c460215062e5feab244b74c3a1128eb5cfebdd5aca2c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2704
+    },
+    {
+      "fingerprint": "0c4773575182b7a80bea08da6c80d283682898bc2454edce460bd5cee1709bbe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2713
+    },
+    {
+      "fingerprint": "7fef6af113426851982ad6746fba5d023088773218b52605abbbda7ff0e1e2d5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2720
     },
     {
-      "fingerprint": "79a58c150943914a42ecfc8ea361219eae7b28de298eebbb2fcea90030dba318",
+      "fingerprint": "8373af3a624c4f11c8d50d86c6611b9aea19f627b42b118ef62c1bd07b138665",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2727
+      "line": 2736
     },
     {
-      "fingerprint": "bd4d125c9ed3cb9b87dca71661132c351202077bbea2edbdc4a6bfe27c8299ba",
+      "fingerprint": "1213a9782f1990c6e6c1c275a3210a1290b2401e2ba9cd5489974a9972fcd641",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2730
+      "line": 2759
     },
     {
-      "fingerprint": "218b8ec275b3cd63a2dafdc988701ef7c34c6a2eddd806b7bf3a26261dca84a9",
+      "fingerprint": "3a3e4cb5adbba15de18a8c3b11528384bc3edabf99034cb031ee1914adc495c7",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2733
+      "line": 2768
     },
     {
-      "fingerprint": "a4421cdbb059195c856ea04ffeac195a60251135a88215847247e966f4f32664",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2746
-    },
-    {
-      "fingerprint": "e4684778d8e21b972d2e697973ee11f67a909f9c3207db2f7cac47d01de94521",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2785
-    },
-    {
-      "fingerprint": "97d73e942d09ebf9711bfd37639aa26236178fac5a8b77c51359e6254d91d004",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2791
-    },
-    {
-      "fingerprint": "4205294e27bd9e8a3afc189c977f5a54ecaacc1d188eb19af13416113f834143",
+      "fingerprint": "41c5bd80098107ad2218f3cf9409d764d5a151133e0648c5672e5c80e2448dc0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2803
     },
     {
-      "fingerprint": "0843203eda9e042485786237730b54e43b220bfc5c6082d4439b7c12bada2346",
+      "fingerprint": "0a99883722fd3391c32f761f5442147dbdfea9010b1d728272dc70696f855f92",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2815
+      "line": 2812
     },
     {
-      "fingerprint": "53cfd0b13ac2256ddf528574d5363ed85112bd54238d1c88f8338f58d24ec892",
+      "fingerprint": "b89d9b75738b42b56ed96689d08374689438b3dd453660ceefd5c96602a84d04",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2818
+      "line": 2826
     },
     {
-      "fingerprint": "5db97cc7971e6888d45e9de12b9b7646909a0a295747edd491d78aed10786503",
+      "fingerprint": "36759faf8d6bc79c713e592d466d3de6e4ec207d1be57b2b5f7ed40c13813286",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2821
+      "line": 2835
     },
     {
-      "fingerprint": "eba251fa16a99c4cdc828b32a0387074a0fdb0e56d881a73ce21b58194765afb",
+      "fingerprint": "8e2595cc772c0910958dc93019487789974dc7ece5a219c288446f452bf8a0b2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2831
+      "line": 2856
     },
     {
-      "fingerprint": "0e597ab73ebc43022090935daefe3cfc4fc6d94f87d7e10d9d8419c5abfe9d0e",
+      "fingerprint": "6a402975ee393dc2d2827f7fdac4dcc1e4927ed152b7998351ca3c55839e2273",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2841
+      "line": 2864
     },
     {
-      "fingerprint": "1c42925121975fe474e9d517e2c60a640d05b5551cb4644dbe0dc6220012439b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2845
-    },
-    {
-      "fingerprint": "7a22fdca9c0456d493ac91d8aa35e6adcd569dfb31f7cd79d8ac85feb8dbb72e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2848
-    },
-    {
-      "fingerprint": "2d2448ecba28181a0bb1dd8240854dd699f3a15d6e0d1de9549125723882eb34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2852
-    },
-    {
-      "fingerprint": "4e22595c51a82e928d49fba02b6261fad63ba920ef29db7d5844314d4aaa7f46",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2863
-    },
-    {
-      "fingerprint": "699321562a56385c57a3ab46de17277d5500c0479e432c95382e8f6f93445aa2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2866
-    },
-    {
-      "fingerprint": "b863ad5b3d6032e9c23d993a6a1bfd971fb0725a40026f1988da9947e9e597b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2870
-    },
-    {
-      "fingerprint": "b78a3c107567f1443f23f7b32944221014237ebad886235b3da05b588d270c6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2881
-    },
-    {
-      "fingerprint": "1ba2b2ac9c2cb537f0368b1706eb6e65942c639ce5cbae643fb3e10f50832817",
+      "fingerprint": "1bb297eed53afe5dec4103f23e3124f1bc7fb20b3351866a3c80febb8526dc7f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2889
     },
     {
-      "fingerprint": "a214235d1360a89e4b090e4251e7490635b52f238e1803b0cc8cf410af0a77a0",
+      "fingerprint": "3d0729a16d54fd193d6f7b1ac6cbe58f596d91fa4e1cf6f97bcc3cfd0f0d38ee",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2902
+      "line": 2893
     },
     {
-      "fingerprint": "7ffb8cc6315732e37c7c6444bb39705036e66533c67754c4eb5e4f1205cbd11b",
+      "fingerprint": "11bc8ec4cb446f1c6ec660876ae11a736a38cd4e1cc279010f2d49c87d54133c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2905
+      "line": 2912
     },
     {
-      "fingerprint": "8a0fe123742306d9f235e3f944d1a3e5a484adab5bec45616b4272f2e9601a6a",
+      "fingerprint": "a97e369052f5a9f53b8f2939473d605b99d5c6fcc72dbeffaf117ec8618a347c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2908
+      "line": 2933
     },
     {
-      "fingerprint": "79ec03273494d7bc3ea34ba60b9396f3d93962c5330e9dbe49d66db68ee9a57d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2916
-    },
-    {
-      "fingerprint": "9c719f70ac0981f64b59a5a1850e0a676ea1cab39ffd9c55b02ae569a86c271b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2919
-    },
-    {
-      "fingerprint": "975ff7055ac0fa3bade8e5306bb627328e9dca6ffa0e559c4e8a00efedaabb92",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2934
-    },
-    {
-      "fingerprint": "1d65010ebd3ac09d2f100007fb8bf1facdeabe3d7ee60cb8dbea0d435e2d7a00",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2938
-    },
-    {
-      "fingerprint": "39357e0dc89ceb8c7131697da1646c1a45431d3805e428b67c8168dc6194e2e7",
+      "fingerprint": "afd6bb2d76307137cbc39552de287eaff4708908ace67c49d5fdb396bc210d29",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2943
     },
     {
-      "fingerprint": "2b0b0d3535f7e06d0c3ad81609d914b3ebcef37cca63dbc57768075b5292e5c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2956
-    },
-    {
-      "fingerprint": "cb82d3b7e4e4534c604dd8075f119af8edeba0fcd16001d538118bb3839db2b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2969
-    },
-    {
-      "fingerprint": "d86817d10ee01e2ce5df598359bf756662028dd3cebfa929f1cd54fa54e4e74b",
+      "fingerprint": "688f3931cac3a546ad21578afa2a463d1b2c61dc806281b315da61dbc2010ba3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2972
     },
     {
-      "fingerprint": "72eee8955046d8019e764f4ed34a01ef99c376eb1dcc1937ea3773f3a1e5e08b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2972
-    },
-    {
-      "fingerprint": "c2bb07d98dc0c9761cb37ad3271b1bb128a865781038439090f585e71c21f9ae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2974
-    },
-    {
-      "fingerprint": "86e90603c80a032cccd5769f626b102739431c64f289c465d0f6ed9ed2a9979f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2976
-    },
-    {
-      "fingerprint": "2bdb4a5a545590031e774a78fe73696a579886ce245d2f5386826dba282f9f5d",
+      "fingerprint": "85b5379039dab6e88ab7313c79cee532685523ea83a03c5be971469ab6d137d1",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 2980
     },
     {
-      "fingerprint": "c1585d266a87de16baa8ad859e34b974b49a61b198501de78790ed1f56b2e393",
+      "fingerprint": "198ecfd2a7de326eb6df04abaff8d2a561fd8490eeedc7aa34f3bdfe0f8ab73a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2981
+      "line": 3012
     },
     {
-      "fingerprint": "684dab6e5ad82ac2a9defbe73a465c8fb0a7ca1159b78c9e70c948e926436656",
+      "fingerprint": "0342502d4c0ab0afaf326d6582dfb7ddfa3fe0302dd236b70f0a526ee44f923c",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 2994
+      "line": 3013
     },
     {
-      "fingerprint": "fe8f0810dabbf05da7c58438c49bf9562592734a2527a5d6dceeb531f87f7fb3",
+      "fingerprint": "44da7400f8da72c3ca57c203af24b65601d8f491791733ac5428feaacb5bccb3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3000
+      "line": 3015
     },
     {
-      "fingerprint": "4483573c60a8c6b6c1c59cb3801db1e2ce29fba78906007c5216feb418f4bbd1",
+      "fingerprint": "62211dd84b0de85e63f4b480b6765f1ad4a63f6bc07c06f33eb58628ef7b14be",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3003
+      "line": 3022
     },
     {
-      "fingerprint": "2945e165fbcf9170aa3a279458814e662c3f9fce3b8ec026c51f0d3c99f948de",
+      "fingerprint": "1f096abda56e82b6e5de533352a1ff9946348b9b259fc09e801647b679fce1ba",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3008
+      "line": 3048
     },
     {
-      "fingerprint": "276f8927aee296e51e6c58c7f6349b5522bab5c84b3b1e04b91fdc5a60dd88e0",
+      "fingerprint": "42dae8901dc0d1f853bdd6039acb459ba57092ed9dfeb505da5484fb7915b465",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3021
+      "line": 3049
     },
     {
-      "fingerprint": "918f8652040ebead244fa4db33f954c58d68f8eb93bc9645d1f29e14d900d68a",
+      "fingerprint": "e38ad1a55ad702ffcd2eaf9b3a28fea240ce0935145fbc51e36a07f6b9925a13",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3038
+      "line": 3050
     },
     {
-      "fingerprint": "a98934280dc51320d6456b73b36df7e6ab54cb88c8c373940a1a2947f5c6eb7b",
+      "fingerprint": "a7124d9098efb812451755e10a0753072fe252e6d7e2aefe90890ef3df93ba90",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3047
+      "line": 3051
     },
     {
-      "fingerprint": "df5693410d5998032261f327f3fa3eb9937d645092f662a69061e8acfa33fd99",
+      "fingerprint": "81fa500a7805f897d77c0ae2d22a32f2312fdc2da96215d590ebd978d561ae4a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3052
+      "line": 3053
     },
     {
-      "fingerprint": "31d3ba99e75b5c9c4dec6bf77faabfc2183963e39879bfcace2344b4037d0069",
+      "fingerprint": "330f803093202a2bc33bb35db8a50ccbb0687487d2cd2622cf064da5c45a4211",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3066
+      "line": 3059
     },
     {
-      "fingerprint": "17f6d1eb27c8e24a24a276471da727f9335cdc00f540bc8ebe853dd0891822d8",
+      "fingerprint": "b5d72438221535d97ec97b15af7b4f6f48ddb32a87341da4bb8e5aaee454fd37",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3076
+      "line": 3086
     },
     {
-      "fingerprint": "5cb5d038d1b42b72e7ce50822018fcd54cb08e857f3d39c8d071267ddbe06b28",
+      "fingerprint": "01baea3a50bb2f79a5dc3d44853737457d094ced6af302c0d75fa406a2eac394",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3101
+      "line": 3087
     },
     {
-      "fingerprint": "498752858e0f2c3b3b01c33024ea563e452d7fc52af28b5fcd673d7e058c7ee9",
+      "fingerprint": "1052c906b4f635b77e744e78b83528002ae2a43694a1d187f6a4d8ab2c2dfb98",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3121
+      "line": 3089
     },
     {
-      "fingerprint": "a3689c26fcc6b840606757ab3d23481df3e540c70a83f72fd5ae5337e7111676",
+      "fingerprint": "cd55649a3315f906890fffd34f8fbe0253db507c4a84da48face5df609afabf8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3132
+      "line": 3091
     },
     {
-      "fingerprint": "ccf50eaf6524fd972bba22b46f7a8f6daeb19f16b3898a30e3abeec31a37a962",
+      "fingerprint": "68e5ada28cf1e64870c1d31237dd88f9ade37bb2fc157e65c6535aa715a06417",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3186
+      "line": 3097
     },
     {
-      "fingerprint": "b766c2b6f0e6200109b24264ec51341419a7d082efcc47c488427fed308639f6",
+      "fingerprint": "5fdee20b8a96df9af7c25ca45fcaa62463bd736675ffd5f39b5c7f2c50d9e4ea",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3197
+      "line": 3103
     },
     {
-      "fingerprint": "16048b20a3469030460bd73431a403f9311c03f53bf4fa7fd93ac38a286f5ee4",
+      "fingerprint": "2d26f96bd01ebd4969849d3cd54ace3d49300fa7fe824a03fe514dae854b88d6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3241
+      "line": 3136
     },
     {
-      "fingerprint": "719dc5aea1547a006998c71a7993ec33f005956017de735f7b9899bb65e32e7f",
+      "fingerprint": "3debdd44f94814aea78477ef7816e26bf1cb7550cc346205d4cc6a417b304ab5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3247
+      "line": 3137
     },
     {
-      "fingerprint": "0c49ecb49cc8a00a2c42c3c6e647dcf81454888f3ef1cc18dc06c454a38a69b2",
+      "fingerprint": "33ba0095ea24426ecc91bd7f8f8185a31a5f6e160ff075510d02fe002b93d003",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3249
+      "line": 3138
     },
     {
-      "fingerprint": "68d266f53740a474f2ab04cd4c3eb99e9a2b493592d4be07220259882c787af2",
+      "fingerprint": "ba7609981ad8efc7c467009de539d7d0d433c3269cc8a1cd74e18de1e9a3eecb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3270
+      "line": 3146
     },
     {
-      "fingerprint": "1bf66705fc0951ed831144a5e3cb68d0834bcf3e5d503769196d91f1a1bf8ecb",
+      "fingerprint": "9bd2441fa847ba949e5665fcc548ab9a2686d024aa57792b86bd70ec04e50722",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3287
+      "line": 3166
     },
     {
-      "fingerprint": "75650acd757c024469eae2946f588a98f11f9237c1c518965de889431726596f",
+      "fingerprint": "3b461b21bb603a834860975feeed25defe7f35776e9decb0bc83998f7035bed4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3167
+    },
+    {
+      "fingerprint": "445d10c92f9ed80da6a5d04e5eb1516d6b5de9e8630f5128d06597ab67ab76d8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3169
+    },
+    {
+      "fingerprint": "a01a5c841ff4f0769cd755671fe12d89292bc574a78f2c4f860a7fa8e22f9cd4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3170
+    },
+    {
+      "fingerprint": "fa1f847b3fa7a22b962a13bbd51a175a51f14e963b58bb52b84ca9b4aad31824",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3178
+    },
+    {
+      "fingerprint": "cfd4ef79a6a8c78a41158efe3b914877a71fa38f2fbaeb6ae6c6ae9411c35913",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3204
+    },
+    {
+      "fingerprint": "f78587dbe129cc8169edb0bf6398321cd3ceff2481279d11ee865e1c4467369b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3206
+    },
+    {
+      "fingerprint": "81af80e2198b10a7314741808cc729e56af8f27fe1b0cc2ac6d73b17831fa225",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3212
+    },
+    {
+      "fingerprint": "b1ed8c7f0a261961e0daa181e6b4479e25ab2c469c050b9fc3e8fe179e9b574b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3213
+    },
+    {
+      "fingerprint": "e981cc98710c01831444962f1e625e80f9fe24006d8caf571057e326f9f2a19a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3231
+    },
+    {
+      "fingerprint": "92806e050013cff8d6f7cdb40d0069e24613977940b23517eac9f03ab9e2fac0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3233
+    },
+    {
+      "fingerprint": "4a232a6ba91fc0d0fbb750a4cc6dad89826d40fd49b6ab2c8bd6200bc83b816a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3236
+    },
+    {
+      "fingerprint": "3af34d9284bb1756dfa34c7a19442fa3c5357c10fc076db50399bb4f06b2acf5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3237
+    },
+    {
+      "fingerprint": "f253fb324aef91dbd375b62981d1ac14f215eda8f6aa6a19ccbe7b05232f930d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3255
+    },
+    {
+      "fingerprint": "67b9aac538f194611e08d598a4bb5394eaaef42287ebd336d71ebd7fd2f80718",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3257
+    },
+    {
+      "fingerprint": "df7ae2c8fcdbe6884be2f2c238c7d7c243df3969415cd9f5d3bd23c5fb7008b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3263
+    },
+    {
+      "fingerprint": "363b080d14e32f4fc7aa8103dcfcc3bd65b64b6fafcc45f7afd4a3aa56ad1677",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3264
+    },
+    {
+      "fingerprint": "48f2e83a95e0eece561978b9ca3c3e615d6659a3e29d4af3839b84e991d07305",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3280
+    },
+    {
+      "fingerprint": "1611bc8aa14322dedb19b173c1c18f0c91a610fef2aac0db6ff7cce527a154c9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3282
+    },
+    {
+      "fingerprint": "a83f703ba2d78e91b8e2f5206ab1a775090a0bfe50a55d8f44cd13d66b4f1add",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3288
+    },
+    {
+      "fingerprint": "b4ff7e4e7e103929d415614c621bd833beac976eb5d4a45731416a3c374a0363",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3289
+    },
+    {
+      "fingerprint": "cdfba43214bd62e8ad099a9c2a2ae03f68a0a6da71397e66cc76ec8692321402",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3304
+    },
+    {
+      "fingerprint": "fcc438193ede10113c239f9262955bd111253ba23304d517c079a3bf09d8a989",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 3306
     },
     {
-      "fingerprint": "940e7ce6c87ae40bef7f0d4bfd60547bc1b7a146c117875c3112ed4d86305b03",
+      "fingerprint": "f28b9341ede9308225a10e1b7f3fb64ff6bba66e64054f9bbc1003a696f622a0",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3309
+      "line": 3312
     },
     {
-      "fingerprint": "34c14b2eb9b3d5a700207685d699d0611b06fdddc896e4f7308053a082eb9172",
+      "fingerprint": "0f6fcbe5f0a0a3869bba235da6847022865330c6e9c7755377dfb654cbeb9958",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3327
+      "line": 3313
     },
     {
-      "fingerprint": "db1708755da22585b64fffc76e1ba0d5520c4273e6deb96c4325e3fe832dd525",
+      "fingerprint": "c35f4e637d85c018d6f4b96a15289d694c302bc7e1c7927aa7439ddb0bee946e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3335
+      "line": 3333
     },
     {
-      "fingerprint": "2d78560e942d0b20943a69df6fd9a611205bef202e7c4d21726f89834192fbaa",
+      "fingerprint": "1a3fd5b19ee01bd4d49bd5dffe786c39d21269265af183d11f5ea1724c39e460",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3351
+      "line": 3339
     },
     {
-      "fingerprint": "01d7f4b7d65dc06aac2ff572337e469df1690488bae086ff06faec6ee603a94d",
+      "fingerprint": "094601be6bb7ac8b0a4d1c1bd4360cf7d0b15ee4b03d198082ee3647bf862335",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3359
+      "line": 3362
     },
     {
-      "fingerprint": "c4afb535a9c728ffd702ae0aef69fc720ff17659ae94213831c745ad0362ad60",
+      "fingerprint": "e68de81b6493b59e22ad4ac36f02ffddc3a3134cf9233d9d8ab11f60a56158f5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3375
+      "line": 3381
     },
     {
-      "fingerprint": "630b578ca75f0cb31d78f22444e7a7013ccf13405fdd3eb70ed8d6b1b805ae3e",
+      "fingerprint": "710a04b08c2630bc096af3a92df80e1d2b9fa3d8531ec48c43306d1b5e67b8d9",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3383
+      "line": 3404
     },
     {
-      "fingerprint": "8496a00b959109807ca295a3869e3f00c9d9430a37a7acd12f100f2ae47ad86e",
+      "fingerprint": "008bd07c3f4c13ceb7f181bc238b10ef0de3fdc8a04f6cebb23ab1a89ecaede8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3406
+      "line": 3435
     },
     {
-      "fingerprint": "5d9f9786737598867f5b1d7bfd47d8e2fb87f231664795935447493176dd02b4",
+      "fingerprint": "b326eae20922ffdef28101f84e1b49000e4f8a4e9cb585b1c9a0e022d49dddf6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3420
+      "line": 3460
     },
     {
-      "fingerprint": "91b41f7f20bb2252dfce85164cb74dd9913a037f05e8556e8b8c1871ef7ac0ec",
+      "fingerprint": "98231eb2a37ca4736942b04e002c50cb8eb879a6133490a8e87297cf4e15a4d8",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3423
+      "line": 3484
     },
     {
-      "fingerprint": "20595d6298c64a6e391e04566bd93c7ec4b2bac5bf2b034f856325eaab3cf521",
+      "fingerprint": "ac071f27a60db68c5eb30cf3efd756cf829cbfdf32d6f54664e16a9e6fdc7f7a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3434
+      "line": 3495
     },
     {
-      "fingerprint": "3396bcbff5cf4dceac3355abbd131270e2f7cbc6f79940d0fef8fe064c5797f4",
+      "fingerprint": "df66580a5725a45aa2371e607211e51a57f09c20dbb66f65ba8b9102c1c6e955",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3461
+      "line": 3516
     },
     {
-      "fingerprint": "cddfb5cb79ba898ca4fd9a7fa1c4e84346bc9380f2320c8d0020be852bd44be4",
+      "fingerprint": "4993b2920c75d1548a313b49b23dad7e87af2211ac33a7cba31e2a1a9a3ddea4",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3462
+      "line": 3524
     },
     {
-      "fingerprint": "be72cb58a4f5625eb5cd799ab19d2015a760df160260321fe70f16593181499d",
+      "fingerprint": "f4623c0e9dee7ef9236b7f34ed031973847942d844dcc4ec4ec0646650e21b50",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3470
+      "line": 3539
     },
     {
-      "fingerprint": "a45fe6f0d954d34fc93b5e9aee13bbf02fc7d4d23d173a2455265fb38694e55d",
+      "fingerprint": "9a1b9a99833497aae5024a0db5b608c4f26d227b9165a0acb787a3f477ed1908",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3502
+      "line": 3549
     },
     {
-      "fingerprint": "c0f256f1f88063d5d80ed6c2942f76bfac1053e5b51e69fc4ebc6cfd1c6ffe8a",
+      "fingerprint": "d91ed6d472c41292bfcb9b64f5c7d4c31612c5407e50de7647e61a5b8217ec6f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3731
+      "line": 3568
     },
     {
-      "fingerprint": "96ca411dc5cedbdb11b00f5e9ff08931561e3368e54306f2dd3f8ca14125e015",
+      "fingerprint": "e3934b4c62a5f2598ea1bf8f11075f57dad1f1c87a27a570807b72481651ab48",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3737
+      "line": 3579
     },
     {
-      "fingerprint": "d03bf90d6664bc3adf282cde51ccebcf0cfaf56b4545c9bbd2a1e55606112b4b",
+      "fingerprint": "f2548b875e2ca16605ff6a752ce9a7970e06982ce661419583c02e14cc58d91e",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3744
+      "line": 3596
     },
     {
-      "fingerprint": "040421b5574505a38c36f90fae5dc90237bd465059817e7cbb54226405cefdb4",
+      "fingerprint": "f78494b6f53172155c79c0aa2b03f6ea54255e22117e910820f5c18f0a0e9ccb",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3754
+      "line": 3603
     },
     {
-      "fingerprint": "be53da2d3a2995c206e424ffbc4f0fd8db8482c992ad2b0ea9734e0ef3c131b6",
+      "fingerprint": "31fe4c1bf0b7b2288ee123c710af45707bd0dfdfcd47c95ed8cf3dc5de768932",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3779
+      "line": 3606
     },
     {
-      "fingerprint": "e64ac6b3b29f18983070ed80011d73c9727a04126ff8d5c67f354d529cd08c21",
+      "fingerprint": "bbfa6349d3c3ba1ed6176af2f538aebb111acc6c2102d92aae4d7e6728898b6b",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3785
+      "line": 3609
     },
     {
-      "fingerprint": "7978491cf73c3c4a001fda73f911dce85fadbafed648d224567ff009848de6e2",
+      "fingerprint": "298dd020f0c70c1dcdda39428f1994c1395844aa7a57079c12a1bf84259f3827",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
-      "line": 3806
+      "line": 3660
     },
     {
-      "fingerprint": "44d4e37d8fa33d602a18fce2bf599bce1813461cad74fe1f66bbade765f06756",
+      "fingerprint": "8f28731a1fb2fab175f22bec9360fce19c09ab638178336891082998e16b7d2e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3666
+    },
+    {
+      "fingerprint": "837b5f095851d37d4bf5d4c5374a886e6d4ac5202508e11e239c4b427e5afe21",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3689
+    },
+    {
+      "fingerprint": "2d5173095597dcfb915665b8393d45992805b29532db362eea391a58e3b15cee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3692
+    },
+    {
+      "fingerprint": "20320a6d6bbe92ece399b9674063a7a9e8d55616e17f655c891153e40238963e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3695
+    },
+    {
+      "fingerprint": "a34dc8f088fdd46e46d95144d915273ad8f28938309289ba9915a41cd32e518b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3714
+    },
+    {
+      "fingerprint": "9d902a7dbe2685a77600954e2945f6f4620cf2ecd2caa1a3c348aaa53f967933",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3718
+    },
+    {
+      "fingerprint": "3c6913cfb96f652d82a7c3906cf87bcbaf227bea5adb2751219c4cb274c5c71e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3721
+    },
+    {
+      "fingerprint": "ac8c1fd464df0d380c9ca547eb25890db2c67c897da6f20e0f4d78fa2b4592c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3725
+    },
+    {
+      "fingerprint": "286cfc776bba364c80c456dd41060f24152988c02b7f1d920e66789b8372d97c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3736
+    },
+    {
+      "fingerprint": "9c39860a3b9da8b07f3b924278740f1434ae9ab2668fce7aeeb49bed1130cbe8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3739
+    },
+    {
+      "fingerprint": "1d026d2bed36cfc3d7671c6f8d41bbc959dce6f54724f56811d1364a8d5adb0b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3743
+    },
+    {
+      "fingerprint": "29b6713e5513139b5623ae7fc8c8e94a5fdec28680cea62c9e2c10cc52eef4d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3761
+    },
+    {
+      "fingerprint": "e964514afbc7b8b2984df78b8afcc64f07e557ed0bdf6ec73d6fcfaf4287a58f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3774
+    },
+    {
+      "fingerprint": "9a040e4cff1116d3e37cf9f79ef41fa63b5986bbae2c807550bfdf50064b820d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3777
+    },
+    {
+      "fingerprint": "bc3780d4b39a112ebfbf9ef22e58ce158fb0be9420abebd9d9e5f6d57ed4faf2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3780
+    },
+    {
+      "fingerprint": "656b10b1c83f4c3b3f5aa6881ba0fc887759677b38b15dd5a6db912e8b630e31",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3790
+    },
+    {
+      "fingerprint": "b9b450fb334c9b8c2f665ddf23cf766d5d222560bcac0618cc9fc75fdcc9ef22",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3805
+    },
+    {
+      "fingerprint": "40e9e483e50fcb86fc9ed716610cc3d16f00d4ca742a74e2b4779e2721300e6b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3809
+    },
+    {
+      "fingerprint": "2f1d6e185c7da713164511658d28531f429208c608d0a39b683e7bfee0cc72a6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/integration.rs",
       "line": 3814
     },
     {
-      "fingerprint": "60e663fee1e63ad1bdcf39aaa401b4dfe0f6cffc73327d5cb8dbf1431e2b7b6f",
+      "fingerprint": "af9dc2e2fab9f234935f5c1cbfabefcea481f012cda0e2b9c2098b509a395ff6",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 22
+      "file": "./tests/integration.rs",
+      "line": 3839
     },
     {
-      "fingerprint": "d5101529968f39a448fdda960f2c4c105e118b6f19a17bd54b82388f747971af",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 22
-    },
-    {
-      "fingerprint": "18af09a91f23077fae58672240f10433129465743618e16a4e8640d3dcec33e9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 22
-    },
-    {
-      "fingerprint": "f5bbf241d2d197ee49e3aae118f2cb5f2f683033727f9026cf861fee349b1912",
+      "fingerprint": "99fea42e9681fa5b358697ddbdb44e26bff1001308e156c1342830d7e6029461",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 26
+      "file": "./tests/integration.rs",
+      "line": 3842
     },
     {
-      "fingerprint": "216c6c02ccf6e09aed543b655146ea88d7b31ac754ed2e2a7c878eaeed264024",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 26
+      "fingerprint": "3f4153cf1f9a04ff0c22c27cce0a3e5fdc455e35b4256d7cd27bd09b5b27e176",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3842
     },
     {
-      "fingerprint": "ba66ddc00c467d16ebb3406353f564a5e44ae8b8ccb3efe4c6525e14b7d4d659",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 26
+      "fingerprint": "b9b7cb3ccd326b64a810d941076d187e58801306c137e32e13a319b5f0484865",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3844
     },
     {
-      "fingerprint": "a65bc4c9f3563b2e613fff8a9c5e56dc46fd754a3eff97fd317afa5502bf8bcd",
+      "fingerprint": "b84bed35202adbd9c62dbe155bbb152f5ddbb830c17ac51541d60fe876427e06",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3846
+    },
+    {
+      "fingerprint": "34a58f7a03dfa68a8832fe4a7674c7b5f48b733012bf66e73dabac47ee801329",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3850
+    },
+    {
+      "fingerprint": "c0510a19c52ec02038dd65c035f8cc8e60082a798661e4d8c6a90055c2d22f90",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3851
+    },
+    {
+      "fingerprint": "d860c29897617a7fc762534020ab31a756f03241e38f93d0efddcc2e3dc1f0db",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3869
+    },
+    {
+      "fingerprint": "17eb282fa5429c282dbbf3080c3e96f1ab3d58f2d181f568f071dea125bde25c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3872
+    },
+    {
+      "fingerprint": "775b95d938cc51c0d30053da392fa0a08cc54a27b5eae844e79aa4d17a774474",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3877
+    },
+    {
+      "fingerprint": "22dcd433e980364f0257eb917da581b184a3e3d949bc2334e755975e00875ca1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3906
+    },
+    {
+      "fingerprint": "191de52185ee7c3333dfc4b83acc2f16c5f035b84fb7e5adfde3d54f5471d9ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3915
+    },
+    {
+      "fingerprint": "98a1b89e070c26a3c0af16ace43680b9815adf06e858c8dc68ff9ddcaf0b4fd6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3920
+    },
+    {
+      "fingerprint": "d35b693666adfecf6edcb7c281ba69a5153ab40b837b55312613027d2785f8a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3943
+    },
+    {
+      "fingerprint": "dfbcaa4e02fa89ec6147269e3ea51503911cde6650b83a2eec6ea04633bbbef0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3968
+    },
+    {
+      "fingerprint": "61ec5982d12257e029dcdc5c558ff1fd6bcfd8fefad5b2747b0be0ca47120b2f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3988
+    },
+    {
+      "fingerprint": "646cf7b689f618084fb74a0083de88a40c77da426059b1ddf04f82d97ef9b393",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4052
+    },
+    {
+      "fingerprint": "25de96c46211660db213beae15d28d782cd8c7535b7bffe78b31b38ff887a0d9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4106
+    },
+    {
+      "fingerprint": "56ea26d058d93afd340d0213f9d0e845eb8045ac8e44773e264287ab640d2748",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4112
+    },
+    {
+      "fingerprint": "a860e85de28bf8a067baf1debbb11c1f87e1ba7b80a8ee40a19078c7117311e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4114
+    },
+    {
+      "fingerprint": "1e7adc338666d9fc141f7c410ea7819f32635bc8df395729106d0fa8ab392940",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4135
+    },
+    {
+      "fingerprint": "4d6d545dd1ef618bf07d5084c6962d04e7e61821137c753e3710c1bfaf86ab0a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4152
+    },
+    {
+      "fingerprint": "af86fd721f2dd255e6e158ba367fbecbfd9d0d60e1de94339895527c3fd28d38",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4170
+    },
+    {
+      "fingerprint": "7b0d4b5b17e2cc77c3c1651aacd89c23ff2ea73ac38c98929de1be35dff4173c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4173
+    },
+    {
+      "fingerprint": "7be60f901c8536fd1a77b1f3398b501e18284b67aed20f9290fea9739ee1fd4f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4191
+    },
+    {
+      "fingerprint": "bdb7f3c9dba637e64f9f66731bae309565ae9abcbd4949ead514eda0b2ee22bc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4199
+    },
+    {
+      "fingerprint": "d35ebe146716c19080b5710a1c943ee0014cea61f51dfff08e5fc80ad70b97fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4215
+    },
+    {
+      "fingerprint": "9018a43d93b0aaf21c467d81ad32aae188d05c6b83e123892959aeabf3c1ff46",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4223
+    },
+    {
+      "fingerprint": "81f8ad81756e99578ca8d8c25fe5f4b93ce07ef611cf2b49379a5b63fd0d31c9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4239
+    },
+    {
+      "fingerprint": "caaebc696a18d0cb041615745a15c12e18ac4b00fdfce4532c138de47357dd2e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4247
+    },
+    {
+      "fingerprint": "b6a2c1ffa082c9f9cac3b7f5e99d95f5c6800d0aeceab946c3dc88b39a74b5ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4270
+    },
+    {
+      "fingerprint": "59e6eeb6c9f52ef7b344011d65a9908e8877f9907564954ea9696ddbcb5d6bd7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4284
+    },
+    {
+      "fingerprint": "09e8125852b97539ac41cdf588af9daacf87cb7b552eb52a3141d37037a9892d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4287
+    },
+    {
+      "fingerprint": "d40564f300a1321f1767326546d4fb5115e12545fe1869aaf9454e4e5409e872",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4324
+    },
+    {
+      "fingerprint": "adf62deaa574cb3eb37f11739ce593a26b3fbd4e702105c4077219c9cb86ed19",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4325
+    },
+    {
+      "fingerprint": "7e0bd12f53953796a9aaf562f0c94cbca3fb89aaad87c569acacba3540a6ae86",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4364
+    },
+    {
+      "fingerprint": "60dc73da4875283e5a04af0c8f90f7e3cc79120a10d2fdb682b7243f5810ec06",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4376
+    },
+    {
+      "fingerprint": "be80ab6f44038d1f354a8362867382fae0970080cddfe437cb45c0937015d455",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4598
+    },
+    {
+      "fingerprint": "5216cc80aded366e30a0299bdc36f38e745c3a7746709004fd4f1dbb832dd145",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4610
+    },
+    {
+      "fingerprint": "798dee85dffeabe260f5d9f42081456457f1d46ff729bb01c959bd09c983c5d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4620
+    },
+    {
+      "fingerprint": "e7849680ae504a123b3be1f1e001e07dd9daef6cd4b8ac3ac5e02516755333cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4645
+    },
+    {
+      "fingerprint": "6805fbaa67f2cf1fb356ff106a75e3408ac2afc6133ffa5b4755663490061d7b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4671
+    },
+    {
+      "fingerprint": "5c99d74d86cb85e12e25b423611bdb01fbbcffbd44972ca896cf6c382b7d6f00",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 4679
+    },
+    {
+      "fingerprint": "59d341ae47be68f25ae0d729b270ec9567a560c87e13b6f67657574ddcf726df",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/kernel_dirty_frag.rs",
       "line": 27
+    },
+    {
+      "fingerprint": "535fdc154a09990c86761ab66804604926c6f5110ab8779692e6d8908e0d939b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "742614983ecd70b79f2d6b2c12b2d1fb727d5a711234c8c6e3fe3aa774fd6ca5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "645e0be563698af948085e112964dd875113f36436382a1424780ad1305ec6f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "cd070c1b8d685d13de1c84a91a3f038bfe39e49fd9a482c8f9c5d49dee0afbea",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "34c7902b81112d09009a483e7e178773f8934b2b372e47da7e4b10b1932ed5a3",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "43f7fa98f4fb79badb2dfcaa1181d90ee7ef62886f7e4a985cb3bb0dc3f42ddc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "96ea0c916d5c04cbbf1d0dc25e95f9badb2a0b32e4663f0d7b4812a6ae2edc01",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "56870efd365e202b4df35beea439c2fd98fa1b35b88da6988fd13978bc93a376",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "ae50a10852ab28d10d119ae06f0004c0263ee24f4fd5262354b1d4137aee9339",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "f0fca478436c8ad22be18e546c28c82d1f2e58b3913b7a3d31acdd14c933d596",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 302
+    },
+    {
+      "fingerprint": "e2fbc35136c92914b708354380aa9a97d8bad2f760eeb42141e8edd8ea5905a6",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 309
+    },
+    {
+      "fingerprint": "ed84362810b15241412958330ec1b2640b54bb90c42dfe588edfa8ab7c64e2c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 309
+    },
+    {
+      "fingerprint": "f0097937a0c1b452146d49edbd69ffd8de824c956319d157bd9f4d89c3565511",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 315
+    },
+    {
+      "fingerprint": "c6a9a6f157fc8c5fd37b53a51a51c824c47714048c50e1ae494377199064691f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 323
     },
     {
       "fingerprint": "e911a98373c91bac64557749ad6b20e83aea957846d7f98e93903ead6257ccc5",
@@ -7388,28 +8660,34 @@
       "line": 237
     },
     {
-      "fingerprint": "246b4477067601a06217565bf7181ed6882bb37eb8911b6c428d488ce631d43b",
+      "fingerprint": "da6167739ec31dd685732ea940d92dc068add08e26ae8b38f4175c7b6b245ffd",
       "rule_id": "rs/no-command-injection",
       "file": "./tests/realistic_fixtures.rs",
-      "line": 19
+      "line": 24
     },
     {
-      "fingerprint": "2c11b4dcd17dadc929afb7e10b7b612e461e69821486bb59b2db3a88628cbf03",
+      "fingerprint": "ea1b8565d76f074c9bc7c5de1eb70988fa9bdff24fb00b4859b72d23d9152e1e",
       "rule_id": "rs/no-path-traversal",
       "file": "./tests/realistic_fixtures.rs",
-      "line": 23
+      "line": 30
     },
     {
-      "fingerprint": "1e843e5429fa6f3e4600b5fb2f3e54d52156dad3e1e9abbecf4501781a7ea8ff",
+      "fingerprint": "16118cfd00ebbabfa188e07db1edd4c34b88db12c3882d2ff5593cfdda05b073",
       "rule_id": "rs/no-path-traversal",
       "file": "./tests/realistic_fixtures.rs",
-      "line": 23
+      "line": 30
     },
     {
-      "fingerprint": "9f0e534ff7d27a1bc5a5defd2f36b81ccc092bb2b181cd67be0cc2088c693b5b",
+      "fingerprint": "686bef2d69b093128594ecd6680b6874f6a843da7a918766e144032ceb5b9785",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/realistic_fixtures.rs",
-      "line": 39
+      "line": 40
+    },
+    {
+      "fingerprint": "9b0f4fd6a6ef1ad2c3c36ba2794677dd851d1a4e8db4f77004070b5954925f75",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/realistic_fixtures.rs",
+      "line": 55
     },
     {
       "fingerprint": "6c09a468ee461508ad2e8550e259cfd5cc9d1322d42e130bcfdd4312126fe956",
@@ -7440,6 +8718,30 @@
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/rule_inventory.rs",
       "line": 35
+    },
+    {
+      "fingerprint": "b1f86769e4dfe4f640a1220c27860f50901c31ddf8259f30e30505796f469a83",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_compat_bench.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "3fb278d510489b4f01f42ad47930e29074f262fe807e16e934cc51e1ea992404",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_compat_bench.rs",
+      "line": 19
+    },
+    {
+      "fingerprint": "d69f911c90acb3582f84850b4b14ba79d82b57e1dca981742b8cb4a52a1deb30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_compat_bench.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "9da738ee524e70d7fba1d8b39f76b969faf13b1b8e8697fe9a2977990a191cb0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_compat_bench.rs",
+      "line": 32
     },
     {
       "fingerprint": "c54622784b8207282f27211ddd927d34569cc2f121906ec11952c266ef1acb03",
@@ -7682,124 +8984,748 @@
       "line": 40
     },
     {
-      "fingerprint": "7d0914f6ffbd60dce55da0032f81cfc2fc6b9f23438066941a19c0ac0e9aa281",
+      "fingerprint": "02c3727163ced0a426185062825a00bd893e461bf5e7b3219fa4fe3262837cf0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 54
+    },
+    {
+      "fingerprint": "2fc34a9063f3d72e420839989ba285f662138798285e7a5661a165e0162c3189",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
       "line": 55
     },
     {
-      "fingerprint": "5ac948416915fa2f2d10122f103f5365c086b0460944f7a31b4a92d9acb1d0f0",
+      "fingerprint": "22a6880816845ad31267fb7e918d0cfb269ba54a59f3f83cf20c7b9d4c158bbc",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 60
+      "line": 63
     },
     {
-      "fingerprint": "5d3a61b43be4f19bcdefdafa4f0a878ba273ad05dde870387b116539e84ebd0a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 65
-    },
-    {
-      "fingerprint": "9bd948ba3d84fde96c4a2eff3329a5d7bc3a4dbf530a322a49f1afeabbdea19b",
+      "fingerprint": "833b22af7775023dd3069317dc0e92744ed89ed435de54cf0f41a388b431e940",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
       "line": 68
     },
     {
-      "fingerprint": "94514df72c5c3e753c2a2f42fe9e72ff12877aa80ebe6437797523c88861a7a8",
+      "fingerprint": "56e4014e523d852b192e7277cc378b5fa0c93387f7fd4e2d805a0c0bc5401012",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 79
+      "line": 71
     },
     {
-      "fingerprint": "a24e3fe622db034f80f1637298b1bc804b5f5041dc88961062e7e78dcde47be1",
+      "fingerprint": "94b499099be153de7d13423811a195945d3f123d90a1e90899259f4d3b771153",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 80
+      "line": 82
     },
     {
-      "fingerprint": "bfd31fcea992396eed0e71586fedc028674ad2f6ae5a8c25444041b2938faaf7",
+      "fingerprint": "876d791af01a28c9ecaf36b1361803c1987b925db202ccea17909b29223bef5a",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 88
+      "line": 83
     },
     {
-      "fingerprint": "d71b05bedfb2e905f00b1769f4984c9385bb22071e6dadc939af2aa35ea5119d",
+      "fingerprint": "afc24512dee0aafe7775cb0d7aa95065104e3e097a6fc462a7fb60cd619564e2",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 93
+      "line": 91
     },
     {
-      "fingerprint": "67d6ac361f48f6c695b0fe6256677ee51787afad82d990666390a4ad7f79cfe0",
+      "fingerprint": "60b5cc5532d1dae2bbf2ea7365fad08c8cf7cc206bb89557a0be47351f08bfd5",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
       "line": 96
     },
     {
-      "fingerprint": "b33f0664c1954688ca9243a678f30b8d952e601fefb9a01cb23ec2275d10df7a",
+      "fingerprint": "1f10200583f8ebd68d490c1f87521246735b36ae305d0978ec4fb486108ebd44",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 107
+      "line": 99
     },
     {
-      "fingerprint": "f29ce56777b580450658671acaf2f5f83bd10a14ca01ea5b07fca60c922c1ee7",
+      "fingerprint": "e3d084d3c3faca29184ac6081c670a3d6d0037d43ef2a2eb03d548d66a145c18",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 112
+      "line": 110
     },
     {
-      "fingerprint": "529782c4bf5824bf03cd4ba0d785892afd5f75cac3fc79f274ec5829b1002e13",
+      "fingerprint": "cc630d42ae9343a4eb83fa517c78d24574c1bce266430235891c72e21e88d6a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 115
+    },
+    {
+      "fingerprint": "7a839fd33c7c2f600a9aac6854585d442b244bacbf529f20e670b5d625b99b54",
       "rule_id": "rs/no-command-injection",
       "file": "./tests/semgrep_parity.rs",
-      "line": 130
+      "line": 133
     },
     {
-      "fingerprint": "4c6ed0ea72587422d25989ad58aa031f5bd8c5942559a1914396cee84ae9ff65",
+      "fingerprint": "847a62713d1b53886545057a173ba276ab983b147b0f59091b281c6ac940007f",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 130
+      "line": 133
     },
     {
-      "fingerprint": "1568fdd3fda7212fd313b83fb0be0e25dcd69735ed2b558332ad9c9a2eefd012",
+      "fingerprint": "92fd5882cc4aaf6805badd6025cdd32349193c680323b88006f0234b064a4861",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 134
+      "line": 137
     },
     {
-      "fingerprint": "f1d2ba5a552a068c666956d7f42008b4b10726a948788f360329a9f53aa26826",
+      "fingerprint": "aac0cf3e8b3d3bb8dedec298f2384f1b132800c826be394a590fe19a8887ba91",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 173
+      "line": 176
     },
     {
-      "fingerprint": "87e83bdd576b4ee1c7c9955e877853c1ba9f110f897758a53eedea2c9f92627a",
+      "fingerprint": "7024c7fd69698221cfdabf23a71612b8781a29e0cded843e9498b17263203d13",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 203
+      "line": 206
     },
     {
-      "fingerprint": "6251309c28e3c2cd3d60e26940b4d42f3392943769ef55870ece39b0d7484387",
+      "fingerprint": "c6fa816cff84e2e8e9baaa992324649a259b4fd8841bd6f6eca40ec1fe50ffa3",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 235
+      "line": 238
     },
     {
-      "fingerprint": "f5a678dc56977164f569f66abfcfa06ca421bc12aabd4b1558fedf8ebd5f9b0f",
+      "fingerprint": "e06928c33b756998fdf94b9351959b8c8e2dee325155f1fa52f9d78d136da330",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 267
+      "line": 270
     },
     {
-      "fingerprint": "ad30c7a839d2e7b3e4d6b00ea7b9c96959a36e21f9e8a9683f47c3ddad6a43c1",
+      "fingerprint": "346da5551947ad4a478b376ffbe297ffba512ac19c72ce013266f7228a45ef89",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 299
+      "line": 302
     },
     {
-      "fingerprint": "52a561f380cf7a0238f7b5a0b2390a89025856be2bbe808964673dc92783d023",
+      "fingerprint": "57ae59f98c0d4d730c58a42c03e48e184b75277d58914e511010f426712185c6",
       "rule_id": "rs/no-unwrap-in-lib",
       "file": "./tests/semgrep_parity.rs",
-      "line": 328
+      "line": 331
+    },
+    {
+      "fingerprint": "e6c4edbe46b45ec98c41c5454bf1f5cf54ff833a5289da9dfbaa877b489eb566",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "bcbba87f56300da7fd91cd15ad2b491c45cc14bae846bec37202bd82e0a1b887",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "b3042ff42959df092d79fee5bb9b4c75634383f44c69394ff6527ce8146ad53e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 50
+    },
+    {
+      "fingerprint": "8f018877587685d470a3d6a18e7780bbba1a91499b305612377b2241487926e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 52
+    },
+    {
+      "fingerprint": "420b5bc108afca25915d0258483182fda4f9dc2adc354bb8cec2bb104c17c9b6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "8d0caa32d20622ab5ef53f24aca331a754820f50e2d9edc1a8dff08394e92924",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "1b9ffaa3eca34f172eff75af842fc00d5e55846c4c059796d2a2ab4f41072b36",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "ad53b109e5acbc5bea3a1e9a31c66f6d16ed77e8cfe51ab103cf08031228475c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "a26e3e99abe4fa02f90accadaa09bc9200ef4c38b19e2aacffca683e3115bc63",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "61f59acd6adfb1c2b2c75628db878c58ff0ac79c565ee8495d552c8a74c45a52",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "7c38ab0c67e4d2afb16fb421ae5f85285fec058f12356b0aedeb65e093b87972",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 99
+    },
+    {
+      "fingerprint": "4e76e40ca0489b7108e79a938463832e9b7fca8250aedf1089f031c3c03d6c7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "48f8b4b446f8a79b644a57c7bc9286eedd0ceb1b3109ac8fb38924c23f97c8eb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "794f1ed690f75907a0097bc4d59f4279b721ce5d15951e08a03bb3ca0615f4f7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 113
+    },
+    {
+      "fingerprint": "235cb9bf4b937d6c9925af4dd4c8da6ad97a5f6cb24c920407f1eba2348a672f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 116
+    },
+    {
+      "fingerprint": "6070e22f28dcf0af7826a8507e2a23eb0720b9afb90de10ec97fe12cd5e8df99",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "e728eba5a3e60f687adb8886d6fb55f0f94124e1741bb14245fba5ad1a9c606c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "2efa2f5625b137d3d0d078d7d5ddaccf2bc43552a079915de676f03353f0ec30",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "1d954120ab7e8f76db67653213b5519ce5345031d028be7389242d043d2dc47b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "124131026763035308f5958c825cdb67ca75c271cc761f9d7a5aeb8da2d86921",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 154
+    },
+    {
+      "fingerprint": "59b158550f2b3b4053c43ecbe63c045aea96cc46ee25ca064e45b315ead6bb2d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 195
+    },
+    {
+      "fingerprint": "af938ab20c18fbff763adcded5aa7e4dab44a65317d46e92ee31e8a7cdc137b3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 228
+    },
+    {
+      "fingerprint": "5cb1c964b321829aa4fb2a70feaf59a308ec3216fb22955343c3a1053ab2af3a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 263
+    },
+    {
+      "fingerprint": "f3069651c148b4fb017838c87aff92828d6f98f23bfa991f393ee96b2b54600d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 298
+    },
+    {
+      "fingerprint": "efa8d099bcb88c2cf02d0042a755482d0a2502f284dfadf5a72860361a49ff02",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 332
+    },
+    {
+      "fingerprint": "b88680a65bd975c28ede23786a7f581b01e89b1ac674a7c3491a8fa4afd88ba4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_go.rs",
+      "line": 365
+    },
+    {
+      "fingerprint": "62c0e46c6d15fad10df4adb8c6c6fc83e11be06237e5a72c4ccb71d5cfb80ef5",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "8c8f55f99526485815e662ebf764c6239e62b688e921193d969c4b0d86e8fb5f",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "b51f7b2b48b0cf3d66af21da2343c81636f7dc30466c03f9e4c5d626820fe67e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 75
+    },
+    {
+      "fingerprint": "cce2def494e5b0971690690e9233a96f50813ec2597fa94a5d925159e5845776",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "0b3906b4e99d2d35394805f1c7451b1e22ff89b68416ad03ceef79745dde03f4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 82
+    },
+    {
+      "fingerprint": "a472ad7ee543f085a6b31c076d3aac956449881796cd1af9450f8549bedb52ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 96
+    },
+    {
+      "fingerprint": "ff017700055ff18f7c09b0445db01080c193b3bd3387c00925935fe3b4c6b449",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 97
+    },
+    {
+      "fingerprint": "31a0bcdd53c65e42eac6296de9f04018471d6f463a1c411536ed0cf22fac4b7d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 104
+    },
+    {
+      "fingerprint": "ba08c7d6258b4d9d2574dc52f7c4d409278c3f42a2c0041d62705d9dff326c8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 109
+    },
+    {
+      "fingerprint": "5a4d43788670595f70071bd8f74991b1b774ebbf639faa69db1197b3d03c748f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 114
+    },
+    {
+      "fingerprint": "d8dc388b0782b56cc3583b9dd985936c710803aa5469f17c6827263f38163085",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "d13c4e8f744b7e6415ab78f98499dc2988b65cf97e42d177388546c7bd752b85",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 125
+    },
+    {
+      "fingerprint": "e0dd1fc440b756156272f7d85ec8b946fd0545bd54bde35f3b11d79c24d483c6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "91ffeacefb5e400c8040ddd9b5769a5d990feaec57c0098a0419f36e7412d72c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "28b05ae50b9733c62ac6e9ac7f4d1a58dff69bbf433c33eee3a4c75af79fbb55",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "44bb3134d32c900170f4500c80d6dc77004e10e030d0c6885a1b87c7c1facce6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 155
+    },
+    {
+      "fingerprint": "ea141b3c1c60d0444ce5454ce1abf81d46dab0d6bf336a8c9b109e21d4dfd3c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 157
+    },
+    {
+      "fingerprint": "312612d65a6f7824ac8f0662b4d912cec69b25596eaead47405c842e3556118d",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 184
+    },
+    {
+      "fingerprint": "b224a6d5ec1df785eb771e09a73dbffd7006612be4528f38040da849b1f3fca2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 184
+    },
+    {
+      "fingerprint": "1291a1d6abeafeb50cadc4ac70d67fbc8037cf916373172f171f9b7c8be25713",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 187
+    },
+    {
+      "fingerprint": "6f200f66fb83193fbe3664375e755eda2ad9029b388823f1983d902a85cbb6ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 190
+    },
+    {
+      "fingerprint": "c6f730fe3ea4db4066d84110d81c2143569c8f13e16ac5ea48eef4774d2b1ec1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "44781015e15889d8077c6029bcccdd2f0dbc7273a6b74352ad65efcddce23e12",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 318
+    },
+    {
+      "fingerprint": "e4f1091efd3019c1ef9418be51ef6d0bad631013c2a75765f9337531c9901653",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 324
+    },
+    {
+      "fingerprint": "f3c283e9bac8ade691c33e96efaed7fe04991ef92c170c7816a78d80f44d22f3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_inverse.rs",
+      "line": 392
+    },
+    {
+      "fingerprint": "7089e6886a1d26475514fbedab6a9ed1a7cc012eebb95c745bf314b7a2317b23",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "6750a6501f8720b63295574b8d83917c7747b4433cb3c8d9f82e61c167eb4138",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "4f200ba74980069092f76196578fb6f358b9dec58e44244bbd6f5d64125b7e3b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "6ef49f3de128e265f900440eb56feb5dcd7cd7d3ef27e338f524e662593d5df6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "d84611e7d6efdffe6897e424d312b8642bceba15d5f13340b7a8aa6845b6dd93",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "e9e39b31cbe03b90c7042f821350452424425331580258c7876135c9373ffab8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "8b8b7c31b706aa4ab6cb5870c35c8914c28ed32a61a5173d34a260f97e446814",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 64
+    },
+    {
+      "fingerprint": "dd7268158e4dc56ea5809c81974c476a732ff5a18838f82c93b0f7b99e030ed7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "9459207195a454eac2c9e466b8f047dcdde027669b2862bbc74b665cffb6f757",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "08d98fe70b48dc915ff4561cad764878f8816c96b1a9ee32571733f3f8c748bc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "09bf79176bb27e4440a4673347264b705ba8e5eed115ffee55cbfb9bce0e8a95",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "d411da686282df5b843791ccdbb90df10ada875d1bb4bcae0fdc18e9f8088256",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 92
+    },
+    {
+      "fingerprint": "90c2266238b4b29d0a0f7d56176f5677929dbdcf597d577da20b7f8bd57e0583",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "ee8213e66265bdf26259f73f87b033a02193b5b4f452baa72c4cc250b3001475",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 105
+    },
+    {
+      "fingerprint": "3856aba1d154d16eaec48c6c75a0b44b1da4bc80fbb8aa93f2b7f623433ad931",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "4491f56b52df6a53f0a47f3b6932f6bcdb745efef121d8429a20a0fab68f79d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 119
+    },
+    {
+      "fingerprint": "3ec9bca8488f81afbf077a74a9dc5e1b97f72b4862b33360da1fd070ec22c7d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "beb0d0ac8578717ad04bc9e78658eb0f316c3946ccb5d2b9c290a965a1a77ad3",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "a3f9476238e143d7a8bf82510d718e2efe55db683d5fa95d48b8efbdab5c1fe6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "f56d2fb9b278568e18461125817838ba8dd56dfe1f071fa2e80ba6b27a22716b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 146
+    },
+    {
+      "fingerprint": "c63dd3d1e49cd2f09735445c955d54339bfdce323f09d10bdc6294e7f8df1df3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "fb48781565ec73ad30a243fb9302786d2997db3b3de7780319536ad8ed47f5bf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 215
+    },
+    {
+      "fingerprint": "0f4f21c6019b253059a60aa16169ea05bb040cf6ecd3b5e338429a026513e5b0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 247
+    },
+    {
+      "fingerprint": "9c0f08c9558f18252171c95dc943bd9c759f662335c22f5e7a3e20afa7766f32",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 280
+    },
+    {
+      "fingerprint": "b987ef26952831eb35c2e6388cc1f2fc27879a07896a5c84c24a4dcc7d928971",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 313
+    },
+    {
+      "fingerprint": "8ca76bb8e22d41d79ab6dcd648b21c29676cde06a92d25bed4a62cec09f6d0a1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_java.rs",
+      "line": 342
+    },
+    {
+      "fingerprint": "42c0f33264cfcacd38cc7ba9b181e59f06c500c2ddd5f33e4763d0755eaa54a7",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "8565ed11fd25248c0af7068d989d6cfe59986eeff655d4c7861a825eadd072bc",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "982fab1c95ba81674328fb70b240fd2f8d9aa77d56f32ddcb2591e83899375be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "941687e528b1222b4c0653cdbbd1e137544d5bfe717664cf851856afde47d35b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "5bb43dc2f3a5059e801335fc424e0992cb48526e8b61d3019bcdae4fb261dcef",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "b00feb3760999f63dc2d95debf7df4b0dcfdce76302e9d09d2b98e61d226d1c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "fa08e006eaf1f4bc71cf5d293b5cad2cfc93351cfe2e8fde5007b4962b0ac6e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 64
+    },
+    {
+      "fingerprint": "55dad4b63743fc67d1b365f6dd212bdb6c778a892c3c7f1729bd3ab646078f17",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "79b0f1c9f6ff553a05a195f0c209340864f4c69cfd8b82afc0844b5fd8223986",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "aaee02caf022c17cc4fd833b517bbc573dea2e4453da945ee6ba4cb4fa7f1471",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "3524352b3c32b51456b8b37da212918231887c487bdce05195db0ec6e77c1ae1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "899e2b028b4575a18b030f5c503aaf26ff71321892c9266b7fba938620e97974",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 92
+    },
+    {
+      "fingerprint": "f05175e3d558a692cbe09335cf243331217c992c1284cd027c5a65ae8ccff11b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "919297c05db8fae063630241aea0cf61f56860009c7df2bf99815be350a6ca3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 105
+    },
+    {
+      "fingerprint": "1464de5430ae4277e9305459a844f5996c843cad62e05955f9069a804b29f86b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "bc8b531ceb58e9e588359077c5b3d8598de734708a049a555460b041b2f47c49",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 119
+    },
+    {
+      "fingerprint": "a0e3d56d297e24dd293036e856b68e75581e9a98fa22f071939d9a8d5e9278c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "7428bd0c251d7046591ef4553ee86a9182bd2f22b3290607ff0571486e7a6da7",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "faad04395158115d57fae28e4ca564eec4c2671d51a76f9b0adf65a1b5e9f8bc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "8169cb21f905a267f78d0181b318cf597d5437585b5ac401ac6c69fc0e783c2c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 146
+    },
+    {
+      "fingerprint": "4504e6b5f97f5c8a431d9c2ab4561b18f2f5df2e4218391a91a0fdf1933b1e36",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "a297135682d35b31ae9ae49266a673bcf8a6737d477fafb920d08d2da5d6eaeb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 215
+    },
+    {
+      "fingerprint": "88214048582aa14a1bae189c66ce8a9859d8db5641a0a19d2bc360eb58818068",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 251
+    },
+    {
+      "fingerprint": "eed55540e2bae623ee97cd39c3ba56b257d70708651b4158f984d5bb58536bfa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 284
+    },
+    {
+      "fingerprint": "3468f58325b5fbd2ca46851e833ea61701d86954ee8479241726a0e3b1194a3a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 317
+    },
+    {
+      "fingerprint": "88cda4a340afcf657a59d54a9bd129272973ce7c576eed4783f1d9ecb06f67c6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity_javascript.rs",
+      "line": 346
     },
     {
       "fingerprint": "56e07b4339a62164ecbff21e94eafbaf1ca97d6e99b56300e4b14acda6318444",

--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -2,10137 +2,7815 @@
   "version": 1,
   "entries": [
     {
-      "fingerprint": "26e527eb940b7550d95d0ef9887b9e2e26d4b72d800f843ac0d8c0798ef92200",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 720
-    },
-    {
-      "fingerprint": "17fc1654f4c266705e49c624e81b4669c5ca852c4a2fc4c49b0c804f8d101abe",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 979
-    },
-    {
-      "fingerprint": "e3e15f8f215e93e43ba4609a129e8e71a12532ed7cafde0578560f3ddd238370",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 1787
-    },
-    {
-      "fingerprint": "2b5fc90ae2b308c2f5862470b4a88b49747eb00290c7400e29c1b86fe4082a3d",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 1807
-    },
-    {
-      "fingerprint": "ac07bdea788e7c42f23235279b6a96602b6c45b087312da4d86bf2624ed46cfd",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 2054
-    },
-    {
-      "fingerprint": "9d89e941020b035ec13fd6d29483a543eedc6c1a9ef5202cd4c9041846e191be",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 2146
-    },
-    {
-      "fingerprint": "87950f94106e530c523090b0538791f4019e828c840676da7046724d1510cc1f",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 2182
-    },
-    {
-      "fingerprint": "d2ac05f4d9c2cfdd2daec32b2087087d246c0b267b120e0704a68166a8cbb74c",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 2209
-    },
-    {
-      "fingerprint": "b07a1397a2ee6134afed32fbd5f28488a989867458487d83f2f88569c037c5b0",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "Cargo.lock",
-      "line": 2794
-    },
-    {
-      "fingerprint": "2a2713cee642b38f6ff0cd88156299b89d9208775e60069c7146a46976dd5602",
+      "fingerprint": "9a7440e5c644a0cdb4f6d69e23205eb5f2c495a8417aa3d58b128155ba8c4112",
       "rule_id": "py/no-command-injection",
-      "file": "benchmarks/compare_versions.py",
+      "file": "./benchmarks/compare_versions.py",
       "line": 36
     },
     {
-      "fingerprint": "6963ef2200eb99a3c2d61fb2419a2634a8c963dd1d9550cea04375dadaf1c873",
-      "rule_id": "py/no-command-injection",
-      "file": "benchmarks/parity/parity.py",
-      "line": 386
-    },
-    {
-      "fingerprint": "5ae8cd6bd2645f05402f640240c152a686837b3c63378c749d443995a2fc2dd8",
+      "fingerprint": "2a582db88f349f787141431679c6118920e5675ddafcfb543e119499899f77ab",
       "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "b7cc8f59f0de3ccf8cb756a378c6a0c718d2fc4e40980aedcbd370cbb0788dce",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 81
-    },
-    {
-      "fingerprint": "84653aa0252a77405aad04126f06f7905e8f28fcb8963105d9a08c6b3e330558",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 111
-    },
-    {
-      "fingerprint": "684d78c07dea861e241f278f81e8c427ef3a8f1c0361bc097260d35803bfb147",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "0f2bdcbd437cc812046faf62670bf1fdbf2f0bf92feaf464f01ea37b60310265",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 123
-    },
-    {
-      "fingerprint": "44dd312e5dd7edce894a22d56f8704ed8f7788f2695d32285a95a24482fe41bb",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "6d8c2db37617146d85042c2ecf129f77276c2b585764b75f542b12bbce9ef921",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 182
-    },
-    {
-      "fingerprint": "ab006da558188cf1a9d8543b2b6f2e10805d944c47a48f840339d7f6621c1e98",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 218
-    },
-    {
-      "fingerprint": "c1887a9dbece5a94dfb3d274b27e939bc6848b868b8ca1a57a82c607c4c64a5f",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "03b43728705f3614b1f3c6e231ce31a1aa0bcfb9722a52dd028bd52bd71628c0",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 248
-    },
-    {
-      "fingerprint": "1bcb211e9f8627cbc5aff8f58057783653a33a364f5b4c5a44f13beeed4b3efd",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 295
-    },
-    {
-      "fingerprint": "826cacd22c6e8c3f6f18a53e45b9e1806a73a1ea3a84dec990ccd74652ff0d01",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 300
-    },
-    {
-      "fingerprint": "d91a669c0868456b6adebd5c50a6af3350db5c04708c7439bf20548a31c86491",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 333
-    },
-    {
-      "fingerprint": "4e62817f3242080ad6c309a486a3ff2d73cf2b342d7f6c8441d2abb0fa401620",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 334
-    },
-    {
-      "fingerprint": "3c6fde26b50a94bd23807c61d20e1a6e778bd3c91059d47cec40cef650e91f48",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 337
-    },
-    {
-      "fingerprint": "93cc4bd12e64915eb4216761bfdfb7a53992fb75ba9280893bb5e001318390bc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 368
-    },
-    {
-      "fingerprint": "326d3d2ffc0ff94b405373704246239a79cd267e4ed7679fac1e3e66fbb1301f",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 373
-    },
-    {
-      "fingerprint": "84682f2463f62374a525e0a241c704b83841295f35eb96e0b7059e34b0115b71",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 389
-    },
-    {
-      "fingerprint": "0865b2560a169b1d8109a294b6cf8ab2906d806a14e7a854ccc574c0807aeb57",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 390
-    },
-    {
-      "fingerprint": "bc5729f8d76734eb5093bd577979426fb57b38f6c5e736513921eefd61ba830d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 407
-    },
-    {
-      "fingerprint": "154c3fa3df5cb426ea371eae3e6733593abb7b3afe01332324e2a3167fd95d30",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 691
-    },
-    {
-      "fingerprint": "8178baf5d3bec2dc00475880cd568eb72f505c08857b94a65f591bef109acaec",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 701
-    },
-    {
-      "fingerprint": "a990b0b89b4b2dd072b881504971b2ad0ed1dc9a62f2c461acadbf6e11349685",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 709
-    },
-    {
-      "fingerprint": "1c8c4058b228248c5bd9c361e98e55ecb004beb6e3a4ad03c785b4c268ea8cf0",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/app.rs",
-      "line": 733
-    },
-    {
-      "fingerprint": "c33c57a6c6523f2d018640ce91f227a0f17a59eb58e1a21769c6ffc48dc647f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/baseline.rs",
-      "line": 283
-    },
-    {
-      "fingerprint": "70b39e612ec7ae391d1f03108f5b53acfec8a6fed21d22bb312e5abcfa197acb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/baseline.rs",
-      "line": 292
-    },
-    {
-      "fingerprint": "d4b50c867863bda676fe489cc5ee6cce60866cfc2b1fc6917dd316bc4565a891",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/baseline.rs",
-      "line": 292
-    },
-    {
-      "fingerprint": "085129a49c9aa8436ca19f2fa49673b441b2933dfcd3528d214b35d37bd0addc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/baseline.rs",
-      "line": 317
-    },
-    {
-      "fingerprint": "b7d1eae33aee81196828838c7d28075e26990fc7f2471d3158a0aa5589002182",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/bin/foxguard_github_app.rs",
-      "line": 1037
-    },
-    {
-      "fingerprint": "08524dc7a5a5fe77070d5b1dd20f465f60e1122396d285f32e7e6af8728cad30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/bin/foxguard_github_app.rs",
-      "line": 1081
-    },
-    {
-      "fingerprint": "6880e55fb893d06e5d8dbd1f8962d1bcca4705bd5289c2a276f9c73c94e703b8",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/bin/foxguard_mcp.rs",
-      "line": 157
-    },
-    {
-      "fingerprint": "8fe279ccfa5eafa41c2e0224e7d54361d5080f29e7568c1782bc15ce7e0b9a2d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/bin/foxguard_mcp.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "8ce7fa76bb415096bbfa250df9152ab53b73f8fb653935ec34f6f23f3e611c35",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/config.rs",
-      "line": 463
-    },
-    {
-      "fingerprint": "607437d2a6019c93199ff8be05ab4d798fd0fb690617f155d6c9ac810285744a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/config.rs",
-      "line": 911
-    },
-    {
-      "fingerprint": "63a1ce966db18def675e0e65ff62df7cba4429f74d2974f1c5d2e0d77468e317",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/config.rs",
-      "line": 948
-    },
-    {
-      "fingerprint": "b48878646916b0242ba69d8cbdf7f211433103b7e515bf1b03dc43867ee8b349",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/config.rs",
-      "line": 949
-    },
-    {
-      "fingerprint": "b93858d96b52df3dcafc3dfafcbb5e5f071a8a6eef904e4eea7e64d3de31715a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 990
-    },
-    {
-      "fingerprint": "fd47a56ee3466518b60b7b1b89d435dbc9a540f9426067c82b1f49f51ad9447d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 992
-    },
-    {
-      "fingerprint": "f49f6feb7cda4facc619e140443fc503856e15a332f21d8e0bc6fb9daf7a19e5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1026
-    },
-    {
-      "fingerprint": "5055edc5b91bfc4f956548765be231eea4ebd2e5251739b2464fe578bd6b6ef4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1044
-    },
-    {
-      "fingerprint": "43b9ba07118a750d7d9af90beb9200430955c28d5843b565b080690669b0eae5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1045
-    },
-    {
-      "fingerprint": "dc91dbd64c9eb3d63f93df9fcf059705cc6c44de8c679b9cad25c8e1f2b67aaf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1047
-    },
-    {
-      "fingerprint": "a7bf73de58d3d0be79adbe536c0e5faac7fd9eebc2015822bb3e21a226de1229",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1063
-    },
-    {
-      "fingerprint": "307d36df056ff52e69995a6f183054d49a66a31ed450fdc723b364d97aa1eebb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1064
-    },
-    {
-      "fingerprint": "adf653afc8459726fe56c6b8f8541811513d2ba6530760cc009bcb675d299ede",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1066
-    },
-    {
-      "fingerprint": "bfbe30698194f129c5a4e9f52a516378e647bc4c539ccbe761cc4ff662d565cf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1067
-    },
-    {
-      "fingerprint": "ef35e6c35a595b4c7cdbd3d9729b1e3a08fa1a53ae85d5e24f6d3307b4b3f94d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1083
-    },
-    {
-      "fingerprint": "c95749c723f3592d25589fb27563a2bd68679e6351709463616cfcc84c7559c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1084
-    },
-    {
-      "fingerprint": "7c27affdfbe58e874d0bed7f649f29aacf21dc6666f5223280e3e3d6abf70f07",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "0cba121c8d607cab1794089596a9b3326bce0081a06a967d315f005ff9176a1c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "6877d25e2affae626ae1b2a0de6fa9f543b3c11298762e768f4a5bd1d1a372ea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "3ff5eee58a7aaa0a06703d8bdbf84a835e6194b97af1e55fa4b07115ab7331d3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1105
-    },
-    {
-      "fingerprint": "c67d8c05d943e1df1244473bede71aaf205054fefd7a204dbd644781640102be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1112
-    },
-    {
-      "fingerprint": "a01d83f4d4f62b4f64c3cfc51d753aa2d3d5b7d7907c527a66250eedb872ed7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1112
-    },
-    {
-      "fingerprint": "9d410e04a7f1f97e2fe793871f5886a52804a8925867f4d8f8bc89d1685b6d7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1125
-    },
-    {
-      "fingerprint": "d0fa53920ff9e083c9b32b5abe6624e4c75fb074a4dbb54a915be6e1bee6dfea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1128
-    },
-    {
-      "fingerprint": "8aeb208817ba40e7096d6b4978a8a8c939996fe72ef81a823e81177834bd94da",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1128
-    },
-    {
-      "fingerprint": "1fefc0f486bd789e04093f5ba985d53928077ae9433c8b313a47d15a7abeef3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1141
-    },
-    {
-      "fingerprint": "daea31e9e36bbc2821ebc313511347cf6f6ed6e874d02102c45a6ed59939bd7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1148
-    },
-    {
-      "fingerprint": "791779a91f68540918d073d27f6ba346d9069bcb949dcace6f30a41bad7fcb24",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1148
-    },
-    {
-      "fingerprint": "97f67d43d00a493b2c618c10c2c77d2a5b914d85bdf64e8cf4899986ebbe5c78",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1157
-    },
-    {
-      "fingerprint": "0280c3f1be6164aa8643abef86cd5eb6c417520698c9765dbd04c600d65f94c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1160
-    },
-    {
-      "fingerprint": "a05adef76bda86cf9c6f92619298343bfa0f33faff921eee45a4d631e6a2cf7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1160
-    },
-    {
-      "fingerprint": "5f5336172166cbd7d281d0aa16737eb835a9e0293ce8e29a9795dcf0f3c9f2aa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1169
-    },
-    {
-      "fingerprint": "5218756965717df52ec3f33d070611afd4b9cc306f8335641e47e3e92b49fba2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1176
-    },
-    {
-      "fingerprint": "3564f7fb1ff4f36872cc09703ede9ac3b63ecdd6d84351790af3671e7d091a45",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1176
-    },
-    {
-      "fingerprint": "0c192be785b5f2d90b7e6ddc89e6b3138fd157822de8031c93ef1d0e87d5f378",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1189
-    },
-    {
-      "fingerprint": "26bada325f3d091e1a0fc047029c0c0d8029f2e74f86824115ece4b483c477c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1193
-    },
-    {
-      "fingerprint": "07d8c055ab50e8d424f4e102a0ad97f55a2ae3904f427307f68b29806385b6b8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1197
-    },
-    {
-      "fingerprint": "5cbbf60fe17d020f8dcd93676842e74a0bace073f87ccafec6ac0270ee4059fb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1197
-    },
-    {
-      "fingerprint": "10f07c6557045bedb8db295945aceab872138c2e10ec6feac18ef579f16a8e13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1207
-    },
-    {
-      "fingerprint": "22adc5a762e53dae32a75c32b522a9ab6e5d33cf6b8b616bfa933405286f114b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1213
-    },
-    {
-      "fingerprint": "7a36a8dcc69c13c7c797366ad7b4a7a63e8a2f11a9ccc33a7e918857830c552a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1226
-    },
-    {
-      "fingerprint": "9f4f973f87e87e8d1bf81db788886019bd9927286d97cd61665859afed339382",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1230
-    },
-    {
-      "fingerprint": "ffe2cf39e14ae18d8933e4f356b1635d4b37fa434cfcf9861d47f4a6c03dede7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1231
-    },
-    {
-      "fingerprint": "8c4a6e5c22cc558430fe045a7540df922459bc2abe6167fe7a11c337593e0973",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1232
-    },
-    {
-      "fingerprint": "804b04a8b2b8f89c4b5fbd7925d4cd48cc82710360747033c0fd7fe33d47bc39",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1242
-    },
-    {
-      "fingerprint": "a6884cc9901a6992c08f1b23e5e63f12a58a6c14a658917676c30870b6499ee8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1256
-    },
-    {
-      "fingerprint": "1784243ef62e7ed39271c8d9fe7829297a48435191f370fd470c1c2ec2bc538d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1259
-    },
-    {
-      "fingerprint": "5a65a208948f57bc40635083cabb0bb59016c1eed2b1f272e172adce05edb3bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1264
-    },
-    {
-      "fingerprint": "0a840e634668998e296112cc732a88851dff71daa2d53dcb2fe96064a72f9cee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1264
-    },
-    {
-      "fingerprint": "3d53e6c63210ae736e3b279fd66845e02e99b08f5dc2f7cb489b185acca6bfd2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1269
-    },
-    {
-      "fingerprint": "9f9d0601084633052af8b80132f6d83a7907ba72d4f88396f61db9d341ae019d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1304
-    },
-    {
-      "fingerprint": "cd57cb409cb5240afc2f5058c64b19d7c07855fb8d6c16f0433da289ef25e9cf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1310
-    },
-    {
-      "fingerprint": "e9e8f4a51e895a21f0103ecbe91f3d14473446eb7d6a8e3e798bf7444e848a71",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1310
-    },
-    {
-      "fingerprint": "610291531d0b33ccfc48f222587469ef56d607ce652090eaeaec980181985145",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1336
-    },
-    {
-      "fingerprint": "460f627ad6352d2b02a706c7efcac1b5d8c72ee74dc6c5d825bf513e875651c1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1342
-    },
-    {
-      "fingerprint": "a0a921f5016adc3ae7c6cb44fb0c32f16cb5c348f8fbb4564e74b4cca88dee83",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1342
-    },
-    {
-      "fingerprint": "c91f154395f4e671e26503013fe07c1aa96699da4e53da6e9b5684bbfe470219",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1365
-    },
-    {
-      "fingerprint": "eb7fcbc0dfc7a09942f4525f30ce4786f1641aa33647db203ab7fe05c62faf13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1371
-    },
-    {
-      "fingerprint": "6738aecfb9950f1d1fca85acd4421f7c231da333186a57073f893bbb6e363405",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1371
-    },
-    {
-      "fingerprint": "d68695a02db29ba19c16330ef9d25c2a14f60acb4467361e5440c25f2ed8c1f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1391
-    },
-    {
-      "fingerprint": "814e755b6589024e056b6de176c2d57d929cf13ab73ee828872c404c67f4b9e3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1397
-    },
-    {
-      "fingerprint": "2cb29a69ca070490670b7fb63ee514c22f423750abcd4c04802c3285653f90e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1397
-    },
-    {
-      "fingerprint": "97a10a7e11511e06ff4fd55c68016c6c5792b58b83883aa381d1d9916e8e8df2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1422
-    },
-    {
-      "fingerprint": "f49617f994553bb1619941ed57a6d3751514d181a5c5dc89352e8cb19226bcd4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1437
-    },
-    {
-      "fingerprint": "68c84ba3099a011aafbf8e1be2fd32a31150b9a92f17442acee58e84364e57b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1439
-    },
-    {
-      "fingerprint": "a4ca01bce4e66b5f35cd31a031bb97082f6f4dbbaa2347657ec400912a3fa19d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1439
-    },
-    {
-      "fingerprint": "9eea650276016273d8da3c39ea0fdfed9a0a1952a695efd89d2c5bf87e8bb93d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1449
-    },
-    {
-      "fingerprint": "123c9c2a94ebe35f67a2dcfb3e0113959f943e48b0918dba6ad6455dc8df91a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1451
-    },
-    {
-      "fingerprint": "ec2064b311a3da76f9d9dffb90779bee8644858dfe789e3f0503f52af7d696e2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1451
-    },
-    {
-      "fingerprint": "f3ed625bb6872d86c36d9594c852acca46a636335f534a2bd0f3dbdd20486771",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1461
-    },
-    {
-      "fingerprint": "e2582d32d8bf5e2d74991c0c1ac9db1c59ffda7a6675e38e4113ff7e49895787",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1467
-    },
-    {
-      "fingerprint": "45f6fbec8445fec4a08a03bd4b3ea93cb7a06bb91d14cd60aae385ac3083c269",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1467
-    },
-    {
-      "fingerprint": "9ef4c103d7d5f86fe78e5374885b71a6f501f125c0b9cdbb94d204932a223a17",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1475
-    },
-    {
-      "fingerprint": "c9678fba3f0ceb15510382e7ae378611e12bf84d70799276b6a3e3f9a7ea9fed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "fb4610a1b85c9fc78746fdf379585ac3a6252cb1ef92f77fd17bc7b07767a708",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "a5899854c275fa3ef230e49af6bf6e7a7e74aded1ab59a61a9b0f5eac427ce3e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1489
-    },
-    {
-      "fingerprint": "82066d57f5a1d6eed23987d6e61341cff377954d6b342b506d8ba90c82d85a5c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "b027df40bdd6cf1b01321cc65cd6d96c20c8ac601778d6af7fe99af9ed4fe979",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "88afab9ee315b37fe6df3a7f3470931c1675250949b59c99fab900da0bf1174f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1503
-    },
-    {
-      "fingerprint": "dd51929249984f6465fb442e7e7a573e719295972487e974e89693dedb647a03",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1515
-    },
-    {
-      "fingerprint": "cfe45702900edf1e251fa85543c051711d99f639afe0488a8a8cb1cac2c82885",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1527
-    },
-    {
-      "fingerprint": "92b51b298c35864e281fc153b0a88bcb25c8961cbad06e006d0e07d3ff8942da",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1541
-    },
-    {
-      "fingerprint": "e717f5431807172022d3af9170ad72edf536ad04394a84f71c4ba4f5b4a503cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1563
-    },
-    {
-      "fingerprint": "65d769b7d4f49696d26f5b66de2df3dfff51fc2cc9cabf3bb7a6aa0bdf56b484",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1569
-    },
-    {
-      "fingerprint": "849dc94350b6b6382e0a75e005b77ed335c4db75e261452f952e8716dbb10b59",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1569
-    },
-    {
-      "fingerprint": "752adb9bffb99afe056604c20f2e10b00e18d6b5065b6c2f41af65d1a2f598ea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1577
-    },
-    {
-      "fingerprint": "c733d6b1d409fdaa7b79ba79b20b8f457436b769a9a998fd0d832282ae73db73",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1583
-    },
-    {
-      "fingerprint": "89418d2b4df8c82d8675c21574df0a09e2111cea0bdc7aeed89050b794dbb3fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1583
-    },
-    {
-      "fingerprint": "c7effcac4ba6004a790560167ff7360dd5480484131653e9110641ce0173883b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1594
-    },
-    {
-      "fingerprint": "06f38ad5eb9b0f3f905d20995be3e663af5335f0018b8909c812358534840936",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1597
-    },
-    {
-      "fingerprint": "3966b56605c3c3e2840492ec9dfebb9ebf51771077eeb84ceb79cadde373e537",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1602
-    },
-    {
-      "fingerprint": "f855e452d285f98ae1122833678b5c6e23a009588b09a633f3f105165f960988",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1602
-    },
-    {
-      "fingerprint": "817075e39a724fed7147156bc33775e1320522b2ba3a7d53d64eb67d5f3fde37",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1612
-    },
-    {
-      "fingerprint": "2fc71f84b93efd7e7ffcdd938ac58b32344de53adffb3b72e75b6d6a34e03f64",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "d9c0562343e6e2a6679320d4e9eb61a070c77eb8027a8fe79f0fdeba9e8b4b7a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "64e5a03c6f35f1adeadd8a1b98842e977f1ca4cb506add36e79615b25280efc9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1627
-    },
-    {
-      "fingerprint": "c33a2033957e2f1eb20ac0640c61d128f4b3db4c8e9d6a7780d4f4967dfb7860",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1628
-    },
-    {
-      "fingerprint": "4d521d3111cf197d309c5d22621240d0dab43cbf4c28fd83ebd8b3a3a3167ae3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1632
-    },
-    {
-      "fingerprint": "96f3593f7c9407572cae81f22ac7e3b1703f46cbcb8c417507a95a0af454c7b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1642
-    },
-    {
-      "fingerprint": "a99f11a7610d68677aa855223b33e96b8a37cdd9b68a8f3473f8d552b717c3f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1663
-    },
-    {
-      "fingerprint": "e4748b7a7415f485e207fe5384f7cf973b117bd3c1917fc327e7252b8b591494",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1666
-    },
-    {
-      "fingerprint": "4eebabacd5a9e64766eca2ccd7917680c166734721a6baa8575011cf4050d9b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1670
-    },
-    {
-      "fingerprint": "1a0587ba17ec5d80823f7c325b14cdff632b100bcae8bf9f116776b81e221c54",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1670
-    },
-    {
-      "fingerprint": "21bd10940761d7031778d95a5b718c39c29f94ceb97b930198bb75dae6b2538c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1677
-    },
-    {
-      "fingerprint": "73635d9ebb9dd71356e6ca3ce6763f256717aba598a9d90f3e0295174861b386",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1683
-    },
-    {
-      "fingerprint": "5cd412f914c6a6e1ada5f42625f4e3f37d235d0dfa0560574d7cfdae6649f2c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1700
-    },
-    {
-      "fingerprint": "0d3130343372d771a142c7359d852146466d50eeecbeb4475d97380bd36955fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1709
-    },
-    {
-      "fingerprint": "73a0bcf8da3fc5505fcfcd30aaab10aca3cedaa87a2575e5a63a8bf32e0105fa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1715
-    },
-    {
-      "fingerprint": "a80308c0960bc34273d487265ed64445ae635901d38772e7a837647dac3d6f79",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1715
-    },
-    {
-      "fingerprint": "a511d97d01d3a531690109e1c97e08064db11bd54a43356a9fca4ddccbf8802d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1729
-    },
-    {
-      "fingerprint": "cbaed1db2206322d4fe40fe3bcf1b17f9386be112428fcb544d6e2e72d2cd541",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1731
-    },
-    {
-      "fingerprint": "6dbc6330110bb3a2d88af2dfdbc422312331b63eb51643efd86f045057aa40b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/config.rs",
-      "line": 1731
-    },
-    {
-      "fingerprint": "439a189d212f74f369e20560a142c794a5045aa2e4ca0c6bcf3d05a6c5ec5e2a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/diff.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "687e0e9a55214e5c8de87dff496d9ed9525774ae44101ec05d9a8c2f292bb75a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/diff.rs",
-      "line": 217
-    },
-    {
-      "fingerprint": "2a91b86751a3cbbd328cc9e764e5fd46469860a1303ddcd4f4996876635e2c2c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 487
-    },
-    {
-      "fingerprint": "73601e0f47563aaea017821b247214c3069319366d03838e94f4fa5422bf4fb2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 492
-    },
-    {
-      "fingerprint": "3351fb446ec4a03f5f413a679d64f83d6233005ffe939aaf856a58987fad25dc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 511
-    },
-    {
-      "fingerprint": "c1b7e410e667e460dffe8ba2f0b589d5b45db6763c4a82520de7141481375975",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/coccinelle.rs",
-      "line": 682
-    },
-    {
-      "fingerprint": "a85ddce703f8ad10e125b2665e215f11b3e8acaa0653d3c72348ed8c0d8c1615",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/coccinelle.rs",
-      "line": 686
-    },
-    {
-      "fingerprint": "e5ba3cd47c5c4f0b3de3cac65efb3929bd3895301e42cc844778e049c1c999b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 719
-    },
-    {
-      "fingerprint": "dd5db6e7b5ffa060cfcc2d5513965a5355f7003d78075c9fbc10fd25cf601184",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 720
-    },
-    {
-      "fingerprint": "48c3ad7c01bf473077544cf2eeddc4de8c2357b4307a81be454880f93452a213",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 737
-    },
-    {
-      "fingerprint": "f814067e30414ffdcfca4f6c335280b6134516b67a4f19db8c224e2894dc3163",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 747
-    },
-    {
-      "fingerprint": "982974589b51c7678f9e923d8fa9c218ac8d55ac84c41b9a04a425c670e595e3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 748
-    },
-    {
-      "fingerprint": "bc15e234104b299d616a41d974e867368f59636f8f8579ca908b341ac6d86044",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 776
-    },
-    {
-      "fingerprint": "45b91fd4ef75a7d0cbc44d87f935bc818d059ac8cc84ab4c52a84595591fa71a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 787
-    },
-    {
-      "fingerprint": "96a1bee845447a1ed2a28c4121fde5beb66ed156b6319f1fb962801cf20fd35a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 789
-    },
-    {
-      "fingerprint": "d04f7b869e272c2c71e9aab4558cab82f72b00f0b28e5b16282ebda6e8585594",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 809
-    },
-    {
-      "fingerprint": "b4fc410d9bbe65df48a51a4498a562891bacdb1a62ff191ea6af7020d53df1a2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/coccinelle.rs",
-      "line": 811
-    },
-    {
-      "fingerprint": "378dc8791cee0be2d1779f1000bea2a790ebc02321318571f8303f387f171385",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 272
-    },
-    {
-      "fingerprint": "51317d0d50c19cc49bbdac8edc3b3eeeab8155e201eb54786b8c02db10f2783e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 304
-    },
-    {
-      "fingerprint": "c3f67942bbd9ebc6621735f62c50c1efa1fd319565f11f311c77892d49dd0730",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/codeql.rs",
-      "line": 677
-    },
-    {
-      "fingerprint": "5ec21114cd325eab18a48e5f67115795d9673e7a682839bd01ff4ff99b0aa0fb",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/codeql.rs",
-      "line": 681
-    },
-    {
-      "fingerprint": "b9f5a6d99333f3670862a7e9c3cce9a27a70a37f7a33ec33c43361b92216840a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 865
-    },
-    {
-      "fingerprint": "98ebfef392a7e04aaff3d529c2148119d79887419cc50c3e21b3174279ac374f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 866
-    },
-    {
-      "fingerprint": "307562b218d6d4f79b35a94985f4cb14975fc403e65de20eaf9600719cd18a58",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 903
-    },
-    {
-      "fingerprint": "aa22f237b3980c75d9f7bfa2f7f248c68076d77a4c106a62acdf832f65f07eb2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 904
-    },
-    {
-      "fingerprint": "737a34a0c13292b9b4734745a588dd2c5e5368f69c716ad0dcca2c5241150c90",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 921
-    },
-    {
-      "fingerprint": "235d389e4ebafe35bd5e9f649220eefc7cd1f0f286c2b89b71f00404dee08a6b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 922
-    },
-    {
-      "fingerprint": "c5aacf3d52588d890ecdab128dd4b6cd14f1f17a6dded6a54477dac6118755e2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 930
-    },
-    {
-      "fingerprint": "299eace7f5429144b3e083de38ff5651db5aa72ede93041b943c48176825beaa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 931
-    },
-    {
-      "fingerprint": "630098604fcf2a42ccfde0d3656df7ce8ee70feb5779316e5a9feb3888d69fce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 932
-    },
-    {
-      "fingerprint": "3f62d33763dfa269e63e79cddfee90ca87ebc8c74baa5e8af1dd71a2d3094b3d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 933
-    },
-    {
-      "fingerprint": "95d4833074811c3ebb1395328c0a6bd720607f3ade6c75409833fa4ef49d8bcf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 949
-    },
-    {
-      "fingerprint": "b75cc161c1403aff716baf3af1f9732269dcaefea3ce4f9f3513369846733936",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 950
-    },
-    {
-      "fingerprint": "c3ae4ba389cde2a95f52dca2e3745ad5dbfa691d33ac09a084d180bbee271830",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 956
-    },
-    {
-      "fingerprint": "cc9daeb05dabda7d3e30f8e0ced0e247ea65135af5f26e3a50b3f9ba4ec6fff1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/codeql.rs",
-      "line": 958
-    },
-    {
-      "fingerprint": "200654956ff084669dda7819d962cd654b83dba3ee1fe99dd4708a1ed1398941",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/parser.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "08a30ab8ded1f8346a9c91e80cc4eca27762a2307e7da7b6cd6d0ca4278d9100",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/parser.rs",
+      "file": "./src/app.rs",
       "line": 71
     },
     {
-      "fingerprint": "bea6d0599d9226782a834015ea477c71bb41bf5635469e1ce7f9ac2581982eb2",
+      "fingerprint": "529085b439fb25207175fe87b9d5035d28740e936bc285acdb454a62d3410a13",
       "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/scanner.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "f8388a7d64821af43fa1572e5252f2b4038fba0ff4d448611644c0d23a66799b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/engine/scanner.rs",
-      "line": 371
-    },
-    {
-      "fingerprint": "ac51464c3d8dfe3a9274fa4451562cb7b11e5c520366942b090e4b24639210ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 553
-    },
-    {
-      "fingerprint": "1044c834caf0dc97127f074e41ca0dc41db9eb020ce2eff3ca6ca0817e8bb05d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 561
-    },
-    {
-      "fingerprint": "8fb6f2835efe4b219305d96d106d1fb7d2c144b98f89e33c9bd9cbdc84b9af23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 568
-    },
-    {
-      "fingerprint": "c516475b7c1dc9b97e37b71d7c5a3bb93bfac0d31084eedfdc669381bb70e645",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1002
-    },
-    {
-      "fingerprint": "93d69f3b696ba369fca5e71e71a30b24407343a336b0cb29c2f3893da4ef195e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1010
-    },
-    {
-      "fingerprint": "4ab5cd969f549fd5c6797f2e96b23e3ead7bb472032ff422dea4c3234e08f815",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1027
-    },
-    {
-      "fingerprint": "326c87bd1d37b609fc3462554f0d1bcff256c429a88ca9b23ef9f7de2ff3433d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1034
-    },
-    {
-      "fingerprint": "0cebec77fc790b1a4e49f0e566a15974eec8615809b60889a6c6cb37cd1f8b1b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1056
-    },
-    {
-      "fingerprint": "3b411ade3a528a2779521079ffd51f513681161b5812cf043dc732a9f9d5152b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1065
-    },
-    {
-      "fingerprint": "f67bef3cca688be1c96ebd4843a39d0e4027a7105295ae2a09751365110ae2c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1074
-    },
-    {
-      "fingerprint": "1d1b2aaded8333b54889dc615ff543baaf2921b64717a0ad0311783a4119affb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1430
-    },
-    {
-      "fingerprint": "4dc5177107758305e32f7ccdbf1e0c385044a676e0c68a182b6b2199dfff429d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1464
-    },
-    {
-      "fingerprint": "f65c3d7efbad3deed48216d48d688f597fe91c1460c426e42b3682c53600117b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1472
-    },
-    {
-      "fingerprint": "05da5e8f591af3b227536f1686bbbc75fa31ed68a54372922c3796050ab9b8be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "85c7dc3244e0c16e8f29969251c1ff7264ff282314c3cf8cd469622e16cc31a3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1507
-    },
-    {
-      "fingerprint": "bea5136930bb8baf406172bc9149a8dbda6e965669b4573cf2370445ec1e38cb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1518
-    },
-    {
-      "fingerprint": "d7e210d6305e7538cd223acfd64b01694e957a742c99f9c3727231d007ae4a54",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1519
-    },
-    {
-      "fingerprint": "fba0bfd9053ef6830c3d153e6605f3f8761fc80e61fcc1a598739779cea0120e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1521
-    },
-    {
-      "fingerprint": "9a225aec42d7b4d76c2042b92bb2c0e814e604b684241e86ad4eda92c43ac84a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1523
-    },
-    {
-      "fingerprint": "3a21f4f8c562d5ef47bc87f078d11c4f38eed391b7614ddfcd193bcdccc7520d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1527
-    },
-    {
-      "fingerprint": "60805282de4b46ab473ba39053ae98f4e63a6faa20aeac8d83baf530ae9c66fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1529
-    },
-    {
-      "fingerprint": "cb04d88686523fe18a5e43821c06d208b04659956c37cc7cc71189880f7fbe10",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1546
-    },
-    {
-      "fingerprint": "a503761d227877bb310ebca6144568c35df341275e5fc7c93639127b04bbfc17",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1547
-    },
-    {
-      "fingerprint": "10c9fa23436f81616cd514e2abc70f2f5095f845e69cbd6f5f9cfd3a5483b7c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1549
-    },
-    {
-      "fingerprint": "c52c0c339131a3155db83a1042cd027c68040fa0a004112263576ca29287ea4b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/engine/scanner.rs",
-      "line": 1553
-    },
-    {
-      "fingerprint": "a9ede1a3dac849591e057cb9955767b4fd71374a938b8be55ef4ccda707d458e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/command_injection.rs",
-      "line": 311
-    },
-    {
-      "fingerprint": "3fd1ffcd04412e93b976def63d09295a5b99d9ef25fa2324bb56fd7c9739d387",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/command_injection.rs",
-      "line": 312
-    },
-    {
-      "fingerprint": "25e1a75edc1a4186b021bc10e33a98cf75fe9a29c7cef888b49115a7bcefc542",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/command_injection.rs",
-      "line": 323
-    },
-    {
-      "fingerprint": "efcb5434c97ad5dc107f5e1498d8da160bd8223e81b68fe8e9971fc12f905824",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/command_injection.rs",
-      "line": 324
-    },
-    {
-      "fingerprint": "464c8ccaaf6ec054b86a455e65b4052da35e8731775a26b908395e6708384671",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/fix/mod.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "ed0838f8f0d98685f358c42439a15528d9e7fe17eccc8b2192158a7fcc459888",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 445
-    },
-    {
-      "fingerprint": "bb7dfef6a3a67c1f12ffc8f3ee8784b85fa9310a7ef67d8bbe94b1b2f960a5d7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 447
-    },
-    {
-      "fingerprint": "64dae8437180d825d20796c3f38074d0a776dba9ca722ba1219af27f401b2b7c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 458
-    },
-    {
-      "fingerprint": "2421b173a30e0e92fcb47882a21957ea9c0f4c19f7a3264b35b684a117e65550",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 459
-    },
-    {
-      "fingerprint": "bf90d5995554683b2f10635600af35f6026b20ccdb14f357007cd264e3fbc468",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 470
-    },
-    {
-      "fingerprint": "a012ed326e99cc9fe2afadb0dfc67e74dfdd68f29e1d1118a80a9e782d532910",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "23d13172fca81f4fe52750efb4caf74039bb0abc609b28e2074041451e9443c3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 482
-    },
-    {
-      "fingerprint": "1dc10b1cf7385697f62c66570209182bb8a246c7eb49e0064a3b5da0f4da266c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 483
-    },
-    {
-      "fingerprint": "c3858f6bf5575eeb98702d470d560813063b7f976c481c5f63191f4cdaa10812",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/sql_injection.rs",
-      "line": 494
-    },
-    {
-      "fingerprint": "3e87d23a692b2b157f85dfac0bbf5f1fceeb27ca05ebea080db6101a9489f365",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/xss.rs",
-      "line": 121
-    },
-    {
-      "fingerprint": "abeb80af6ea624e36d5b01de216c679d6615682cb855f251d5dd65b7c1451abe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/xss.rs",
-      "line": 123
-    },
-    {
-      "fingerprint": "e78865857c320e9dc7ad033eb1ed1fea6a0e51dc335f9cf821d3fdd7abc67c23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/xss.rs",
-      "line": 131
-    },
-    {
-      "fingerprint": "4d3a8d9176cee403b8ccbdb4597e8409b71eeee01fbcd24d491a663b68e2956c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/xss.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "8dd74fbc5b40378a7c75e89abb7b40bb1ad7aa25a62db741a2b450480c7b4236",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/fix/xss.rs",
-      "line": 140
-    },
-    {
-      "fingerprint": "0fb7af0d28786b9b48fea422733d7388ff8a7f7abe362fc06091f3e76266b3a9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/git.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "1771f06dccf7397d4276534cae956ae92672e2f1d934f8924f23f5d28551d0a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/github_app/review.rs",
-      "line": 823
-    },
-    {
-      "fingerprint": "562ad31268b5ba3baa9425195993c949e428faff545359b6fe92591f0b74973d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/github_app/review.rs",
-      "line": 850
-    },
-    {
-      "fingerprint": "afcfc9524dc4e7fb94241bc5470e6e8fc46a2f2643def2f67c2dd8647f55066d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/github_app/review.rs",
-      "line": 879
-    },
-    {
-      "fingerprint": "a94a0fac87c21efbf2f7cabe80823f4988f97380d05856c518b8821555145f32",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/main.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "e34d88f407f6fadd74ca0c7f5f4c8bbbb4115aaa331115b939b64c15abcba374",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/main.rs",
-      "line": 141
-    },
-    {
-      "fingerprint": "cb3c84ec1d77277c7a562a19890ba03c14ad7e04453555df08a5c31b19d84401",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/main.rs",
-      "line": 146
-    },
-    {
-      "fingerprint": "38c69955cd649ef83dda58d8bf5ee68e618a95aa9747e408d51deeb799b8b03a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/main.rs",
-      "line": 274
-    },
-    {
-      "fingerprint": "99ff4be68d25ef2154c8c358c64f0cb715fcc4132adf3a3bb75d9f94fb06a282",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/output/mod.rs",
-      "line": 140
-    },
-    {
-      "fingerprint": "e12ffb1f2614f7dfab2270bf583a5ea2e81fda8bb80f56712a45f6cae8d620aa",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/output/mod.rs",
-      "line": 181
-    },
-    {
-      "fingerprint": "46ad53c2b7c95005be6dfe970683b23cfbe95e31e6e7bf7bf81cbdbd8cda269c",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/output/mod.rs",
-      "line": 185
-    },
-    {
-      "fingerprint": "418832b6782e3b54db430e30724ae6bb45db30ae806714907a21fafccda54a16",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/output/mod.rs",
-      "line": 230
-    },
-    {
-      "fingerprint": "dc364934659dee287c6ca3b292b5fee761104705b9b78aa2e6a6bfa1318288c4",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/path_identity.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "b5fbafa79237f0222f7a47b2594168c1bb48f8dcb58a4b25e5cad28f11b0dbc6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/path_identity.rs",
-      "line": 75
-    },
-    {
-      "fingerprint": "cb9ae0b7bc17e496be2db505e41894211fdf604fc3395527cbc1583b0341a531",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/path_identity.rs",
-      "line": 112
-    },
-    {
-      "fingerprint": "a2bafb7a3c3c1cd104e82ab1726eeb3f58dc15234fcd64d6d878fe48c340805c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/path_identity.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "27d8f4df67af848fe9a073c670fab131803f15090c223fa7559a1160093f0b9d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/path_identity.rs",
-      "line": 186
-    },
-    {
-      "fingerprint": "e27e1dc22cb91fd742d651fe4107b9be4bfb4b49f7f619e79f759cf19b310cd8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 271
-    },
-    {
-      "fingerprint": "d542b4bbad9d872c3bec302fd8b4d2ecd1de1f3b1a5e8b2cad8dbac0f4ee0825",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "4fe32d264c30c3d0ab7af8be321a299f7c19683b356964385e7557a30b9ecde2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 614
-    },
-    {
-      "fingerprint": "cd33a52e8e91d5dc3acf0b42ede3131a5b4b6dd231e775c55fe12df211a64346",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 639
-    },
-    {
-      "fingerprint": "d5836794e553d5441a6b3c672562919007d3d71fa8e9c8949741e13a3119cdfa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 647
-    },
-    {
-      "fingerprint": "8a950c5b02d75743e42c4c79606227fadb8065686d4ede5f34a21751cf3e6bab",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 650
-    },
-    {
-      "fingerprint": "11e997204df9e46e03b550ef950d9cbd6c9e2be2df26ec314ed7b83a4be14322",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 653
-    },
-    {
-      "fingerprint": "c90d702a98bba16d6c76ddca500ef4a3e3e1a4849c1bdf42a0290355c9ef4de7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 665
-    },
-    {
-      "fingerprint": "214f55557737692cf784337c3b808d8b990e942dab7bd4727ea4bb048fd54b1e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 669
-    },
-    {
-      "fingerprint": "6f81ba27ebec1d05b3429971e2cc285865af344c43ab98a7ad49dd88b4fc1c99",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 684
-    },
-    {
-      "fingerprint": "e60530e15b42bbffe10eb521326bd527104c837f1dce0640e3f7960d05b95344",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 694
-    },
-    {
-      "fingerprint": "1e3fdcca9fe8cfd7d5c07a03a8ce850c8fb55d1667b869f836cb81241e2bc1df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 707
-    },
-    {
-      "fingerprint": "edda87ca3dd658a2f55e41a9818cadcdfbdc8b22e8a0f13a7273b447e8d20ebb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 714
-    },
-    {
-      "fingerprint": "de0035eac01e4001608341a625bb74fd08d83521c259be17d2423121232fb3f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 739
-    },
-    {
-      "fingerprint": "55757d883354d3eada53240a2737315e38e849d82da862d8e0500f9c161a2640",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 758
-    },
-    {
-      "fingerprint": "623c8085c04f653152d89f219feeb7ce708ec7a0cf03103be73911204674a183",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/cbom.rs",
-      "line": 765
-    },
-    {
-      "fingerprint": "8e881c253420d34d7b84174d7ee8280ce1cdb4891fee27f08ff88a7834021821",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/json.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "7a0058aed994c642dbb5205e8fdd81977afbbb23c774def12f9d98b131839f30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/sarif.rs",
-      "line": 341
-    },
-    {
-      "fingerprint": "ce5e48ae309c832b72686a06f3e2b18d3a326556cfa4f114b481cd8dc2c7eb05",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/report/terminal.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "f97cfa6114e9eee582f4e982720fc3bc770cf210b7c909bca859f7a4d25a61c4",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/report/terminal.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "f7e3cca3c557aa9e1ae1880b610d4a6453845fbd6fb0c55b58e7f090b5f93632",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/report/terminal.rs",
-      "line": 126
-    },
-    {
-      "fingerprint": "132a9248b391ad4e2e3a1dac6a5c4b1cdf08de834fdb018074e700eedc3c9187",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/common.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "541c4abef44b5dae89680adfdc5397047f3249d6f47c00e8129c6faf9ee6f2dc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/common.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "667ea92e202fabefabb1741116f57dcf027152e79957b947870999b1957a35fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/common.rs",
-      "line": 407
-    },
-    {
-      "fingerprint": "f5019ce3ad62dc3a852c435364ccfc792e2c876844254010c072acc6f8d5f431",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/common.rs",
-      "line": 408
-    },
-    {
-      "fingerprint": "c29709aafc4d8a41cf6941ab08b64974bbbef928a329348ea960d9907e94628d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "7e03f786e15ab3e4ee75e3d11d1c68299fcdb22108aebac11e8baaba08ec33de",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "6b89bb439134293a7d43d9bfffc1d9f903d5d0005952b9661cb7ec231c3afa11",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "4b7348d9c44449878fa261747258fa8b7409473d53b1af1b704cbe70ee8a0397",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 47
-    },
-    {
-      "fingerprint": "39f2a9fd9ffbce6cfecacd3058e173402aae35189a28e4f8f7a42d3fc4267a18",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 54
-    },
-    {
-      "fingerprint": "dcb50cbd62abb5f6f1c7f30ee4accf4fd1510c25f69b56faf0167ba346ac0a0f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "415b9d839b1fda603819cc35ec82f2ce475a15902292ce3dfb31ae978b82fd69",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 69
-    },
-    {
-      "fingerprint": "a8b166dca8ceb89221d77c042fd1a0074a14766cfff8cffae7a30bcff1902a98",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "018b9844033be4aca9ef1812c36933954bbda67756a379dd55b0d206c4c6321f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "6f26b599fc6b344d589ab6409d7e0ef39c9794bbff45f05f53269e4d6faa2be3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/config.rs",
-      "line": 94
-    },
-    {
-      "fingerprint": "51646a5804f21d44db4332489c19d956be0d0b44781c7b527f28feb53e5cd37a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/csharp.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "b59bf1bfb2de19e64894d7b555feafa059073e3bee1b9568416941b6a7070fdd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "f83c221eecde60ef82ee193155d4b0d5529c7f742ea4b017f79058c55a6bc865",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "8ca694d8d32485480ddaeed527e3bb9f8cde5525b8b0198eb87790fa41f8b81c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 38
-    },
-    {
-      "fingerprint": "727cbde16d8ab12ce4b399b3dda66054d5f797349613f4145dfda5e7cdc88b8f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 45
-    },
-    {
-      "fingerprint": "11387bf12f2d701272695deb1250134801a31b7cc3c5e117e070a256b029c1e1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 52
-    },
-    {
-      "fingerprint": "bb943085dc13fa5d66b4448b5b52617720d0923e76f9fa343dfb03dacd8c0dee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 60
-    },
-    {
-      "fingerprint": "1c6e4fc7b26001aa0f45e8cf84ba5c16a37a0a4fd1b0b98ce647b7c1522f2da5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 67
-    },
-    {
-      "fingerprint": "83e0b04b218ea951e289985e4e2ccbc37dd31d19527fc1f5273444468625d553",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go.rs",
-      "line": 75
-    },
-    {
-      "fingerprint": "adf01283677825ccca62de0c326345d641733cc7a72cb7d60ee255026dda8475",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go_taint.rs",
-      "line": 1324
-    },
-    {
-      "fingerprint": "b5b4fa603d603ca81719a7d07a4e61ffd03756cbce6c6d924c985b71cea1c1c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/go_taint.rs",
-      "line": 1702
-    },
-    {
-      "fingerprint": "ee702d574c2ec170394362ce53850a51cad7090f629adbec059227393c859bea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "90c637f2c782afce381ffc3a726e73abc33a2217baf6bf9986ee242099870b4c",
-      "rule_id": "rs/no-weak-hash",
-      "file": "src/rules/java.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "3370bb38960d840552b925343e8f9cd4a72c62c666d5831efe2d54e68dc7d540",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "b3968d2da3535d0faaa3c62fe2add56fdd246a11b3af9015f2eeb4ca507595d2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "32924b8dc48bdfe57f0b73712d78e4909ce9d7765098617f9cc92839e3ddf3c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "d6c708eb7a35a86c01241c559610f1c0903525ed3e08e6e389ab3794dd062ce3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 49
-    },
-    {
-      "fingerprint": "2c7c47495e576c6cee03d7259bc63b42363429faee4604523b8d9f9b895c198b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/java.rs",
-      "line": 57
-    },
-    {
-      "fingerprint": "9bd355445f4f61d716456c2abd29753412de7c6b8d9dfbcba6eca4c113aff20b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "c4a167a6da8e6f61f41d12c91c2846377e5349735eb2048b038d5ff83fdaa610",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript.rs",
-      "line": 28
-    },
-    {
-      "fingerprint": "9ee6ea663b55aab7c3fca5724f7c4049aa3c930e5d1b852ea22ca2c1bc1b180e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript.rs",
-      "line": 36
-    },
-    {
-      "fingerprint": "60b6705fdc91dbabeaa940d26386516281c8949391978c03938375cd0bb5135c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "1bf61e474fae3b589b3a1a8adea2eb5e64186a5990b9e1bcfc10d4baafdc8dd2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2121
-    },
-    {
-      "fingerprint": "cbbc0d0d25c5890c8b79ce25cca1b893ffe65191e4d5689a7ed486191669bb2b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2278
-    },
-    {
-      "fingerprint": "fbf80ab1edefa8f07d769d067a83e0c766793ffdf6a09705e796dc7219c3aab8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2300
-    },
-    {
-      "fingerprint": "388d4a80550015bc009dd6f5ee0fe37a32132f90928d10ba630ba31bb9b8db9e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2309
-    },
-    {
-      "fingerprint": "ba56537d3721391b7b00983663942e737b637388da9c17183767137356788d6e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2318
-    },
-    {
-      "fingerprint": "383ddc031c09dcf5347d810967d73c92137ef3f6bce3329b1004ce4e53bd93c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2514
-    },
-    {
-      "fingerprint": "d63d1a79ce1cde075e5123010e56f26feaffa7ca637a500c40fc2dbc7015568b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2534
-    },
-    {
-      "fingerprint": "cb358b49b2a9b567918f46b9bf861de6dbb67cfbada9399cc11c9944750844ff",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2550
-    },
-    {
-      "fingerprint": "1a8c3ffd9182547ade25f69248e9227d3fcc979d7695d89ee7ace75e05f90109",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2568
-    },
-    {
-      "fingerprint": "c5b02733711d6bafcc705bc8af79ef3dd1f11a1ae5935b5e41892104c99cbfed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2584
-    },
-    {
-      "fingerprint": "5491016fada3f63b02dc6246d9f3735f63d00cff8c626e08a470e71e4c77a0eb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2601
-    },
-    {
-      "fingerprint": "dd6d48917c773089431e5b8066f433434af09db68b3760486ce2f79a8dc7480f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2621
-    },
-    {
-      "fingerprint": "720d33a911135ece1247d2bc13161fa45bb527b162572a6a61747de0877b7d82",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2637
-    },
-    {
-      "fingerprint": "9a22dadeb61633348f13d853a295c79d1b77e6acd3e86062c33863e5309c184e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2656
-    },
-    {
-      "fingerprint": "4b7df8c00d5da91eb39ea86c837f309833ac2d250a20fee86160b455687a6783",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2681
-    },
-    {
-      "fingerprint": "788899b102fa609a3c27e887bc0cfda1327a3ae43ea8348cb37a2c44fcb484d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2700
-    },
-    {
-      "fingerprint": "587a9345ced278bc63ded567dd5ea4001f92836aa3b3fb833faa2ffefd7b8c34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2709
-    },
-    {
-      "fingerprint": "c3e46ab3db13536585dbdf4be818e3845cf4db0a38888f1d6e84f63f3c1aca7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2729
-    },
-    {
-      "fingerprint": "7ac4871ad4dbfe116faae2b5197a910382d9d1a7488c1b8fbbac2a142f9f142c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2749
-    },
-    {
-      "fingerprint": "2625582f4072070a60ef723cc19dc7a72e012f7e7e434c5ee0a826dd9da54ae4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2766
-    },
-    {
-      "fingerprint": "64ca95ac30c43cb8a8520ea15cc142aad51c7175ecd573fb0675d45a72e32338",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2787
-    },
-    {
-      "fingerprint": "6984f661784668d3c11d2e10ef11be89cecc9d8d4647cceaafb060c3934ccf63",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2811
-    },
-    {
-      "fingerprint": "73eb5d28f558af0bdd37b40c36263d5b8bb420cbff3dece1dd10ef071bce226b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2837
-    },
-    {
-      "fingerprint": "d42e311b43ee2ae57101972254110ca9b5b2171e508ab1c37c05ff2d4e85e144",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/javascript_taint.rs",
-      "line": 2856
-    },
-    {
-      "fingerprint": "a4bca856cc76a588767ea90129b34cfcdbb4023486b26ddd23901ecd10721273",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "f97b78fe1547fc50b566791dffb8060a7a9ecbe8acdeeaac609f0818a2e5530d",
-      "rule_id": "rs/no-weak-hash",
-      "file": "src/rules/kotlin.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "654b1e18e48caf6f01ec082945325a659adfd22d92bedc4a5f5d824c8f9d906c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "477f37f2d17cded8a2230756c4b386ee6174f295f540cef713ce46da0718293c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "670e44e2ec6c2f9d31f4aa269904600c78add7abbaa627bae9727872258de4bf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "a7e7a0637836c83c3cc54588a038a9caa8042eb2c5b93b62b2168255542418b8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 49
-    },
-    {
-      "fingerprint": "94bf254b494e7a42ef8e5814c5bc04fbe357a0067be117f226c967c4a95b17cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin.rs",
-      "line": 1031
-    },
-    {
-      "fingerprint": "dafac73300294807dd8a29d1ab06128601f57e417fdd1f4c4a57b2c5663c0a21",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/kotlin_taint.rs",
-      "line": 766
-    },
-    {
-      "fingerprint": "6340137fe978156cfde44d9522eb196b7a097fae2ede158488a96fd3e0012083",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/manifest.rs",
-      "line": 489
-    },
-    {
-      "fingerprint": "b000e3b2a486603c1e3d9ce3c43063adbccbbf36ba10114269ca6606b0a445bd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/manifest.rs",
-      "line": 533
-    },
-    {
-      "fingerprint": "c7258887451f20b6ad406335dd94e4dda6c6da90023268a3fa854441d48feb6b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/manifest.rs",
-      "line": 755
-    },
-    {
-      "fingerprint": "abe1cf13fda36a89a400485e484d235c02ccb3e128bf37b04721bba9a1f97786",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/mod.rs",
-      "line": 976
-    },
-    {
-      "fingerprint": "f6e8ef0d3a7b96e20e4a77928a146820798c89b818a9c35828f905713be9ca5e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/mod.rs",
-      "line": 986
-    },
-    {
-      "fingerprint": "e3b7d0b3a0becdfd9d5c664c9d1f235a0133b2c46ddc2041b380509f6cf40bf6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/mod.rs",
-      "line": 994
-    },
-    {
-      "fingerprint": "d3f202c67f11aaf37795ef054e74f88ca51aace629d09f1c1f098a3c071ec1df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/php.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "d713b0625cc1279c1d0e6f8193d63837efd877a6d739cdeceae2ba78c1caf936",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/python.rs",
-      "line": 19
-    },
-    {
-      "fingerprint": "f29816de2e4818d08906b6d75d31baea66983d763218c5c28b08e6b706c72def",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/python_aliases.rs",
-      "line": 316
-    },
-    {
-      "fingerprint": "385271f7b8f8e7028a62f55895ddf8dc2b7e351d324032051cff85eb5829fc5a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/python_taint.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "32670b615b429611e964755b6208e06d15fa14dfca6223ee48b65c4dfb3e8219",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/python_taint.rs",
-      "line": 1685
-    },
-    {
-      "fingerprint": "5144585ab0f5d37444198c3b2687f23523533732dc422d337d411f54dae5d2b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/ruby.rs",
-      "line": 836
-    },
-    {
-      "fingerprint": "ba95fdbae9bf77a2271f838aabb6f11a4228263f28bf160bc42c7743342944a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/ruby.rs",
-      "line": 839
-    },
-    {
-      "fingerprint": "af9409323fb8725b36eb884a43a3db4109a44cc2ce4ace7efc4962e0548ad2c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/rust_lang.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "19e18f199ae89abc2affff103f91156f184d3270d4f7a208cd2cf5479db47d9f",
-      "rule_id": "rs/no-weak-hash",
-      "file": "src/rules/rust_lang.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "645126a5bad82bda2eee5024956c7bde404c9f67e00fba00af02ee2a39e4cd65",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/rust_lang.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "05c2524d07da952ee1e9ec00bb2eb034e2c70ee430bf174d6e8e86ef4fc02cea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 350
-    },
-    {
-      "fingerprint": "dc68f471abfb732056c9004f38062e4cbe08c1b858a4ba343e132d7a40f1a045",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 358
-    },
-    {
-      "fingerprint": "08779c8ee735c7784440218ab990f0b4b62f3b28f3e1d940350ec4c4f73ae1c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1066
-    },
-    {
-      "fingerprint": "bfa4a48299378da919962752d5819f969731ff362b60f43aa4598cb58609549d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1354
-    },
-    {
-      "fingerprint": "68ad49be087f312a6d323cfd7998ea78b9e2ad65265aac772d6a8199bb05c709",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1355
-    },
-    {
-      "fingerprint": "f7a856fa0b11f4912c62e4d3038dc266cc1317e9dcb5cbd8d7259653e146a065",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1370
-    },
-    {
-      "fingerprint": "7baa6360d74c18f723ed7fbde48e42e90b60f98d31e3057d47eebba9da880e55",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1414
-    },
-    {
-      "fingerprint": "52229b57ef1c7a3fa461da7679f9d03fc59f93b8c7b0f8390fb3bd786cd2e140",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1415
-    },
-    {
-      "fingerprint": "94eb9d3781663e776bcc9a4f82072814fb8af759c54265746dd154a7027b72fc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1439
-    },
-    {
-      "fingerprint": "2311dbb2a7cc36534d0ed5efa9695941ecaec6caab8dc0995e80dcb312b3903e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1454
-    },
-    {
-      "fingerprint": "69071ed5ca521b51f771e0c0b31f1356cebe29ac48533787ea69ab90e16296e5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1480
-    },
-    {
-      "fingerprint": "eba657cb0f5c3dd501aed39efaad3909076eb5ef4e5e54dc6909e4a34070ad85",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1483
-    },
-    {
-      "fingerprint": "fca6b545711ef74466c8b553d38cb63d6785e799abb9c30d8fdcb73de604ee92",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1503
-    },
-    {
-      "fingerprint": "a3b9aa5f45a486786e1af7a6cfb88a32b1e9c76548055c75c0f8d2e6d00cf697",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1506
-    },
-    {
-      "fingerprint": "50aa31b9550887bc61fac49aac2b6fa669c9b2b779d5f6492c621099e0a5dd16",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1523
-    },
-    {
-      "fingerprint": "4ee5dbf12af3175ea5e54d18cbc45bded6aac38450fddc612b8d2ed4c9560fcc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1526
-    },
-    {
-      "fingerprint": "d97b68050385e1ee32b04428088a42ea87d98f6520010c214cc799be4c5e51df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1543
-    },
-    {
-      "fingerprint": "f3383ef99c7a2a2f1397d729452eca4e7d51646206e15bce4a4e58849b672db0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1546
-    },
-    {
-      "fingerprint": "b6385b40fd9e4102fc211e09244cb4fb0d32a8ebe20d4fb346d55aa57d2412da",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1563
-    },
-    {
-      "fingerprint": "30e80a47981961599039c71ea2a04ed1b4a99d70dd494557383bf3ba9d9c88a7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1566
-    },
-    {
-      "fingerprint": "a0e7cb6c4ce0a17d37131a1f9777faff02cd562d37d4c60d1324234df39d8c87",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1585
-    },
-    {
-      "fingerprint": "16ce40fbf16f4441db6b285cabba08957d1c3216cfc5b502d07abf97e9674eae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1588
-    },
-    {
-      "fingerprint": "36f416fdef5642a0a0c885ec63f15edbf41b050e67e64ad4dae5b412fc0970b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1609
-    },
-    {
-      "fingerprint": "9a3eda78bd3215a65553ca7ac02ebd7b3ae5594ad3dfaf1e3e5744ba10ed7926",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1612
-    },
-    {
-      "fingerprint": "cc0b3bde9ad90879520ff5316aab841da96ec2631c0224047c6e4ca565af0baf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1633
-    },
-    {
-      "fingerprint": "fd1c332119a5332b5bf284b8d6ca95833a8999cf7ba4ca8206d7037eda7a1864",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_compat.rs",
-      "line": 1636
-    },
-    {
-      "fingerprint": "d00b5fb54c083e505c3891bbaffd26f193a2f20ae51a9ebc3aadaf97fe593112",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 548
-    },
-    {
-      "fingerprint": "dc7a95c7335e7f6866e3737448806aab48f967a156bf397dabaf49f2e237cf83",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 648
-    },
-    {
-      "fingerprint": "b9b4965ac6d86c5a21f6a9a9a681f3e2cd35afcf2bc477992d9e33c3e4238bde",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 731
-    },
-    {
-      "fingerprint": "89de24e9c4a82cff867b3fd439145da198e5ff99b6d461b7b877a55ff0cad83b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 743
-    },
-    {
-      "fingerprint": "b5d975a0d694d12105912d5885414c0ec0b675f8d44c645385fbb7885b742802",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 755
-    },
-    {
-      "fingerprint": "e755d7626e24236e3c90cb27492f379571e268df35396a3b1febb2ec4e1842c1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 764
-    },
-    {
-      "fingerprint": "a290358b740ea016b11b2e297e155d3bf065e40e6f328cae6d4a8fba50d1a0ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 773
-    },
-    {
-      "fingerprint": "cfe0e25710a111023303967b439fd621e8715c7d6dc95e4f5fcf26b5cc040762",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 782
-    },
-    {
-      "fingerprint": "a765aa76460a1085e4b3905b55d54607f2929974c9a49992a5a1a0b28a716f2b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 819
-    },
-    {
-      "fingerprint": "e6243844f065c81d1e0d6929d5abd8d206b45eddbca7e9ff11aafbfd4ae37815",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 842
-    },
-    {
-      "fingerprint": "383b4b6550e80934d2a72cc278cab932bfb4cd709c0f91c5fdf304b3f12fd034",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 857
-    },
-    {
-      "fingerprint": "13d4c6eb4d47a5ee05dcda81eeaeb1d9e79d35634dcf167da4915994ad142d7c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 872
-    },
-    {
-      "fingerprint": "8022fcb8f30f8e8564de0d508874061cf5cde5c189bc0a3682554117cb767960",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 895
-    },
-    {
-      "fingerprint": "87129c93a27990a6ef513d1839889044ca324e3998bd302aa0985015322d1df9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 914
-    },
-    {
-      "fingerprint": "f7715a399e60d5c297765ec65fa81a1127aa871ee768628755e185dc62988516",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 927
-    },
-    {
-      "fingerprint": "e210195447b8a639f6650de31496b858f27bcae9469a98149d7d1de337115e9a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 1060
-    },
-    {
-      "fingerprint": "fc8df3fecc25c6658de871fd17c0846738d6a856c00f63f5f65a7cbb13d9e482",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 1109
-    },
-    {
-      "fingerprint": "7c4c495bbd5683edb91f8dad461f273dd55bfc368d42c666361d4499a3f81015",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/semgrep_taint.rs",
-      "line": 1126
-    },
-    {
-      "fingerprint": "de05ca117a64342b617dacb46b039e283229fdc9e8a4faf2d50cef54494834c7",
-      "rule_id": "rs/no-weak-hash",
-      "file": "src/rules/swift.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "424f64ea7f4a86b3ab44825776456181b4afef3cf46e9275e382d746bc58799f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "5ba4b40171cb10331564abcd8a610248cda21a71649cc4db475fe51855f128f2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "c75bea11a81a0b03894809543d8f67efa50f3603139b898bdec154d0828b12ff",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "8ee3bc50cab3129ab5ed047e104be06cae0d7b258a99e2ae521260e3aedd2ec7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "d7b5b89b7e498c607fcdd56c1988bb2663073552855d59cc3206501d1d861205",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 51
-    },
-    {
-      "fingerprint": "88ad5081528df8fca27fa3d3ccb2d0e740a5dec8ce57066d8c9290a1acec6b4e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 59
-    },
-    {
-      "fingerprint": "da5dbb8bd9745d058224dddbd01556680f2104c794d49ebd2c1af7fa3484503e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 67
-    },
-    {
-      "fingerprint": "12b2eb4dec9f40ef883dc4a6d2ceb2220b12067eef3c54fe9e57256bf1df9819",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/swift.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "e607c1db0c1f3e822407c289165a688b9dcd814af1f54a37cdcd2281e21b2d8e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/taint_engine.rs",
-      "line": 814
-    },
-    {
-      "fingerprint": "af023f5e53b261acf50c40c3b1cc3d84658ff2c93dbbd502ca55950fd05e438a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/rules/taint_engine.rs",
-      "line": 839
-    },
-    {
-      "fingerprint": "11755c78a9019b2384073451fe4103835374a4302e90f906965f3de07dc7f27d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/secrets.rs",
-      "line": 189
-    },
-    {
-      "fingerprint": "87aaa88b46756d7df2449ff7f633af96ef2cce9da1b2d927f92215f512d626fa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/input.rs",
-      "line": 354
-    },
-    {
-      "fingerprint": "7f4f0cca69c67a6182fb4d7322f2eab49e3eb526a4c062b66ad470074b38f760",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/input.rs",
-      "line": 357
-    },
-    {
-      "fingerprint": "a7c91b3ba7f4e7fcd7f5735e66a3a11466826eb8760425dea73a45711f520135",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/input.rs",
-      "line": 361
-    },
-    {
-      "fingerprint": "b4d0007020671beff8a163598ed61a00c5f206f0840bf98c79a05b45fb6d657b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 434
-    },
-    {
-      "fingerprint": "6ced696090546e95e7e56ef20b39039cd57c4806f87520fd65521f2333b94180",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 461
-    },
-    {
-      "fingerprint": "a8b9acc7cd05cb074936a3884a342c523621606480638d7af6790262d033dbfa",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 642
-    },
-    {
-      "fingerprint": "d36755630817b1528de70677379fe5f090960e82a0db9b9c3cbe2fbae979a47d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 646
-    },
-    {
-      "fingerprint": "80d040df5940f60161b2c3f5327b912715e6ace72dc5eb2c9e79953bfd67d183",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 666
-    },
-    {
-      "fingerprint": "78e2957014dda9f7db46134cfd3977cd5e53bdb6045f3a9883964c528e7a7f75",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 687
-    },
-    {
-      "fingerprint": "57c84ee65eea06122d4895900832429676bf293cce4b77fc1efbe29a4877df13",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 716
-    },
-    {
-      "fingerprint": "f7623592b5cd58fdd43ac073f7d91edcc9ee02ad95de0cdd8a3e977ef6cffe12",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 752
-    },
-    {
-      "fingerprint": "d7e9c01a592bb73fe9adec73e71b8a22a3180acc56bfb17143e8779c0733016f",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/input.rs",
-      "line": 828
-    },
-    {
-      "fingerprint": "f883f552282a1117eb3a4aa5d601bcbe476504618a8de3d04aa1a5ee97db9a81",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "614a02e5c0af12f274f4c332a6ad4d0d1f358e8a7b75804a7e3eb5150c66ba39",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "1b05e36783cef19087ce2d56b0006c25510f83a3f03a9831c67c0962e89dec30",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "50fdf6988664bc928b187a9ee8d0d9bc0e76a6b6253ce4900d5da08d7dd98057",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "7d1066ca48fdf7709e137eee55a00750ef8f5a202f3e86feaceaa99546d1f428",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "103713866df419db8c00e3ec1ed827f895f3a70e2573636f8e026b4551b141bf",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 338
-    },
-    {
-      "fingerprint": "c2f9b6f9c32b10c5cbf57916f8dc756c1a5595fb14e633d034e52e2374cf09ff",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/mod.rs",
-      "line": 350
-    },
-    {
-      "fingerprint": "02c6f06955b5dd3c96eb101bfb4ce6879ffdb7a64f28a2460cec653bf7b0b62d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 391
-    },
-    {
-      "fingerprint": "25a2b7d60006e4073828e2651ccb66b68d18de6827750caf830378e77606d7ad",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 395
-    },
-    {
-      "fingerprint": "acb20240443c2f78c82d49c4c73ad22cea0c032710368f43a5c683634da516b2",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 401
-    },
-    {
-      "fingerprint": "91918c3d775a40343e94f032a46d2dcf6d789d5f1e1d3fb39adf4909cca44fc1",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 406
-    },
-    {
-      "fingerprint": "57bb8e16ae775836eeead3eb2e020fec237769671b7c92ee3837724055dad67f",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 414
-    },
-    {
-      "fingerprint": "d09d4cfdd3a79df3c9a15e450180cc7820edd6e88770ce1394a8cac359640eb9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 416
-    },
-    {
-      "fingerprint": "02d3aa6b622733cb5ac42697d6c41aa6217f08e50f11e50bd007aab84d2a6056",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 427
-    },
-    {
-      "fingerprint": "a7f8ba72364ffd2b16bfe6fe0ec2fb65b1745573317f840a9956411caac70a1c",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 427
-    },
-    {
-      "fingerprint": "de2a05fd4cdfd2fc8e6ea8b8f33de4da1ff297bd1c73c94ca35dda0bdaa2f39a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/state.rs",
-      "line": 428
-    },
-    {
-      "fingerprint": "6a7150a8ece6d348b04109e814190aa37b45751990e26d03aac1f470337552cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 135
-    },
-    {
-      "fingerprint": "a21862aa287109e7634fb8a284fae919ed3e4680a8fef8e49936b0bd9e60658b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "5559964797ce1d13c063bc31c1eed259f838232331b4051e9cb4ef65e195f56e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "04da7d1096f89730d47eb3e2be47d66a56976528a6cc4bd9494552246de34dae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 189
-    },
-    {
-      "fingerprint": "906f5e84875b9895136f9b106ddc988500422bc23b61979c948866499757a36c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 201
-    },
-    {
-      "fingerprint": "8b57c2fce02c6253e186c6ceba9f64b357bcc56983635ca649b1f975b255cce9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 217
-    },
-    {
-      "fingerprint": "f74052c3aa7b41bb88f3e2e0b7eef0da6f1466000665d1309f396d8e03f6ef41",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 243
-    },
-    {
-      "fingerprint": "aa6798866f8838590a328f61c5a7960cc0007fea5118180a64fea474a28b4d26",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 704
-    },
-    {
-      "fingerprint": "2a69be4766f5a7a5871fe1955f4b67572c040c3cf70234c409227b084094677e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 744
-    },
-    {
-      "fingerprint": "63c18173e00084d6ba08ec17d235c72cfb799f3ddb2cdb7a501434d9eb7d3015",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 784
-    },
-    {
-      "fingerprint": "2a07c9e116faeddbe136ac244dc5b0c135a1d4c3c9feab8c988a43c58991e9e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 824
-    },
-    {
-      "fingerprint": "bd568616c08b861547e343ccaebf5e874cddffcf47e57544192dda724f4e2509",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 838
-    },
-    {
-      "fingerprint": "a895ecfd9f83df89ff10b06c92060828216abb4cfed766c5c3c31a1dc0af9dad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 840
-    },
-    {
-      "fingerprint": "8896ac697084f45fe2671f3fc1fa2eab595add27850adc3da02c9da6fab5fcb3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 841
-    },
-    {
-      "fingerprint": "43fbe93ce99e9e2bdd9499f9a89ee5842293603181aee9bd1124f90eddbf40b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 866
-    },
-    {
-      "fingerprint": "6fd7c1decc86e53cf674261644d3a3fb7b5bc7823e65d47b2feffa919ae0916b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 868
-    },
-    {
-      "fingerprint": "57254b06bfaefcdf223054aaef32566f105093b81a80836e5308cf6806fe7774",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 869
-    },
-    {
-      "fingerprint": "12a037f3a35672eef6cc0befbd54872ef85db828951374c3f7b8f83c73f3f10e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 881
-    },
-    {
-      "fingerprint": "c5355a927316e097ca7cd242a1c9cd298b8f56c387746401366e8561f3ade5b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 898
-    },
-    {
-      "fingerprint": "e749232d695bdeba1761b8f28b333a699fa5801c33321f19a8bc8ce7b279e374",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 916
-    },
-    {
-      "fingerprint": "bd6a7c467096956ac4cc0765c49cbef7fe530165f309825ddaaefaa1fb92564b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 920
-    },
-    {
-      "fingerprint": "1632f66b4cee94d2cb9808e4ec7d66ffebad0177c5bec21a1e0f59d6679a7f70",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 934
-    },
-    {
-      "fingerprint": "4123a4791f6ce96e73057a421d6d92b9d2cc6c673c582d00460f10bfdc3c3e8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1365
-    },
-    {
-      "fingerprint": "9f319a18265b637225bd34efe6bd977b30a27276e43b0c19babe4cb158d0a6cb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1479
-    },
-    {
-      "fingerprint": "5f55285e26ac419b78ea8423b60b1ea1c3cf7267eb70026b984a0c336b9e7a45",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1742
-    },
-    {
-      "fingerprint": "c1f9107e89d94f9fdcace7247d2dc55bb69e6a5d7d7bc463c072cb826ed4d65d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1749
-    },
-    {
-      "fingerprint": "9abdfeac7786d250bcf5b60c6db66ceb7ab3e9c15210472a01ca06499aebcbb2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1801
-    },
-    {
-      "fingerprint": "ef8bbc4c0fa75deba9d5676a165592e662de060c54e60ef2d0443834b1881781",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1813
-    },
-    {
-      "fingerprint": "d135e4ac20a81ca28e1fb13b3f1c95231ce4d8b572723382d0837eb0406fb7e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1865
-    },
-    {
-      "fingerprint": "493773b35113c3636e10da3b42efe5d35c4ce4f3e5ab92bc718d4091e3559086",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 1873
-    },
-    {
-      "fingerprint": "6ae422676bb2abad052e6db1dad71d250288bcd147bd20a45f9aef5e9f413bec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2111
-    },
-    {
-      "fingerprint": "ecb58cfaf22a2032de484f3f06092afdd91aaec411673ffcb519b085a497cb76",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2112
-    },
-    {
-      "fingerprint": "171afee94c7b5556089aa562970ffac26e5f200695b4892c6a90fa3291fa56f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2195
-    },
-    {
-      "fingerprint": "3164162747b188b9c0d3f7d088a94f0081bf1f0a9b927c533dc0e55f68e22f9e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2224
-    },
-    {
-      "fingerprint": "45210621a1d3d458cd20c71233992d2a3ebc8a79769c3c09aa25073254247e51",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2230
-    },
-    {
-      "fingerprint": "b605132130c211394c1cf731c639318d7f75db727128a4624110e5add3b7d633",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "src/tui/tests.rs",
-      "line": 2246
-    },
-    {
-      "fingerprint": "2dafdf212dfe08480a62ae5edda7241ec832f43836ec3cdd323f536579039a2b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/widgets.rs",
-      "line": 1108
-    },
-    {
-      "fingerprint": "45ddacc677c33795697c69a5d26eb32f32d9280c2636cecbaea7c72e2df221ce",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/widgets.rs",
-      "line": 1108
-    },
-    {
-      "fingerprint": "c8cd61d7c981287b4b6e2bf058f6c509d168ba4717ce4ac69a3014cd60c7ea2a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/widgets.rs",
-      "line": 1123
-    },
-    {
-      "fingerprint": "6f6b9ed08a2c411e9493bb2297a2f8241947b1bdc658d8d4077e4cb257421b15",
-      "rule_id": "rs/no-path-traversal",
-      "file": "src/tui/widgets.rs",
-      "line": 1123
-    },
-    {
-      "fingerprint": "a2620902862597457c466e9172eb3dba9ef308d7b8bf99dbd301c9795c254b85",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/ast_rule_batch_bench.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "beada04d745fd3f38e115b0ea946c6d7cec2a077b519e141feb73c1163c0cae3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/ast_rule_batch_bench.rs",
-      "line": 26
-    },
-    {
-      "fingerprint": "f4514c9eaa6024b256f62ead0bcd066a59b008a7af2cc3c9ecb390216765a732",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/ast_rule_batch_bench.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "575ffaf4fcf786413ea90c3c00d4ac18da66a765fdb055b4ced290472561482e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/ast_rule_batch_bench.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "0a42b62356bcfda1e3101c7a3984d2142b3c47ae38e6d4833d424f9aa9c69e45",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "65d13a0f10ee8816cb77a05dead5b3a17f47f84248740d9574bc06669a91ac9e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "433cd3f0889bffe7b0592e65d9298cea78c5848114aae9056795cf2315131222",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "1ec6ba7f3356078b65dec9cdba0551d57bba879602eef81a966ab1dc194e3854",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "835e315c53de1f3f03873ab092be6e1e41976c6ab2b42a97eb79d35205d1f82f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 106
-    },
-    {
-      "fingerprint": "7465caf895f2654f1c71af53511394515712c5027f02d4ca0286582c8f5fed8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "2eb8cb29cf86689a3a3adc2cc78b9296f2df4ba132650cb523e5790421888554",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 195
-    },
-    {
-      "fingerprint": "a8c019ee62c699770dc3ca5d4ae948ee0c480ed869ea3e4b7698eecc52af2f4d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "0fbfee7b7fb457db978e237d5badd726e1b371486c62933e6c1ad003d6c12d95",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 244
-    },
-    {
-      "fingerprint": "e4c1e998ff0addd04964f8ef0ff3415760c5e38077fa5e83dfdeb1797be61b55",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 10
-    },
-    {
-      "fingerprint": "2381de6d4719e806185346c3b851822fd35c91294d72be78406a3db4fe233c81",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 14
-    },
-    {
-      "fingerprint": "70146b54a95e08cc0cb141f3971827f3f21360df2d5d1a3c5eba06f05bec40b4",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 14
-    },
-    {
-      "fingerprint": "8151c43f9600bd8397f34b02b579b0361ac3d40641d7a2da0605b706432c8ea5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "22ee50e53d948a6591e5cd0d8bc02a389c163cae181f34c1e287b4f11fc56d92",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "484be581378fa54e10f4f6525fbe325f7b8d9a7498ad3f3eb1dcc9e955aa4920",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 46
-    },
-    {
-      "fingerprint": "ff992325b96ed461e78d3ee363a88e9fd26b9941f5c0f779cea1f70c5168fca8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 51
-    },
-    {
-      "fingerprint": "ed50c9667d0c555c4863cb79224b169893ef625ccd4cdbaddd4c0e27322d7126",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 52
-    },
-    {
-      "fingerprint": "866a8dd1b1e021c3ee0bb86464a38b01c89401171dc79ee8be9bede2bc3c9bb8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "aea1a1d8e92b571cb7b7441e16a08d959e05606555e46d2b1818b1de05f0318d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "84849ef16cc4ba2b74c05c11b3f4aa7238b01aab498306380bf6b4332635b031",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "99222843b20a82990d43133acee7b37ef5aa66594e6191c859803a20c2f93666",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
+      "file": "./src/app.rs",
       "line": 78
     },
     {
-      "fingerprint": "ec0a3e52c2b8b9d862daa10e281da819388783267d4b4135db0d6617250f8a37",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "c758b4e69aa12bdebee86de3365b0d85b15bf60e218f17918c43cc42111f577b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 129
-    },
-    {
-      "fingerprint": "c7238cd2047f1cdf3b3b0ed06c236928d819fe3b3ec8ef730ee7a50ba16e54f2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/coccinelle_integration.rs",
-      "line": 138
-    },
-    {
-      "fingerprint": "23ac45656b99b597ef3dd1e92e203a232bcfe7a4850aeb2c163277bbb004248d",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "d2a720785f7fd546be41022d69984d3b2b2c7d4fd288abaa8cf4628304123b76",
+      "fingerprint": "a1f32ac359f47a7a1a756ef599761a2cff007ed607f514af12cb3f7d16b19011",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 235
-    },
-    {
-      "fingerprint": "3d3a9548abd30cb4a16de323a5c1f3cd3e1f5b82d694c6fea788880c042ae7dc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 235
-    },
-    {
-      "fingerprint": "f44e1ec87c820650182f409ec6ee4f2f1106aa41d4aa166889b188dd809a8c79",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 295
-    },
-    {
-      "fingerprint": "e3b02b235e35af0b3fbfeca3e58f4a687be78a78b642fd563ff07ba4d27b3932",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 301
-    },
-    {
-      "fingerprint": "23c23660db60119820308c7c7d1be38d73e4e5f701bd74f063ae620359ed7cdb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 310
-    },
-    {
-      "fingerprint": "071ac062053902f330ce5b96ece104474196e30aba739fc1944e1c39bdcca8d0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 317
-    },
-    {
-      "fingerprint": "4f4dfceaa54ced2eae92eb546400e72977ae1bd5c7a446243b295e0dc4fd7131",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 348
-    },
-    {
-      "fingerprint": "1209e93dace0e874a4cff128dac57b0920b185e034404ae7010db2aad27d2fa8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 440
-    },
-    {
-      "fingerprint": "7eccd0c248f891a359f078f0110a8992969f7896e64f5ff8f2a176b3a1085c41",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 442
-    },
-    {
-      "fingerprint": "ed25afc47fbc6c53f4a06e1d345db63c52e2a8086aee373a9f132185c295cf13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 505
-    },
-    {
-      "fingerprint": "2f2a5fc4f1b31deacef754a52b08687a7ea8cbb7f308c7f7471329b1c376d6cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 508
-    },
-    {
-      "fingerprint": "fea4487f3f4b8e9e2499c4c3a0618a8cacf0bb31efbb9d00de42ec467c7c1cf7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 511
-    },
-    {
-      "fingerprint": "a9275eaa092dfce6165d08877b76db8384630f2e546cf3cb89d9f1f1cb62b260",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 514
-    },
-    {
-      "fingerprint": "f808f5909f2dd0acafc85b5a57ad9cbe6caf00f3d2827efbac17ed00812426a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 516
-    },
-    {
-      "fingerprint": "16b7efa586f3b794b2a991be82a3806bc185f7771c109ffd85586da7be0238f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 547
-    },
-    {
-      "fingerprint": "ef9c4b336aff384d52f35b431a2f535818eba5b34770e0aba4185f6dc4b8f3ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 550
-    },
-    {
-      "fingerprint": "79800a0b9f0ff16f91d9ac9b916ff76b9911c562dfe0d04ed9764fad26772f35",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 571
-    },
-    {
-      "fingerprint": "8edd0ed99f8599c7b050fcfd0bec2ba80aba29b7f0cdd81d6fb2e19e7d60f900",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 575
-    },
-    {
-      "fingerprint": "cb16dc6d6571fc5e31fc8596b13a56e4f61c36a37fa76ffceb887a2798090b19",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cross_language_matrix.rs",
-      "line": 617
-    },
-    {
-      "fingerprint": "cca76b4eaa1a94e2e7ed7fadc692558c7e9494e7d50a385aa97c215178657aa4",
-      "rule_id": "config/apache-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/apache_vulnerable/httpd.conf",
-      "line": 12
-    },
-    {
-      "fingerprint": "7388772c5a17d001e2e5cdaa6ec016b488f9e348380f2e820a068b3fcaf09c60",
-      "rule_id": "config/apache-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/apache_vulnerable/httpd.conf",
-      "line": 13
-    },
-    {
-      "fingerprint": "182aa2a3c84d26312d10f87aa53c887c49c95e22ce5c1a908bb16009b9c36246",
-      "rule_id": "config/dockerfile-insecure-tls-env",
-      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
-      "line": 6
-    },
-    {
-      "fingerprint": "74cc1c5dce221c350bee70cba446220ec98e9f5a0a1a0c684d3acb10b5f395f6",
-      "rule_id": "config/dockerfile-insecure-tls-env",
-      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
-      "line": 7
-    },
-    {
-      "fingerprint": "9fbec51bb5e3947eb2a350dc9070cff9e39706d6b82dfd884a61594f755fa558",
-      "rule_id": "config/dockerfile-insecure-tls-env",
-      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
-      "line": 8
-    },
-    {
-      "fingerprint": "122be477525966bc2b84e0eb949607bc20b285206a897dc7e5b166ee1d3a5611",
-      "rule_id": "config/dockerfile-insecure-tls-env",
-      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
-      "line": 9
-    },
-    {
-      "fingerprint": "d61169e19132005dfc65c02d1e9630e0a8fddee2f40e53949a381e013f022ab3",
-      "rule_id": "config/dockerfile-insecure-tls-env",
-      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
-      "line": 13
-    },
-    {
-      "fingerprint": "01eff1369b351751de61a81b44daf97a1bae693487dee7bff915c79207b61a74",
-      "rule_id": "config/haproxy-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/haproxy_vulnerable/haproxy.cfg",
-      "line": 4
-    },
-    {
-      "fingerprint": "07f744316b556274ca8f1bd652650c0ba7b137747b07fce3d224dc66f75594f5",
-      "rule_id": "config/haproxy-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/haproxy_vulnerable/haproxy.cfg",
-      "line": 5
-    },
-    {
-      "fingerprint": "ffa43ddfd340072bc1a9be2e5932ad560fd698121407afa9b64edef377ecf14d",
-      "rule_id": "config/nginx-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/nginx_vulnerable/nginx.conf",
-      "line": 9
-    },
-    {
-      "fingerprint": "7bc9a246aae4e807f7d99c596cc91592399dfc87b6003c74aa57b6c157898885",
-      "rule_id": "config/nginx-pq-vulnerable-tls",
-      "file": "tests/fixtures/config/nginx_vulnerable/nginx.conf",
-      "line": 10
-    },
-    {
-      "fingerprint": "0fca57684a0f495e2ef699557e3e45855b09c1db512e7c281adb12af9eb36dd4",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/Cargo.lock",
-      "line": 6
-    },
-    {
-      "fingerprint": "b8078cfde095c35f86be7219f7787f65710427d92804bc0eeeb0cb4a12cc3d82",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/Cargo.lock",
-      "line": 15
-    },
-    {
-      "fingerprint": "7d6e77a0cea6bbad3a9b4a915488bcf8ab699aa1d3e9b1e307be01a8ae83ec1a",
-      "rule_id": "manifest/cargo-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/Cargo.lock",
-      "line": 32
-    },
-    {
-      "fingerprint": "d5caef4ee4e083d7f52fecbfc420a0c8a6630aa8fcb6689ff8c453207cf1ad36",
-      "rule_id": "manifest/pip-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/requirements.txt",
-      "line": 3
-    },
-    {
-      "fingerprint": "5207d81992b3638f99be9c0111f24b965b6d8096ed63319149fe840dfe3ebf64",
-      "rule_id": "manifest/pip-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/requirements.txt",
-      "line": 5
-    },
-    {
-      "fingerprint": "0dfceded66d414886fb17cde6f6e170d298be39fb51719cc51d38d57af199455",
-      "rule_id": "manifest/pip-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/requirements.txt",
-      "line": 8
-    },
-    {
-      "fingerprint": "c11f6a7579133d4a296baba27aed3c177ea51e0c29e38d756a1290c14c1faba2",
-      "rule_id": "manifest/pip-pq-vulnerable-dep",
-      "file": "tests/fixtures/deps/requirements.txt",
-      "line": 10
-    },
-    {
-      "fingerprint": "9d2cd4cccc5afbcd837086797b314f35e8d89719e88737aba0a9337360570c94",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/aead_no_cow_vulnerable.c",
-      "line": 27
-    },
-    {
-      "fingerprint": "231e12870ad9b08e43e9e60ae9249a113b53ebd87b7ea3903cefc8518442d745",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c",
-      "line": 35
-    },
-    {
-      "fingerprint": "4e36ad6e8e33fb15938886b6d38683789bd52369d8d8f4055a5bcffda9eec950",
-      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
-      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
-      "line": 29
-    },
-    {
-      "fingerprint": "debbf895535d931119a758457c054dccd260549f15339e98c36a562bbcc09234",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
-      "line": 29
-    },
-    {
-      "fingerprint": "cafb81e153f2df6bc7dca8a08a7c763996c3b7178024bd56bb9173cb143f01cb",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
-      "line": 31
-    },
-    {
-      "fingerprint": "53cee790d48f9f1afc452a0cf1a53e83c56a798632b95479773132ac8bef2aac",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c",
-      "line": 33
-    },
-    {
-      "fingerprint": "1aa31d81625e2a99fa10acb41086b0d4c0093ec762f6d8df410be54ce2a782aa",
-      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
-      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c",
-      "line": 30
-    },
-    {
-      "fingerprint": "f38449484cb169bcba0dbe31fe5efba662be71bfcd755c397aca34cd7a4146c5",
-      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
-      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_to_sglist_vulnerable.c",
-      "line": 33
-    },
-    {
-      "fingerprint": "a2c79310b13739aa45471c7c7ca9184451705934a84ae4e11e9d455b1249b055",
-      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
-      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c",
-      "line": 28
-    },
-    {
-      "fingerprint": "5fc8f219a20a8ccbcb8bca9b02574aa04369f477657ee6b0964f15555ac4882b",
-      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
-      "file": "tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c",
-      "line": 28
-    },
-    {
-      "fingerprint": "7ddceaf20d067b4b92c792c10c0c7b9860bf71be137e5fd08cb2f67e3fb7f128",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "0c30808c31dbf7439b3193f01f778316f9a33c7aaae33f34f87923770b2a46d5",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "7262f444a10b51e63275caf72825889a3eda621fb38233ae4503b740aa06f951",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "1aba013367850a1dd1fc57d7a9e72bb07059a6c49b2922e509e2eb4dcc3ad5ee",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "5c8771dec816762d2c98fca808ac51a870d0b42dd57a31def265e883791dc8e9",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "35e61ed1c0752084ca7f5a53292aaf138a48461006a2e8ddf6b7d13385e17d01",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "eac944d5e1a2c6feae3119467353d701e2bf32b153dc6dd6a0ff6174a70a37d6",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "ac00919b5c73df1c91d28ebfa747b87d38fb29fb7e5de5cd4ede671ce100024a",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "7d4d717e0f02ec0e1607d49b166152684a2e5be01b24e13ce22e6283b52ab091",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/cli_tool.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "e66e224ac2516a402b6f23e88ca2d5f53a92ebec5b92528a3b6fcc6253d52aa7",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/realistic/django_chain/queries.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "cec595bfe3398f97c7bc1bd4fb562483e5c8aff4943821027a25c7b6012be8b8",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/realistic/django_chain/views.py",
-      "line": 22
-    },
-    {
-      "fingerprint": "ed0c9f03cc78fed5e5c5679086bf44301f1d2564c417c057385356ad67ba5a9c",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/realistic/django_shop/queries.py",
-      "line": 20
-    },
-    {
-      "fingerprint": "1d6e6b2b963ff237e60470c0ba14ba57c74cdd13cb9db91737bf74b460e2b577",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/realistic/django_shop/queries.py",
-      "line": 27
-    },
-    {
-      "fingerprint": "7e111a1e431d0f78049212f7d44e2143ac3b56baaf90fa4c4fc55abd033ae95c",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "786a8f2c41098168a9ce47eae91647822269dcaaea40bf4bb829ba4b0560ffd0",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "ee43af471b9dac64e98487377251f6c26c8e785274bf751591a749e26b57a428",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "085fad2fa794ccb554208a69f357e009b07ffff1115df2e3e6a8722d41113b92",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "ca50be76e3952345123bdf855835e3cfb3ee9218a3e5579d6fe219aaad289c81",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "4284c578d24b83efc9de9b3b9432e2936c0355ea63415abe73d3efec0eee8c26",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/realistic/django_shop/views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "1e911c8f8f8aa7b758b9e7c721c7854b49fd9bc9380282ac6780f8488204f092",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "a78d242fc9ce19866f176e90d6c1cbc242d87b069aa9e5d226c576d196f66b4a",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "9683b28aac71c1d0c22175220ca0de607b700056ad3eb76fa11a92a17d6c8249",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "9863dc791617c123b5c8339a31b965b4472d33f9aed2cb3ad22c780b222efb0a",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "d35dae3ba60694871013203dae991411763c6af432a96bc91a417ef8f331583a",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "2f62653634deb1b6a591c29e30ccee6e55063b0cc9884419a230546ea1c9f912",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "847b2ed23d547f3d8caf7a9311fb9917708eba5d0b81fad84d05455e681bfecb",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "154c018904a61ea19a699f97893357c3673f17a82d8e01268f06d3d44dbad67c",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "8ebe39199b3caffd158a1b1bced520d19377fe701548e972359cfbdebfd40825",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/realistic/django_views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "4d2e022792b56040561d4c5f12225077f02917e9c146adbdd7aab11c809bed03",
-      "rule_id": "js/taint-sql-injection",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "edab1ccecd7ac0a8721597985df4512d98f9ba91edbab2820dc37a038836e2d5",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "4526476a652a71ab3648c159161b9c01c455b99ed888419bb45b10efd13b09e1",
-      "rule_id": "js/taint-command-injection",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "fdc3a5bb5275865fd2306cfb7091838a454ed58609379bbf75f2d93e856339aa",
-      "rule_id": "js/no-command-injection",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "29901713f644260a131b135e0399533555e38bec1f37f366d7dedea7eaa7fb4a",
-      "rule_id": "js/taint-eval",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 40
-    },
-    {
-      "fingerprint": "8aa89227b7f1ce67998361ae8c055b123d6e51a08db3bd1afffb10e2817210f7",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 40
-    },
-    {
-      "fingerprint": "6eb3b1cbb46ec742cae9dfb4c8862e61616b6f98e86038ed195ccf2c8c110565",
-      "rule_id": "js/taint-sql-injection",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 48
-    },
-    {
-      "fingerprint": "afa2ac4ee64d6282733737ed4edf20ebd3843b95799fbfcf23200134cd7372a4",
-      "rule_id": "js/taint-eval",
-      "file": "tests/fixtures/realistic/express_api/routes.js",
-      "line": 55
-    },
-    {
-      "fingerprint": "22773c1b28d4cee3876d220a52b7a123e8271b24c1cd9aabb51ffa6300d854ff",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/realistic/express_api/services.js",
-      "line": 17
-    },
-    {
-      "fingerprint": "e2ffe6d984d17dc362166572b5a659942506bddb1ebdbb5973fcba8dc5b98114",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/realistic/express_api/services.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "d47115213478d3de4af6e6ad429ab48d6ee4866de4ae0aa37185252901d5906a",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 25
-    },
-    {
-      "fingerprint": "bae2a47fd5c5d9a0c35014b49d2233939dd210950312cd55dffc4737c56324ba",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 25
-    },
-    {
-      "fingerprint": "10e344e160a9726f0ab27c74c0d3d8188564f136fc0e12feaeec2779c6391d59",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "6b3ed194a03d4a877b6290810ca92280df7826714ec28e3f33a3a6153059fd2c",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "e069247a9438625130fab05a1f0d22488a4a308147251e4ecc02136cc4d78234",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "7db74d28cfc2c8c35f6fdcd530650a5ecc422ec76a6671da4ef2185ad3566724",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "6fd8ad8288e5de040cd2fd127b36804889f56321bda76834c1aa68eab8a4ea67",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 46
-    },
-    {
-      "fingerprint": "30321be41f33c22c7c142421c30a0616746a6c3217200f80d24179b415aa795e",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 46
-    },
-    {
-      "fingerprint": "f8fd12d7e5ae24d61a9f97e794dfbea8c75c61a0f224b4564ee98ce988389901",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 54
-    },
-    {
-      "fingerprint": "05697b4b88669ca8c95b1b40404a814eb0ef951ceecf31ba316ebd9590d11158",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 54
-    },
-    {
-      "fingerprint": "6d8ff49ce699d9edfd04a6325b14d80fa9783f8a900e94fc930731d3bf164fc2",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "48550223f22ea4bd56cead743e8db79ef987fa46dd75c0d13564b2f0d7f5a840",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/express_app.js",
-      "line": 76
-    },
-    {
-      "fingerprint": "172dcb8ca889f89f9c2a19a5257f15f1c908f8914bf8e9b63b588aa372e873b3",
-      "rule_id": "js/taint-sql-injection",
-      "file": "tests/fixtures/realistic/express_chain/routes.js",
-      "line": 22
-    },
-    {
-      "fingerprint": "3d9c17406e0ae505331ff7cf3b287ed3dcecfefa30c4b99b9d0464d8e4280bb2",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/realistic/express_chain/services.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "03b4bc3d5f64e9e9bec104382472559caaf36add5024d7ea2ff091dcbcb4da08",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "4b32e124e2d8bc9b2b30ec0c336c0ae5bc198276a68981e8a050918c60a2b407",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "479e099b3a2a17cf3c19ed48babaa7074d188b14c4f5e717cb6404a2a7a6eb98",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "7fc5717ce549eaf27143130a4c85045c250ea755e81e2dc92f65a2ad605f4e1d",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "5cb16dfe6d8caffdc45baa354a863b34f79fe9c886f0636e38d20409273af11f",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "e6e5fb920c6ab791912e8a078411667f81c75ba3343ce278221ed3c3dcbb3d68",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "2fb4071c25d26b28e9adf929212bd72fa80f2167eb6fe2066a38ada99931e8ec",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "4f2b0f42728457462cb278e3bfa7ec5eaa0b454eca06205ab704b94d97c6ee2d",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/fastapi_app.py",
-      "line": 62
-    },
-    {
-      "fingerprint": "8a2be401fcb946c52a0812397e02657a857d516aed042e80728a4b1c9629cd0a",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "d12c68de3731863c068ff7f21d7cf8943a876cd5e0b651166de168ea6b51ca17",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "6d08f3590f6c1b21824ebe4b42566b72107c7153af757528e522ad2fc78ed284",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "7b5bc58109dec5c2991b29dd35afa2ed806ae1954c9d3f7e373fb4cc3b2d7321",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "0bdbaae3b2934d15c7888910796481706605bae1f1ec000ca2c40b0cd87bbb49",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "613a5593f54778ec47718ef0557842b3716e829409888a2ca57d03ecdfd711ca",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "afdda845fbb547bf6defe18187fba7d328ecc2d60252963eeb946b08458851fa",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 64
-    },
-    {
-      "fingerprint": "8c2055c6cd0419d139711d0374c58afc5dc8a2ea8f92486325082af57a6c7be0",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 64
-    },
-    {
-      "fingerprint": "cc8f7861a76a26d46a6882ee36e0d914fd5b65c40b3b3c10b7e7de7193fb0382",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 72
-    },
-    {
-      "fingerprint": "922d7722ebcbca1c8f737dff7d7bf216304dccafbed8cf8eceeb447835e30af8",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 72
-    },
-    {
-      "fingerprint": "296f48bd961c97171c7f30726ad65f81b7341a4dab2666b8e8284f29146647ca",
-      "rule_id": "py/taint-yaml-load",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "7460915b0eaa793fa88eb5d90098a51544d632a45afaf01a7ef2b39b8fb5b840",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "cff75567667d883480abf2a2a271120ba315bf8b8e2054cc8d7e780ec3e20f93",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "4acee6452ea9f412951bfe766a8e7c883b88a38dad7dbb7c48f812e7adb05c55",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/realistic/flask_app.py",
-      "line": 104
-    },
-    {
-      "fingerprint": "ede89ba35b864e9a384ab8215dc1b32c347b83d8f395f6fe8913566f245ea5e8",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 36
-    },
-    {
-      "fingerprint": "769b568e3fbb2c4600f1497ea08b611acf7b3f903506ce83461305ed50216bfb",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 36
-    },
-    {
-      "fingerprint": "72c3dd6c1946a052670a609dd8325de676c47f2fd9a2d933f85e775a93cd9947",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 47
-    },
-    {
-      "fingerprint": "ef53339944a2b806079808b96ec4eab5395987242a2bcfd56c09af474a6d3ccf",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 48
-    },
-    {
-      "fingerprint": "0e27313660face6e449cd277b95278c8957b35953797813ad0014f8186d6224c",
-      "rule_id": "go/taint-ssrf",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "971e4d892fe08d61b03c9275f19c3711c3727fb9e5da3e53063d96038dfc7f02",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "257e96fad56d279e0547820f1f16d410ba28f02364e90af606036702fe980294",
-      "rule_id": "go/gin-no-trusted-proxies",
-      "file": "tests/fixtures/realistic/gin_app.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "228748ab5ca40216ef6b28980dbc83beae98d1f835c1659b9a3e600e46aab1f9",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/realistic/gin_chain/handlers.go",
-      "line": 24
-    },
-    {
-      "fingerprint": "9ec139f5d82e62336dc572b2868de02d05ac9c843e28f15b1e1818a5f4bf7992",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/realistic/gin_chain/store.go",
-      "line": 14
-    },
-    {
-      "fingerprint": "a87fc6ef824d8fe8dbfdab496275523f491d34585055fa84bb9ee568b278a84e",
-      "rule_id": "go/taint-ssrf",
-      "file": "tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "b228cd3d15778f22335b32a113daca00e1411f91263b76c9bcbf1c635a56571e",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "9628fe4bf7373704088f162ee469fcafe2e28d5b01cf3c7f442d7a1b88f51414",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 32
-    },
-    {
-      "fingerprint": "ff26c9d0b5fe73d1d254e1f7bb3550c1fa3f9af5b9e79f54356521b78e66067c",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "0c5deddfe278a0df50ac5f8f93c89aac1774feedb2163e3f4334a34684d583f3",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "8b75c43f4ea8a0306ee82e11378b941bea207c70648b7c50616c79464ba63556",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/realistic/gin_service/store.go",
-      "line": 15
-    },
-    {
-      "fingerprint": "e5d16ca2dd911e64f6452d37ce9ec71f4ffe3fec181fb9697733bdd3f2b84188",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "2e777b7768266f787d2ba89419af1ed85cf7faa588df3e3895bd18ca8865113f",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "8ea3cbd26a419eb7767fba6f18a05c8467f4509293ef287057a0b84dee1bfbc0",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 28
-    },
-    {
-      "fingerprint": "d8b703e1edcda7d7ad207517a53e70ef0c35f6713d2699902239d38343e61853",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 28
-    },
-    {
-      "fingerprint": "9d35f702fa063d370291a9849784867f4e089302fab625b290aad9ee1e5d7c9e",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 37
-    },
-    {
-      "fingerprint": "6a124eecf6a21ff9d3b3e729aacfaf3cacdfcb3d9e72ad1976328f665d6be7b8",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 37
-    },
-    {
-      "fingerprint": "de9a1c056d3238fb46ca0bea3e856252c560e39513a36bee78e5a631c008baf4",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/hono_app.ts",
-      "line": 52
-    },
-    {
-      "fingerprint": "5c1650de0e78ed87d863ff06921f9957ac7b116e6b35b39b080fe1613de5c9ea",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/realistic/next_app/actions.ts",
-      "line": 15
-    },
-    {
-      "fingerprint": "637d7e1d8fdbb4995dbc564655f8b68504b4b2fbf5fe4b7d809a57dfe533cf60",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/realistic/next_app/actions.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "680c0dc5824725600b4d73cd4bcaead1fbe2bfcffb7fa2f2002a3c65ed4d4115",
-      "rule_id": "js/taint-sql-injection",
-      "file": "tests/fixtures/realistic/next_app/route.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "e0b7f01ee441f17459304f1876e4d53a556efca51cf947b480df8b2da2941969",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/realistic/next_app/route.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "a98581f4cedf5abb72731ee30f5a8cd4b7b4eb7281490ae68d715fcf2b89160d",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 20
-    },
-    {
-      "fingerprint": "de24c3d13ccdaef2f693c8fb98468a6529013e542b2849d9b8be4ceaed9c1d44",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 20
-    },
-    {
-      "fingerprint": "93c2a8e9f308a7abab56dc3e14c836370056592e790c9d73b0f3492505258af4",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 27
-    },
-    {
-      "fingerprint": "e7691394a54042552f03bc99120fe3fbdf9823702a0fe5305a9cc8fb65ef103d",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 27
-    },
-    {
-      "fingerprint": "3f739c89bea90e6e10cf9b6efb8a19bf8398bcda96ef16267342d6c2137f19bc",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 36
-    },
-    {
-      "fingerprint": "fb0eecea560c3cbb1e4b8402b7bd8f2dca388d9e11f9f93ec465c8d84a6cf3a5",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 36
-    },
-    {
-      "fingerprint": "39ce4132611577697d5e20d7b5e4cf880c9335a1e42e6a691cbeea51696ce81e",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 51
-    },
-    {
-      "fingerprint": "b866cc29768c3ae885d040c7f729f7034ab26c308fd185f81659e488cb2d10a6",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/safe_cli_taint.py",
-      "line": 16
-    },
-    {
-      "fingerprint": "dd317e26c39458c4b0d9aee7365cacce90e67864c250a2de30d22a72ee9ba252",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/safe_cli_taint.py",
-      "line": 20
-    },
-    {
-      "fingerprint": "7663daed7116be574ab87734251b96b3e3310d9fe7fd83a377452f2728d023a0",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.java",
-      "line": 13
-    },
-    {
-      "fingerprint": "f7f90c964b1334869dbe7f70cf7dd13216ecbb25b841113e172e0f118f5ee44f",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.java",
-      "line": 14
-    },
-    {
-      "fingerprint": "08ac93463e48644502c5e87a5c068eb6318b2ba0c27d6bf9bfd4f7278506b306",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.java",
-      "line": 15
-    },
-    {
-      "fingerprint": "ce452f6c3734a72d1860c91abc9504a554689f81591239b7020b5012c4c83077",
-      "rule_id": "js/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "571180ed7c3607d0f5c530cee1ae4e6dbf1bde9b9d3c6cc1885107ba0fa88b9c",
-      "rule_id": "js/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.js",
-      "line": 13
-    },
-    {
-      "fingerprint": "beb2d63311bf9f7674824f020a33fd44fd497ef8bdbc6b9fde2f92c4a178e114",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.py",
-      "line": 12
-    },
-    {
-      "fingerprint": "937c24740f78c304a19aa190259546dacb4ad4bf1f3ce1a871cbd22321272f4e",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/safe_crypto_agility.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "20c2a6f43b7e717fac0cde8f3d713b66779c887ea1b59624653d852c14f3e972",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_deno_taint.ts",
-      "line": 14
-    },
-    {
-      "fingerprint": "2216608a3f185d9726fc118496fb6927e57e885343812ee6d8a64baeef542a04",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_deno_taint.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "0856f21da66557ace48d61ba81094d57ad1004da8055ebafb9c8dca75684f09d",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_django_taint.py",
-      "line": 12
-    },
-    {
-      "fingerprint": "930de877e513c600bbfaeef7870c27c22623f17fe10f56283d8b63f0ad6a53f1",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "282be6ef062d1de96c66d1229a42a8898c04876a1bb9c8b75af50cbb8d41e4a3",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/safe_django_taint.py",
-      "line": 26
-    },
-    {
-      "fingerprint": "a6d7197db5a7cc17df918274f7be27647e7976ce232e4101de65165673be6222",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/safe_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "868e78f26e695287f6d4cbf0271629e7109ca33e6ada0f7b2e08931417ef4283",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_fastapi_taint.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "9d7413d057ebb43cb55fa1ec335b67e13050008516c99f3c67a42ce3e05acbe7",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/safe_fastapi_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "456fccdb3503cf100b292e113169e08852030e6f3a35baa3b2306a1f5a941e59",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/safe_go_taint.go",
-      "line": 27
-    },
-    {
-      "fingerprint": "b42fdfaa5c420f4a3fe62b0e09c542766707032ef41252762e8f662090386de9",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/safe_go_taint.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "fdb9bc819838ab95bef5143b2f0976314d910f9948541e2fc4ed5f79f73414d8",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/safe_go_taint.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "805a4cb3ce1dc7151addec5daa77751e0de567637643d30f030feebcd11ea5b3",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_hono_taint.ts",
-      "line": 8
-    },
-    {
-      "fingerprint": "5671ade78883ddc129e99fd4646ab30dfda6fbe76bf9610b02f940f0547ea4f3",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_hono_taint.ts",
-      "line": 17
-    },
-    {
-      "fingerprint": "5ecad7ab194c0e192c42ffefae62c691616294f8ba75325d987a8d67f9a16add",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_hono_taint.ts",
-      "line": 25
-    },
-    {
-      "fingerprint": "cffcdf8cfc2c0810abbbd2ac46da2c6e40d70016c5029035cddd4f1851a8a080",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "517b0ea422fd88eb2638d94ae89d66422820f181780e2a96d04aa42d579308ba",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 22
-    },
-    {
-      "fingerprint": "3777ff04d307e3e2ed78f6f2dd3d641f476a12a8a32bf690e2deabb0f39c6356",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "c6d7d487ef7a11e40799175e23616e637909da70aabd1f5c50b961c7eaa18efa",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 42
-    },
-    {
-      "fingerprint": "dd9f8ceb3dbfc15437e647845582f30fb153c549893981f312a8ed04d43716f4",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 47
-    },
-    {
-      "fingerprint": "8072494dafa78f8c229e97587dba4882cb84e6fbbeaff4ca24668bcee88d4ec3",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 78
-    },
-    {
-      "fingerprint": "12e9e8c847cef734a9552d1c6b4bcbdcf7d364a461f34664b3fbaccfbdd65ea8",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 84
-    },
-    {
-      "fingerprint": "6b8209bbd50e35d10edfb72cc5aa47ade0d6f139ecdd92ccfa8873886bd4bfb5",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 90
-    },
-    {
-      "fingerprint": "065d9c3ad1215349b569ea0768a2542e4837173670b9e17406f035f08a1d95bf",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 96
-    },
-    {
-      "fingerprint": "3e2ec861014d632d7b7e24beecc7be23580888b0db42b2af16aeacfee2655114",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 103
-    },
-    {
-      "fingerprint": "25950985f4f4384558cfb657c78eacc6130718460f8184ac18d763cfa3a55072",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 109
-    },
-    {
-      "fingerprint": "6b309caa78175a399349ad65e38fa56039bc7fd3911e8cffe3b5120296a4a1b6",
-      "rule_id": "js/no-command-injection",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 116
-    },
-    {
-      "fingerprint": "f5dc6df08855bb1db85bc7a9553d71b02a2ae2f4c70a4d2c880c71fcff0fdd6d",
-      "rule_id": "js/no-command-injection",
-      "file": "tests/fixtures/safe_js_taint.js",
-      "line": 122
-    },
-    {
-      "fingerprint": "8e6c16f2f64ef1c2b38a11c923f90624edf44d4e33ef05e4fcdd965ffdc2e8dc",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/safe_nextjs_taint.ts",
-      "line": 15
-    },
-    {
-      "fingerprint": "32e699354a927c472b54c3ee69683a01a62af461bc71a795abf0d9060f3b37a0",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/safe_nextjs_taint.ts",
-      "line": 22
-    },
-    {
-      "fingerprint": "bbff26802e3d60dc88c31b39af8e3c70549fa07aae05bcd32373b4ae5eb6c1d4",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 16
-    },
-    {
-      "fingerprint": "7e80ac6e2b938e847736711887d802be0198bea0261b84a7f32154dfb5201001",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 23
-    },
-    {
-      "fingerprint": "557946d976613570c40e7d82df6763ebfe8a7755942339b5a9cdbe0e518f41c7",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "e33970a5087f3c062678040a4b8eaed41a27ebd260e1e71d52f692d9204f4029",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 42
-    },
-    {
-      "fingerprint": "f2a982ea13122373fe5499a9fa358da6595bb41f87fee569161f0bd157549eae",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "9d450122dd404bae78280afa7ee40618b6119b0f846b092b6bfa366d83cd10e6",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "1fe0b991b73a63dc0152210313de31ae32a68902267170736e04f3176b7df130",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "68d60aefc6ea725020fd6125021c371566de5362946558c05be44946182aa87a",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 91
-    },
-    {
-      "fingerprint": "69500074e951bc735b33c625543e8ac80db6e4395833f3493c3bc07c1e1ae85d",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 104
-    },
-    {
-      "fingerprint": "0372f821f387253a907c85635bf38d6445a7d008624209af8d85a17db0e7074c",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "788343a5558176c8cdb62456a9262ff11958b3313b5b7651612ff28f2f791d22",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 165
-    },
-    {
-      "fingerprint": "7468a336f0ba59cfd80495243c1c3d118971ebaa86962831fa2e6a40fcabd74c",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "eaada929b895d2f468ab4a7f108f804851872d1ace8286fcebd077aa857e4c01",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 177
-    },
-    {
-      "fingerprint": "6e951c0841e39c33c046c76fc6a8825eafcc87e709392910f7327c7be844abf7",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/safe_py_taint.py",
-      "line": 184
-    },
-    {
-      "fingerprint": "991c5d4d95aa796175cf96ac1e3a8b0f899c776f5b0a12b99c268a12d02974d6",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/semgrep_taint/safe_js_eval.js",
-      "line": 5
-    },
-    {
-      "fingerprint": "8d8a32678bfbfa359d7afe15ecbdca042c33abacfdfad967a9c652c62de34d7a",
-      "rule_id": "js/taint-log-injection",
-      "file": "tests/fixtures/semgrep_taint/safe_js_eval.js",
-      "line": 9
-    },
-    {
-      "fingerprint": "77e919d55917f59b9ebfe86e768e600aedc934529a46049a3f931b3919f9edd3",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 13
-    },
-    {
-      "fingerprint": "3978727f2460250a87f2cdef7bf6b9d00215e726cabd70cf2f74c4ef923dcbd1",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 13
-    },
-    {
-      "fingerprint": "cf7676e33a69ec333dac4c4f435e1102b90611aa64c59be67efb0e611ad6bd58",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 19
-    },
-    {
-      "fingerprint": "3e2c4d94d77152b4ad20e1373fa9013289cddeef002d7eb4e8e4a70eff88ae56",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 19
-    },
-    {
-      "fingerprint": "87665b4cc9c0dfca5dcecf6dcd44201ae66e99f2b51d96063b435354daa6bafd",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 26
-    },
-    {
-      "fingerprint": "7be5bfa17fdab2911fb58e822a0f3a52336bab638fdd21f123d5da258ffc1436",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 26
-    },
-    {
-      "fingerprint": "afd859c2f10294e58fefd1c5b8f0eb4e82bd73206b9cfa3028f02db0b1186ee7",
-      "rule_id": "js/taint-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 6
-    },
-    {
-      "fingerprint": "eee25efc2b1e2d21e98d0cb59407dcd4f88b58c79c07b0fa7f50b4d9adbc2297",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 6
-    },
-    {
-      "fingerprint": "ff6ac41d5ff58d19b95f608873bc6021e308fee1799bfae2097bcd9f04750552",
-      "rule_id": "js/taint-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "91d8069b2c49e6c80996797d3f99807c0f2c78db15e0250f4c926fa70d0c1b80",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "ab9099ed14e07beeee359ff2a396bb55097c30fd6d45682729fb51c7b57d7135",
-      "rule_id": "js/taint-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "564acab7a2a5b740f6354f017de98b7ae4cf2829b03b2c52938e39d99e30cda2",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "62b41bb7820d394f16507bc9a97611f76c303640c8669f52165232ac5b691123",
-      "rule_id": "cs/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 21
-    },
-    {
-      "fingerprint": "9dbbb25983acd7706a3a69b520323257d906e7328880932690c96a4f90b7d03c",
-      "rule_id": "cs/no-command-injection",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 27
-    },
-    {
-      "fingerprint": "bd8bb15d38e01fc101b9edd23f29f59de035aa427f524567f93579c4e2f24599",
-      "rule_id": "cs/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 33
-    },
-    {
-      "fingerprint": "781331b16b4fca0724ac7ee561e408441ff43be5139f86e852d82e01f7407a20",
-      "rule_id": "cs/no-ssrf",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 41
-    },
-    {
-      "fingerprint": "fb99c69774e147d5051e844f4495d9efc9eb838904367a1df227b4fa131da17b",
-      "rule_id": "cs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 47
-    },
-    {
-      "fingerprint": "7d91ba4b1c08481da5fe4b4f245fb5e70d94221ff237d6b659167dcd2ff3a16e",
-      "rule_id": "cs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 48
-    },
-    {
-      "fingerprint": "d1470c9eebf69df59d6c7c861d213e533415d2b80dd680572e5d30c724e91497",
-      "rule_id": "cs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 49
-    },
-    {
-      "fingerprint": "bd36af830f81c52ff5ea38c620d60cd03186e10c93ba4aee5693100bc6bc5ad4",
-      "rule_id": "cs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 50
-    },
-    {
-      "fingerprint": "916e1a1592e73684d7709e81ab765b8b666348a0179adb79adef61a1c58e8a41",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 56
-    },
-    {
-      "fingerprint": "add3e274d1d5ab6e1308044f1293dabad7ce5b898232bd721499330a39abe981",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 57
-    },
-    {
-      "fingerprint": "513022d0c9c7d948c4ebe924c733ff505a05422270055b9567597a12482bdbed",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 58
-    },
-    {
-      "fingerprint": "ab0c86ca9848bce79bd63a820e5268c754af4b45b79660f9ddeb32da5205ca79",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 64
-    },
-    {
-      "fingerprint": "77432bfb5107b96c750d89f9cf945e9eb712227e64239f0c320146bfafe6d0ee",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 65
-    },
-    {
-      "fingerprint": "6070362001a4d4dcadc8f561c75285edb893b74d97025ea34f45b326c06f2216",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 66
-    },
-    {
-      "fingerprint": "1bd4b77411a12b861cb17200460952a62e126a2d6ce906a21569be901038511a",
-      "rule_id": "cs/no-xxe",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 72
-    },
-    {
-      "fingerprint": "0ad5a7fdfdfcf91aec0b60b31257981e0ed8e77f6cc5c79527e8915c62bbbdc4",
-      "rule_id": "cs/no-ldap-injection",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 80
-    },
-    {
-      "fingerprint": "da3cbdf4d4172c023f7bc7a70100ab891796d573d632932d0adda2169922c9cd",
-      "rule_id": "cs/no-cors-star",
-      "file": "tests/fixtures/vulnerable.cs",
-      "line": 90
-    },
-    {
-      "fingerprint": "80bb89b4d4b6a49ea2c45c37f11441d748fe0c7c46361be766b1711cc834dc65",
-      "rule_id": "go/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 8
-    },
-    {
-      "fingerprint": "92ec46a28fb21cd67cd3b0c4b854079bb74b7fca956f566e5c15bd2dceb24602",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 22
-    },
-    {
-      "fingerprint": "2aeafd91c60ad3e8d17dddb864e5b88d34405ab36ec831cad4695905c967de2b",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "2544f42c75d8db9e048dac34973134c51cfd0032231d902d47a1717c0e6bc283",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 28
-    },
-    {
-      "fingerprint": "4d361f24d83e404eb03e931e739d0810f9e7bb1ff59ef535b324d728ef0b8645",
-      "rule_id": "go/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 31
-    },
-    {
-      "fingerprint": "bb0844b2915872f8d0a29ede56096b47be87444d95b6b7f414f082dd7905851d",
-      "rule_id": "go/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 34
-    },
-    {
-      "fingerprint": "f3bf785bee57e5965395b66eac112567f1eadb32523bf3ea69b90b4144b30557",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 37
-    },
-    {
-      "fingerprint": "e9749d6e242fe71069cbbaea1b929a7d497d14c801a3f89f195b7cfeb9956e0a",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 40
-    },
-    {
-      "fingerprint": "265b00410655df91d038647f514d78280c354b2a58bc68d18a7224ffeb46f35d",
-      "rule_id": "go/net-http-no-timeout",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 43
-    },
-    {
-      "fingerprint": "fb9df63854ea70bd63a8d3224a3f327c56077573946fbf7499629fddac315ccf",
-      "rule_id": "go/missing-ssl-minversion",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 47
-    },
-    {
-      "fingerprint": "af2ff5aaef41a629ecd8ed2ac96524ae9b0db2966c5aebb22bf3f285d422c2dd",
-      "rule_id": "go/insecure-tls-skip-verify",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 47
-    },
-    {
-      "fingerprint": "b5fb51f69e16d5e0483772c8f2c243977e766b68dbd93967b72792cc98ff3ce3",
-      "rule_id": "go/cookie-missing-secure",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 51
-    },
-    {
-      "fingerprint": "d8e1d0396b40597a275ecaf1d9e48d43a8650dbfa2c10632d2662c2522ebd96b",
-      "rule_id": "go/cookie-missing-httponly",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 54
-    },
-    {
-      "fingerprint": "f7eb53f118105ecf1338564f4705cf8e4517db2c1c83c0be7a0bd07f9a43e580",
-      "rule_id": "go/math-random-used",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "014c82dae93b1b14c55da8a13e2a9ac397e1b84f4c7cf269ef431e0fc8fe690f",
-      "rule_id": "go/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "beb8cb3506a9dcb8182d76a2436e74dd73537b1e7f3ae325e421b4399989b01e",
-      "rule_id": "go/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 64
-    },
-    {
-      "fingerprint": "e2dee9928305eae185be09c53903a2596713634900d41b70fb48d5a634043982",
-      "rule_id": "go/jwt-no-verify",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 67
-    },
-    {
-      "fingerprint": "f7a5f479c70065ee4f28809d358cfabed0d2c4bd48dbfeec3d6534219ca4551d",
-      "rule_id": "go/jwt-no-verify",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 70
-    },
-    {
-      "fingerprint": "9a764021db70aa4d3944869c3934fe3a9abc8c796de45e5bed044a68b226fb24",
-      "rule_id": "go/jwt-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "50eddcf314d8a5a3fd0d07f8ad2332a0f469be55839405c77823074ae2a6b3ff",
-      "rule_id": "go/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 89
-    },
-    {
-      "fingerprint": "a5c11aec7e197211b1e084f3148c890efda35756cffbb3bcb7d78e589f1fa6a7",
-      "rule_id": "go/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 91
-    },
-    {
-      "fingerprint": "e0e4b95e68eb3d07f7f054e24657f7beed6bd21f6394c6658bb3d0d854a07499",
-      "rule_id": "go/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 93
-    },
-    {
-      "fingerprint": "e9e7820bdb2a99d2be34d6a71aab1ca4f114d64e9dd4b3158857bc8b602376f9",
-      "rule_id": "go/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.go",
+      "file": "./src/app.rs",
       "line": 94
     },
     {
-      "fingerprint": "5daddf624f76bbb202bb438b47edac4810dbe319de33647e1908458a57429469",
-      "rule_id": "go/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.go",
-      "line": 94
-    },
-    {
-      "fingerprint": "7858ecdbd8c0023409b5c802ba0e702f3c1867b5b229f8a6ad018d7185f1732a",
-      "rule_id": "java/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 13
-    },
-    {
-      "fingerprint": "4ecaeca12c1ff5b6cd13e9c9176745f92e882e26e58067d2c6abe8dbb641a26c",
-      "rule_id": "java/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 14
-    },
-    {
-      "fingerprint": "19f3cf7e24fb73f599d6354dbe4676be9855615af82274c3ecd3ecf99e6220d4",
-      "rule_id": "java/no-command-injection",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 19
-    },
-    {
-      "fingerprint": "b822fa3c271899babf70aabd6b743841808e263c91483dfd5cba65323b552c23",
-      "rule_id": "java/no-command-injection",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 20
-    },
-    {
-      "fingerprint": "bd7cad7fd2bdb8e096dc51e448f2341a7feadef7c1a3cfc7694dd16f461a487b",
-      "rule_id": "java/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 26
-    },
-    {
-      "fingerprint": "a673beb8a6ec255456dd484a10258d44abf43c6b27722cc07b55dd1c6ee926b3",
-      "rule_id": "java/no-ssrf",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 31
-    },
-    {
-      "fingerprint": "6b25be7b253bcbc7d844008a385190df0f470179015c4a78b75c633c2a9aad2b",
-      "rule_id": "java/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 36
-    },
-    {
-      "fingerprint": "9a1b311858af238470418cfa7a6a4a6f8538f5b1093a8e9fbd3b82d6e196b840",
-      "rule_id": "java/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 37
-    },
-    {
-      "fingerprint": "224d0239f52177f6f3b7ccbb12a88c3ca63aac9b48597865e419d456ce38b17f",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 42
-    },
-    {
-      "fingerprint": "cedbb18d88c77244412e5e7fca4d4344961e2265f880835ffe594d88febed844",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 43
-    },
-    {
-      "fingerprint": "69b5161cb9706a7b34f6514cd72f1f0b7076995c4c4fc298a49bfdaa34bd108e",
-      "rule_id": "java/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 44
-    },
-    {
-      "fingerprint": "482ad5e0d1a2479251c0ee2f5b7c98b64e37858a9c4280f69e0f7e8b90ec12ee",
-      "rule_id": "java/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 53
-    },
-    {
-      "fingerprint": "605f15346c6c4a1ed04a3aa81570f026c9760ecd53ba2b6f12276c29d1c194da",
-      "rule_id": "java/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 54
-    },
-    {
-      "fingerprint": "f3545312dc23f8b412bdc3a99c46620ff080c1c1cdccd8e2e328e390a6830c2e",
-      "rule_id": "java/no-xxe",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 58
-    },
-    {
-      "fingerprint": "b3f98f402e4b8d2bda0a474c8e66d4207fbfc0d8881bc0a31fa67788a46b8465",
-      "rule_id": "java/spring-csrf-disabled",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 63
-    },
-    {
-      "fingerprint": "0b1c9c19f72890d7f2d3a3e4af465958e84661f6e7c227e4c034afe40af5e34d",
-      "rule_id": "java/spring-cors-permissive",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 68
-    },
-    {
-      "fingerprint": "089ee8a769be2b839dc87c2b823d3db47c6737d22e923ba72064d7911671572f",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 73
-    },
-    {
-      "fingerprint": "3a93d0bdd0a6086bfa0e21b0e6fa39e53779b7a063237f504164583563a4b94d",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 74
-    },
-    {
-      "fingerprint": "c21c53af39c9886396de47c6916b798ee0a96b8652f9278b4ae0534808bc831a",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 75
-    },
-    {
-      "fingerprint": "449dd77e296a262c75aa565050d0706eccb1a82c4febbe32a35a18cfb49236b3",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 76
-    },
-    {
-      "fingerprint": "5d591fe7d66e9d785d95eb99a09b38cb7abaaaab0a6a02f8bec90fcc920b84a5",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 78
-    },
-    {
-      "fingerprint": "021b43260b332e8e80bed679c3575980b18c93979f7c60bb8fd77daf2cb422ae",
-      "rule_id": "java/no-xss",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 79
-    },
-    {
-      "fingerprint": "0a7bfae2cab34c7bb6d7730e6b26201fb16cfe244e692387e95796ae831f8ce7",
-      "rule_id": "java/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 82
-    },
-    {
-      "fingerprint": "9a1a84a235b6e3238a24dda43e06c23aff5043b96d6d758734e7fc737f693646",
-      "rule_id": "java/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 83
-    },
-    {
-      "fingerprint": "b4fd9b32149f4afa70438de69e204d1294b96fa6b4be29f22fcbc7af76f40c5d",
-      "rule_id": "java/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 84
-    },
-    {
-      "fingerprint": "26e797effb120f8ceb546ef9b93a6b5b4ae6dbed7ed5e2aeb7e6e3eaa0f5c574",
-      "rule_id": "java/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.java",
-      "line": 85
-    },
-    {
-      "fingerprint": "365dd09432060e168ff33564ec524211436e313fac1fd09c496bb7cb7a732998",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 9
-    },
-    {
-      "fingerprint": "039ebc065984c4790103dc355bb15d608bd5f069d167e889b33d12a5371df164",
-      "rule_id": "js/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "dfa00e0e5db86546622bca67cefa3fdd349ca7990006b8c2c12fcb0ec7b30701",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "c664d15fd7e181af287cd408c89d3ab368a84c122444a9689ffb8e712d8072a3",
-      "rule_id": "js/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "c5733794707665e91e4ef231dc7340b7779026bbb8b956066fa2fd95965a79e0",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 23
-    },
-    {
-      "fingerprint": "141714e8e71171508e5726303e06ab0e990e5f3c37a6e5cf16f2dfd1f271d017",
-      "rule_id": "js/no-command-injection",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 26
-    },
-    {
-      "fingerprint": "0ed5064d8fd951750517e5a101474a4c9572b387a0fdaa2954487b0bb9c2ba6a",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 29
-    },
-    {
-      "fingerprint": "a2404e50192c3c3cac0e7a65cc38d173fdf64c4529c8325f9f79d57620cdf909",
-      "rule_id": "js/no-open-redirect",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "759ecd5c6d9fa5d1c9757247a416cc5cb945148c1deed04933c8f2106a3b977f",
-      "rule_id": "js/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 35
-    },
-    {
-      "fingerprint": "178f74840647211575e378453ec91ddca6a9a07f6fa788760add7c89518f570e",
-      "rule_id": "js/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 41
-    },
-    {
-      "fingerprint": "a2d13b71b5e1bd3535349d34af97fc067905772bf517cb06464be6f2c9661593",
-      "rule_id": "js/no-ssrf",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 44
-    },
-    {
-      "fingerprint": "f2a38e8c8b72ac2b605531ba25c1f852e01be08ebf923fbef39d61eb6fcf05fc",
-      "rule_id": "js/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 47
-    },
-    {
-      "fingerprint": "efa07d0cc08479a2ad7a3eba4f518f8e80d92f4af453cb97d0600f223c65ce46",
-      "rule_id": "js/no-prototype-pollution",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 53
-    },
-    {
-      "fingerprint": "65d3b6219cc82505572167f80f5a29841f9c916a0041d52c83aa375e20ea2837",
-      "rule_id": "js/no-unsafe-regex",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 56
-    },
-    {
-      "fingerprint": "b1623004d47035a76c03620ec7283c07bcd6339a8c7c2d8fe7bcefd99242d4df",
-      "rule_id": "js/no-cors-star",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 59
-    },
-    {
-      "fingerprint": "86d2aa628026d51fbb6a04aa5a1e654ce11de2fdda2b1bb8e14ba9750222721e",
-      "rule_id": "js/express-no-hardcoded-session-secret",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 62
-    },
-    {
-      "fingerprint": "9813bc4c62b9ce15cf3e65982547d7bf3842d9c02a4e45b967c3bd58f433e29c",
-      "rule_id": "js/express-cookie-no-secure",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "5fca449d494d61415bb0b5050151b70070f7b0a318f794d710b3bb5cdc837e52",
-      "rule_id": "js/express-cookie-no-httponly",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "d7a384260cf9b187d1597459590ff08a828845dd475080625a97346f5ececf68",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "e463cda0530917026b5fdcc98f2c9b5c50ff2b91dd86cc11fc7c0c7bae958841",
-      "rule_id": "js/express-cookie-no-httponly",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "f4059c4542eb2d5f2f4806f2be50845c8cdd823e4b6991358893206cd8a2ff65",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "be59ef289fd4e5ee7993896bf2616541f2fd14e1a27fc436e9294b010b63a7dc",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "45c0af8633a1205cc367c2b41748abc1bc8545ee1b395a0f82d4d33d62ac9977",
-      "rule_id": "js/express-session-saveuninitialized-true",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 74
-    },
-    {
-      "fingerprint": "cc2fd05e4ba5516d05f92914b0b6910249b88c97f0d72864447ba90e2fd7a60f",
-      "rule_id": "js/jwt-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 77
-    },
-    {
-      "fingerprint": "1bcdf545654fd29567a94ba6bb29961916e6a55515768827cb859342024ce36c",
-      "rule_id": "js/jwt-none-algorithm",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 80
-    },
-    {
-      "fingerprint": "9343330782ed8e41bcdc8a8f935b2d16064f4b4fb946a5b2405df4f7c481d3e3",
-      "rule_id": "js/jwt-ignore-expiration",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 83
-    },
-    {
-      "fingerprint": "40c10ff42a0d9653db1071143a1b20e09101fbcb629d4cdcdbeeb3355d65f258",
-      "rule_id": "js/jwt-verify-missing-algorithms",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 83
-    },
-    {
-      "fingerprint": "2e25bce24cc5718b2bb336dde3df2e5bb9ebff601a887cd411002529cd06fcb0",
-      "rule_id": "js/jwt-decode-without-verify",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 86
-    },
-    {
-      "fingerprint": "0ecd669561bc9caa07097d121fec78fdd3a231918f9eb16d31367a4f5597343c",
-      "rule_id": "js/jwt-verify-missing-algorithms",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 89
-    },
-    {
-      "fingerprint": "7557db38000476bb799521dede921ba323e8c3a0e6844521e12a328a3d5f7c97",
-      "rule_id": "js/express-direct-response-write",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 93
-    },
-    {
-      "fingerprint": "d2e31d96115174091e9edd8ffaaea323bd231a94b4abdc401afad1133f44031a",
-      "rule_id": "js/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 97
-    },
-    {
-      "fingerprint": "a116304af66988cb6a5d6e4b8d4c259d11e6031f29c8724c0b2d9d9273581368",
-      "rule_id": "js/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 100
-    },
-    {
-      "fingerprint": "14158b72b616249cfdd829a17ec245467a74e357d64299d852f587b6364cb573",
-      "rule_id": "js/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 103
-    },
-    {
-      "fingerprint": "fd67427867bb9575d40f6bf4fe260113528e8e352b82782379f804f97850252c",
-      "rule_id": "js/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 104
-    },
-    {
-      "fingerprint": "cb04b044791be80a3d4f685cb135058f637f66177191fd838c2432707488f5d0",
-      "rule_id": "js/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.js",
-      "line": 105
-    },
-    {
-      "fingerprint": "62e9d3df44f81e283d2386807ef123a6b0aea20138ef749c074abfc2b666c446",
-      "rule_id": "kt/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 7
-    },
-    {
-      "fingerprint": "732924110c49c679ca65c768e57629bb036e335e411793ae56e98a36d47da6e1",
-      "rule_id": "kt/no-command-injection",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 11
-    },
-    {
-      "fingerprint": "ad99a59fd7726e3de058ede89cbb4c34cef1c00121a54dbe74ae5b2d57b8e88b",
-      "rule_id": "kt/no-command-injection",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 12
-    },
-    {
-      "fingerprint": "ecbb1380821d73efbac0c1e3a2f82f6f2d36befbade3182034bb8527747012c4",
-      "rule_id": "kt/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 17
-    },
-    {
-      "fingerprint": "aa47e33844eb61ef39c146b8203abe685bd38aba55e3ea5194a1d911c3860956",
-      "rule_id": "kt/no-ssrf",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 21
-    },
-    {
-      "fingerprint": "8752688b85dbb3dca19b4022145eff0ba599a8e75de692038e489541a8c04391",
-      "rule_id": "kt/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 25
-    },
-    {
-      "fingerprint": "b69dbb7cf5555ebe50e61c3d54cf0b44cf8dc4b92e404abc1e63709626b94c11",
-      "rule_id": "kt/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 33
-    },
-    {
-      "fingerprint": "eba42d6a43bbe68471bc2511309d8272fde3216243806c227162c780a98b00e1",
-      "rule_id": "kt/no-xxe",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 38
-    },
-    {
-      "fingerprint": "9ecde7a3dc2c16478036e972d64f8ebeb98ab0c57cb9e6bb57d9a4732041f059",
-      "rule_id": "kt/no-cors-star",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 44
-    },
-    {
-      "fingerprint": "2bf902f4860a94b5411f53551bb4e15c9555e0ab062cfcef0e7eac42dbf520fa",
-      "rule_id": "kt/no-eval",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 48
-    },
-    {
-      "fingerprint": "16045c3fe690084df1d0e1ac82ef4492f3437cb174acc93593445b5e503e8ecc",
-      "rule_id": "kt/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 53
-    },
-    {
-      "fingerprint": "4b41deefaf554a3b64fcae10e42475952dc5ece6e3ec8d0711c45afcb4443c9d",
-      "rule_id": "kt/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.kt",
-      "line": 53
-    },
-    {
-      "fingerprint": "daaee9e693f26e4fc2048ee775881d7b8fdca9977a0db0611916cecea1782c37",
-      "rule_id": "php/no-eval",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 5
-    },
-    {
-      "fingerprint": "d2c86d7f1c27f1687318aa23d632721879c07ff8cd0133ef42202a42f586b9c8",
-      "rule_id": "php/no-command-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 8
-    },
-    {
-      "fingerprint": "971935e5f96c435ada32d891004896edc7f39506011f9762e2404ace5998ca46",
-      "rule_id": "php/no-command-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 9
-    },
-    {
-      "fingerprint": "341ec40a97f8e635e6884a0ee6ea957045551ff1571e73ad0d3dc9e1cf36a0ae",
-      "rule_id": "php/no-command-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 10
-    },
-    {
-      "fingerprint": "00dcc59aa7ba69c174841222263cbb7227715ac19e8d90b264bd3c20c65a03e6",
-      "rule_id": "php/no-command-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 11
-    },
-    {
-      "fingerprint": "ae71584ac4edc20d2c386588f9ffb061baf5d0537a72b140b6e50c7dfce8de9d",
-      "rule_id": "php/no-command-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 12
-    },
-    {
-      "fingerprint": "315d93e1de2d4757a6f0ca83fcbf468da869ecee7ded1b1da3e2d2f36fb0697a",
-      "rule_id": "php/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 15
-    },
-    {
-      "fingerprint": "d25a1b2f51c4e780391d55f5dc0e2cc4e0b25cc078ad7b49672529742aa9a6f7",
-      "rule_id": "php/no-unserialize",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 18
-    },
-    {
-      "fingerprint": "7b11ccec78ab78ed0931c69c2baa9ed1f81a32080cc964e3abd7dc4000e689fd",
-      "rule_id": "php/no-file-inclusion",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 21
-    },
-    {
-      "fingerprint": "ec17b0b74544a0a1c419ea6e829d06c1e9d9b5a4724dd46ee0396cc520186295",
-      "rule_id": "php/no-file-inclusion",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 22
-    },
-    {
-      "fingerprint": "d629db58c283143926fa182b25dfa701dc01ad813bd7ab251ae6072a2487fdfc",
-      "rule_id": "php/no-file-inclusion",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 23
-    },
-    {
-      "fingerprint": "a08b2d9fcbb6c1fe04176f468fc480372e7db7c5863bffe9fdf504f7c5839183",
-      "rule_id": "php/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 26
-    },
-    {
-      "fingerprint": "57b00ae457b7f5596d4890eca153497206f78f3b82ab85dec7c568bc2f4ba936",
-      "rule_id": "php/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 27
-    },
-    {
-      "fingerprint": "0f4f68576c862d2ff79cc957e8a28c7d9d06c70c4a6211ff1e9f221dcbe4d286",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 30
-    },
-    {
-      "fingerprint": "40207b7d1faca890d3a8a35b0995bb14b7893ec306308374b9c39ade59f784ee",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 31
-    },
-    {
-      "fingerprint": "077582dcb6557aad0376ab94b04b6291f266e41b83942aa18f894f60cfb84318",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 32
-    },
-    {
-      "fingerprint": "bdd01fc355d02e988dae0c7ac7cc1f482464d57d04d09dc7cba6ad96620baf90",
-      "rule_id": "php/no-ssrf",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 35
-    },
-    {
-      "fingerprint": "3ec872f5e7d1d0f3163094977fdf1b3949ef28107ea5cac954ec2dbef122028b",
-      "rule_id": "php/no-ssrf",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 36
-    },
-    {
-      "fingerprint": "88e2d6bedd3c59a597691183025a032129c8381a82f0d6a1297b4edcb9dedeb9",
-      "rule_id": "php/no-extract",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 39
-    },
-    {
-      "fingerprint": "51c2f0174f01516379866275cbdf2129ae5139831004e8443fd1f1d85e7f7db6",
-      "rule_id": "php/no-preg-eval",
-      "file": "tests/fixtures/vulnerable.php",
-      "line": 42
-    },
-    {
-      "fingerprint": "44d64bba6b6c2730991a45ecf862da6ce148ab5f5439f48ba86a7e8a5daf8344",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 11
-    },
-    {
-      "fingerprint": "72d9816b690d316e941d480692772715fa299fd5441245f8f244f295b83efede",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "6714ee91aba031e2f38d01317706fdc2412c8158715080d61dceda8477a805db",
-      "rule_id": "py/django-secret-key-hardcoded",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "38b8af3e68bb35a0aa583e664ba987e6c0d21a0a75ccdf779e3e15032ee78217",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "d6d7cc2daf6964793a57595782fc87f5652d27b27c9a998e88270c0a255fd203",
-      "rule_id": "py/flask-secret-key-hardcoded",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "f85c07441e91b827d7153a6d935fbaa2c02cd29007ae005b3420f97e44a0701c",
-      "rule_id": "py/session-cookie-secure-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "fc4b8475aaac5bacf16502946b244c53d721774b47aa32ea7904f4418cf141af",
-      "rule_id": "py/session-cookie-httponly-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "91c5ffb630abce824fde45e4f2665298977d01f8848ccc7d3d684644a8cc7a8d",
-      "rule_id": "py/session-cookie-samesite-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 27
-    },
-    {
-      "fingerprint": "d04f7173ecf7602b5d3f36fa5c86d564ad92f6af42c37b1f6a4a862e726ae915",
-      "rule_id": "py/csrf-cookie-secure-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "be0554c97f525e3150841415a6823b22a912bcbb47303310e49480efb4c0cc5b",
-      "rule_id": "py/csrf-cookie-httponly-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "03d62cb73d7c22c2242b76fb27817b3cb5bc22dd83f57a1964c11c95d9aa7afe",
-      "rule_id": "py/csrf-cookie-samesite-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "ab9bdcd91bfcec0fda0a0de2a8da3f982d76612f553d3c81515300bafec8ad03",
-      "rule_id": "py/csrf-exempt",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 39
-    },
-    {
-      "fingerprint": "1214843797d0e93da6f69adc03a09eb4dfcf32985582566fb2e42b9367e630c9",
-      "rule_id": "py/wtf-csrf-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 44
-    },
-    {
-      "fingerprint": "265d5fe8d5a7a787f58677595f3681e04dadf35f313d383b7e7955f6faaa843e",
-      "rule_id": "py/wtf-csrf-check-default-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 47
-    },
-    {
-      "fingerprint": "15c4410221b39dd6e8f4fd7f18113dcf83ea810592d036e56ad708e3a8560461",
-      "rule_id": "py/django-allowed-hosts-wildcard",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 50
-    },
-    {
-      "fingerprint": "388a8e2a1f63f3b3d3580ab21bd64175d2edabadf1319e25e454a3c4c02d8044",
-      "rule_id": "py/secure-ssl-redirect-disabled",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 53
-    },
-    {
-      "fingerprint": "8180da97b36f936d4a400ba633a28118cf8f77c9b1ff50a56ba4121bc822a765",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "7046dd4b0950d9a57d43cbb5cb5293854ed977289869d226eec435de3c6df760",
-      "rule_id": "py/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 59
-    },
-    {
-      "fingerprint": "8a9dd0088207e67639bb8fac42bc631cbc711e68640d7c97992d340761f39d74",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "4a0ee15cf6b1b4291e21c5fdcfcec2a0ae8a3103a5382ded00578ec96cbbe23b",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "a26a00bfcbadcc4f320483fda6e9ba4edc6b6c062872dd36798c8b8ffabbb15c",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "c4b0e2670a328d0b35826c227573f4900cd84a0a3206cca89fff6edae5867bbe",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "e6ac0586526eba8dfb4a4fbc06fbe6dc4660f99289d0b75203f26294c2d91199",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 75
-    },
-    {
-      "fingerprint": "2462bc2514d2da52ef4ebcb4d77aa86b50c2ed5211bcc4a680e4590bc7ccc982",
-      "rule_id": "py/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "cbda0bb402dfd6bd588d1bd17b1cfdf49bc45f7569b6636bbbb298718b39b9ca",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 84
-    },
-    {
-      "fingerprint": "910711be56db68bddd4f46c81cfba03af9301ca787937501a990e00e2f3af908",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 92
-    },
-    {
-      "fingerprint": "5b113e6b6dab55b76656fbb0676f9d89acbe3d8cd1664fbcdc1630f9ef61c21a",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 96
-    },
-    {
-      "fingerprint": "9220a4cf355b235a0dfde74f9c7026efd5abd8a063c02ed791a4f27467346b77",
-      "rule_id": "py/no-debug-true",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 99
-    },
-    {
-      "fingerprint": "9e62396216f88293cc3198c4fe373d0e8dc675af945db72af28ca40c09f00217",
-      "rule_id": "py/no-open-redirect",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 103
-    },
-    {
-      "fingerprint": "a910ad4cb4182e108554aa68aa3590ea1a70dba4df26fef8b81aad11c4ad40f6",
-      "rule_id": "py/no-cors-star",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 106
-    },
-    {
-      "fingerprint": "7ca6533ea21b2d91a444ebef5c651b26293c02373b90b41dea6778d1608455bd",
-      "rule_id": "py/flask-debug-mode",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 109
-    },
-    {
-      "fingerprint": "82165a8c7f544de546faf8d532d57cec98525e62e3aab5758406ea32734df85c",
-      "rule_id": "py/jwt-no-verify",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 113
-    },
-    {
-      "fingerprint": "57d313727ab7520ca0c21cc312afb5c04899f02d0609ad8d9b58402166a56316",
-      "rule_id": "py/jwt-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 113
-    },
-    {
-      "fingerprint": "81a8e3dd73dfb77a245026aa726b87856b7c5d228ebc83c1263296530877f4b2",
-      "rule_id": "py/jwt-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "f05e65ba0085f5ea69de3999277caef6baddf17f9e6c63d1ee3ca10ca475a885",
-      "rule_id": "py/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 123
-    },
-    {
-      "fingerprint": "aa691f5f1e55df30f770ed5cfef4ff9279176eba18955acda7d564471af5ce72",
-      "rule_id": "py/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 124
-    },
-    {
-      "fingerprint": "31b62633bf46c0eda73396f1d019623052f3e99969a0535575d4269e8949fc77",
-      "rule_id": "py/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.py",
-      "line": 125
-    },
-    {
-      "fingerprint": "5131f6f591acaf9b02587227af453125835dbde54436ec90114634f076d92bde",
-      "rule_id": "rb/no-eval",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 4
-    },
-    {
-      "fingerprint": "ca9c4dc177f6cf4a0c262224fddfb89b565e80f8a5ecdfc0f1f4f8765e0cc45d",
-      "rule_id": "rb/no-eval",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 5
-    },
-    {
-      "fingerprint": "059abb68648a91b8f700c56e28d291c451c2fc7ab22f7c1fb3e0803bb148200f",
-      "rule_id": "rb/no-command-injection",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 8
-    },
-    {
-      "fingerprint": "d7443d63b814af067cd26ac23af77a527acbee3123db35e636b17db3b9761b62",
-      "rule_id": "rb/no-command-injection",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 9
-    },
-    {
-      "fingerprint": "14295d8ed1412ac2b939313ea2d11614b05ae24574fd6df4f0159bf270d3a87b",
-      "rule_id": "rb/no-command-injection",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 10
-    },
-    {
-      "fingerprint": "e1bd02d31ef06c8c61943b389cdbc186c2a3b55333eed50ee45a0d3147632a14",
-      "rule_id": "rb/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 13
-    },
-    {
-      "fingerprint": "bb860ad690113cf9600da253a282a670ac53bee0b4fd62f6ae483d191aa78ee4",
-      "rule_id": "rb/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 14
-    },
-    {
-      "fingerprint": "44b0caac1ffba4b62c3386e1684a60129f310ec65fed279be71c2f0d8454e629",
-      "rule_id": "rb/no-mass-assignment",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 17
-    },
-    {
-      "fingerprint": "d1f3aa87e44514135153271cfb47c3caf1405ef2e4d2b1442bb8b94dee580729",
-      "rule_id": "rb/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 20
-    },
-    {
-      "fingerprint": "c84bd2e22ea67de225d5ec4340ed33d965bf093ecccb4fa8816d1831735a8861",
-      "rule_id": "rb/no-unsafe-deserialization",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 21
-    },
-    {
-      "fingerprint": "f44b2cd8e1976f3f50e8573475b1f465242644c03780169b46a5ec52f9e8359f",
-      "rule_id": "rb/no-open-redirect",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 24
-    },
-    {
-      "fingerprint": "f71930c219cc4318578bf45d74b6a854f0a14ba7cffb38703b5e58c99bdf42b7",
-      "rule_id": "rb/no-csrf-skip",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 27
-    },
-    {
-      "fingerprint": "877e99c2c81961da47b2378ae14e2ed49e2a63b36136fe54954e075b40987876",
-      "rule_id": "rb/no-html-safe",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 30
-    },
-    {
-      "fingerprint": "f9901b3aa3fe0179e275c9189680eea2eaf945fee8719d82f8af775af540a256",
-      "rule_id": "rb/no-html-safe",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 31
-    },
-    {
-      "fingerprint": "9987f155bb467eb39b0fbe58d150d66b79e5c6ca6e2dd3be74b5c2b49a680c51",
-      "rule_id": "rb/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 34
-    },
-    {
-      "fingerprint": "f0c71e6212950e63a33bd5f92bd4f09aa32447d3b83e4500f8a6d59380ca13d0",
-      "rule_id": "rb/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 35
-    },
-    {
-      "fingerprint": "38623fc67fe028198c8af3b53ec0463f9b6c346a209c609cb869e242b3596af5",
-      "rule_id": "rb/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 38
-    },
-    {
-      "fingerprint": "2ba3785cd40ff643a5988081bb439ff243657254350fe059d1adfad0862d104d",
-      "rule_id": "rb/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 39
-    },
-    {
-      "fingerprint": "45877691efe76fe6c9f6ababd0153570ccdfb7a43345141a456d0444352f6058",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 42
-    },
-    {
-      "fingerprint": "2cbbc090549686aec4ffbd374888408ec9ae7bf2e9155f89d2a0ac05d93ef543",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 43
-    },
-    {
-      "fingerprint": "a339ce7fe02e76b90c34e2d7b02b658c7fc9e8f7d307e0902df7694efd225169",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 44
-    },
-    {
-      "fingerprint": "9262f2435636964628c829d4f71cc37968577e7d0b3a27ea9263fc70d9c806be",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 45
-    },
-    {
-      "fingerprint": "e2d7260b7ba96dc98071e601cc5efdda755384d403583f5c7117906b37c06cb6",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 46
-    },
-    {
-      "fingerprint": "f871dd30239aaea0ec748a4e20279c6792c2b5d3e381c2846932c40d1755532d",
-      "rule_id": "rb/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 47
-    },
-    {
-      "fingerprint": "94e081911bb1fe495fa7b916d49a0e10b895670a13b5e23ee0b1d4717913112b",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 50
-    },
-    {
-      "fingerprint": "f11901b310a96f6e5ee1d92afe602823660117f1233b7b1a91b36c0e9c137bc1",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 51
-    },
-    {
-      "fingerprint": "b33b9786955619c1425c267cb17be6e240a883d56d7d67d7b380bd8d3921ae59",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 52
-    },
-    {
-      "fingerprint": "30f6b8d3e126ca801fa50bb9e3a14ffcf9bed4bfbe2d10a19539244e6303ac5c",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 53
-    },
-    {
-      "fingerprint": "7382ef4d1616234e6ad5c57a6837c25941256f96946f51dba10d2f971472ad6e",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 54
-    },
-    {
-      "fingerprint": "9a19e2d2007774b913882dd0573869e0b2ea9dfc7d9afeb33f64eaa99265f7ab",
-      "rule_id": "rb/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rb",
-      "line": 55
-    },
-    {
-      "fingerprint": "55f64c9f2d59ab5bb32b0a644a9c6e27ba53aacd10059b038a57793faaa0db08",
-      "rule_id": "rs/unsafe-block",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 7
-    },
-    {
-      "fingerprint": "61314f459a03fa9ca9314c98a44aff11234e9c64847b225d583d53e243b0c9cf",
-      "rule_id": "rs/unsafe-block",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "bb99ac80edb346700139ef477de5e2f25ac81d55b7c9f824339fb7bbb8acbe76",
-      "rule_id": "rs/transmute-usage",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "66b7289e96d4f02134c4cf765a349baa1f871f7bf9176d757fd67ebfad13f26b",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 20
-    },
-    {
-      "fingerprint": "4033f12ffa98e34650d8e96cab02340eae45781725ccf787fc24e783e94cfe49",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 20
-    },
-    {
-      "fingerprint": "a625dc6243ef2242505a497096d73acbefd94085d318c46a69bcfd2e66115f81",
-      "rule_id": "rs/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "416f2acbf877f2be72385a2021f7058f67128e187b95721cd4643311c03f133d",
-      "rule_id": "rs/no-weak-hash",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "4b6d54da527f058afbd8532f0ffe1718bdccdce6fdddf038fa550b0dda8de48c",
-      "rule_id": "rs/no-weak-hash",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "2e26e3e1401de2918d35b223bfd0e78b40e4ef805a556da289c7bcf600701901",
-      "rule_id": "rs/no-weak-hash",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "43a67108988bbaac6fdf99377a9dafbd4bdc21ba1385a6855cd7fc44bb8abd32",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 36
-    },
-    {
-      "fingerprint": "55678e142d9d7419a0ce7ef17df469aa902190f0b308841d700cbe7dd7e8edc1",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 37
-    },
-    {
-      "fingerprint": "9f83904557b47c87405e73580fc6ce5ae53884ab573667e4c8215f3d779f8277",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 38
-    },
-    {
-      "fingerprint": "fdfde1104a06945292342499f74d2b9ce29470206e8b1138365e0f89bb8e858a",
-      "rule_id": "rs/tls-verify-disabled",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "d4e95b977255f9c265ff711af2d974b17a411d60839b31dcd46e5ff3a9fbdc5f",
-      "rule_id": "rs/no-ssrf",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 50
-    },
-    {
-      "fingerprint": "3f378aa3a0a2d2c9705a63124b7ce1d06805951caee7fcac89d4c8600d8e2c84",
+      "fingerprint": "211d43675e5af86f6a802118eed2e4916cdbb27dc130d40bb98c2369001eba75",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "7c73ae5da15b3ba71e11679bfca5d9dc664d4cd39788955718983970f9482d21",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 56
-    },
-    {
-      "fingerprint": "f1f21afa584b02a1006125a71c8936135c3d533ddf8cfd5ef752101de922b05b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "00a2fb3374291a99f397e11ec8892698007bc3949e1656a79dd38f4f12017a5e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 63
-    },
-    {
-      "fingerprint": "924e84b505bdaa2a119eb309c30f70c78203ad4aaa82083da2f99922a79eee9d",
-      "rule_id": "rs/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "c7ed7f80d499e2170a501d45b23d945ee31a157cecf7872b4b66af4350956dfc",
-      "rule_id": "rs/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 73
-    },
-    {
-      "fingerprint": "e51f1497de93b15e1162c5a658f9d53341d8d391a3d1dffddb743387fc16e5f9",
-      "rule_id": "rs/pq-vulnerable-crypto",
-      "file": "tests/fixtures/vulnerable.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "cffff214acd2940ef44ee7e60cd0eb52f1d7393030de3d062907b0f0ac4c51d1",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 7
-    },
-    {
-      "fingerprint": "ddd2585bb291418669eb1798c08d60eb9d970f03eac7abdfb4d381a7dea12d75",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 8
-    },
-    {
-      "fingerprint": "80c598c4d25497ade73316ccc730895540ada900c5c85df8af24f38eb57e7ee1",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 9
-    },
-    {
-      "fingerprint": "7f9786a4fa7b53c3c28818a23b41405f9ffbe37457108a5e6cc705a912d94d4d",
-      "rule_id": "swift/no-command-injection",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 13
-    },
-    {
-      "fingerprint": "f149185498f5698da1a18893ac367a0f07433d56d1a1a5aa5d2f1268dadf41ec",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 22
-    },
-    {
-      "fingerprint": "6bedfb98b6d930258662c60a2b59b9d05f6ca917a18d00017cca9019f7e2c758",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 23
-    },
-    {
-      "fingerprint": "e09751061c8ba00d9b2c7fe01f696bdc6b58a1ec398fc333596c1ed3d84270b0",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 24
-    },
-    {
-      "fingerprint": "964404d6c41f437e93a0489d0574828368a420bb4ff161ad0523e8aa77546214",
-      "rule_id": "swift/no-insecure-transport",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 28
-    },
-    {
-      "fingerprint": "989ccf4c0de3b6028d767e78d4c3abb0f9df1e8de4b140b1b82fc475241a55a5",
-      "rule_id": "swift/no-insecure-transport",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 29
-    },
-    {
-      "fingerprint": "a64140375b5fa07ce5d595cc1896e4757466beed7f46b0228e74a987f40c9efa",
-      "rule_id": "swift/no-eval-js",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 33
-    },
-    {
-      "fingerprint": "82050c81790486bb9fa06fe06e7ad4ecf5feebe920717f5557e05345d87cc6a3",
-      "rule_id": "swift/no-sql-injection",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 40
-    },
-    {
-      "fingerprint": "fb227873f950500821e7fe7409aa1aad992db289a8dd7d4593003bc2ad38db42",
-      "rule_id": "swift/no-insecure-keychain",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 48
-    },
-    {
-      "fingerprint": "31adf694d36068dadc10499f9f1768648da69384612dc42199041c9b77d82e0f",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 56
-    },
-    {
-      "fingerprint": "2d938431985642f023f27660f9afed961080aa56b9e09458f1388f6955d790d3",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 59
-    },
-    {
-      "fingerprint": "a07778f9c9c9b0a0e4997a4b82777d56171a79388fa4be094cdb8e0a6c4f7c59",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 60
-    },
-    {
-      "fingerprint": "1177be0108cebbac22dce80b2d7f90d39e3de4bbdd3eb998afd4b155a812de9c",
-      "rule_id": "swift/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 66
-    },
-    {
-      "fingerprint": "31ec83f12dd92eddb604ab798da30c80602e978ab82f4061f19fe2e9a9a09b38",
-      "rule_id": "swift/no-path-traversal",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 67
-    },
-    {
-      "fingerprint": "5734476abf368572189acc03d20309f879da475f6868d18fec7e017384a96ab3",
-      "rule_id": "swift/no-ssrf",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 72
-    },
-    {
-      "fingerprint": "6bac66cdbebfa91f875ecc25b05a1228b265f35fee4a91ca135a48cefc1ba4c5",
-      "rule_id": "swift/no-ssrf",
-      "file": "tests/fixtures/vulnerable.swift",
-      "line": 73
-    },
-    {
-      "fingerprint": "e57f0f135ecac1022a71be38c16fb75658d7e0a4e623afef6768935dca6a5aa2",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "bbffad23e6c0952438444256d2c9085d86345d5f472436f6071476d2530bd332",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "de1214bd254616b7aa62ec17a8e3c30550f1ee8c845af299398fc438086b3883",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "92922dbd47dd57cd2ac903c2bd39a655a6bf2c2d58961c0119b07527de8da91a",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 25
-    },
-    {
-      "fingerprint": "0d26255e81ab19fa0d8f55cddaa3a433af3ccf710b3b16efae9637f7890dd41e",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 25
-    },
-    {
-      "fingerprint": "2d275ce553ca527e5ad80cdca151d52b5323a20a2cc4b1a7b3259e33dd24908c",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "a207b1c48d16f7f1da88a5d9d0b0f31a0172dbf77c9a7d5e6bdf16cf430398f3",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "e77f9f856cdbb8c386d0cb7ef575d4b811605b9997d18d8406739530a7614dc0",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 37
-    },
-    {
-      "fingerprint": "2f43b6c5dd056d61352e6324fad701e2a9cb3263c36ed7a50a273a9b75ccd911",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_cli_taint.py",
-      "line": 37
-    },
-    {
-      "fingerprint": "379b4b3006d8c8936a5f6f3aae7bebf316aea9ed2022ad0d3205d1f5c21bb4c6",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 10
-    },
-    {
-      "fingerprint": "5e0c5316af04aacd6a0c2c454e8b3f82669ace3429ae4880756fc61280a7f370",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 10
-    },
-    {
-      "fingerprint": "eae633ddca13c6fff86298b1f03cb6628ee05bf0388535498164fb80e88246e1",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 16
-    },
-    {
-      "fingerprint": "819444cc390a3434e0677e742580dd9969611f46178b839974c506ecb0ee30bf",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 16
-    },
-    {
-      "fingerprint": "197f882857a622033f865864e06227b87d4729f6fdf55f89dc52b6648d628bf4",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "f875f5fea68b9f455b34d1f23e5588c302fad8cee4c1b78dee85ac32dc6476d4",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "0daa17708903696f48aab41f97b51a132fa33ede48930acfbf977b41e6c80ae1",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "c0282b5060ccb304125c65982f3780d1b7d49cbcbe3e69cb4693983938e4ff68",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "cdfb55d824bef54533d77eddb87ba3c39cb1b89f5a2a9757812b2e7b5b384528",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "6a5dc6f32630e2c96409a92a02af83ef101c9b032f7e678837948e310fc7859e",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "f912c5dd28576acada845c5be70744785d088e6d2b353d5c7dfe7532b95ffda5",
-      "rule_id": "py/taint-yaml-load",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "067b4c7519accd96c232efe23da8bbd93a9bcd1962e1ab3e1cbffa4607b75b90",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "94a4ceb55a3c245efda83924f0f532e5fb51b0a52846657213e2fd3f7f923720",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "254d1c60dd352015cbd8af4de112d5e6a55e68d202c06590c3f6f6d82365f5aa",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/vulnerable_django_taint.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "673a00889e6b5a3583756f13e033132e41bf364f85eb2d8788015e0f2cc4680e",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "f5ab1d5b9678e5cccf0ebbfc37b61c0ccda8d54639502182c47ab32a6a0e556c",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "6eb92a46a0ec331f4713f60a1874986bffac4eacb353eb029859f92ffd81c3fa",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 28
-    },
-    {
-      "fingerprint": "badd09873698d71a5113ea241d4aa3038ce73244fae6faa4935ac26c739b560d",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 28
-    },
-    {
-      "fingerprint": "bfb961c2665d50928ca7ff6a2d817d7e1807fd2bc358bb53a6776123d1d46f46",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "291af20d310288ce8217d5fcaa66d2dcfd02ef41f62adb2fe87cb3ada1a81b09",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "1316efff994048b0af4ba8781956dd3d722ea84d92832db90dcd6275f8fe5470",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 23
-    },
-    {
-      "fingerprint": "a97a2fab86afb8b5f0e273e3e093cdfdf0f20d8bf6086b5072f4c444564f715f",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 23
-    },
-    {
-      "fingerprint": "b1462aefcf462154757aaada2a217e5c0a9ae3e909fdd2b98e5bb08be30143c8",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 29
-    },
-    {
-      "fingerprint": "74ff9fedf5489216d9c72f6ef3df5c970fe57ed05cf4b39e55dcb11e94f101b2",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 29
-    },
-    {
-      "fingerprint": "a64272869ca9a63c131d8c7be16c3d19ebb137d4a06d2b6fda19b370412618c4",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 35
-    },
-    {
-      "fingerprint": "8a8a4feb3ffab5369fbef3d2e073d5104cbe32213b54fc32ff65e8eb77aa82d7",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 35
-    },
-    {
-      "fingerprint": "39edb2b9d0f6298c7b18dd674c61bbf0c4fe151bb4224c6934c4cb6b72a49b99",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 42
-    },
-    {
-      "fingerprint": "62ab1910bba8734b4beb1a3096ee2dc9d0ae8e3c1feea5a686c4fbab4ad49eb5",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 42
-    },
-    {
-      "fingerprint": "89c3698b9d6ed8fb7ecb9f574cf2d33c5480dd18613fdb3468c3fba3624e5852",
-      "rule_id": "go/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 49
-    },
-    {
-      "fingerprint": "a124e4c5f8fbd88ca4a1f669a2560f67f9fd1904e3bd796b71a080c9a93d5731",
-      "rule_id": "go/no-command-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 49
-    },
-    {
-      "fingerprint": "50e417e67dd896c61a2864f9e6466810c9c3c96a72bb25916d3f68e2e5c88d2b",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "e1d6f66d5741c4796911310a3b768d7cc9b78804b1f07d4001687475505aab71",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "55d5d3712ed153005e5cdf76a55bdd88441738f181d8c606e3745ea29708f22e",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 63
-    },
-    {
-      "fingerprint": "fd5e9093fc5d2fb6df2f57e4e599102b97877f06b33a2d3923e0a709757a5f1a",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 63
-    },
-    {
-      "fingerprint": "a8f3f99a7237f5cb9f7217dacd47b96dce2332fde02487788f445e2f7f083365",
-      "rule_id": "go/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 69
-    },
-    {
-      "fingerprint": "b7ce08f5009015815625c1f38310e6325e45bbd05e549bbb11caf16bfdf043ac",
-      "rule_id": "go/no-sql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 69
-    },
-    {
-      "fingerprint": "271e4781ba671e675d5ddf87ebc0c7b9a1ef6e42edc1e3abce7221f92168f9a9",
-      "rule_id": "go/taint-ssti",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 78
-    },
-    {
-      "fingerprint": "345bcb464c8b60eda1a7fc313bbda7a758671d6e66ac9d84db5c9a3715561192",
-      "rule_id": "go/taint-xpath-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 86
-    },
-    {
-      "fingerprint": "d7db7b756702e8c8037b78c3f38a29bea165ec7abe4d8efbad852c462ce97d34",
-      "rule_id": "go/taint-ldap-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 94
-    },
-    {
-      "fingerprint": "277fe0fa798de8e5143dd1b19674f9b83d6152f9ad70ff810b5834b045c66063",
-      "rule_id": "go/taint-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 102
-    },
-    {
-      "fingerprint": "5b325c2e03dffd12cffc5434509aa3b2652eb3a1f47a718c2ed35bd0065a82d6",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 102
-    },
-    {
-      "fingerprint": "aeed00abda4122f087525ac98f502e6eab75b7c45663b4727d800adba589ce6c",
-      "rule_id": "go/taint-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 108
-    },
-    {
-      "fingerprint": "2ff4900fa0d116f743fcedaca5311a0ec162aee7eda532f67cd33d72352fd478",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 108
-    },
-    {
-      "fingerprint": "1af8bd0b48af939ff81bffc13323420d2963b1458c995f3b209417446f9bef9c",
-      "rule_id": "go/taint-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 114
-    },
-    {
-      "fingerprint": "2bb2ea008c40eabf12181d9d9fa42c32212cb0286031dd0ed5c2fbd1691dc168",
-      "rule_id": "go/no-ssrf",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 114
-    },
-    {
-      "fingerprint": "4271c3425ec30cc64c02d0137b594bf7a718db8b29f8b83d50abbf268034b7af",
-      "rule_id": "go/taint-log-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 122
-    },
-    {
-      "fingerprint": "28b3a5bb692d1c6f67c0951f6a17ae4e70a4fa5e79304c99e76e428eddf20e2b",
-      "rule_id": "go/taint-nosql-injection",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 130
-    },
-    {
-      "fingerprint": "a54bd3069ab4c5660cb1d5e6c6e873f5eb6507d9d07837a7a95bbfcc6c0a3e3d",
-      "rule_id": "go/taint-path-traversal",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 138
-    },
-    {
-      "fingerprint": "413330410715a36edf2f1da3af93613816ba70be8938275de01570f2ee5ba024",
-      "rule_id": "go/taint-path-traversal",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 144
-    },
-    {
-      "fingerprint": "1630dba88460698f5384b03efb449eb5e09be5bb76f48dfdf1c2bb4a6e915b95",
-      "rule_id": "go/taint-path-traversal",
-      "file": "tests/fixtures/vulnerable_go_taint.go",
-      "line": 150
-    },
-    {
-      "fingerprint": "912097ddbcad5a903b9078eaadc9c0714ad722e33b184d45e52ae0420700dd5b",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 11
-    },
-    {
-      "fingerprint": "2f0649c6bf8e6242ebaac0dc2058cd82ea0d90ef737f40d7c2a8d487fcaa25f6",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 11
-    },
-    {
-      "fingerprint": "88cc453d6cbd24dd19b7c8568cbe248baafe65e547ce72bfc235e085f79cfec6",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 18
-    },
-    {
-      "fingerprint": "1afb5736ab9f5291e2dcd7308e4befc299b6743bf4c8d9e72d671fcdfea149c8",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 18
-    },
-    {
-      "fingerprint": "b153de9953136cf01c61dfbd862caa0526df1e682a0ab5dedbb8bbdf3ff4a18e",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "ce470983319b7c5df1283daa8ec39fbe25a2e466dad9ffbdea7e1d22a1c8c095",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "ffd3e907359f6fa07dae4e3bdbb8c16868c048f85cf912c6799a5a5c9475408d",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "3cd8c9f6a0c0a7af5c9b6ffaeef85929d70a60bcf240bb12060790865353f3f7",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "ef8104104f3251b5fbc3a126115cf9a36c82420689ef7c5b25463b52f8cdee23",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 21
-    },
-    {
-      "fingerprint": "17e4cb571a036bbc71900f6eec320376008c0f073b4c7f1c232301baa3c0063e",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 21
-    },
-    {
-      "fingerprint": "2d6ccef3db1909e54deb9bc2eae0ba9a3f19481a349b4757ff4e03243ecd44b8",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 27
-    },
-    {
-      "fingerprint": "ce63aeca2e326bee2bd436dce6a97e43ab4aa0aa9cd3c04f0917a383741c10c4",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 27
-    },
-    {
-      "fingerprint": "175ad5da4070d002bc5a5083be9fc3ba227ff89c2a2f82b2371a8cc9e35d5cc1",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 34
-    },
-    {
-      "fingerprint": "c85f65bbf3abb09d5397f3c845dfe319c3890a824fed0de88189a9fe0bd89a67",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 34
-    },
-    {
-      "fingerprint": "d6b6e584036058f4ec5a5c42aac5c41f0a568f06d81f2f7e2ccecf407df41627",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "2fe3b782cf612739df1c78db2cf13a6502e9206aa4e35171b3e65b768eecfaa0",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "d3a0fa666732d6cb1ffa02d5a2322db018ff4028842a8538bd234a5b33ca842c",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 51
-    },
-    {
-      "fingerprint": "67193ef5a07794d55765958bbd7d96a6e14f075c41854fb15e5029fd2d632ace",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 51
-    },
-    {
-      "fingerprint": "344909a6ebf05348c7096f2d7e753dc0ca531949b51df6d6cc8739e41ac532e6",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 58
-    },
-    {
-      "fingerprint": "1f4527f2b3ae49fb9d91f5dc70c76de3275c7c74a15c82531957e2ca0fbda10c",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 58
-    },
-    {
-      "fingerprint": "c4307c2e10149b1a9305a62ed1a2612aeb64ad17d0e42419c5c3434ac73bff74",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "b073c94698fdbf266ddc0b4af7d4fb6bf180d5b6416d0d5722deccd0ce009953",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "769546a438cc5a1661f58385f3c324a20ba0216b727e6210fd19ffdec4495457",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "5824256ba9d58bd4d2d53e9a5054ec71ff92604ebcb1259c8f7bdd588bd4579e",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "ba6c83704b1885beb1d162276da346b8dd2fa2a480d73b52722b28787df538d1",
-      "rule_id": "js/taint-log-injection",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 77
-    },
-    {
-      "fingerprint": "a6fe6bb201dd743901c721535473117d1452289fa9e10b6dadba898f39a63e94",
-      "rule_id": "js/taint-xxe",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 84
-    },
-    {
-      "fingerprint": "70c9af6c0e8a6e5c0e8d1fd1224f5c94f9d14df97949c270f3d33d339452a98b",
-      "rule_id": "js/taint-nosql-injection",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 91
-    },
-    {
-      "fingerprint": "2d5b4c0e0bff8c31d5a170ecc31eabae4c4e3febf301d40c5b371d6b709b307e",
-      "rule_id": "js/taint-ldap-injection",
-      "file": "tests/fixtures/vulnerable_js_taint.js",
-      "line": 97
-    },
-    {
-      "fingerprint": "12cd9d85748bf95097532c3ecfe11fe61fdc580bc6f946ac33adb5f9d063cae2",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 13
-    },
-    {
-      "fingerprint": "5ff80f5701c59b42fdf1909a06f4bb10c9fe1578f92a0742ca9e6e336a13765f",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 13
-    },
-    {
-      "fingerprint": "9237ee72aeaaced38d884cad1492b27956183daa75ddfe0ada6f0d496a8934a9",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 19
-    },
-    {
-      "fingerprint": "3672563f5bd8b9d3c919a5c60148983d0ff7327c052a6d022a62de0dbafbe7fa",
-      "rule_id": "js/no-document-write",
-      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 19
-    },
-    {
-      "fingerprint": "91ae20fa132bac2d728a99c352ff61ca8854bd4a597b4cc1479191ab09a11c36",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "ce915ca1f7d802ad7843b1647478e71d157048f724da9a898883733a4ec35109",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "4d8ab4b1e1251e752bfbc5e67cd7ead35e1babf144aee81424585c5c27fe6515",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "267cab98c7af3ca4af31143375ac2f81a0eb8d51318b95abbc01574bcb532163",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 39
-    },
-    {
-      "fingerprint": "d9a98e32f8d5cdb6137d96870b5ae1373d59f89041c32a81a2a3b178efce6139",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 44
-    },
-    {
-      "fingerprint": "5c0368528b9b8571031d6a21a8dc5f172ac9f4edf2e04600ba5da07d965c5f83",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 47
-    },
-    {
-      "fingerprint": "6b9db1ba74e9f5981999d0ce272f4c5e6b449b63aff6d199c9a7e1e4f30aa56c",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "3b0c6cac5b1fdb55368d180d806bf9b542de2e16cc41cba3aabb06dc373d9e2b",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "79c23c5f0b1616a68c166e9db6f83963f21468adf2250f54333f185c412e2768",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 58
-    },
-    {
-      "fingerprint": "7454ac5da6acd03769bd39a508c5e602660c1bd2465ef27c592acba85c24a981",
-      "rule_id": "py/no-weak-crypto",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "d724042b2b25471d5edf176f3606903c3eaef6dbf7475ac0e0d07c2623d83309",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 66
-    },
-    {
-      "fingerprint": "40872065716b4fac47a8d83e494d18ba0c2b60bf70e25f1e80c46c8dcfbf3c33",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 69
-    },
-    {
-      "fingerprint": "3c2e03133ba2fbc2968e9a266826c6d724c515466bad39aabc1d14d9691051eb",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 74
-    },
-    {
-      "fingerprint": "7b4f3f41f628993745d475d9071ee1286de194bd094884104d375bc3014ff113",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "2f098702d3d2b6f7b80ff66bf20343f8e6d3401fa9d79cc82c570ee1222b8b8f",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 80
-    },
-    {
-      "fingerprint": "89b3c30a22b0ce8ef4441de328a215dae3c13ae67db9806b70c770650033b989",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 83
-    },
-    {
-      "fingerprint": "d54ddf48c96631fbbf0371899f84b91b8f6e6b94f3f0c65f68dc2f62bd1efebe",
-      "rule_id": "py/no-path-traversal",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "895724f2e8c6cbc1144cf17dd1e7ecafc8e93c851a230efdbbf57e324dd10802",
-      "rule_id": "py/no-path-traversal",
-      "file": "tests/fixtures/vulnerable_py_aliases.py",
-      "line": 93
-    },
-    {
-      "fingerprint": "a9ba13625f04823b386424134085e8eb5e69dbe625d73d57f58eaafe88b81b84",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 15
-    },
-    {
-      "fingerprint": "decd219767874cd986ee5fa67a74239a55396ce3035030f6aa87138a1da40e2d",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 15
-    },
-    {
-      "fingerprint": "350e04ac5c83f9c459ac5e172a26bba5739340b5faa8ce54bfa1ecbcee3cf275",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "d0207727c4fdd13333c240637abc3d565167b6ebc173dc1d664c9bb466b787e9",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "e00041e7da36c426920fa7b453344dd4fa883ce3759c210512c64787a391bcca",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 29
-    },
-    {
-      "fingerprint": "c892e614ccde5585ab3c4563e0450dd30e954db4fe8dbc846262e42832cbd310",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 29
-    },
-    {
-      "fingerprint": "ffe01d7b2629bce227adf79ef23708a0d17a3cbae50f2e78437306c8b84cea71",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "453233eff5419c41e3b70652b32bf59878561a10d1f19e477e52a5af8090d357",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "cc35705cd80666115b0497c4d5ab46af8639dd22c00b90a5a2dc32b731610d6e",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "5c43912dba5622d1bda77a35200e7ba3d11badc5f3a4b2592e99d6910a9fa8dc",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "4c5222d9662e36b060019169a7572812d58cd354f336d3bc8fb2b75864797b99",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "a7fca691dc1d54f00f16a134265de0f5bbf3ba862b131cc5d6bafcc7a690e086",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "1c1182cc66f319a522f208620f207206f5671b889692e8d7693139b6a1c0ed53",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 54
-    },
-    {
-      "fingerprint": "0da756b833368861c8ff1fcc5d9fc350c42acb6cc894470f41f468bcd4950806",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 54
-    },
-    {
-      "fingerprint": "fc60725e6f0c44a07447b2828ba8351b7a3e226a70ae402f80b6e7ae7f33d47c",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 60
-    },
-    {
-      "fingerprint": "356a5f485060e934956dee85f4e3f3502f8cf0fdf76a2b07d7760bde082ee53f",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 60
-    },
-    {
-      "fingerprint": "310d2a360cd1a6191fbf820c589cb27fb742513251520cb0791556100dbef947",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "461f15b7da5b8c55719f94326971c9406aa676654f037c0868c78e93312c8b53",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "7872424fd4a4594563e96ac91364c25f8567d6a00d1b91f7846eae9deed8e8d0",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "a1eaa18d64573fb8cd2781c0c1839901764271370625e82eaf4cf33279fa3dc6",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "9b36276d999736d8ff9a2ff2d6e5296c60e6d4c65af8fb4c510e05577a0ec145",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 76
-    },
-    {
-      "fingerprint": "a51526481269f763d51b233363c43bf7c7fbd547b9105801d45ebedd473fee6f",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 76
-    },
-    {
-      "fingerprint": "e60afb6ac7854e3f5407f28c3097b51a677be3c7668cf9b81a7322b5389830b4",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 82
-    },
-    {
-      "fingerprint": "316bbc63df2c04dd85604d3e7f25b6f905e4fa8afbd49f87f80fd55a320c1e40",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 82
-    },
-    {
-      "fingerprint": "27f18b073f9042a4b824222493d07940a6f5b6abc1cec3461236f10700359dd7",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "c6bdaa437eea617fef9ea75de6894857fc82749f18eaf6f35ed2512f5932aebe",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "77645ac0b3eaa3a35053527fad3b46106ccfbf2f12f63551c7e08d70ae6545fc",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 94
-    },
-    {
-      "fingerprint": "4d1ac224eef76a19dec5abe4e4853bd18d2e6ab7a7a0cc00f38fab1362ac65a5",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 94
-    },
-    {
-      "fingerprint": "5422345f34fc1db28db9c998403457a33dc93c179ec4d4906b95b2bd7c2faf39",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 108
-    },
-    {
-      "fingerprint": "4fb1a559e68e8ea9465f4d98be7305552f5bbf846ec43fd2f32ec4447f1dfb89",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 108
-    },
-    {
-      "fingerprint": "93ab4ef2102c8a8e8836f4dd0abcf70ebd572e0a2714004ec1b54613b975dc1c",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "336618fdcce534672982ade23fa10e7fcfaa54631d50085dca7826648e140649",
-      "rule_id": "py/no-pickle",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "e198f668910f82331193520353db71ff02e70ce0bd82ba0c3e106c686fa8394f",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 131
-    },
-    {
-      "fingerprint": "18e85aefe5f7e47dab1fc2078e4570e472c61633574c3c3a4d385f05c2c7a0e2",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 131
-    },
-    {
-      "fingerprint": "6ea634b0a7b42e41c5e757d581a1980fb20a51e4d7c0455cb214cb5fa3df3067",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 137
-    },
-    {
-      "fingerprint": "d9dfed23d169ea9ad41f18e40c579818647096277db92141416072a99af1fe8d",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 137
-    },
-    {
-      "fingerprint": "e31b934ce8ca23e2316dd07322d1209681e0485793068d509f02130908eb7be5",
-      "rule_id": "py/taint-ssrf",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 143
-    },
-    {
-      "fingerprint": "88b1cae800c5b97593fee96294ca54a6d280476f8b0ef27c58d5ef659c8e63d0",
-      "rule_id": "py/no-ssrf",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 143
-    },
-    {
-      "fingerprint": "a6f6549704dbffa9d9e265e7d6b0cbd457f3e87c4f4c3bdcf9a0838683c0ad3f",
-      "rule_id": "py/taint-yaml-load",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 149
-    },
-    {
-      "fingerprint": "92d21c14be3a73232d3eb38fcfccd3125525635fdb24c156900087c768ae0e04",
-      "rule_id": "py/no-yaml-load",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 149
-    },
-    {
-      "fingerprint": "147d06f38179f5e76258704241fc9a1d5cbc632568517fa50e12bb7f060cbbca",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 159
-    },
-    {
-      "fingerprint": "103a462e2d273b058b4123f4af8cd2c8a62952e9251038f35870633d91abec08",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 162
-    },
-    {
-      "fingerprint": "b2a5bd47f7d8f3eb6c13a648ecb83c33d9db28adb1a02efb179685b04d88b77e",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "351688691bd061bfaaa723d3e98e54ac1a59a39426e34ddc54d744afdfedef28",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "f77a0177d99c138b545bf1a2283f303e6827f3c9c3b615e9add784072a385b65",
-      "rule_id": "py/taint-eval",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 176
-    },
-    {
-      "fingerprint": "caccb41be8f20963f785241a9f6f8c76771e1e077e4d9f9915356e96d151d350",
-      "rule_id": "py/no-eval",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 176
-    },
-    {
-      "fingerprint": "8a32055951dc833b68408c23beb5002d3089b07e8fb0a86c9125a437a41c0a39",
-      "rule_id": "py/taint-sql-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 185
-    },
-    {
-      "fingerprint": "ac24a483e81a9e1943179e9914859fb3ca215c84108b966ef8e3a0d9f81f464e",
-      "rule_id": "py/no-sql-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 185
-    },
-    {
-      "fingerprint": "58457cc7fabd0ea901f8ec7bb209583653f953d45b18f2f19122a2a492f058d6",
-      "rule_id": "py/taint-ssti",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 195
-    },
-    {
-      "fingerprint": "aeebf902b3afcc49ad1637f1826a5d3b8bb0ea01fba9b24e75d19abbdc146fec",
-      "rule_id": "py/taint-xpath-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 205
-    },
-    {
-      "fingerprint": "ae4eff687020c523b8223510746dfa7677579a7f15a22fa02e6bbc9de527084c",
-      "rule_id": "py/taint-ldap-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 215
-    },
-    {
-      "fingerprint": "c2d72b3deffc0b821d83a0992109df8b619927697962c83b0a2810ca5464f193",
-      "rule_id": "py/taint-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 221
-    },
-    {
-      "fingerprint": "d7a7764c41f5f431fcf8219d4c8c79c9fe9c093276fcbfe5ad63403330fd2cf3",
-      "rule_id": "py/no-command-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 221
-    },
-    {
-      "fingerprint": "dbf4fd2ecc9cf90a801af36f48432a61f2a4cf219af49b8c4eb779859f4f5479",
-      "rule_id": "py/taint-log-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 229
-    },
-    {
-      "fingerprint": "cab337fb08775ad7564ce151177a51888e740602da040b2199c04606e6b8c69a",
-      "rule_id": "py/taint-xxe",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 237
-    },
-    {
-      "fingerprint": "b7b66f1e1167a212c6deb6d2de48e177639974921b8af3d64733c78183c31638",
-      "rule_id": "py/taint-nosql-injection",
-      "file": "tests/fixtures/vulnerable_py_taint.py",
-      "line": 247
-    },
-    {
-      "fingerprint": "2c62e40f4e1d63c4cf3d57e1fe93c1197840b7fb73bc5d367953e9c0149a3326",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/vulnerable_tsx.tsx",
-      "line": 6
-    },
-    {
-      "fingerprint": "89fa04df927b713fd9b90b9dbba4b5259a2aa5535d0de6438da6c493f6636d75",
-      "rule_id": "js/no-eval",
-      "file": "tests/fixtures/vulnerable_typescript.ts",
-      "line": 6
-    },
-    {
-      "fingerprint": "0ac21ba14f6dd2fd4da127365a5b3aed2b516812bec64131ac57d50f7c152b3a",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/integration.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "e90eca37356da4dec12f9ba19778711f9e1dd35abbbfa732a6e3c6f9acab7bbc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "e20d4c0d4b1302729db753fb352b6396efce66d2ea98116ab39bfbfd067a8020",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "4b25d128113f93ffd554ba69f3ed2dc512d735ccc6612d928fbf943860e91174",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 83
-    },
-    {
-      "fingerprint": "01099ccbdc104fd744d1fd247756438c547df75fee9965835cae895777606b5d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 92
-    },
-    {
-      "fingerprint": "accbfee7f4159296057031d09787d5bd4cd74516dafa4b2d6925291155216667",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "de05ebe8eb8ef53187a92180f08a80ff82ab00cdbf178c9b5836d680e3e622fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 102
-    },
-    {
-      "fingerprint": "10b5baae63e12c73849c9be4cb5cbfd642197f9f72f9cd4a46eb1c01649917df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 107
-    },
-    {
-      "fingerprint": "313bb578d2462ffd1d86a3b376e73040b869affcde1695e5b8d7915412fb88c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 109
-    },
-    {
-      "fingerprint": "3aac268e021401685272caf141366dfd20d43a1cb863cc0ecaf557b8f737099a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 118
-    },
-    {
-      "fingerprint": "09ddb58b7c80f38304f8947ac854b814cbcff460f38a9f71116e3128c69c66f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "40a588b3af2fef3ec6fcdd8cd8b84b71d2f225ba5b01676494396ed2d904556f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 129
-    },
-    {
-      "fingerprint": "e7ffd780f5f5b62c341ca6c0a50575ccefdcd3ce484867d26bc52900a512c008",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "e547fb3a66edf8914a46ca2c5604c1ebd9e718a5cb380814dbf933c30c86d51e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
+      "file": "./src/app.rs",
       "line": 139
     },
     {
-      "fingerprint": "f54625a8554ea3d31c99469973499ab895f1a10ff93c89948deb3dd82df8232a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "c49365a69f5a7e0f74143712854d49fe6884bf7b9207740e26acb7e3e37a921a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "ee817f31f5ef067a0b7643b487cd77a534cde4b6687a504a1e97ed0fc5490cac",
-      "rule_id": "rs/no-ssrf",
-      "file": "tests/integration.rs",
-      "line": 254
-    },
-    {
-      "fingerprint": "9b177309b974a83b8433c6bf2071d1279e3e3bcf94650aba48f33cea9dd74a5c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 270
-    },
-    {
-      "fingerprint": "d5b1db252d5c4482c3eed1a889436a124673f60af9f7d248f65ea4d8ff3dee40",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 364
-    },
-    {
-      "fingerprint": "b386e531c77c91b3d1cfa4d6bd84afa1f1fb19a06f7aa075b81acf0cd1ce6677",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 402
-    },
-    {
-      "fingerprint": "2f2f2e63f5bc6755d4e9de50ed904338f2e7840681e1641856295e6ddb1d1370",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 439
-    },
-    {
-      "fingerprint": "40a1bd4ed5bfe1ad74370190712eb76b83412660a6f8f168ecdf0972ee8f1aa7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "36d89e675fb69bfba83d8019df471fcdd999cbc2fae128a4594b528385317a59",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 505
-    },
-    {
-      "fingerprint": "d3d131403938cae1c25911c43f9ade9e7064d3d7d2e536465abdc59b1188d70d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 539
-    },
-    {
-      "fingerprint": "1de51f9d582634d7c08242791a820b6dbf3eafad0a1066db335b84549b310325",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 572
-    },
-    {
-      "fingerprint": "6df08417b3a7b2724e4d6b7bfb47fec72a67cb3f4a8bda81f25b7e380903d9ef",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 605
-    },
-    {
-      "fingerprint": "4036ba53daa3b2d910de33f4c58e2f469e075fd30c1f06a9af8d1fbbe857bc17",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 627
-    },
-    {
-      "fingerprint": "f0111525a0cbcf3c61fa90670ec570689a4df5d5da753fb3608bb68970487d9e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 647
-    },
-    {
-      "fingerprint": "e842ef94b12fb65d06c7872a772b7988d1ed39aaeebaeb965269fa4e7354a708",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 714
-    },
-    {
-      "fingerprint": "31915a0440de73dd2cf7b7f21df76ee229dbe5bb69fd078bf52bbda4e0f38d05",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 769
-    },
-    {
-      "fingerprint": "d829066c757e8a815813b340bf8726d672c669a2ce3e1d9b32ff1c0a9015575e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 800
-    },
-    {
-      "fingerprint": "6cfe05734a6d8399becc4e1d10e527d5b7b195d43ae32bf66757483542041039",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 822
-    },
-    {
-      "fingerprint": "c5c6e367840eeb832294f035cc8fe0367df7bbff3ce69c209cb891ce876cfc8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 848
-    },
-    {
-      "fingerprint": "88c6e1e346010e003ac02404763aa923c2bebde7ccca24071235610f8960c14b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 871
-    },
-    {
-      "fingerprint": "4a051e11f8646b6f4a4013fe9fc2c56181a4dde7e8b53267a2f734e044ec7fe7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 894
-    },
-    {
-      "fingerprint": "86d134731111e2e43d27340d31c5d8d03a247145b898668ac6d0a3d35f11dce1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 916
-    },
-    {
-      "fingerprint": "0a3020f77a1e48df2edb607a3354247d180d1870a28929df62c02a5e589612b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 939
-    },
-    {
-      "fingerprint": "fd3090e61aeed4aa071a3718a836015761a128ee5e180a72b6a8f8f5817dfefa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 961
-    },
-    {
-      "fingerprint": "1de06dadacfdd3436f7f1c860aa3b4099dfcf14417531895e48edba17052636e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 981
-    },
-    {
-      "fingerprint": "fe3793daa15a061dd99327a90bdbd069c4610cdb5fa588fbb8c76988e5c7cd3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1001
-    },
-    {
-      "fingerprint": "4c8ba6f2379ad5513b47a4690f6e8aaa1d8a8de3d1f9b1ded75c3aa9393eecc3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1052
-    },
-    {
-      "fingerprint": "78b66df6239934f6a700ef8387757f7e8cefb81ff5fee29bb5bb55f6ded75cf8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1122
-    },
-    {
-      "fingerprint": "8463c25d30c0663b770348880a44da989b3b982fc47d9d0578d7d5611682f7c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1154
-    },
-    {
-      "fingerprint": "8bb710cae0ad24d0f0d5cf32d1f22c1788b3d6309f2f92e77c85c6d7d685dfd5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1174
-    },
-    {
-      "fingerprint": "a41463432e159f83493cddf32e041bd83f1a6387b90c6f2ee6680c613af466e7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1217
-    },
-    {
-      "fingerprint": "73cefba65f7dbe06bae8714f1e6b8b51bf6889cc047ee1ec7f727b72efb4ac1d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1239
-    },
-    {
-      "fingerprint": "2e1bab2a97d9619c10ce3abafe4b77f48b0ed503d447229d48533bdadcdbc25d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1241
-    },
-    {
-      "fingerprint": "57632105c23d6c44141c305e6d5e362c206a23b5f261e56c688ab247b669b6c5",
+      "fingerprint": "7431c5014318b158907f22e56d9bc5936ec810c35f0735b2938378e06954d2fd",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/integration.rs",
-      "line": 1247
+      "file": "./src/app.rs",
+      "line": 198
     },
     {
-      "fingerprint": "9ac3242580627c2600c8e21bd88bfda9f008093a4618d6103a7b1411f52e702b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1248
-    },
-    {
-      "fingerprint": "ed6e8c70b395edbba41b01e7f21c720b0aacdfc2d37a6e564a2118e938f5ee11",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1249
-    },
-    {
-      "fingerprint": "64406d04968f10e01e07b77881ae13dba003e5d7bd2d94490d088048b936eb9c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1251
-    },
-    {
-      "fingerprint": "b2f90bcf8c9b11fdfb277be539cf7113276fe0b692dc34e58a63bf58e3ace02a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1252
-    },
-    {
-      "fingerprint": "d538e03102a180d0137e9fcf8190033fe517eccbc3104cb6ec62ded0f3a08dc5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1317
-    },
-    {
-      "fingerprint": "85dd4ed44078b7e42df4c2e22cee84446b9df957d6e2b7fc3dfaf71b670010ef",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1364
-    },
-    {
-      "fingerprint": "8c9c29b4c0535a3d5c54a4bf3d4eb82dcbee53441924a665c99ff6438399d312",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1407
-    },
-    {
-      "fingerprint": "8c5dc5fd6dfc266e2b6c913265dbbbeef1d7359d85f833e283c976b3d02d847e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1435
-    },
-    {
-      "fingerprint": "45faa4058999899fa5d25f3da8beaaefc0a1b68bd180894f2f3d28d2a763edd3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1482
-    },
-    {
-      "fingerprint": "04308a850030f568770611c9c64b6afdbd1002440cb2828752e7717618b96337",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1529
-    },
-    {
-      "fingerprint": "cd5f091fb8cdc8b993a277a00289f22fcd3decf06dd0e5c1ebff9ee58c0a4270",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1580
-    },
-    {
-      "fingerprint": "de1da56c4929d448e8e4656adefac6c0d5d55e22709bda14e17fc7154b4d1834",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "8ce9f0d5ced39621fecab9d4c6c1764f3ef40e88dc6d638de7465ea57c6ad803",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1657
-    },
-    {
-      "fingerprint": "14bc436c22f06b92099e76d45345e8f64e5a98dcd91b6c1c088423e4995731c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1690
-    },
-    {
-      "fingerprint": "4c1edca6465895c76a175e1356afaa44b8039aa4b6c87c8b2f3138c0b9da20e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1721
-    },
-    {
-      "fingerprint": "149b435018228a944a5232692ed107ee399f7783558c7400e806bad46b34e6eb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1752
-    },
-    {
-      "fingerprint": "b0720a4e45b7ef1a490b00e1655099f0f17cad205da030e04625fd00a6362907",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1783
-    },
-    {
-      "fingerprint": "dcff05c436ea014f3efaf2ff33a99517e6455a8284ae9b6236184c6e1896a267",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1814
-    },
-    {
-      "fingerprint": "f8fb666f0d7d38e66ca3f5793780c61795acf85f3d2b619c986106a52272ba4b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1845
-    },
-    {
-      "fingerprint": "46a39ef15f0d66c433b063362894a0912abe50dac08622202976bf65e4c0ca17",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1879
-    },
-    {
-      "fingerprint": "fa8df1192501aa0d21c7f0c841c8aa4271b6345db66e1b5cd1395bfb47e2fb1b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1885
-    },
-    {
-      "fingerprint": "c1b82a5596fd29b60063319296edad413156870fb281be7d7cdbf29d50e67948",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1925
-    },
-    {
-      "fingerprint": "26982982ee48d241a6f3660cb052c747576a9fb6d21fc3f85565ef6cd24e324b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1928
-    },
-    {
-      "fingerprint": "ecb231945ab4c85c9c30c128dff95f2dd671af204ba9d1abc91c98cc52a271fb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1934
-    },
-    {
-      "fingerprint": "27d206d80cb72501ba956acc3d58e6b097e35edb898037e64a7829270fbb3f41",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1949
-    },
-    {
-      "fingerprint": "545ee747a958ee77efd154b25cf1e87555ca04a54d8e22515192ca03b5811864",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1962
-    },
-    {
-      "fingerprint": "7174acd821b557963130abfef95a08c9ed233c9f8180d559a916e166c5a1656b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1965
-    },
-    {
-      "fingerprint": "96957bf0b6172d888e4e2c0e74e48f7f52b3e5c1e42ecb54edfa77f462585041",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1971
-    },
-    {
-      "fingerprint": "c3ee59ab571353a5577c8e48f1342c931df81dbff7dfa699d1eb9246c26b7ea0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1985
-    },
-    {
-      "fingerprint": "2babf85793c2d453bec255e883cf94542bc8361d583f0c4bd86354a0e590c67b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 1986
-    },
-    {
-      "fingerprint": "88e6547b66b9bcf16182f92a2aaea932919795b76208b63962f7962d8fd04b03",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2000
-    },
-    {
-      "fingerprint": "d8c39421e9c76b672dafd0b1da012f6b8c9647a8cc69ad0d9c9e262c561da72f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2003
-    },
-    {
-      "fingerprint": "f2066905e5bd72b87f41cd356f9fbb5049359211fd82dd6c59abfc6e005f6a35",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2009
-    },
-    {
-      "fingerprint": "163703d5da213602049644924fc66df25faf062d9d2ae7494272b3510883daa4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2023
-    },
-    {
-      "fingerprint": "63e760ec6bf7262b2645a85cf5830f65b8d40f3c0550c7e3a3e047ecb69e4585",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2024
-    },
-    {
-      "fingerprint": "290f6318f5cd0e202b4314f4cb95a5dcb36f00ff679e97bde8fcff57dc730ce0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2038
-    },
-    {
-      "fingerprint": "00936dfaf449fdf5d61f51ea1bc5a47c3a638945d558719c17c323a0da39f3bd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2042
-    },
-    {
-      "fingerprint": "51d46ec32da0a0904dd06f2afb2c9af8f27027600858cdfea7cab78232d9929f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2045
-    },
-    {
-      "fingerprint": "e585238b9f9dd31bbe10b1acd5d66d658b11a65d19f9d2ed53e7a74efdf8e09d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2049
-    },
-    {
-      "fingerprint": "ea1dc6ae4cc61d3446c09e0b3dd878ac1e601c5ea435ee026eb21794e3cf6b7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2064
-    },
-    {
-      "fingerprint": "0b609d43ee3f58927dddef091f7392c00c2cb6a4dd69bbbdfae2a1f4beef947e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2077
-    },
-    {
-      "fingerprint": "f02fe33c516d1b48c0fa22feecdedfc1ac8d4a8b3bca09089ef4a9d504db2caa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2078
-    },
-    {
-      "fingerprint": "214bafde3c71a38cd0a2835ea2382a22159fb818abff013b91e23520e566d61e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2083
-    },
-    {
-      "fingerprint": "248669218c8074882cd5bebafdd1a0dc434a6fd135361cc1bbd0788b1f6c37c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2085
-    },
-    {
-      "fingerprint": "9ec15d20a14e4b7ed06f51621cedd295f2be0da5452ae3cb2072c5011a015666",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2090
-    },
-    {
-      "fingerprint": "20fa2b4fd05d2fc5b3e11cb6570431ff5c673f5f37c89edd312662f1b804d4dd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2103
-    },
-    {
-      "fingerprint": "d8dff4d07c7c1db886b5c5e5e6a401b2dfc3f3f7fdbfa658cb96ed1530a0681a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2110
-    },
-    {
-      "fingerprint": "576fcac56bae5af0d57ffe86ffda51e8ea7d63745ea8263b7bb27b3016af7b08",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2119
-    },
-    {
-      "fingerprint": "a281bd97a94225ef688aca5b99fc0e7aa60e92486281aa0193e67b1d0e0e8da4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2134
-    },
-    {
-      "fingerprint": "b1459329dce437243b635dd36bf9a7667d8f4db23f2aab05337ac476d8f6270e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2148
-    },
-    {
-      "fingerprint": "e9118b3af945fc0eb7943a43034a2d07611fe7acb6c795aca7548445ad8d4836",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2153
-    },
-    {
-      "fingerprint": "ea3ef593bc858fa9d6bdca89d14b1cd318ff98b4ec87f898f0c77cf9f775ac3d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2157
-    },
-    {
-      "fingerprint": "a1a663b4b6be949478cef4a2f6704f278ff2a2a37e92eb28b2c2485d0ae1e43b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2166
-    },
-    {
-      "fingerprint": "cb80e2723121dee3a256e8be593aa46ceae6a6b0a5275659e52f7bcad8706d65",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2169
-    },
-    {
-      "fingerprint": "c04ee26e01495c2bab4f765976714d8ecc53c33863bd104be1f73dc6b5fbd4a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2171
-    },
-    {
-      "fingerprint": "3a7309329798951820a0dfa0ed00a29e0d3de4eff159d3c956d8af7936da3b3e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2182
-    },
-    {
-      "fingerprint": "b5f890632324118d289f3e1e12a22e3475f5e26bae06145f46a5aea34ea08e64",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2183
-    },
-    {
-      "fingerprint": "78e1e0a72633e2a3abedc768068596843939bf4cb8501e06cb3f0061c0835fad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2188
-    },
-    {
-      "fingerprint": "e04f42d3796be4b5d66f0aef97d890386182d12f3d0f766735afbfc71dafd944",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2190
-    },
-    {
-      "fingerprint": "15ccd0d82c3cdebe8c2f4dbc3d0757b451783da472bfd05d57ee7f2bb7cbcec1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2195
-    },
-    {
-      "fingerprint": "b217ce7ba18828047c6c8598f88db60c1384a127a43526972bc247edac37f44b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2208
-    },
-    {
-      "fingerprint": "a43f937d2a758d2127abc4ab2c953baf4085325b9c2773eb314e43e0e3766ea9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2215
-    },
-    {
-      "fingerprint": "3da881fa1656681caf06a9c8fe5e265610aa821f4512462c9f947c900a60095c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2222
-    },
-    {
-      "fingerprint": "3ba4e8811f405f55a30f95269e8849af48109553c784a9f82ce7c54da32ea700",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2234
-    },
-    {
-      "fingerprint": "4b6f6b90353216444f48675ef6be2f25c229c7032c4b31e7b098cd7cedeb8c2a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2240
-    },
-    {
-      "fingerprint": "2fdaadcf2a51426fe01313fced56487fb335efc4fcb9905139e86b15d519d6b3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2246
-    },
-    {
-      "fingerprint": "2fb6ee731d7661ffa893ab6b48eac7632751d244e3c67a42290cc0569f198a8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2251
-    },
-    {
-      "fingerprint": "5f5884617ad341a5ac4251c82c3f16813cb5e5c0a53ab9fa0dcae1f84d3051be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2257
-    },
-    {
-      "fingerprint": "e69846861989bcd5ba4bf74afcb04c31d0a4cfa4e4a7ff5a88de70eeffffa116",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2265
-    },
-    {
-      "fingerprint": "547e9ba3f8db49b04efafbdc927f6366db7bd938592ec02aed698fa0d4f1d522",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2293
-    },
-    {
-      "fingerprint": "596b027b9f56dcedfba1d119e65ccfee5c8d8e478e81dde04f7408a2c8c0c382",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2294
-    },
-    {
-      "fingerprint": "a91a256fac11bd26a188e95b79dd79c3cd082712bae47f28396da414420db438",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2299
-    },
-    {
-      "fingerprint": "b36104b17a4850679f885f7e0550ea423561893f15ef5d893f8001f94b1ac57c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2301
-    },
-    {
-      "fingerprint": "7d637783bb02290c900e4c8b981d23a4a5f8ddf2aae5f791cc820c1728c1dc24",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2306
-    },
-    {
-      "fingerprint": "fb067ca0506267f0ed8c510775695cb68a7a2fbbba3d4ad2f4d45f6e06835037",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2319
-    },
-    {
-      "fingerprint": "ff76224c6f7c074e7685ba6344f5319a88bea468f6c790508b06aaf0d40d6f82",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2328
-    },
-    {
-      "fingerprint": "2794e89e44830f2c56794eb4a0570f407671622be442cd228c18e3601e2fb4a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2329
-    },
-    {
-      "fingerprint": "1afd99b696a22b2ae281d2fdb95f9cfda4e8b150d9937faeb441d29ebf0258d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2335
-    },
-    {
-      "fingerprint": "9e72f8a13858d33fdf353dcd4f8ffc053da7b6ae6a28d519a251448fed6e2489",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2337
-    },
-    {
-      "fingerprint": "a0444d94d5628f0106a658929a47144990b9bc0530b2a4fa8aecd33bd36345b1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2342
-    },
-    {
-      "fingerprint": "a60f11923e650a29ad68635f771e1660a2715f3405157e6c56a264bb22377bd8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2356
-    },
-    {
-      "fingerprint": "f94687235d81dcbcbbe1de10fe2c691ae774b836004d3cda231254c55a834b3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2358
-    },
-    {
-      "fingerprint": "0a6b236e09723229abd9d178050cdfd8eabfbdf5ef1f1746762174e4692a752e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2364
-    },
-    {
-      "fingerprint": "0fd9ecd3b364a4405fad63cb41d1ee21be9f014028c3102fbd547d4c543d224e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2366
-    },
-    {
-      "fingerprint": "dbe7cd6c1bae0c05b8c6cd807674963ee91e4a7960ddc6aad0e573d917e3f47e",
+      "fingerprint": "9e380ebf09a5be84b13d8705e1fe53ba395566266e3f498b9706c49f60442740",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/integration.rs",
-      "line": 2373
+      "file": "./src/app.rs",
+      "line": 203
     },
     {
-      "fingerprint": "42d8488228c8c5283005b3da070c07a308874c236ff5d9c45ed83e1873685f85",
+      "fingerprint": "8e7f34f79d045509a46aa2115632df621d8ba6ec76d751e7bbfc5888c763623c",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/integration.rs",
-      "line": 2376
-    },
-    {
-      "fingerprint": "e80b55334c9f4ccb63eb3a196e817b2cd9762da94c80dbe1df28465fdb610089",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2383
-    },
-    {
-      "fingerprint": "c7a9bc46c24779edbf1684ab9b03af80c7d2f200e536b9a840d519592478da9e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2403
-    },
-    {
-      "fingerprint": "cab104ba8434cc4a5d172f9f1c5661fd2a3d9fa09f20d5bf849a4a4fbdd4082c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2425
-    },
-    {
-      "fingerprint": "b9bcd371269bd023c85a220705ec680646c87463d10e25816ce1a29524a100a4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2452
-    },
-    {
-      "fingerprint": "f65ea6c2b9add5691f340c832b1e331941e03b1a37ce0acabe7b0bc767f54884",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2457
-    },
-    {
-      "fingerprint": "7f441ee5912bf87e7e544d589bf4078005747f50840518898afcc8f2d9001921",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2458
-    },
-    {
-      "fingerprint": "836c14ab7c90b0292706a9919506e93b0d5607c0ad652e257b1e47373066b100",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2474
-    },
-    {
-      "fingerprint": "cbbc0736afe065eab35ea2a0b039edc7ac1bc0412dd6a62404529f42e4880e9f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2498
-    },
-    {
-      "fingerprint": "751bedc137fa8348ed42be94deba531c23cf52bc01c502c201c497044631b124",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2501
-    },
-    {
-      "fingerprint": "4335bb3f5f7b0a7d69b00703dc0c81234384309d03d7067584297eba7902231f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2504
-    },
-    {
-      "fingerprint": "b466da86b2216747d684801edc0e523487862a677d6de6a8f883b801dd5372b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2506
-    },
-    {
-      "fingerprint": "70783fc0e2e9181cc1dd5da70137f6709cd4e417abf61d365f7ee8a717b8d8d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2510
-    },
-    {
-      "fingerprint": "3e98b0be9c0763d307ebeed68cbd1d85547947992ed70dda0920202248704317",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2521
-    },
-    {
-      "fingerprint": "80526d6559d8dc99b19858b74a398527f651f9e35eda1eafb95bbcddc550a33a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2523
-    },
-    {
-      "fingerprint": "23c3f5ff5071803d7c532f33c0a006c906c4c2b5e479b09c3be415a81b937df1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2527
-    },
-    {
-      "fingerprint": "ccb953072c3cef27ccd84ab7dace3b37e8ea8434b2b146ccc9401668d27ebd23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2543
-    },
-    {
-      "fingerprint": "0ee5d3ade0a91c075fd50122e6919a6f4e46f42b2e126dc62d49887651c9aaab",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2544
-    },
-    {
-      "fingerprint": "5540a5e25c7b9eeb867eef601b383a95f7b758adfca3e6958141c3e7aa6c862e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2551
-    },
-    {
-      "fingerprint": "f9bc51c804740467e95614abf4cfb59d0dc63cd17d5694c4eef5f57406233ae8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2551
-    },
-    {
-      "fingerprint": "efa931f0b019669d554f0836bac758516c2aee1a877b811f5a5c9f8ae92eeb46",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2554
-    },
-    {
-      "fingerprint": "c58f211baecc8c8695f48e7e56be45d2a23e53f5d10121fad0c83508b9dd7849",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2561
-    },
-    {
-      "fingerprint": "a89ce854d985845f79a0441c8dbb44084fe18f72a50869073c2f9a28ae26df2a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2577
-    },
-    {
-      "fingerprint": "d7a8c720fe1e6d02671e59da2acac1babd4b060f39fe2fbb4b0691f45f652bae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2598
-    },
-    {
-      "fingerprint": "d6f76c2270772991d44f76063857a0946ead88d07ebc1f3381163e194458054e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2599
-    },
-    {
-      "fingerprint": "d1039140030335815efd252b51f0697af2aaf6f8f7bc2f694feff8ec29748868",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2606
-    },
-    {
-      "fingerprint": "f9c8a3d09e7f17314847e856a0a32006e35f746f03b5b2dcc056a368f13499ed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2607
-    },
-    {
-      "fingerprint": "72b6d02be9e6823c1c09b458fae73dbbb8686564b8c056930412498430f0f295",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2613
-    },
-    {
-      "fingerprint": "86363a427e624554ca3875ceabf845d01e5ff2558fa78f99af1e3a78541277fa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2620
-    },
-    {
-      "fingerprint": "c8c63a35050fe7d28650c1b4210d30784819666d104b463cebb19509e47a0bea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2636
-    },
-    {
-      "fingerprint": "a7ae9fefb319134bd51a3070b89c71062cdb17813c4e4ce56b401168274ac2d3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2654
-    },
-    {
-      "fingerprint": "be1f8da593a91b71d37a4b45e7fa3a83df241148991e5fbc3e421c3ce61d10b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2660
-    },
-    {
-      "fingerprint": "208291809db0ce2fb903af2144b206e0d9b2aa7cd80dbb62b2a40167877efe3d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2674
-    },
-    {
-      "fingerprint": "df3c5f8457be058bf41726e34c0938b75aa62f2cdb3d66dc660f16ffa3460256",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2674
-    },
-    {
-      "fingerprint": "2cb1de535ca9b0eefdc87eb554e32cf6a7a613de2572711cbacc72ca25500233",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2675
-    },
-    {
-      "fingerprint": "06bd2f822efd47db040fb0a59081caeabdb8be36501731e6b3194fb7f261977b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2682
-    },
-    {
-      "fingerprint": "46089de48168f93e0dc9b0c1e7f75bf1577e1f461730af7d0afe18eaa929dcf6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2682
-    },
-    {
-      "fingerprint": "b436f515dde3313794280bdac6dd942b92e06f96dfe3975cc41eef387a0c3c11",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2683
-    },
-    {
-      "fingerprint": "81569593e11654546f53be24d3b1c28785dce98d7af386cb8f48c81b1cebaeb2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2702
-    },
-    {
-      "fingerprint": "17300ef76eb12a70d6eb49e57901158a6c080a5f4854b9dc150b902d23c3c963",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2703
-    },
-    {
-      "fingerprint": "077378458f41c84f2b27071fac8b31b72ac0ffb4b3a7c61aa0da389b87d83dcd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2704
-    },
-    {
-      "fingerprint": "333506c1229361cbae196637298dd477ababc2b0d53a8dbb5fbbe7ff253a071a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2713
-    },
-    {
-      "fingerprint": "e52b89adff54bb83d6fb3e493a32849dc38ac9332ae550c8993a829494ed0a1f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2720
-    },
-    {
-      "fingerprint": "03d60c94164376ca2f1919cfd49a19b72ecc93b943bb491f296e61025ced83dc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2736
-    },
-    {
-      "fingerprint": "3a212b47af24559abe66ca1772060fe6f6f4ba78752edde1b19f906ce37caf2d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2759
-    },
-    {
-      "fingerprint": "f3573684f2ff18aab03cf9248f101e305906a5ec5c64d3b0268a02d41363c6ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2768
-    },
-    {
-      "fingerprint": "b9795453c9b18f5d154dc817a9d28cc9a51aafcef2c4c4fc1dfcc60e971c0171",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2803
-    },
-    {
-      "fingerprint": "f46729158541aef6c85c4689536c0ca49343a1afb09ef590f7bcf665bb9be065",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2812
-    },
-    {
-      "fingerprint": "a268664b252913b7726030424abb8e191122536842a2d16e2ca15e8c6ecfd262",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2826
-    },
-    {
-      "fingerprint": "26b922b418b96c327f9b063036e7268f3716430aec8c6ac0afe2e9f10e65e379",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2835
-    },
-    {
-      "fingerprint": "37f3a30d375f4203f2cd64054b2221e6b0b95637b62b0d7c076b29fe5627a425",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2856
-    },
-    {
-      "fingerprint": "5e57384c6dd54713aa60223bdef439bd5369190f86c5845f2d2c83394af383ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2864
-    },
-    {
-      "fingerprint": "0b1d97e4bb6d86744be0a4b175ccee198958101b582cb9c5797541bfecf64d2f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2889
-    },
-    {
-      "fingerprint": "6e198fedd1ba59b878642a5081645b3fdebe47b49d05080b5b75200f5feb1aee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2893
-    },
-    {
-      "fingerprint": "55afeda150777dc6571ca9ba866dafbf6c4b4e3c85a5971ec108aad282f67e62",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2912
-    },
-    {
-      "fingerprint": "ed6e652ce7688d80999c38dd688195ed89a0eed5e4596b657c1821873d78d45d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2933
-    },
-    {
-      "fingerprint": "4f64ceb6311fbac6e9bdb36f82450552ccaae2cfaaa6c15fdef4f0a0b326fccd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2943
-    },
-    {
-      "fingerprint": "3e4e1d44f42620912ef2b34f66d0275fb82a44a0f578128a1405d9f615ddd7fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2972
-    },
-    {
-      "fingerprint": "5fbe943002e30bc4e4cc65e792d8bbafd4d995560ee8e91bd903f801daae2603",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 2980
-    },
-    {
-      "fingerprint": "f8a0291c775806c5174dd0d5b698a2119863724b53527b55df2a8cc614ee3d06",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3012
-    },
-    {
-      "fingerprint": "7ac4b7aa59ca49eb21963925c9033f68b32103f5b31ed2e8e49c5c0aa070d6c3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3013
-    },
-    {
-      "fingerprint": "f401571c3e89b3bfaaac9d5a29973a93ca41e0535bad4af984987575ace81d28",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3015
-    },
-    {
-      "fingerprint": "b032f032b61b6716d6dda6dbfe28c288e18e44e720349f73de9c51251646e137",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3022
-    },
-    {
-      "fingerprint": "8f9a8e9c00058faa310a3b485fd488c62d50272705e015c693b1abf3ed25cefd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3048
-    },
-    {
-      "fingerprint": "97fa42060258759a8898402dcde3cb59cf9019f74409d50ff0420123903064c9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3049
-    },
-    {
-      "fingerprint": "18f9f9b4c1ef36ba025658419a628bf709886051dc99f9811fbfbc5b119231a3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3050
-    },
-    {
-      "fingerprint": "74e08526111e587967c92de03bfc7971c98f5ccd6e02a5094e7b735db24779bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3051
-    },
-    {
-      "fingerprint": "d9c5e7aa61fe03cadf8105995b3978aae7c99acaec964cd0192d86471746fb6e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3053
-    },
-    {
-      "fingerprint": "dc8bcd032ea13ef105ab8348344489f43eb274eebabbfc13d13fe84b1e3defc9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3059
-    },
-    {
-      "fingerprint": "96359456beee424befca4cfea614e6b9225b27456fc9c99ffb1496b2c2ba745f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3086
-    },
-    {
-      "fingerprint": "a9c4870e0bf4ddc4f82f8388081cbdd601b53e49b099e79fd2d042ea807f7a03",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3087
-    },
-    {
-      "fingerprint": "2885dc4c832f8177a664a34869d71b1ebddd6ac1f45512ea70b8be027e6e60e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3089
-    },
-    {
-      "fingerprint": "6380dca363a5a24a052fff614746cd7861c000f15534fb973ebac24c719f2b76",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3091
-    },
-    {
-      "fingerprint": "fa820e508cf7d407c892b2f8dd6429da26502483f657de5d898fc101ad92714a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3097
-    },
-    {
-      "fingerprint": "885cb6d8f2e9003f03da616db2acc72e0ab1097d187ee664d8b17255385fee33",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3103
-    },
-    {
-      "fingerprint": "3439230f65a2f41d779dcfd0a531e1c4acbf433048cf9cfb474e4885f3354647",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3136
-    },
-    {
-      "fingerprint": "5e2205fa7cadcd5da01e1dc52b63289a828e7650acc0faf1b7dbabd28d38d5f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3137
-    },
-    {
-      "fingerprint": "aa721265ff5afd640238c2d098f2b8b5868f5257f60ed25686d6fee4a1882c91",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3138
-    },
-    {
-      "fingerprint": "0c870a4dfe43a82e2efb0cbdba6656ef75be271fb0a9cef5c92f76f284f30e11",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3146
-    },
-    {
-      "fingerprint": "6d5d2cd162d7854a4f8c18b54a45e93689211d5c8305a68a927d3662bd0d0a2e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3166
-    },
-    {
-      "fingerprint": "447fe7bf6edc642a58b163420fc5f7b30cdef3d6569de6c14ab03e6eecb6d462",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3167
-    },
-    {
-      "fingerprint": "fe5ba2661e769f9fb8f4a553e3a04977d38d8d484a3ac10a86be6fbe635b4251",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3169
-    },
-    {
-      "fingerprint": "ae00d465eea89493b88188c2ce69db8bca9bc530ca7162369ceaf7d645d7f39f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3170
-    },
-    {
-      "fingerprint": "6f79efba72ba55ec21c2dee6eeeac32234a45c9326da42b697f4c7d63704e1d8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3178
-    },
-    {
-      "fingerprint": "2bcf9a1f220583d7ad8b458724826d9f66a99ccdf0edd6d3049e6dfbcec61df0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3204
-    },
-    {
-      "fingerprint": "87f52a380303ba9304bd246fa71fd201e12a4ae300db64f53e51737012ef235b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3206
-    },
-    {
-      "fingerprint": "03e88b2f92ec8564bc5687e21ab94d32398012db4ec8e974daf8bddeda6ff91f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3212
-    },
-    {
-      "fingerprint": "85bae88e83c25b86d740daefa88ac255f291bcdb97487af02ffd89ed4b1a7aea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3213
-    },
-    {
-      "fingerprint": "e1e6cbc4460d1b29257c52f7e7323630b3dc7d6f5803a7591957eb32a65d7c66",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3231
-    },
-    {
-      "fingerprint": "eb96ada1654cd95457672cab976d99a117e80592d02f3b7dac14c78e5fc5b1f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3233
-    },
-    {
-      "fingerprint": "ed7821da4ad862c7c5d4744ed746fbc764ca23a1f06d01815b6df78cfb2573e5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3236
-    },
-    {
-      "fingerprint": "1ca4188331adff668ec340bdacb20366a1f8fb5545b3098d342fd64fa81f360f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3237
-    },
-    {
-      "fingerprint": "53016ad406f11df4d9556503d7594927868c3682350905c6ebb56862ee3e108c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3255
-    },
-    {
-      "fingerprint": "e19d98996f4ce5de8e09614453b4434ff36afc2e34ea74cc62e23eaecf3098c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3257
-    },
-    {
-      "fingerprint": "4f3798dc9cea1a05920f29838373eed0cbc3d9e99bcc227da3136f598511fc70",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3263
-    },
-    {
-      "fingerprint": "a69d1aaa1762de5f848b5aadafbf67125d5aa409edd15b52c78c325ddf8b0925",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3264
-    },
-    {
-      "fingerprint": "707b37caea9dbdf9662492578862cae2603ccc20f075a317d11d35d777c83fdf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3280
-    },
-    {
-      "fingerprint": "d2d795fc2ebc5d2f9171baa79926c36498efb0eb736a9e2a874feed044ce427d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3282
-    },
-    {
-      "fingerprint": "8ac762c2176fd8cc1a78a732d10060af2503909785ed9e293b2620a9f4418551",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3288
-    },
-    {
-      "fingerprint": "71706bc53a004539b53622e2801e20253fdf64ae8bfab1ba892fe5954cd89c4e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3289
-    },
-    {
-      "fingerprint": "1049ec7638898c66bd2629541bcb07e97e05a2f14fd427ff444bfa0eab10fc42",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3304
-    },
-    {
-      "fingerprint": "bc8cb977db68df88eaa15317030d9dbe61fda7969200d0da0448ac9edfb032e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3306
-    },
-    {
-      "fingerprint": "18770a87b59c4f0bb1092918ac8ea7867fc0fea6961b1c5228aa6a44fe72e2be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3312
-    },
-    {
-      "fingerprint": "0a459b62a90f9f1404bd66d6c4ed36bfb413e825d3649783199b11e9918096ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3313
-    },
-    {
-      "fingerprint": "f57933c46700472e0606983bf82b8244a81f0f6142d236241660be37c3852b4c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3333
-    },
-    {
-      "fingerprint": "0ac6d1e1570ef04df2e97c27413596c9fc45b478f6bee8258ea88a694a048056",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3339
-    },
-    {
-      "fingerprint": "5de91cbb22ac36c9b642ea5b2b163b4e0498551bca12490cd8c20b34d70239d2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3362
-    },
-    {
-      "fingerprint": "56f09fd947961358417c81398d230bbde26115843057d118d44a7f3806c91258",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3381
-    },
-    {
-      "fingerprint": "b03d4227798862c52fb71ebe767673b8f471d2484f093d90b68739ff7e70b43d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3404
-    },
-    {
-      "fingerprint": "57c22b42251ccaa647e94eb093a9fd8ee9b2e7cdf23218fdc2a951b999b1c1e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3435
-    },
-    {
-      "fingerprint": "300b5e3bc0ad7768ddc5b79318507fbcf5895989f66cd346400680b9306605af",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3460
-    },
-    {
-      "fingerprint": "09e20bfdeada4d2aa702ce213bc7013b7d8fde02c499b95e56951626a2940f88",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3484
-    },
-    {
-      "fingerprint": "4b19c00750aeed95206e89108b19193a4e6cec7d63e0a6d1360e1d38a35af564",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3495
-    },
-    {
-      "fingerprint": "9489d3ad439e646a6c467b6bc5c771d3211c03038563d4c5445a447c4d01bf59",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3516
-    },
-    {
-      "fingerprint": "ba1e7c65200784beb97633fef37b03c78e5124cb22f134604b7e12c22e9c2824",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3524
-    },
-    {
-      "fingerprint": "8741056e32491cd183e4da8274c25527176a6fa524b2da30653723b0a764dd30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3539
-    },
-    {
-      "fingerprint": "8051b8051e421384f2ac763f12c2cc3e2e2cc895e954a3f9e54db4b62128de6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3549
-    },
-    {
-      "fingerprint": "67797c656443e23e974deee5ff42a8c6aae6dbfe7164ab775c11ee2949609e40",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3568
-    },
-    {
-      "fingerprint": "554f7f5dcc6e5641f17751424260e6ebf60d2731a2a8bbee931dec477d6f5c76",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3579
-    },
-    {
-      "fingerprint": "5805496bf713253516b124a65bc5a57651e97e1ecc940547909c33723c42bfe4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3596
-    },
-    {
-      "fingerprint": "c000a2610c71db289dc9497f56a31034435d84774a731acca1760a7ae2e9e798",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3603
-    },
-    {
-      "fingerprint": "287557f958ad0e872421ad83aa4fc6433a8ab2921531f998b3a74b1c3a5f6e6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3606
-    },
-    {
-      "fingerprint": "44926bafd33b2320a10c787c22276abda7efc92717a710b8158aa6a22034ce5a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3609
-    },
-    {
-      "fingerprint": "bb9b45c3580202fa6ac92f3665162e33ccd206a4e25848981a88abba304a3fbc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3660
-    },
-    {
-      "fingerprint": "399345f6d1d2fc28c640ac612757e93ea1bc37c695322fafbc780297bf0c372e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3666
-    },
-    {
-      "fingerprint": "e6dcfff01b9869e26ee61cbf2073eadc7bcd7232925b8d13d07af2b2bc09cc8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3689
-    },
-    {
-      "fingerprint": "0fa576e4630263f692c12812becd5f279c00e3c02957d3c271b8da6c0d9394b1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3692
-    },
-    {
-      "fingerprint": "21f694fb24089e5f333f36c32e106bf9a4db7bfed9e66859841cbb1f2182f39a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3695
-    },
-    {
-      "fingerprint": "3aa725111d4f0adce56ce5eb99c38c7ec722df1844ca27c5e38418d6d930fe0d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3714
-    },
-    {
-      "fingerprint": "1087a921f7d46cedbe1121f5237f0a43e71bac9656d308cc19c8932826b01fd6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3718
-    },
-    {
-      "fingerprint": "e6c86b9e3c2b06fcc387e536517cc73d9da5b1ed69d618e225594fe2dda3066b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3721
-    },
-    {
-      "fingerprint": "4b78d2301f7f52c24af4e44f2c57551c99adb6ee7f56a17cfba7ac711892199e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3725
-    },
-    {
-      "fingerprint": "72cfff3e1caece64d48d4029705dc951fd686853f14d6ffd18575699565e88d0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3736
-    },
-    {
-      "fingerprint": "e1dc4821ded9b8448526188a8b45835bf9d4649955f24a0713bd09d4316514db",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3739
-    },
-    {
-      "fingerprint": "5daf9434e57d78c67fc741d0a63ccb8f155790aa1b6fe3c68d37f94980bb2d71",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3743
-    },
-    {
-      "fingerprint": "cc247b842fb942f28d1ada83ed39d986c1cf446a41496e05aec99451362bdd38",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3761
-    },
-    {
-      "fingerprint": "192fd132d7ac2b1a9c1314e8790aaed6c1a55e33f6fc868b125ba87f2ff5eca8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3774
-    },
-    {
-      "fingerprint": "3d03a22350afb723afb5a71e4eaff08f065a4130ecea48b43e9c14bb3aeaa145",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3777
-    },
-    {
-      "fingerprint": "950792a83e10e224f9e403ac73ba50f4bbbdb4822ec423d375aa3cc28c000096",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3780
-    },
-    {
-      "fingerprint": "08945e7fca4c7b845b0710618405fc149b84775b85bcfcb722dab46035bc5a9a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3790
-    },
-    {
-      "fingerprint": "8f44298be6cec4d48facdac0080052617b2696df064fe51ab4d74a4124a9833b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3805
-    },
-    {
-      "fingerprint": "605f76ffecb99dc74c2cde0c2ff6d9b4c5038505dbaf3e497ac3ec74874be538",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3809
-    },
-    {
-      "fingerprint": "8db676854878fbf5046ac4a6cac9a63b1931a4b05a41486794317892cb07e47a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3814
-    },
-    {
-      "fingerprint": "f6d2323eeff700d8e40b15268e80c757b7741d07b9605f366d8b8ba34ee7ba8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3839
-    },
-    {
-      "fingerprint": "3fabb9cd51d7d557602b132a057fb71486eee3afa7451e7ea75f13d01b9eb02d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3842
-    },
-    {
-      "fingerprint": "f67c684f98d0ea9ff59670167bad6e0ab78165e52d18f0e8b151b379e6fdc1f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3842
-    },
-    {
-      "fingerprint": "9440014a5699c2f448569b7c0184dbb8e9de3f85d5b95f2ebe185c5cc0c0c6d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3844
-    },
-    {
-      "fingerprint": "96a7ac0f11f04d2feb3bc10fb2d8131b8253b7da7086b3bd24e4f599f125f7b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3846
-    },
-    {
-      "fingerprint": "05857dcf916d598e37e803ac71354598cf51cb499c65d7ad06f67c7bfa9a2279",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3850
-    },
-    {
-      "fingerprint": "5007264235d0dade1567ed5a4e8f2df58ebaf29fd7a5c03ce69c6367e2d29022",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3851
-    },
-    {
-      "fingerprint": "b8db99215911a3d494c19639f4a8da77731b5cc5278c74652b58c4ec5211326a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3869
-    },
-    {
-      "fingerprint": "cd46e8e53359779187401f975056d3122c597f1528d99acfcf2c390ed8cbb3ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3872
-    },
-    {
-      "fingerprint": "6480ce32e4f730729777ef9c0205842f9fdcbe23fcd1cf236f9f8982ae8ed31e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3877
-    },
-    {
-      "fingerprint": "b286a3c98638ab1e2e323d79c869a63bc746dcf4c8f1ce12707c7571284d79fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3906
-    },
-    {
-      "fingerprint": "565cce2183ad2fd40f1c5ae1548b1b5b4a0a47c0248e000e37f54a6450a540dd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3915
-    },
-    {
-      "fingerprint": "a56c273171c1eb5b175156502b28578ad0c101cdb33ede4013b513be517f35c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3920
-    },
-    {
-      "fingerprint": "241e79ad3de5a0912859ec8458b1ad3847e2ed2305fe195886251b56c05925f2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3943
-    },
-    {
-      "fingerprint": "752113008aae38e1ff8bfa4406fdfb76d1abe80640016be064724b6b86593c35",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3968
-    },
-    {
-      "fingerprint": "6078afd406381314795d5be4470ff9bac47bc3eb695a92aeb0b143909ef14019",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 3988
-    },
-    {
-      "fingerprint": "e262fd9bbc00ac69c2bf949fd89ea9dfcbab00ffcca4b36a64145f8e734d3c07",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4052
-    },
-    {
-      "fingerprint": "c503eaaade718206dc486c585e4c5a9bbc568a0bda7493083364d0ff573a9b7a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4106
-    },
-    {
-      "fingerprint": "7f0f6bb72f1e85014f145e7802a04f4833d349956a7b2f01316803f7e6c2e4bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4112
-    },
-    {
-      "fingerprint": "21c991f247e093dacbafd4d1ac00a398597bbb006c7df37ccc95b271f5f8347f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4114
-    },
-    {
-      "fingerprint": "e85a97a74e4da8a9dd45ac1ebe14ec04f73dea0ab34c5e92d5590c27564890e4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4135
-    },
-    {
-      "fingerprint": "b3ae2de7b3b08a1a5456e648d0cd1e7a7968830aa6d4eae176d5b4e7a12f02a4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4152
-    },
-    {
-      "fingerprint": "a34304e926c7b20a73005e1bf08c76f49eb1cf28e4b13348b05bda73d09f6ba1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4170
-    },
-    {
-      "fingerprint": "5ee79b6af0e71e9c1b3afbe92f814a1fcd3aa3fe5d1e2a2920a83621f6ff416b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4173
-    },
-    {
-      "fingerprint": "9cc7ac7e5434ba60e456a326b1efc64fabf8a996d3bb6f1e66621e7602702797",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4191
-    },
-    {
-      "fingerprint": "3dfe4d9fe09828dfc94d1f22a4a0cc230412f08e2097abb79c29621893937ee5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4199
-    },
-    {
-      "fingerprint": "b24e96ad75684b548e8b77494dd62674ab4432c85547506795df8212fa80fdb4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4215
-    },
-    {
-      "fingerprint": "04f83a3bc2332e2155f59d25cc33ee969c7a2a8bb75acc6c9d29af0bd42c7609",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4223
-    },
-    {
-      "fingerprint": "f8b26c56f534aed38cb67258871104ee89163ddd6de6a560d8c804f2d85dd4b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4239
-    },
-    {
-      "fingerprint": "59e80aa0e8f872d5a5f4604999cca8e76e98edc43b3fbcb3b7695ea936983cc4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4247
-    },
-    {
-      "fingerprint": "af60986c98790f5ea3cf7d878645739c43e601ab0f02d886fac27d10273ed835",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4270
-    },
-    {
-      "fingerprint": "eb94a008e85d05e06967b513bc81064bcd642bd4f30ef0759968f58f09fd3e9c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4284
-    },
-    {
-      "fingerprint": "41243a2ddb83aa8c2f78b2aafb6109969eda3e0f0c1ee37e6bd7abfb8786fc3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4287
-    },
-    {
-      "fingerprint": "543fedc3c7f3af9027561f38a49dabc1568bc41d5f2629dd149831dcfd59be8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4324
-    },
-    {
-      "fingerprint": "fecb1ae6359d9bedb32a631b7c334e936c037af58935345cf125200487793820",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4325
-    },
-    {
-      "fingerprint": "a55736bfe23f80bb51f35137b240b7b912b3a1b4ac707fb4a9e088a05688a096",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4364
-    },
-    {
-      "fingerprint": "9313f506786da9e1451cf7974a0a5c4f373524b5d8efd24fc7140971e50d5fc3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4376
-    },
-    {
-      "fingerprint": "fb46a1520a10a19a869546e29adbd801c61e2921376afcfeadef6926f4937c2b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4598
-    },
-    {
-      "fingerprint": "529f4b8f3edd97abd4816dfe26e5007e6401ba73be4bab05cd1f451138623cd9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4610
-    },
-    {
-      "fingerprint": "a9336c512144c828edcf35fc104f1c8c9a0b55ae069db6b0c53615f508daed73",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4620
-    },
-    {
-      "fingerprint": "1ee5ffb4cc249a5166e59f076cd823b6c1e40d67d98514230fb4dc5070beafaa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4645
-    },
-    {
-      "fingerprint": "7d79c953d1c7fd7ea2135e401e41c24fca0bfda891eed7197165af7bc6d72669",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4671
-    },
-    {
-      "fingerprint": "f68209bac1aa3a64889710f7660461b07aa3b665cfd7eba86a38a58879dcf4a4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/integration.rs",
-      "line": 4679
-    },
-    {
-      "fingerprint": "5b676a923612a17253cb4241ecfe1149d305cd1f3a17b037d532754e079ed18d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "d8de9860cce1f029445d41e5ac78042695657cea1c29f836c36dbf3c06f3cf8e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "d5b309c69371a75b1c10b0cfc7ef2917ddc4beb45ae7b03e84ed5ece2d6d1088",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "692ba80c3d0728606ae57fab7d132c1a963c81322a88136c29cde06386056b60",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "da284e4240b4e9a6839bcbe1f818e42179fe370737cee444e876c6e3dab51cf6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "44802833b7c83ce91b817285f9b6c281462a821138d9c40292f5399f9a813c61",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "57c9595a878fc649d941f9d030b25a42eb21408e93108b39c69bc017bd276f6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "9117a4b6813d43e352bbeba89c57d41ddd65427c55167738d626587d237b296d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "554fa6ef69849cd965f126a560ddf9533eb75499a396af844bd3c69f5e8ce3b0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "0fa842f18a766c19f6c762ed86d21b01117765175c1edbe7b4e313dbf904b6e6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "813304b455e9dec6e248b3de2c7ea8c9c23efa5fdd7bd42ff14e7a56dcca9624",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 302
-    },
-    {
-      "fingerprint": "99e2510f3f768bce6cb4dd930e5b1c7b3aefcdb146e4d64b132233d7e74dc6b4",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 309
-    },
-    {
-      "fingerprint": "09cd31badf15add9b71d42950ed19f0de255b9d9fb50ac82973dc38d41699ad8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 309
-    },
-    {
-      "fingerprint": "70247f8dbe0ca49d7fdb3ffbbf76b971581bc88b7d2bd6c03198c0029bb764c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 315
-    },
-    {
-      "fingerprint": "8ff30d0e9a833d9fec7e919d83d7d9aa3ded50299df6cfc10ca42b0f05862864",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/kernel_dirty_frag.rs",
-      "line": 323
-    },
-    {
-      "fingerprint": "dc18b3811a71980f4bc74e9dc2fe44206a0bad562cb259681efc2d340f946219",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 6
-    },
-    {
-      "fingerprint": "44e2510952f59f7aaba733df279b6862c157813d72c8e36d0ff7ec3ccbbe26ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 7
-    },
-    {
-      "fingerprint": "1117050f4d7c985fefc16faba94e26fae8d31a41c5bb24b667288a2c67f2b7d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 8
-    },
-    {
-      "fingerprint": "934a08a87fdb317ad96e5ca90902a28f9cf5ed75917d24aa7dde4894f898ef1a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 11
-    },
-    {
-      "fingerprint": "eaa7fb35f9a6150923f102020e012efe6e0d6736f3aa9d912f726a527e81f691",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 12
-    },
-    {
-      "fingerprint": "fdcb10c0aaf863dd53364fad417eb5adc55bebcbcc90340f75425e14d18023a8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "8d49a6a35cc9dbefa62f73c5f1000ae87732cdaae58dbe77e1a5792762e267b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "03c49776d30d96d7d3a082d3649afcd035bbfa3c199b4e87dd522efab5831eb0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "619f644c972a758e318adb84988c4781bfd9d03bb7547690245e3e4c06f0c03c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "4cc12810301d0a5537b4335ac331ec38af1bd847c5eeb7ab190ac94af3736126",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/mcp_server.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "e53ef71394f965994bf154ed3065da42fd5c1d26102990f28b1662155976c216",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "6a82e3dbb2270a84e458ec4145fd4a9167b60021eb342bb7bf268d8f11799281",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 37
-    },
-    {
-      "fingerprint": "d7cfd0d150db26e42e339a832e8e7f8bda725d7971ecdb567a71d6c56d2c1553",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 38
-    },
-    {
-      "fingerprint": "5d2e1819f5ac84190e1902f6291a76c94d132065f1e497939bdf9c73c3074191",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "a55772a45470425dcdfe359e2c4f3453c501c3df783d234f6e8d7c1a2d2403b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "16485cbfca1a0974cb6bf6240741f5f8bcda3be5305424de6c8cadea0f9d9c29",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/mcp_server.rs",
-      "line": 101
-    },
-    {
-      "fingerprint": "d4caffc61609c1f8230bbd3bb687ce5282d8b51ca2c9a2e6a67df4d1f4b52ed0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 101
-    },
-    {
-      "fingerprint": "a4e75e281a4ce7395f714f372d8b9bcc5b3754842c611e7a4b1de669b3b81cbf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 123
-    },
-    {
-      "fingerprint": "49f1644eb63e49445864d6471bea86493d4701169ea4276f7ed228e6bd04a907",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "2253ba753bf81c1abaca598ed37d64516e0e4398e77a05468f79545dfc795e1c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "43a4752e3d4ab35fae3773a43e5113e3eb008330bf303b9d95fc7133c7fac7fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 131
-    },
-    {
-      "fingerprint": "73e3c78cac8292d227254c3517d604c7d12251ccf5dd47953db8ee093c236ddb",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/mcp_server.rs",
-      "line": 169
-    },
-    {
-      "fingerprint": "802d07ee054bc35f62e71937db7fb87a06e38e7ab0317dec24cf12d1311e2170",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 169
-    },
-    {
-      "fingerprint": "87ae70bcd85a9e6cb8abbce0f312eb397aa3df3945cd2909e13e06809601d09e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "67e04bf0213aa9602334a6850343ceba3f1d26eec408252101af50275577e07d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 177
-    },
-    {
-      "fingerprint": "4a42f0184c1b237af25cfc0660a31ae6326981d3087d594325979090e905b613",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/mcp_server.rs",
-      "line": 196
-    },
-    {
-      "fingerprint": "4332da8f561f2cac0aaf5ec4bddfcc4c5e4538b50ac4291b4160e93314226501",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 196
-    },
-    {
-      "fingerprint": "05a40327a2d375aeddc3e1dd4ed465e511725862a93e11d2fa8f4d9f60be9575",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 218
-    },
-    {
-      "fingerprint": "ae94927e06980f0f0ff3893c10cd544b924792cefaf65d5ec9a8bc5501e71cb4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "7c11326459ff0289990e63a5c406697896f0badd99f8d671d81ae616c3c7f932",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "c5014ae863b0f4b37472fbb1ab40ec19a4b6283d260f73f1334530c134b703d1",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/mcp_server.rs",
+      "file": "./src/app.rs",
       "line": 229
     },
     {
-      "fingerprint": "7d74f3dd6fa03f6a8d86377d2ffbb3673b083b5e9b39dfdb16464f76783f158b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 229
-    },
-    {
-      "fingerprint": "fd758dc5fabce949aee88506f9db07bb901f10c0942e138ddcf4e8d6c01c9ed0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 236
-    },
-    {
-      "fingerprint": "57f614af85b624cef768da96ae8ff56480e21521a54f37806ed3196c95f9beba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/mcp_server.rs",
-      "line": 237
-    },
-    {
-      "fingerprint": "4bafebd7d3eb5f7fc47754e7f68339b578680114204d9ccd59d2e94683415764",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/realistic_fixtures.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "30e52bb2c4338c5817a122277ab3ba1e983201105df8d7944bfb39fb45bad6f8",
+      "fingerprint": "04c1f1f1e9ba96001d8a35776c8f3aacafd527ac79e857a1137f4afc172ad985",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/realistic_fixtures.rs",
-      "line": 30
+      "file": "./src/app.rs",
+      "line": 260
     },
     {
-      "fingerprint": "e56ccd6a010411541ef69ecce7ffc5f5cd3cf8105dbe11c01b0008843068c6b2",
+      "fingerprint": "f238a7c797b85ce16494165ed83d9c03b74749cf66520c07e0e974fc2f6e6f9e",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/realistic_fixtures.rs",
-      "line": 30
+      "file": "./src/app.rs",
+      "line": 265
     },
     {
-      "fingerprint": "e412384a0016814f1153762b774e262676fcef318f1d3cea76266fc140f24e8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/realistic_fixtures.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "368aef39fb027e812f843c537945ba5078c8d02272dc0c6c6806197e5cc5f8ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/realistic_fixtures.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "7cef49e361e76d83ebbcabae09d7d75df13b85823dad9cd6bed24a5357c4c0bf",
+      "fingerprint": "f9308fc18fef84a889b6d6ed0227d371ed0985c2ad7c388fc56bbe05c417cc4e",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/rule_inventory.rs",
-      "line": 14
+      "file": "./src/app.rs",
+      "line": 281
     },
     {
-      "fingerprint": "b5364fe21fb3466d3193e837d5d950e8f19a75fe8cba3694f014990eb61e43b1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/rule_inventory.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "36add59ba2eaa7106ae806fc7d5f6bae59f1024f732ed5480105aeb3585f5616",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/rule_inventory.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "c087a473d41e6b2c141e1460eb57c949a91c0e2371340efaf91873527cfff5e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/rule_inventory.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "bb76786fe231d34afa055af18ce1261cdd3902dff87551cdb7519bc161e9381a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/rule_inventory.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "e8af280826775db7c5803843b2bf50903418c16fbdc78fcad84f167a307e67cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_compat_bench.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "82fcbd3d7f88913e43fcf60b983fb4dc136b7ae91937b3a57c0710d347fd4536",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_compat_bench.rs",
-      "line": 19
-    },
-    {
-      "fingerprint": "05f6833bae093a53ea69bb5b8175a44c6cb1aeac07db8c15c7a620b29dccca13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_compat_bench.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "2f9780411e6222e8cfeba741b4026fc63847dad0b01dde6c52c93e0914df2742",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_compat_bench.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "e8ca6229fde41d7400464cc84eeea64622598fb82a32689213cdc56ab0a7aead",
+      "fingerprint": "51f8508062a2b055a9c21216a61af6e8311130688110a4bcb0422c6c25fcb9ae",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_integration.rs",
-      "line": 13
+      "file": "./src/app.rs",
+      "line": 467
     },
     {
-      "fingerprint": "55ecfbcd9904148ed802a36d56fca1652ed2132e87aaba8530020088b8348c6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "82d24c5d604685d4ca76a63be8ea327601591d5499b9fcfa54c6cc9e4b6aad3c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 26
-    },
-    {
-      "fingerprint": "ece14bcde58b2e6a6b82d3fb5dca2fd03ec74c1509189acb0fa7cb8e7920ae91",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "ca31bdb418f4d2cb168303bc9d5256665b4b8fd84c621ce6384ff27b869f6e57",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "ecb79ec6ce9d432742d1a4a54de59ecefe6343dce1f97d24287af95f8bb57617",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "379949bf011a82eab1e52af698f8d272bd67e83f52fcf33229c9bbd3a5e27416",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "261d92897d4eeed56ccf4991932808e715b1b601b47bccf66d62a0c14ed1f73b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 56
-    },
-    {
-      "fingerprint": "a10be81a75a055f8a99f2bfbb34bb77b22ddbe196c22740d8471aeab1f8adf3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 60
-    },
-    {
-      "fingerprint": "5403cbcbc5e09e61a8a13cec9184d29a07f8e31b7e82626dc25e7ae4d4830b73",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "92208d7ef2d66f9929cb55cb7bce8463c38343a3929d2b3780ceabbf7dc52b61",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 76
-    },
-    {
-      "fingerprint": "b94815bd5cb171e60c3f418b850a6f39c90c5dc65983f34cfd90161f55df62b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "0e8d7a96a235f7318a1f9a8852662cf0a9fae50263f393c4940e7e3a807a74b7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "01c46e92159f0496491850d724d798e356693b8c637a79e661ee2309f41fa106",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 103
-    },
-    {
-      "fingerprint": "949496f0e32b9ce843676d7fe36a4c1ac1d7c59d0b1464733c666c7d33607fcf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 113
-    },
-    {
-      "fingerprint": "53b17a5f2ac6eccdd6140ee1611af4a1ef6a8df7842784925f572e78fabcc521",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "7e6c1dbdf7d959150ba8f9e7c6441b6bf56bde18babb94101d741a66c2b782f2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 126
-    },
-    {
-      "fingerprint": "f147ae61d612b2c6a505084abb7187b28bf98d89ac4c013e9b168e284f42a497",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "f1f21c853763b3f85876492a4520e4fd6217f888edf1612d9b48a3b03f81cf2a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 128
-    },
-    {
-      "fingerprint": "29de3047ce8e794d375f895366b144c6fdc1955c9f3e78318c04566d8aecb4c6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "5c29aed385e9a6ccb20df293cb9e7acd374539f0eaeafa5ff2ed67a5375c9b1d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 138
-    },
-    {
-      "fingerprint": "37efa047d4178f353968e939b200f4b46c3616ffb0cbc68630b3121e06513dc1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 152
-    },
-    {
-      "fingerprint": "f30f34380601834b23a2960c844f9058a494af70ac0fcd8ae8f2705acde0b707",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 153
-    },
-    {
-      "fingerprint": "79b399bbe118dfa79913540fc1ddd59be27d399f30f2f80e66750a8400f3d53b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 154
-    },
-    {
-      "fingerprint": "64e9e22cd1079083379782fb784e901ba63b23b2ec14f8ee3b028c895347388c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 163
-    },
-    {
-      "fingerprint": "8bfcbff65558dbd4c4165b2a2da2471f14e0f4066f79f6c88d7ad15da93eaf7b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 164
-    },
-    {
-      "fingerprint": "1d09409988993529c52bdd7b2e929945832f05a2d8a7cc096b4454bbc0127d09",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 181
-    },
-    {
-      "fingerprint": "f900e5e9c31738c18ad035b66f6b2bd45ea64ceae59a300eb26927b581f95c02",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 191
-    },
-    {
-      "fingerprint": "cfdc289968b112b89ec68fe70326ab68d535dd110cf55b843da0f3b008bfe575",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 192
-    },
-    {
-      "fingerprint": "3e5583a0ad0b515c9654f409a485055dcc382a72506abd4a2d2321ee80ce5cec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 208
-    },
-    {
-      "fingerprint": "f5077bf9a349517e6a3e747e3d3596cbf979177840234afd258dd3881ff3f29b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 210
-    },
-    {
-      "fingerprint": "b8bdec6458308d9e9f8fb6976b6cc767450aca143d5725e20468b30d15f24b4f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 223
-    },
-    {
-      "fingerprint": "711335af0ebed91c5160ce441d8735c7f4cdd53842001be6e2a6d13b2bb31315",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 224
-    },
-    {
-      "fingerprint": "41e0a340294153f119f5418b13564a7f9a17fc248ed46d96c6430fb3262589ef",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 241
-    },
-    {
-      "fingerprint": "dc863f9def16842279cc6b761549a7d0c4ed200c6c501a72be379016f78e71fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_integration.rs",
-      "line": 242
-    },
-    {
-      "fingerprint": "eac902f450f0fb90d5cc3c1df23790dc60c4b1e4ebf2aba8cfdb5811535c76b9",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "34a66dc04512bd11636bf38c044dec457a416d97169d5e763a57ae5be0a56b27",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "83e549a4b128f9a4688b9c9b9c5a341e1fcd459ab1003f87967ced51e93e9264",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "ffc140bc8d5a1363ad5a804d3683493848bce522d9706008bd63bf3c1afcb857",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "7d0c191a6cf5c84840ee321c27db63b5ddb09f60826669a35169dfbdc4d15b8d",
+      "fingerprint": "9ed304f5a4ca5c5d3859acf005410e8ceefb7731f92c9b808104640f1400cb2b",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity.rs",
-      "line": 40
+      "file": "./src/app.rs",
+      "line": 477
     },
     {
-      "fingerprint": "a2beafc9390db3cfc89f09058dafcb3a64a6b60eff43cc9707a4e1d85fb1ee4d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 54
-    },
-    {
-      "fingerprint": "f40e3535b9594cfa33b3ec307fcf4422d1cd006f65c8fbe2ffb881da24c74e1b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "e1f9fa7723a1ae788aecb2e7aa044f061053b0bfd47517bd249fa4e753e23c00",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 63
-    },
-    {
-      "fingerprint": "8dde96376ef87474763628945878c844d7444865d988d4626006869cf4209a74",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 68
-    },
-    {
-      "fingerprint": "0206fc8f40f66871a10990226f5d7d75a0b84d3cd8eeba9c322a7e4e9c7536c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "e1d22f37a1031ef0554dd06ff97d142928bdcb3e34cc1f93960ff3ea2a3637a4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 82
-    },
-    {
-      "fingerprint": "5539b431c0176d413d8bcd6b6b12e8b017811c77ad3e8ea4ffd825be15c28ec4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 83
-    },
-    {
-      "fingerprint": "7693e951a50fadf76edae36b996d349bb70412554abfaf39a53e2c3ff4d2df88",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "d0d23cabf16a744221b157468693592132c50ce7999103008d18977362c7c15b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 96
-    },
-    {
-      "fingerprint": "abccdbfa93babca0c61f2fd2723db5729f5ca74779f7fbc5f5fbceb958ff8580",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 99
-    },
-    {
-      "fingerprint": "fe7feaf0cff960df9ed08ca12805e52a812eda45144d0716556eca16e32a24ff",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 110
-    },
-    {
-      "fingerprint": "8aa9fe694eee3df9f2b7889480089bed4c7f59efbfb5f9b7ce2d695b0896d8b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 115
-    },
-    {
-      "fingerprint": "36f017f590cd8275202ff7b6459607ae2c29433dda8cd090440c2e695b016f13",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "736d1843426ac24651b62b58784b50967e6ba084e051b8332aef23d492d0bea3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "fa7efe4985a1824499beb665ca07ebc2a89cdb732d24a2db094eea3cc08f1a2f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "a7637797d37d7a9ebe8c310099d91fe980346092e12e286983da8f6c182ae69d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "4b3c8a6abe4eabca91765b9a2fa3ca0a2c2062bd37f880345677b549d550cc97",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 206
-    },
-    {
-      "fingerprint": "1ccabe6818a30795e427c3366ea6254dc07596bb2ce03bb0d42c594292c07e04",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 238
-    },
-    {
-      "fingerprint": "857a67b989cf2798eb13bad529941e47f409bc282b90a0e482c19fafc2da8530",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 270
-    },
-    {
-      "fingerprint": "6b5f9b22c3faefada3054f15b3c3eeca036a645eedba5a7b4e641f84eb38b347",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 302
-    },
-    {
-      "fingerprint": "bf086cc72c82987e6de1185dc36411b856076ae166bd19925970828acbbf7b27",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity.rs",
-      "line": 331
-    },
-    {
-      "fingerprint": "9867020ff29324e2cc391bce161c1bbf0145b052e0cfd2ebcb8cc458a7e689e0",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "eb65b9f8b85491f533b3901f1acc8ea6810e238d277454dbd23673835f176334",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "960d15c1c57d5e1072a46c7bfed6f632a94e5e80da359eed731c46bb2219ff16",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 50
-    },
-    {
-      "fingerprint": "84b03431b020f6f65c3d412f2800b274483ca9114912096c0837b9e69ce5230d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 52
-    },
-    {
-      "fingerprint": "2cf50c314c62e66349ea7a614c42a1e3a859dadcbc6c86ecc1ec70952826550e",
+      "fingerprint": "038c945c475524ecd7861409425472f0e05d20ec002adb9d3c5e037e82d15a3e",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 57
+      "file": "./src/app.rs",
+      "line": 485
     },
     {
-      "fingerprint": "c88b04a0514753edcde7b895e31f3e0b2efe463e9599fdf03f3be50a0848ba1f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "8f5df9785349b3c3e33f649d95d624fde05e275c5d4959a5d526f7a1f487fe47",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "30d9efd1d30d6ed5141f87e90a4cd9b8268eb9099c6a10a3a7b6f42d4f91b6bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "0265382cab14855c708d840953393b1a746db096e21bc9bfaeeef34bcabc2057",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "008c2594ae4cccd2246683eafc22bd55acdaef29af0b794f35d4ad0d3819f8b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "d43762b2ba9c6fd32f2956852d465302fc2d2a89e4f729d06b628a2dc30cdf5c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 99
-    },
-    {
-      "fingerprint": "c08efa0866b9a135efd03e8b9075c1af8f1b548ea2ae09631fda2dd0ac1d49b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "78e9b930f3f8f207147319ca9add46ee3185d7a1027c999482a329bd9d4e09a7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 108
-    },
-    {
-      "fingerprint": "4a2e1d6f8e0d824ece7403d1258cc03c68d76897304842d49ef191f61dbd4d05",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 113
-    },
-    {
-      "fingerprint": "b323dab13517179b0f85a08d6e1af19f64d3d22a0149d874afcc72c72b7bb39f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 116
-    },
-    {
-      "fingerprint": "ae690d304111b4655fa799a9fcf5c38c8776f365dce02da5449a676d57178e13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "4c9dd90648458a0a7b263bb02b5ba6864618a9d8e28d99641d9a1ceda35f8917",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "71a0bbfdcfa1c0bdd37b88756110cfcdaef368c5ff90b74018fe558ef5435a65",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "131204f10711b6a51701109dcc2686c3743fd3c67ace4ec201b42ce5b19638a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "367c3fbfaa9481d189107132b7d60bc67482d08584bf1e46bb6245e81d407d7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 154
-    },
-    {
-      "fingerprint": "95f257fd21e548ab7eb979e34ecc44e13dec236ec1f2215e69007c6a2e8cd033",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 195
-    },
-    {
-      "fingerprint": "3f0bf9aee0b437a63241a4a1fec8c31bb1e1bbef5679108a2df75bbb0acb899a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 228
-    },
-    {
-      "fingerprint": "4af032b51e7b2e742b2d3e3398b150d952c63f931a1af28bda3016aeae62a424",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 263
-    },
-    {
-      "fingerprint": "38ec7574a5d1fa30b24e4be229c65f4b2fb609994d8451c77c77469b0d2d9cf9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 298
-    },
-    {
-      "fingerprint": "e2e093c2c89495bdcb4f736b191fd68e39f318c4f9287574e8632e8da82c4527",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 332
-    },
-    {
-      "fingerprint": "ca1ec4b033d2aad90c74d56a894457902f58b0a6783b7e0af271d59e51de864c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_go.rs",
-      "line": 365
-    },
-    {
-      "fingerprint": "f160efcbc0e23cdce9a8026626c4e1d26bc2e23b62cc90b4bd8f8fc2c20be1ad",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "5758c45e9d2ef39851914b968197adf2b6709437a8d84749c48cd3290ef5a9e3",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 57
-    },
-    {
-      "fingerprint": "c752658a5193cd7dd0b42ff2eb66984accfa98f9233d1a979c8e98f4f7723486",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 75
-    },
-    {
-      "fingerprint": "e84ec2128b658c1d681bdf1de1cc6a917a0827b6bc204ea10690da5ac83c3262",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "ff121f6fe52ec934fd37478e93cf6dbd7e4205e002787bfcf936ca0cc010d03c",
+      "fingerprint": "3a983db15edfeace37e99946d33cdf4e5d13d5174c8ff87906503165ca26988d",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 82
+      "file": "./src/app.rs",
+      "line": 506
     },
     {
-      "fingerprint": "48788b76fd676ce468c679cfd0f64ea684f8f1322807bf456d3870018199c2ac",
+      "fingerprint": "4413510ce9a29f103d3a322bb5d4236c995ddc465accb59e683d3703b0d3874c",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 96
+      "file": "./src/baseline.rs",
+      "line": 185
     },
     {
-      "fingerprint": "821b4f5047302df750b85a7db2374d1644b7961c07bd69742b097abed3b5aeb2",
+      "fingerprint": "a0fbaca8aaa31c3757d790d868bda125f68980ba4855aa736be219dc545af3d0",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 97
+      "file": "./src/baseline.rs",
+      "line": 194
     },
     {
-      "fingerprint": "89f6714f3059c044fbe2c0c15fb9bcb7f797a074d1b1f06d8282a888e2bc1946",
+      "fingerprint": "37f35720a97b3d6f968a4859db706b0ff3f9ce29d3bbab40745473bd86f6c0d4",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 104
+      "file": "./src/baseline.rs",
+      "line": 194
     },
     {
-      "fingerprint": "5871139745836a362b60da0b635664fb9df66082083ee1ae59ce90525e98ec84",
+      "fingerprint": "5d72f04be86542e999521bff866403a140c4b24ac73c494dfece0714b0b84a33",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 109
+      "file": "./src/baseline.rs",
+      "line": 219
     },
     {
-      "fingerprint": "a069e940efa9cdf6e104e9bc1a4f62e1477d2c4bd39100063dad6f60b6efcbcc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "c4a043714fa7a5c56936f0377b7ed350ddf688ef7745dfb8a44236ac8a6e6193",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 124
-    },
-    {
-      "fingerprint": "571c15a7965ec06a44686decd2976dc42bd5ee3beab3ab6042ac20d3d0616ecc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 125
-    },
-    {
-      "fingerprint": "6eb7c9edb097e1166edcb900c1f233afd800fca088fa2bc75e8fea64143967b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "f733704fae72a145e6429755fb98dcc06c19e8ff905ac7721a8fe20d8c7daee7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "e9cdf02e4677d28bb3f19f9d0b7d5043ca0b975b32b5eca76b2a24f729a211cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "c11fd7ffb7779edaa1fd7b44625881e5678578f1bf9b9eace5dbfb8bfb14ea38",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 155
-    },
-    {
-      "fingerprint": "94eb9bffb212c623b797c5e7d271e76db8686b430ae73cc044cbe7e202e24667",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
+      "fingerprint": "ba86c559eff463a1bfba7e82a8792af7f8bc70dca6c8f6fa692cc27bf771f002",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/bin/foxguard_mcp.rs",
       "line": 157
     },
     {
-      "fingerprint": "b48fc329a53706f9066403be9f6bbf6472410cddea0828d7b141b35f9b3842c9",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 184
-    },
-    {
-      "fingerprint": "e22d5cc92c9e21be669eaa55e51186b434076bcf2941e67eb5f3b0acc4dfbb2b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 184
-    },
-    {
-      "fingerprint": "d6610807a8b38e7ee93b2ea5da9858064fc38d1a4297e757ceb3d29068d4da93",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 187
-    },
-    {
-      "fingerprint": "bf3f8fb2240c9bb796914352f6a70b94f9b33511e863092ba30c458e3d18df0e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 190
-    },
-    {
-      "fingerprint": "6e0faedb2551e29009b5ff2c390741037a7d7217f5ec023c28f0765719447652",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "e03b35e93a415a3ab0db5e0ae76011f1e09ac451c5d1b016caf204cb77c34896",
+      "fingerprint": "cab611422684277c954b61edcbc4a2b1dd5235f7e805a018d5fa4f67f30113ca",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 318
+      "file": "./src/bin/foxguard_mcp.rs",
+      "line": 168
     },
     {
-      "fingerprint": "fbfde0ef4da8ea3ccfe1651b2fe0ca72b53e60a17aa393968c7c9ac56e26a8ed",
+      "fingerprint": "bd6fd6b5a85ac5a912093c47881706394700c797a7b6f118c947f9233ab66a69",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 457
+    },
+    {
+      "fingerprint": "22f6c124120e6598103c08206068f81118e803a44fdf21cf9a599e37f554b450",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 474
+    },
+    {
+      "fingerprint": "c6c80340dcb431a71eecbf3f026a0c1c58404e82978f4ec9dbd0f6d2bd9ea06e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 908
+    },
+    {
+      "fingerprint": "69132d933ed844d58da3cc9d581c67b331ce587463096f1cf395e8e1e9cb69c4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 945
+    },
+    {
+      "fingerprint": "400ea6a6d4d8b0a99d4fb1dc92b648436c23b472f76b5a0053f9895ea6ed770a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 946
+    },
+    {
+      "fingerprint": "48b4b81c4aecd319ea2bad382d32abff8af5cd0c64ba2dfb4a4d262c2214338a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/config.rs",
+      "line": 1009
+    },
+    {
+      "fingerprint": "8212fa642d116798a52f8e726bff0362c28220a6e9c6d3ab430cddb80dcdec23",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
+      "file": "./src/config.rs",
+      "line": 1047
+    },
+    {
+      "fingerprint": "b47537cf3266c89c02cf719ba5806786728e3bfce4392b79798a8d61e0997b60",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1049
+    },
+    {
+      "fingerprint": "0e305919346214352f2cb10be6edc9f4511620e1abd7286ff8aa31124d2f9331",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1055
+    },
+    {
+      "fingerprint": "5fb59360233a4d875ce81164ba6a77d93cee70f315cd3c8e59808e673c0fc178",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1073
+    },
+    {
+      "fingerprint": "97c6fc3ed2b049f56150d8c74640d1a09b446cd32ae0796d569528d8af6c11e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1074
+    },
+    {
+      "fingerprint": "aad257096dd0b8ba159641db1afd1a673b91a2153e1e7b59bb67ac012163195a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1076
+    },
+    {
+      "fingerprint": "83463432f569bf840b87603d39690756dc7054d5f9511ca861dac2625d1d1daa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1092
+    },
+    {
+      "fingerprint": "dd3f1741f1c67154725e61c8f1d3d25125fbe255595a6431add7c37fe4b28d7d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1093
+    },
+    {
+      "fingerprint": "be77ae9fc8a7628087e6d2c4eee9cf72c748c2fe927b036192ff2234d70c83a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1095
+    },
+    {
+      "fingerprint": "f426ef7d9c2dd1e91079cfad3dbdaa1744772935c7667366503f523eab39b862",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1096
+    },
+    {
+      "fingerprint": "685bd785f1603f7ca70f62f3e33d6ddcd9f6b4e44ed881027ae24929b432abfd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1112
+    },
+    {
+      "fingerprint": "1972a1c64c347c8d21aab0daacb272a69303f5950a5fd0360a1f9869dd34036f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1113
+    },
+    {
+      "fingerprint": "1eb85b91bd04aa8bc8b1cae0e1556fbbd693ab65d0db29d1d99e8dceb3b460ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1120
+    },
+    {
+      "fingerprint": "93c3ca9da83d8631261942066016ea97a6ffffa1395254b5e32c2835691ceef0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1120
+    },
+    {
+      "fingerprint": "5f52af10d5fe55f01dc9a76335cfcc4dcec79f1e669b45979038bfabcab14473",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1120
+    },
+    {
+      "fingerprint": "ea2a2c762137d433c74ea859989a3e6cf9bc16e679e91c6f2589607b68d5d031",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1133
+    },
+    {
+      "fingerprint": "135c4a02f2a8ad57730d783287f7ffae2b7d50dce2283d930823e997028073e6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1140
+    },
+    {
+      "fingerprint": "ab877079ef292d891e54465bc19e2d6af7d4ec16aba0b87e543f3c22494e88f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1140
+    },
+    {
+      "fingerprint": "63b3cb41c18cb59e827ba9bb771aa779e5a58ed004dbacfa42cbd51efd21aff8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1153
+    },
+    {
+      "fingerprint": "c770843b5a5c83f2dab5576df195f8414edad72f619b0b2cf4da5148ec28f6a0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1156
+    },
+    {
+      "fingerprint": "383f70d1d26963669efe54974003c0e36466e92edc07367541f02e1f4c2bb20a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1156
+    },
+    {
+      "fingerprint": "08bff8d2c0a43cd014adfa786eef74e5d0e112c52323cf6141a3ecd592c212b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1169
+    },
+    {
+      "fingerprint": "586e57dff77ae37b11872bedfbf4d08bb19697b8cf81b0fc1654766c730dfd78",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1176
+    },
+    {
+      "fingerprint": "f04a4cc8dba4d73ed5e7c7bdd728ba04beab26dfb47c1f5c59d4df9f0bbc5b67",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1176
+    },
+    {
+      "fingerprint": "dfa4cedb98e4c82dda747e258580a6c7f0f748fb32c94973caaa8b1241b91cb7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1185
+    },
+    {
+      "fingerprint": "8f2e0d91daf11ac2065c26f5fa4a4de109a5401ca92477ce4bb0c347194bab62",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1188
+    },
+    {
+      "fingerprint": "b2c286bc5c71248d3bb873ec1b320a9268a60c71d7c1d26676113ce415453dcd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1188
+    },
+    {
+      "fingerprint": "1e7918a378668dd230d209ea66bc6c14a01390c01f982f20af5c53414afb592f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1197
+    },
+    {
+      "fingerprint": "50c5a4c83f5671281f34e5dab18146005fbedd5c84989864fab60d5c2ca63e03",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1204
+    },
+    {
+      "fingerprint": "8620988f344a6c5348b3620473de14ade37eabab626e5b7fc6e3128ae94e70e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1204
+    },
+    {
+      "fingerprint": "17a69b3bd6ceae73cdfa68ee6ec1674b117cfb240bca2e579db62a79cdcc462c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1217
+    },
+    {
+      "fingerprint": "50da19348a7d049875df3f9328343ade97ae7ee32b63c3d0c780c442d29581c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1245
+    },
+    {
+      "fingerprint": "0b4eefd16713d9c03f9a08b76c38a852f8f924c8aa8d0635631624fe3c538891",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1249
+    },
+    {
+      "fingerprint": "b41019a7558ab2792c6ac50df0824833fa65890ed8dd6d5e1833093891073d6a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1249
+    },
+    {
+      "fingerprint": "fff034a4a4f2a18b35b6d88305c011a532b17f24e082f5ce9ed45c2565cc8227",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1259
+    },
+    {
+      "fingerprint": "dbbd2962524365d83ce3ccd140f0a9f4c66040c470652d222f39eee2283172fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1265
+    },
+    {
+      "fingerprint": "a12c3c66c0805a5d48e96b53d9af403bfa0ddd1552919839a3fd590a2f1c699c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1268
+    },
+    {
+      "fingerprint": "31d5b3c567af035fb54d374f862ea953a986e347ce6f7c0c03ee3a4e2b7cbfe3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1273
+    },
+    {
+      "fingerprint": "eb86725149359042b80120333b7cc3d8865e37e47685173dfd5c57c9178ffff2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1273
+    },
+    {
+      "fingerprint": "510d7506d27a32d2f834008b1c9945f9492e584d31451242bb16faafefd32aaf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1278
+    },
+    {
+      "fingerprint": "b5c364fa0d6b8d82d9e7d1dcb48ec34e23d94d1b07da88a06652e19d31dec2ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1313
+    },
+    {
+      "fingerprint": "722d79ac701d9b13e384eaf87a4b5dd5ce252c5c371a28d911eea3f7fd9a0d30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1319
+    },
+    {
+      "fingerprint": "a122f780d64f74e2fbf7a91cf83fda4dbd8d49876b39a64a9c99c73e2f4f84d3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1319
+    },
+    {
+      "fingerprint": "3acfd28c3d19c15dae43a0876b8c43754a0eb403524093a8d3152d27aa706b7a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1345
+    },
+    {
+      "fingerprint": "d7cd8bce57cfc8b58c05404462d291117d1ae20095fed51dd20d8ced906e34f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1351
+    },
+    {
+      "fingerprint": "eb7fb8135cc812767e5194ef1553364caec17cefe862c68813b2299464108cb6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1351
+    },
+    {
+      "fingerprint": "bcd4c615f53d27ffd3671c917b0248b2e77411039283193eaaf6e9a339ceb2f0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1374
+    },
+    {
+      "fingerprint": "948b487a2a72363ef4d57432ce3e3d1fffe80239f5728e1477a915636fc9b65a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1380
+    },
+    {
+      "fingerprint": "917d090c9899d7bed5108172c40ec396612eda7c012baf810ae436b63db725e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1380
+    },
+    {
+      "fingerprint": "070462fb9f0ee41565e732a8dc6a6043eda3b63668091945eb8e930bee67974d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1400
+    },
+    {
+      "fingerprint": "f113c5691652abc0eb4b2efc74a9574c3abd6ce75efe8617329621c8d751d4ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1406
+    },
+    {
+      "fingerprint": "f98d8a2ba51994793fe88a3b500823c16b7dacbe7c52bd37d48ea4d3c6821b8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1406
+    },
+    {
+      "fingerprint": "5b8952c322a6513f2cb581adb81c43c5ae74ca279bff2e4d7dc6834f40b78894",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1431
+    },
+    {
+      "fingerprint": "5a3d36816bb44822fede7a4ebb1ece52de8d76ed2af61b25b18c09aec77cdcd1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1446
+    },
+    {
+      "fingerprint": "b5e669582e4c33cc9d6863f085be98f6f5ce8e77f12b1251734204535fe600ca",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1448
+    },
+    {
+      "fingerprint": "c0fc267ac89b31c7d68eab7d10f72a37a2d1b1c976b1cf5de84db975e108c9a7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1448
+    },
+    {
+      "fingerprint": "3b661d2b78583413ec64aac91702a6b967b2b0ce87df178c4a1759d33781236a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1458
+    },
+    {
+      "fingerprint": "b2ecc94f5f99d86967f972d3df97c297dae89375d688379df37d85875c7d5182",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1460
+    },
+    {
+      "fingerprint": "ea82362d0aef58973e6ecdafcae3c6b66d45a43a9441b1da70696904acca9e84",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1460
+    },
+    {
+      "fingerprint": "2cb94d92f286cf0001fe93c3813d77e4030eeef46ca200f3f999d1f13c9ac265",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1470
+    },
+    {
+      "fingerprint": "3806a5f28d0974d9b373c88afc1e1d88c874bc7f7ce1732570605da46f87ca42",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1476
+    },
+    {
+      "fingerprint": "122397f148a26cf27cd8b6a9bc8bcbe5f67c499c9a826b32524899fc5af40d0b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1476
+    },
+    {
+      "fingerprint": "f06f7e2b1956419ab6aef09cf64be53238209295b2a3f015c6d80d20c9c7e652",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1484
+    },
+    {
+      "fingerprint": "416d1f2e262e1e5de95f0960b727e4e40e1b3f7b97c5063f3e17b6c61392e8a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1490
+    },
+    {
+      "fingerprint": "ef8a1e6b002e1113ceb4d5a76ddd8e1d40e7acff48dfc94357deb2192a3c6e59",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1490
+    },
+    {
+      "fingerprint": "dbb587ea19d5156d107ae2ec066467c8968fb5a0af9b03d6c89cbd24bc9f665f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1498
+    },
+    {
+      "fingerprint": "2d075aff545202f4560c36f2b55745f029fb95b6f532f6c245b7cd4c01eab407",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1504
+    },
+    {
+      "fingerprint": "4c8351d18d3684649603b8e5cd5464f8f8173352fc56dbb61235ffb21c7b449c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1504
+    },
+    {
+      "fingerprint": "07c172285e76d22a721a11f928e9111475e13abea46b192ae06fd639a8f83623",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1512
+    },
+    {
+      "fingerprint": "b54d2345971200754275bf894d204b909b8a67049eed0db9bd04b02453c3d3d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1524
+    },
+    {
+      "fingerprint": "fbee85e8e272db76475e804203728dd28479bafa09b224f59e7fe423a7113c01",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1536
+    },
+    {
+      "fingerprint": "167ca1682340405f4c026bf1e6baee50c9db8c87909bdd63ef9f56593c85051d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1550
+    },
+    {
+      "fingerprint": "43bc4afc81bfd95ff50fd7f41ab546742a09dbcf4597339f153d3d61c9f22252",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1572
+    },
+    {
+      "fingerprint": "51b9d19cda1256c81b3d00ab6114c1332a1ee6a942312cab34d1247eae443b9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1578
+    },
+    {
+      "fingerprint": "53404af0f9b3feb7223f466dc73fed13670f514a63436a71dc6eae0d225c8dbc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1578
+    },
+    {
+      "fingerprint": "11685bfc6e6c90f6f38d2dc07a70adc0a9e13e54665fab3506c6578cd60ef0c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1586
+    },
+    {
+      "fingerprint": "580e48cdca058a5897a93048bce5f536d23509d67eba887e8e9f3510907867b3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1592
+    },
+    {
+      "fingerprint": "8ec05ed020163b8861b6a8c35e0c75a68326343bf1db7f867bf1259c5936118b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1592
+    },
+    {
+      "fingerprint": "82e57f7fad1e6bebcf6b2699d91dedfef0a0fee345d74cb4fb235ea1a1e8ea81",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1603
+    },
+    {
+      "fingerprint": "abc116641607d9af37e47683e5fdd2ef8a5ad37774e172a1502af2a9393aacfe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1606
+    },
+    {
+      "fingerprint": "1b3a2c1375274d7c0fe948d06f0c8d2ff21964f5100c5e058320e5fd6d8e44a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1611
+    },
+    {
+      "fingerprint": "458d2af3f72811474055fd2a535355de0623392337596f9e0358d79161893ba5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1611
+    },
+    {
+      "fingerprint": "09b0593025048351639c834fcc28c607ba61c57c1c6fc3bf74cdbcd422dfb0df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1621
+    },
+    {
+      "fingerprint": "969267b3c2ef819d55e2d2ff197a891270755be71c700e8e1e2cc0d62e096b27",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1625
+    },
+    {
+      "fingerprint": "f067682d4d4aec95066523ca7bbcaea23789a1bdd69e330829f0a6f55beeb01e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1625
+    },
+    {
+      "fingerprint": "d114f0cba5a64d6d94ced82976ace9a8a8497cea151ae97a2a70851b8dda92f4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1636
+    },
+    {
+      "fingerprint": "2d1d4d0e23fddab626c465bfc43364f0fc3d5e237c2d87fcb69bf533f9942b7b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1637
+    },
+    {
+      "fingerprint": "ab702d93c0e7d3541941e70cbdbab46481b450bcef88f69e378aeba65cbef145",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1641
+    },
+    {
+      "fingerprint": "e069deec1bcb7af6790d01854bdb18934a92ccee2c3c14006879c197342282e2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1651
+    },
+    {
+      "fingerprint": "f136b67bacfdff972cb216861ff6d3e93c5b2faf55b779c52dfcd1d9fa026a0d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1672
+    },
+    {
+      "fingerprint": "1944153d0118b6a49e0aff7a30ad7050a56c646cee9ff14009af455086a310fc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1675
+    },
+    {
+      "fingerprint": "1cf533cc501a10d79dc09cd27cf0fe7fc21df5f3a708f3e7a40023e44fd4e416",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1679
+    },
+    {
+      "fingerprint": "c5e849768b8d7f163ad1234a1894db4be9125ec8851000433ff181737bd01608",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1679
+    },
+    {
+      "fingerprint": "5c430c65a1a87663c220be12a856e8bc3c57de901bc23d96053ed7a956f00c9c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1686
+    },
+    {
+      "fingerprint": "4e515ece185a9a6ddecdbccddb79643b9caaeaafc7c1066210491db13b8ae133",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1692
+    },
+    {
+      "fingerprint": "38bc857891b2aab8aeb43a07cd14c265b630596e52149f17624f9ba095db1129",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1709
+    },
+    {
+      "fingerprint": "a3ae08196966a61e218728f43f7a7f2f394a762bc3722dac672604a42d0ea6e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1718
+    },
+    {
+      "fingerprint": "995bc40e11bbbb02e4ae673b7f02024d4126f9bbcbb672a6ce3bb7640249cbeb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1724
+    },
+    {
+      "fingerprint": "b57969899ff07a430edd9e3ffc370743e84124e6b14886623b566268185d8800",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1724
+    },
+    {
+      "fingerprint": "0b61603a5345c9b4610ab57b0675433c0df5d6e40554a08570af06c0ea77a1a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1738
+    },
+    {
+      "fingerprint": "6e3cda0c18d93dcd402eafb994b54cd632226f1ea69d9a8a424b42e119314984",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1740
+    },
+    {
+      "fingerprint": "09a3eb2923a0a33ffb5f9984dcd9620f7473f0cb58aebf33a69505e00b876f9f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/config.rs",
+      "line": 1740
+    },
+    {
+      "fingerprint": "ca88ae016d2b058e624b5cb8e0d63acaca9ca2d87be8abf2c495edc994e0aa8b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/diff.rs",
+      "line": 39
+    },
+    {
+      "fingerprint": "050ac6494b7d123296791a64a34e3779b23c94fa05cb143c4e54097cc2c78f3b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/diff.rs",
+      "line": 186
+    },
+    {
+      "fingerprint": "d64b7f152860d61aa4709104fbcd3580f8f9c47cb11ace9afdcf96f5e0a8782f",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/scanner.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "b9fefbf2f85fdb848229b46c4feb67bf1de6eb9ae22c9abd1a168eecabea6347",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/engine/scanner.rs",
+      "line": 194
+    },
+    {
+      "fingerprint": "22f6980d0c5e39daf53e07e78e810fc30ff8d9de208abd8ad56a69db6552b20b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 332
+    },
+    {
+      "fingerprint": "bd90e88690e841180674abe8075a76800b9ec0e5f945c5228d2250085d1a5218",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 340
+    },
+    {
+      "fingerprint": "229fb04563cc22d25814055d81da6f21ad7e364802617fe7ccb0cddecb816e43",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 347
+    },
+    {
+      "fingerprint": "383225eb67c109f5775c7ec1186aab0a386e21de833af5d04a32dcb1aa5e22a0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 751
+    },
+    {
+      "fingerprint": "5d097fb5037819b2de7062df8b422912b3cc871b455f464d6fc5ce8215bc1b33",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 759
+    },
+    {
+      "fingerprint": "359eff47d8a808fb9f47f5e047660c34d8c1804683b3e2f779d9f6613a167598",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1066
+    },
+    {
+      "fingerprint": "88acc1f658c1d045d4e1087bd11c8ef38d45059e5eaaacaa58db75784643193e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1100
+    },
+    {
+      "fingerprint": "2ae6972ffa410d6b26f38a6b69b045166b96e61e535a02be9039eaeb7230d029",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1108
+    },
+    {
+      "fingerprint": "c0e54a9f4339a3adafbf576989b04a92cd745142174e755fa7cca0c518741428",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/engine/scanner.rs",
+      "line": 1117
+    },
+    {
+      "fingerprint": "219a0836f42e060e80aad57d641de8560a8d44f9de16fb691b33dd2fab54ab69",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/command_injection.rs",
+      "line": 311
+    },
+    {
+      "fingerprint": "e101af24af4a5b5c67a48c5cff6b4800668958c7d24128e163b6a86f69c7fe4d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/command_injection.rs",
+      "line": 312
+    },
+    {
+      "fingerprint": "51eda003da502fdce2cf159910ec6609bca9496584a58063ee3e2180a242a9a8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/command_injection.rs",
+      "line": 323
+    },
+    {
+      "fingerprint": "f39a46315cdabf73b5ebb3e8e3f26f98141e6cf4e4ca02300ebe41993664a43c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/command_injection.rs",
       "line": 324
     },
     {
-      "fingerprint": "e58e2c28b8c151cb6948f984c96677f7b1d94a4474688da6608e8edfb620ee67",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_inverse.rs",
-      "line": 392
-    },
-    {
-      "fingerprint": "62b1ee570260953c4ae1fd89e2bd64a0fc1852940483596afe24e25a139cf1ae",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "b5cad3a6bfd8877f07086c6b44ffb4954bd0d3b7401bda803631b7dba47ec47f",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "67e000921f72543b012b1a87d9ef4fc2280e4020e4f1a1ebc0817c340697b691",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "ffdd3368e276cbbe9243c53f2d8b0c0b26df69329e507f0e803d931dfa50d8ff",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "24156268caea76c0aa8f0451388d12d448e7a90c70bd9073fecc453c0b332999",
+      "fingerprint": "36b1406c8cf224e3d3e4ec5d82412d4d527c0a920ad1c574d149ae6a4acf8fb9",
       "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 49
+      "file": "./src/fix/mod.rs",
+      "line": 71
     },
     {
-      "fingerprint": "52cb58a76c2ee47139b93e0c576f0813d907fcd8b8a489c4181a7191ec3b292e",
+      "fingerprint": "cd6cabd79f991d0bbc8d204451a940345df6017df3c138d7ac978ac52b6c3ac6",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 63
+      "file": "./src/fix/sql_injection.rs",
+      "line": 445
     },
     {
-      "fingerprint": "56c9d25a20912902ecd564f1579951d41163173c65296f9bfd64f64ca54605d9",
+      "fingerprint": "0c7ad33728a18681c062ebb19c61aa8066e4cf297716de094d53f28497452a53",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 64
+      "file": "./src/fix/sql_injection.rs",
+      "line": 447
     },
     {
-      "fingerprint": "a470fe97ba06c47896fbc32f623c53ebad868a18e5a3a3344f4a44886602b2ed",
+      "fingerprint": "e6e0e7935d7bfacdf34201e553faab131db03615f6c0d9475a780055e52a1a55",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 72
+      "file": "./src/fix/sql_injection.rs",
+      "line": 458
     },
     {
-      "fingerprint": "9348a1c9646a391afffbb243c4ec9cc9d8f805f4d3c77e9427079ee0569ce5b4",
+      "fingerprint": "eb4bae085bb091f2a20c5de13a5208aa5b461d4017591f3e5d69c033d17bac47",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 77
+      "file": "./src/fix/sql_injection.rs",
+      "line": 459
     },
     {
-      "fingerprint": "97c625befe913d2896cdeeca770b8a1121e4af82998ac5c76cd6b110fc4ff662",
+      "fingerprint": "ce61af43963edd759895f5e470b024bf444bcb9dd642bf1379a821eadc3bf9b0",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 80
+      "file": "./src/fix/sql_injection.rs",
+      "line": 470
     },
     {
-      "fingerprint": "d5e9c0ad6ba0e57a63d532ca605ee8a80973c718b015cbdfd917959e5a494c5a",
+      "fingerprint": "4d112f335f02cea66624c6e4ef338e3456dd5989da25b5ad272dbb03937f9b35",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 91
+      "file": "./src/fix/sql_injection.rs",
+      "line": 471
     },
     {
-      "fingerprint": "d5cb7568c92502494c41033de7bd8a986a8c352df5ccc47809ab5c138ef31071",
+      "fingerprint": "aa8f8ed9382c4b11f6bb533fbf9c676133112d4ff430cddb59968566bfff8d23",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 92
+      "file": "./src/fix/sql_injection.rs",
+      "line": 482
     },
     {
-      "fingerprint": "809ac1811c00682212afae6efed3630cae91768be0070f5ace8ed74bc5038e61",
+      "fingerprint": "07c411ed0ad46e102b6ca093366a8858144c3fa27d98ba740974ca33de9798a4",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 100
+      "file": "./src/fix/sql_injection.rs",
+      "line": 483
     },
     {
-      "fingerprint": "09f3a7debcb8f2f7521be821253db053d0ec9a22c5e41baa1c876ef20861df21",
+      "fingerprint": "7fff0ac20b77f343a31f1664bd1ca1815aff3e3f3a6ec0cf0fa89506e0ab2e3c",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 105
+      "file": "./src/fix/sql_injection.rs",
+      "line": 494
     },
     {
-      "fingerprint": "735f4b1451afeb419c67b824e65063fbe6f696bdd8287bf7ec3bc8330ebf96a2",
+      "fingerprint": "9bd01ffdb9d477afa299abeb2d48f56fd41f387deac98147ad33747470df66d4",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 108
+      "file": "./src/fix/xss.rs",
+      "line": 121
     },
     {
-      "fingerprint": "aa21018360675d18dee10dfbfa27bf087e549586a8f185f05ef51704c544f8da",
+      "fingerprint": "2a3fe10dd384278e1c8cbfbcc2ef7008111798a3a5fd91a1d8cfcc29d4f5de94",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
+      "file": "./src/fix/xss.rs",
+      "line": 123
+    },
+    {
+      "fingerprint": "d9832c024c4eff83b387a3e2bf91470627be483963a5e30e80e691fd8ecad9b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/xss.rs",
+      "line": 131
+    },
+    {
+      "fingerprint": "22d6836689a5d38ce2cb21fd1482882bf512254050061e5a93a0feef4073a844",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/xss.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "d1fd440c7258eb63cd81268a69dc3894717097f8f96e9f667280ee6e9c0104ec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/fix/xss.rs",
+      "line": 140
+    },
+    {
+      "fingerprint": "5eb20cf6ebaa65d640c2d2b128ff0c6a636f0b1247d389b80361dcdbd07df559",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/git.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "1d11bebb4c5efb624d60c3af9b1a13041b5e1cd5f99366c79ed8c3e9902ead82",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/main.rs",
       "line": 119
     },
     {
-      "fingerprint": "d8864ab36563667d6b8d959b74967e742f58619bc25688d2e67e229726a2c4f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 124
+      "fingerprint": "ce5bf5f9756c5e245d267b733882d5959d376f27f43bac0a4ff1329324a2c65a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/main.rs",
+      "line": 211
     },
     {
-      "fingerprint": "5d3be4e45bc29bbce68e261274b448442b47bb3c302c42820dd2f65be263d1e1",
+      "fingerprint": "93943d211221ebd8b38ed41ab5c62697de86accce48be658088d69a0b8d595b3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 285
+    },
+    {
+      "fingerprint": "43555dca89dce52d60273b59c305098358834ce6a834a6902b7569f14ad47226",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 419
+    },
+    {
+      "fingerprint": "fb52b9622825521cd2899d3633ed0f011b3229bbcd37ab3d5ad0be4d8911cd94",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 444
+    },
+    {
+      "fingerprint": "35a091320c20ec2c7fb0665d631ef0566364cbbaf8949e14ce01759ea78ea6c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 452
+    },
+    {
+      "fingerprint": "39cd3985750e4795bd061afcc0fff7a852f483fe44f9cf9397a3e90fba41420b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 455
+    },
+    {
+      "fingerprint": "e6bac8e284a44c4f3ff82d8993d7e9a7a0a97f42eadab438857591c437364d8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 458
+    },
+    {
+      "fingerprint": "16c4d01242e2104532d9f5f516474347580c45796cca308153a956086a0bd6cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 470
+    },
+    {
+      "fingerprint": "2abdfc56c2851a706daf5731a40bcd14eb3140e53e2f1a900237fb039e9ada85",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 474
+    },
+    {
+      "fingerprint": "97cce2b7ea9eb107d4e4c11eded9c861444f439bcc88d223baa724f630d81255",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 489
+    },
+    {
+      "fingerprint": "f744ddf4ba6b37fd2054a3906b712d8ccfff4120387adad5d6f8fe6eb18e4912",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 499
+    },
+    {
+      "fingerprint": "ce3f1c6d56920024c8184fc6a2e02aab077b1a2048bb32163a28cdec6799c586",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 512
+    },
+    {
+      "fingerprint": "ab833235d5a1f6f7206f91772b08bf398a12503322494cf18f86f4d737afd611",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/cbom.rs",
+      "line": 519
+    },
+    {
+      "fingerprint": "5f4cf6f5e9a841f947c7bfc69baa7e35197bf7648e23e09ac1a725bfa971c75d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/report/github_pr.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "80049cb66ce024fb90232d6c43b17ac9d09de03031a8cf7446f345a62618a45c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/json.rs",
+      "line": 4
+    },
+    {
+      "fingerprint": "5f6d3c27f126c52bc227085d910aef9404833d8443b28715fed002a1600fe318",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/report/terminal.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "7791472b4e480d45b313149a6ab61cbdd07d19679518a91853b4c63de453dacc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/report/terminal.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "2983c8ba4418d36f980fe995e752223bffd6014961a78a2f67c1f18e96854a56",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/report/terminal.rs",
+      "line": 126
+    },
+    {
+      "fingerprint": "c9c4e5fdc9646709f55f5f8165fedf4adf5527c21726dc6137b0587886455117",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/common.rs",
+      "line": 387
+    },
+    {
+      "fingerprint": "f529b455a17ab78f1ed0fd85ef7ce52d5da9c07780b626f421004fb22e07788f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/common.rs",
+      "line": 388
+    },
+    {
+      "fingerprint": "c7c142467e1cfb8ea99f8962a87e158707fad7dda57d4a07c336a715ecd8979c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "8a8570a54c45ff882124aebe07e70cf87bb90c280098f8e52e45f3b48a4e840a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "8d5f218a36ec02822bed7ba0ff1b55a40f0bb9232349adedb65b19bf609423c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "7a62ed4eb5b1d718db009ca24564253bce02b3bf0dfd0d76af550d149125797d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 47
+    },
+    {
+      "fingerprint": "8fbd5e6bd58d24fa890d74e32d2b49649c84b7685e4ff8f3020f800b04f4e1ec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 54
+    },
+    {
+      "fingerprint": "559ada4f664692de3b02a04928e51499a48ed907b3283f654b90d89cd1b241b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "89b9b51ba08d99b0337f8968d2b6489cfb2e6a4826fba18a74448b14a4bd6777",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 69
+    },
+    {
+      "fingerprint": "90ba7b88a968419e4fc8052e43f796bb3118b9f382ff6989773fa4c5f35d622e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "6f927a18b7b1a16dfe0633ae71a788caf6e8ce1cf15a4e7ea2ea2a10256990f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "3af3ccfa03f975dfb43b66200be741feb918a6212c7fa9c87e76e4792cc818fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/config.rs",
+      "line": 94
+    },
+    {
+      "fingerprint": "d5c46536705413b5a5565ea61dbc82edb4531ed7e4af63328277125f80b45327",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/go_taint.rs",
+      "line": 1425
+    },
+    {
+      "fingerprint": "96126836713e4eada89a6d7a244ba5d34f8e1c935b28a3828c44dd5de0451cf5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/go_taint.rs",
+      "line": 1784
+    },
+    {
+      "fingerprint": "4ed6ca0c3965bdfe86d90a726769ba374cc8093a678dbd9eeb99223d2c76713c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2154
+    },
+    {
+      "fingerprint": "47e8b3ec39cc8b38e2666ef6db34b9f793a316270fbaa2e3cc1b04fb1d33b6c1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2311
+    },
+    {
+      "fingerprint": "fb548acd113f1f9f6a647afcfe62e2a96deebf0551f5ee7f269c7ea9a9156828",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2333
+    },
+    {
+      "fingerprint": "a5b5050a34fc1cf5a2a77e7479ebcddf50f955af8724e2bac405d6012de3e000",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2342
+    },
+    {
+      "fingerprint": "a40d04c7281c51f0aa7a0a324db36d6bffa471bd7863025790e972c1f2713293",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2351
+    },
+    {
+      "fingerprint": "e14ed58e3bedae73085b837aa23d21a2364690a404d86aee4e43aaa2afa944de",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2532
+    },
+    {
+      "fingerprint": "cf7b3610b3da042c927ee760248da24ef3b6b48a2653ccb52c5e0f3cd226b397",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2552
+    },
+    {
+      "fingerprint": "c2d907ec76ca2de7b432213f9d93cab8c717a334f609e01653269e3c5c0db878",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2568
+    },
+    {
+      "fingerprint": "652f725fb41859958a6f0d90413db589d2e21e4c96bdee7cbf76ad3c5e7ec928",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2586
+    },
+    {
+      "fingerprint": "a1941697fe494125b00f3c0e8029143968aff1dff2220193b14549f4a2737660",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2602
+    },
+    {
+      "fingerprint": "daf23977ff0acd20e37becca02b3ffca21ee63211b1d34d560f79c818da5d847",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2619
+    },
+    {
+      "fingerprint": "62fd7511cdc804fa3c2d6e3b0239eb99303cfcdfadae317706ab71073c5e690e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2639
+    },
+    {
+      "fingerprint": "525f56f9f940c7f4adfccddfb0a78026678471659035e497f0da2bd22cb88f9d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2655
+    },
+    {
+      "fingerprint": "5351eb3c16ef3b9988df806945bef726ae20eb95dd079074535b1f423d8d0392",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2674
+    },
+    {
+      "fingerprint": "ea0ef5c7173d35e8e72681f4aca54e90f8e6fc146efeff3b91b856d1e15b56c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2699
+    },
+    {
+      "fingerprint": "c9932d7cadae05fdafaa785fa9857b73b7d7d5b7ebb16725a3277901c00a1e81",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2718
+    },
+    {
+      "fingerprint": "8c86ef163beaa6f3c6914132680dcac32614d887233e6d105b2c8d29829aea02",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2727
+    },
+    {
+      "fingerprint": "5f36b61486bd23937759d491ad8f42e71b264475a2b0fc85e915de2706140ed5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2747
+    },
+    {
+      "fingerprint": "18de66c287bb19c288137c0453b3293e925a88afffaceecc65975d57762fb7e1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2767
+    },
+    {
+      "fingerprint": "36c13fc7c90bd219e465da161b3692e1a29fc1d2d0f600418d61519c4b96852e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2784
+    },
+    {
+      "fingerprint": "876fbc0a5f356d7f3cb92698cc402aeba1e9b45355e9551a09be63ff8925e5ab",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2805
+    },
+    {
+      "fingerprint": "bb2c6f9aea79794f40984b6cc95deac563bd314f6d2a4ac8d4f21c4eaac2a9a0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2829
+    },
+    {
+      "fingerprint": "8f9db2d88474d3962e0ac8bf2acf3d8fcc5b6879a698009c6ef477a687e8f1bf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2855
+    },
+    {
+      "fingerprint": "98189480328e04b84eba4a7e0e8f167634158f196793fd8b9e1e20566532f392",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/javascript_taint.rs",
+      "line": 2874
+    },
+    {
+      "fingerprint": "20d2fc779fa278699161dd057447746795f9d6f879e9c1d43c75eee18220b293",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/kotlin.rs",
+      "line": 1450
+    },
+    {
+      "fingerprint": "665b09682d4baf680c183482c0aa3ea07dc882ae2fd1c39de79e207dcbc8a215",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/manifest.rs",
+      "line": 519
+    },
+    {
+      "fingerprint": "27aed9ddb0f708fdf6a20e716ea85a9ddbad7cdc9e6f123250f1f490700ad782",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/manifest.rs",
+      "line": 563
+    },
+    {
+      "fingerprint": "18a02eca89255bec65c684f5d575550cfb9aa98657f248c6d2bd1e5e83c3da01",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/manifest.rs",
+      "line": 785
+    },
+    {
+      "fingerprint": "933de5e652a715e168a3199ed686c7d4d9bf527b17c287b22fd65ab177190afb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/mod.rs",
+      "line": 667
+    },
+    {
+      "fingerprint": "405110dfc92e9f67fce7cd3a08089c0d2c5062fb215733343030039f6d1cf740",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/mod.rs",
+      "line": 677
+    },
+    {
+      "fingerprint": "a2a5163b61f7d13fdef6a316b9daf89f1d222c6648f2e933a9ed52ac6afe0dd1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/mod.rs",
+      "line": 685
+    },
+    {
+      "fingerprint": "5f6662f4717da5fcb3674901505bc993aca6b350e7668fe4eff11e30d22ec7c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/python_aliases.rs",
+      "line": 316
+    },
+    {
+      "fingerprint": "e33971ccaf4eb42a77eddef9a30e18b9cb65e32d391501cc11dda6647d4143fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/python_taint.rs",
+      "line": 1626
+    },
+    {
+      "fingerprint": "d11b2916c674424589de2d7aaadab3c9d71f0b4edc58c31e1be24c25a68a7543",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/python_taint.rs",
+      "line": 1816
+    },
+    {
+      "fingerprint": "092f8c432395dc299543b9639d4fda80183dacd7ce369d9dcfa09921c24b99dc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/ruby.rs",
+      "line": 839
+    },
+    {
+      "fingerprint": "9874e20f2c2ad7389f8b72d2fe9adb9e415c3e2f368bb7e7ca463e9f3875f50b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/ruby.rs",
+      "line": 842
+    },
+    {
+      "fingerprint": "4b1551e6b90efef862119d3b8f16290ed6ce836a3f61e57b89d56e3ecd4c997c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 893
+    },
+    {
+      "fingerprint": "0b4407c68967f3c6e81ed81bdc48d3821ac67c9c36779cbc0c0c5a2e72796c3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1074
+    },
+    {
+      "fingerprint": "4ee54ceba3b3d030af08dbbd2acaa3a40dba364b1f46cb88014a90484b2c392f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1075
+    },
+    {
+      "fingerprint": "5ad40f27868b5c4878612bd488043f211c77bf38e25265101b5d2f5aa879d81d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1090
+    },
+    {
+      "fingerprint": "903a9bec70203ec7ef033f2289ad597aa0bfd6a8791e9cd17ddfcfc56ef733c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1109
+    },
+    {
+      "fingerprint": "adf0546439b77897d35bcfabfb7f1e77aca11e15e1c345d5d3a4e0b012ab145d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1124
+    },
+    {
+      "fingerprint": "8a6dd190b54355c65d3977dfcd70fdb6c9ac66623a1e9bc40c8c59629dc537ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1150
+    },
+    {
+      "fingerprint": "2027193b2b891df35ec0bbc138659bd2e40c2d53c8db50c6fce4f836f54968cf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1153
+    },
+    {
+      "fingerprint": "a7399c31bed5b5c40455563fc0cec0e3881569c6e6f8027b6e000a74b5f3a7ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1173
+    },
+    {
+      "fingerprint": "1b6d13c09eae616ea28b4cbc5d78c198064fe0ee9ad3faa8d70a3635147a655b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1176
+    },
+    {
+      "fingerprint": "dd786eda3089a29298ced62a322fd68ce2a088f4d6c8027fa9a4f89f6617eb72",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1193
+    },
+    {
+      "fingerprint": "82220d9a4536076a8ec1c9aba7f70236f4d188f75b12ab07e4e79624fd101e8d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1196
+    },
+    {
+      "fingerprint": "2dbce23fad803768da1ecb84ba796ddd6688c1b721b32e0c027a84bb8045bd82",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1213
+    },
+    {
+      "fingerprint": "06d39fc5ccf42f92c91199e44bd6ce53aae80dfa913758ad9d77098721c41a5f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1216
+    },
+    {
+      "fingerprint": "885e6784eb81d323e8e7cfb555d63ac89b932262964fa359c4039a793d82cb63",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1233
+    },
+    {
+      "fingerprint": "33d3339c8c85d1ca626d1278390a042ebf3f2120312182bf377517fb77052bb0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1236
+    },
+    {
+      "fingerprint": "914be65a35c1e22ea10299ea4c3fadeedd42f6bbbf3a4789ef150f337603ac2a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1255
+    },
+    {
+      "fingerprint": "ef1e9c7a525e6dfab9907d4a4285838ea94bfa04dd1bfbd729cbaee5f44525e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1258
+    },
+    {
+      "fingerprint": "aacc394eb5c8c1a2b98f1400eb36d7dd2d8485d71aa1af9b486c1d1496a30677",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1279
+    },
+    {
+      "fingerprint": "0fd3c8d21101c38a7c7d0f86fd8c90c3319356b689cb7cd8789a7b9e8c012bba",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1282
+    },
+    {
+      "fingerprint": "c827a033c2b77f48ee309db28f6d8b2f34b66b2d8b1cd5bb3a47ac0410dde5d4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1303
+    },
+    {
+      "fingerprint": "f745823b985b414a24386052dab15d46ea7e894ef0dd605142da6ac223aab341",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_compat.rs",
+      "line": 1306
+    },
+    {
+      "fingerprint": "02cbb3844fc6dc00821863cc03db6d58208ae028306c1387298c7dd7988e86df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 544
+    },
+    {
+      "fingerprint": "a8c9b201e6f67e15812b587c1136795a27e3c0d6df6cc74d16296a17efd37adb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 644
+    },
+    {
+      "fingerprint": "4dae15c54a5000a9aa96a4118a6c45c28fc1aebd5f3fada41e188ec0712ddc05",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 727
+    },
+    {
+      "fingerprint": "43c2edefae60a455292a3ab0c21707861683ba23f605e6b76c5c0c730ec58a15",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 739
+    },
+    {
+      "fingerprint": "6b8664702af7a85ad06c1ec4c6cc5719780668919a3824b94a92154dc9b7bbfb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 751
+    },
+    {
+      "fingerprint": "cd3195baae90e2ae3c1196ece4afa266c7d269fb690a48e15ebba2bcbd1bad2d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 760
+    },
+    {
+      "fingerprint": "6987a3c347e29b3f8e5906eeba82837805a1ed8c25c3335ac358852eaeee3e2b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 769
+    },
+    {
+      "fingerprint": "b4ceeaef38735d01c53ee6c492a9d61857faed3aa98e71c65cf65edfb0b17830",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 778
+    },
+    {
+      "fingerprint": "bf45e9556aa2f629ab41ca87f1e8241446e9507fb55bb9cd629400f42cbfc785",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 815
+    },
+    {
+      "fingerprint": "769dc396a81d756f397a1fde3b7c1a6cf1a54e7a3779c9457ce37a7d955de9c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 838
+    },
+    {
+      "fingerprint": "aa14ff6e5c737523ac91af344a58db2c1d5f5a67d9a87b44b8f002ed0d7eec4d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 853
+    },
+    {
+      "fingerprint": "52769fd75ec81f94df04c934b252796af268548258c8cf22aaea33466b8f28af",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 868
+    },
+    {
+      "fingerprint": "a8be1eaaf73c5e4a13e95d64b0898e6f1aa18f24a0a7c180d0822810881e3230",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 891
+    },
+    {
+      "fingerprint": "9430ebd7293fb4c7d37591af6789e29aa36532e5a3948e61b79f497ab3552bd1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 910
+    },
+    {
+      "fingerprint": "13474c02cea276dcfecc955f435488897bae0d4a3fbc40845906249631eeb3a1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 923
+    },
+    {
+      "fingerprint": "1e9274b42b5d3d085d9ee7ecb445d2692d564bc498277986fd91707d240e9338",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 1056
+    },
+    {
+      "fingerprint": "bb7a5e244aa0176ffa5896ac1cc5cf0a49b1035a99656c26e6fd504ca0ab4cb3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 1105
+    },
+    {
+      "fingerprint": "276ae2e21bd29e749efb48e94a511202fd771f092f848ec2012ea05581b8b4b0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/semgrep_taint.rs",
+      "line": 1122
+    },
+    {
+      "fingerprint": "5c962278a8a9d6e849a1e7401fb0fbc0e651f64d49b69c493bd83ed7499b288b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/taint_engine.rs",
+      "line": 439
+    },
+    {
+      "fingerprint": "8428c9fafa1167380a09380037c06fade3d47320885c363f56a7749d905b4f5e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/rules/taint_engine.rs",
+      "line": 464
+    },
+    {
+      "fingerprint": "00c010f9d5b52be7b7f62eb7aa83821675698e70068300b44cf3a35eb02c0183",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/secrets.rs",
+      "line": 189
+    },
+    {
+      "fingerprint": "a9c8fcec7e0f8d2ed00f97c62c3c262049fa6a0be84d890fe2c6573b8ffbc072",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/input.rs",
+      "line": 353
+    },
+    {
+      "fingerprint": "a4bf62c0839404811dfd72a830af96cfbc69c811efd8277c23f0ad6159b61b3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/input.rs",
+      "line": 356
+    },
+    {
+      "fingerprint": "c3c766a778d00195b9bcb8b211363f7a8380a1e98da9edea8ad4856802a7b545",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/input.rs",
+      "line": 360
+    },
+    {
+      "fingerprint": "cd8bd547cf6841c1dc4f18c01205132ecb681912c90e6903ee05f7ece412cb24",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 433
+    },
+    {
+      "fingerprint": "bdb849dcc83f2a2fdc3b28a9c286bbc11ec07a2dfa55ff0e73fbc3ff7cb0d8dc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 460
+    },
+    {
+      "fingerprint": "b2776b1da84156ab53abcd9a4e84ae5209a51a43c88e9f3a5ac9612436bf1e9f",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 656
+    },
+    {
+      "fingerprint": "cb99565883a3e9b6f43e9dad53786a7dcd4238be4c8073513b6092fbd13c83e7",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 677
+    },
+    {
+      "fingerprint": "98d0aea83d0b8d9b2bb64a724e26d0bce9b446c82b21253ec88c8c26cfcb67c8",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 706
+    },
+    {
+      "fingerprint": "a6014c3a16fe2301bc47d705b18a5b2a4d013dd0227d8a5087e3cb66d6d581b5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 742
+    },
+    {
+      "fingerprint": "1f8fe66ea5c95be0cca097d650ee1eeb23b3924ef52a5286276db6f8ab3d78ef",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/input.rs",
+      "line": 818
+    },
+    {
+      "fingerprint": "8057ec702926ff34e8d01850067c450254093fa31f85f82a2d9c24dc028e02d3",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "d020af31678b12cb6a247932790eada972c30a9bf32fcd80628d5198348c6fc5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "cb9a1a358c05f93a24c913d4dafa67d0a4d1916adfeeffd01e9329b2024646be",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "9e978c2a2fdf3c908681f1caed6682c1780e58d8be1335aeb460a387852186ba",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "593e03b6f9414af4c616a5da4a2b3d085320d934e925508eb73e6e09bb98580b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "07a7e6453c02d8573514dab6226f94db0365ed1c4bdce10cc64289f3d055dce3",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 338
+    },
+    {
+      "fingerprint": "173daac9df8e3061b2e58b46e437bc37c54ba90aef42a3d1f3bcc044e14b518e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/mod.rs",
+      "line": 350
+    },
+    {
+      "fingerprint": "45fadfde12770e4394da5204892402d970acc8f956726e4be855902e120254e7",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 391
+    },
+    {
+      "fingerprint": "9f1ae2ddea463248a92d929db0db4ab8e4944198f035048b03c4c62470d35df8",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 395
+    },
+    {
+      "fingerprint": "4378fe2f0bf56aafb4d785b825337bc12d47617c8942da210c9c5ab1e306940a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 401
+    },
+    {
+      "fingerprint": "772c86a89a184d7e9166e3f117609b603621cbe02043a3d9d39b766b7c6f22bf",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 406
+    },
+    {
+      "fingerprint": "6ad81bb180fec1ba099873a269b4ffe0998d0254fa3dd9887ae37fe042f3bd18",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 414
+    },
+    {
+      "fingerprint": "7461437daac9da136eeb75959421b5f52d6fef3368545458272d75230aaf27ee",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 416
+    },
+    {
+      "fingerprint": "bd9fed9153940e5b677166e1e9b1b77845fb576d5dcf06e3cf17fc284f2abae7",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 427
+    },
+    {
+      "fingerprint": "3697d5e2e739247bfad9ece792be03b9f37657529eea5918ec1f648d995ac7c4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 427
+    },
+    {
+      "fingerprint": "8cd0472914f53d6064a35db1da105de30b21aedf762602ead20218dbdd00d443",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/state.rs",
+      "line": 428
+    },
+    {
+      "fingerprint": "81005764c289184dc0ca768dad9db3fa4f7e95c5f8071b208dbad7b8043ae915",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 135
+    },
+    {
+      "fingerprint": "6d3dc65fa18ff4c45257fc70b00cbefe31c3bbc1bdee5cd812fa4e4a06aade1e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "74b581d9cc611d9ead123ac5574460408e540ff9aa19f3bbc7cea7a180ad43a6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 168
+    },
+    {
+      "fingerprint": "1ebb58865f82cced352e5c083b51d30235d69ba3be1c0d2212691f857db4b1ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 189
+    },
+    {
+      "fingerprint": "07decf885bb0e63ee6392486683ac6003376265cce91c679ebdcfdbe3a4cc5cd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 201
+    },
+    {
+      "fingerprint": "5928e5c11cbcb500cf5d07d7a45e2f22f110506d275925e35064c275c8d2a762",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 217
+    },
+    {
+      "fingerprint": "e6f8d3c8cb4753ca1b4dfee656e4b9f09df4bf9cde35510a111312d9527b2e3c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 243
+    },
+    {
+      "fingerprint": "f7b5861f37540f03ba0c796b0b9f020605f166473c4b612d90ff824f2d48a8b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 704
+    },
+    {
+      "fingerprint": "6575cf0a2d38a7b0c32b73643fd46423522409b512dece8a09c53529949143ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 744
+    },
+    {
+      "fingerprint": "07847fbedad3b5ab1bf298e87bc0573a4f9d7b1f5c5d22cefd8b7ebdc0e84b21",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 784
+    },
+    {
+      "fingerprint": "1c5537394ece1bbc023e8654d1ba6b4af648dad2dbe926ef9a02f345738b84f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 824
+    },
+    {
+      "fingerprint": "8a6be895e15d177bfdd411c478d76b7de7158c7600e314834167a5fe450bfb14",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 838
+    },
+    {
+      "fingerprint": "222782497219482ef5595b2057922d131e5c52352580c974117479bdf510cfa6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 840
+    },
+    {
+      "fingerprint": "f3c67c1d9b7f2e4033a39e517902f74c09d9ac22cd44ae8e90123745edcf36bc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 841
+    },
+    {
+      "fingerprint": "857411b32e7f8481ac66e2b424246db496442404971292f23ba4bbaa9c80033b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 866
+    },
+    {
+      "fingerprint": "016ab901ddaf3034f2e3eda1192731ca2362b229ed8238e94960cdbd40e64583",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 868
+    },
+    {
+      "fingerprint": "fb378ded04629057a1e764b7ad0facb7c5bffabab769c0751404180627d56026",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 869
+    },
+    {
+      "fingerprint": "bf1d28f12d722e449d83b27569845b61e0156e914a07cb519a49e312e8b78078",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 881
+    },
+    {
+      "fingerprint": "96a75bf5e963098324997124a62f2f32d3223bae7c6b65952a06bff0b15d9bd3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 898
+    },
+    {
+      "fingerprint": "76790f2881765d84f89eae3297c7705da3b82b128a8cac996b60104c8b242cd3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 916
+    },
+    {
+      "fingerprint": "81eac1c4565d01ed719d9460e5f23cb2f6979209a102f2f0f580a02cd527dcde",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 920
+    },
+    {
+      "fingerprint": "e84925e8d242d60820f8bf7309e665f4e72effab126e2895403c82740ffb9304",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 934
+    },
+    {
+      "fingerprint": "91d941844d1154c6648f4706acf9ffdba5d3d24b87638be647a02c78b9e1e491",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1365
+    },
+    {
+      "fingerprint": "851605796b854b9b5575113609df6d32cc2ed58596a450ce49c406820fd2da80",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1479
+    },
+    {
+      "fingerprint": "41a7227550e539888d880d9306e32da88d83469623b51dec882f1eb8179ae78f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1742
+    },
+    {
+      "fingerprint": "ff37a47d5572f8b155eda49e554c2ab9e77494440968e77cc3e9fda87006011b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1749
+    },
+    {
+      "fingerprint": "4feed9070c9e0610ee17b7ea16dc4a4a2b3dd49185df1923477de2b760fab14a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1801
+    },
+    {
+      "fingerprint": "47a917ae3a627c497883e08da3bcafaad4d054015ead5b9d37fe1976228e8355",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1813
+    },
+    {
+      "fingerprint": "7703e215ff4100bcc0c93eecc3276cf5e35adda3edefc47251f56ead53d1b769",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1865
+    },
+    {
+      "fingerprint": "596a02c3fb88bedeea0d6d91632e9f6b7691db330f187cdd32848918daefe6b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 1873
+    },
+    {
+      "fingerprint": "8016a3f2954870904ccce085c7f66b1716afe341999feb7c49d8be993a8e2dca",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2111
+    },
+    {
+      "fingerprint": "b9a5f8abf3f7ac4db14c0ac7d757d0e95506976a2ab7a0f417dde0133d936052",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2112
+    },
+    {
+      "fingerprint": "8b0915b23223245390646653b0dab7fe5c3c446b6864ac6679340becd4d150fc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2195
+    },
+    {
+      "fingerprint": "408412e3455a72486933aafc1a9f8f60d21d24050f275f7940fbf207878fc77c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2224
+    },
+    {
+      "fingerprint": "21508f5400199ad08a623c9ae5e49149d49ff167d473e252b87bb536e1a5c269",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2230
+    },
+    {
+      "fingerprint": "3493e45778c172aa930aa914f0ab993beacf9defbb589a71544b1d1ea8d48510",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./src/tui/tests.rs",
+      "line": 2246
+    },
+    {
+      "fingerprint": "aaa22e0722896b2c1f112bc92a64a0f9ab4c976d464cc30c144b2fdae1e29b55",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/widgets.rs",
+      "line": 1108
+    },
+    {
+      "fingerprint": "ecc083c6c881632de48bd5167dfbeca0389e061666ab8eab4e45949f16b7b62f",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/widgets.rs",
+      "line": 1108
+    },
+    {
+      "fingerprint": "10c4c5bacef78892ca4e4fbc198d439d6b0185a618dd32522a5b7ac41748d172",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/widgets.rs",
+      "line": 1123
+    },
+    {
+      "fingerprint": "ffefe06fc8b1b21468a8f4adb3d41415b62611f018dd8c9143f9b28d8b6fd541",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./src/tui/widgets.rs",
+      "line": 1123
+    },
+    {
+      "fingerprint": "446854433cfd47fcdb01e1b2806729e420401f89c4091709dcae23ac126c67eb",
       "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 142
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 17
     },
     {
-      "fingerprint": "bc01f2e8cb3cfe730243d3fa8588fe351abf674e72966be4280347caf83693e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 142
+      "fingerprint": "0bc2ef7c099371ed84298fe8280908f909593da81de80224cf0c9dd982e70ed6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 21
     },
     {
-      "fingerprint": "f3b8ce1b7c76c453cf9a2cfe60bdbac5640b1165213be5d3bc3a96af64ba4435",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 146
+      "fingerprint": "7182fa8ea9637574b7f15f1f3b8ee00001222b86d19ada86f74eed8d5c46daba",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 21
     },
     {
-      "fingerprint": "4f541787e1ab73d07b60dd5d358d99d553bafe2a07ba9f03df3d1fcc815ea416",
+      "fingerprint": "cb27ed7e543c44e9c0a4aa561346b24873d75592a2f890dfad9ca7a19f423f2a",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "b6771aa52172ae0858f17d19dbd41ffd426fdaf73aa505105c299928ac1c2430",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 99
+    },
+    {
+      "fingerprint": "ac9f239eb36a78b60a69b0b1d29e225c9b030cb0c9f9242d3a37f74ca94a5236",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 163
+    },
+    {
+      "fingerprint": "c90ed31c9121eb955ad787f5141a44a64adeccf9dc2b6a2877f4fc436b9522d7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 190
+    },
+    {
+      "fingerprint": "6160ac6b4b1ad90a594db5c2ffd6469d0d98cc723d5dd899ed7f7127595d2cac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 221
+    },
+    {
+      "fingerprint": "aab65138cae5c724cb5b38c2b31c7f96d32eba42042440dbcf65e988e7f293b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/cnsa2_compliance.rs",
+      "line": 239
+    },
+    {
+      "fingerprint": "4a209776a3e7761ab74111288af55ee22e648562b71cd1de503b72f66abeb137",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "31bdb4677402461813bc5151258065f4f2b5b4d236839a5eb4bb3642a81ab119",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "f23ea9eb3ce17e933042e1701c2e2d7eb3aceb348947490d8b95c5c685a5b384",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "14085aa68d17ead0005ad9f29b8cc4d7171022f4fe4a524e80e5f126ef26a2e4",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "5ade42bf57f329dd9eedff00ae05a230d886361b7b92cc2695da22213106fb6d",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "c7a74a1f579eec452755f5fe7ee21cfb78867089f9597bc0bf04bedbae408258",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "9012d4dd59031f6775d2f8d39de4683eaf21c7246f1d86181cf5c6a62062db88",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "ce0460cb2be4f1757065bbea251f8713a7f1d80a7b916b07bc9b9296fec758c1",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "6703ad8bbc6f1706965cd59ee76d3eda6990a3fca7f02a23d312a1cac4ea757e",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/cli_tool.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "4ffbf43f954fd0b2a4aae715a35c838645b0466c8276f58a817d3c29367c0168",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/realistic/django_chain/queries.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "8a694f47d13c005e27ca1389f411ec495466eec0f55451f06cfc820a8889607a",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/django_chain/views.py",
+      "line": 22
+    },
+    {
+      "fingerprint": "4661d4bf045626c13f97e28751d4097d6afd9cc2c881de265e8715139d29104f",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/realistic/django_shop/queries.py",
+      "line": 20
+    },
+    {
+      "fingerprint": "8e1c6c15d5fe088a702bf0f33ddd9d209d0294eeec879733fb009f4a8a6586ac",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/realistic/django_shop/queries.py",
+      "line": 27
+    },
+    {
+      "fingerprint": "a00e8e971717aaf1d525f60ead8e85689f5be1f4a7c3d65cebabc02b3e7c3749",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "d0583a017292c4ca49be171e50d8cc0caeecc63b6b540d57a7a3becf5ee1b3a4",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "6b2be3216a76c2b8e32374fb45979dbd66b9da5c0d9e33a9ab568d7e8caaf364",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "f7cb0739f6df6d8ed47ca61c6f1bfffe1264e978d84c6d24155413bd4e3ca851",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "6847dd99d3b048dffb156bb8d388d615be7c3ff5cf48fe1ed1ea6df803809dd3",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "b792ac40617bd592df636cc40ae1b722c34e4dd2d16da353c2bbbd200ef99389",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/realistic/django_shop/views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "e8c71844162df36ace093aca3bd1c779a056eae4c1c3250febc6d04a96aa8a5a",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "f327d0583d87e628d5eb14871c68ff41efcf42c11f45a9e1df124773f86ac183",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "7633558ddd927396ab56cb307ff502a3ef5506e4874a5c3e6c49fec544fb6779",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "47fd0251f66834ddef6be467375b9e040f52cfe853f28144829c157b88dacc5c",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "18eabf5f16f80eb8617b75c3f900b9391c54d05f8f7cf2a39aab0126aba23e2f",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "19df579e1f9c30b810008132aa95d986f26a6061512c49e285011642c1b0f9f2",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "9ba8d442f67676f5e070389da4cedddba329fbe15d5fcebc4166b1a34fb1e86f",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "53efc244f8e8d2c117c91d0b26dd5695bd22f53c997a68fd7980f8909315b2bf",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "27a11374ecb1751bf92cc18df667d563c688c1b4b8f6b7e01f6e7949bba2df92",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/realistic/django_views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "e4f5091ab56d0e18f16579d706bd1135b1fd2262512d716ce65a93d63198c246",
+      "rule_id": "js/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "588dc3e0f8a294f585a1f6945f6c17bed75db7592930bcf42095dc604fb47a94",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "ef7bc31cddb427fe670a7368d0eb24487dade939ab1f960bc1120022d348baba",
+      "rule_id": "js/taint-command-injection",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "3b9c82ed9775020ad78e855752aa9f97bc3973bdd3487fef7ae0f8615756b29d",
+      "rule_id": "js/no-command-injection",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "039d787c9cb2fefa4cf0a28fd270fdbc9199bd689fb0c04568b3cfb17f303e4d",
+      "rule_id": "js/taint-eval",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 40
+    },
+    {
+      "fingerprint": "f948a7a6ef251b66e30361496079f721e3ab7861821ecf07e80a26a6e093a4aa",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 40
+    },
+    {
+      "fingerprint": "09753d7ee415a1a792c143bf89ae399467ca71dca009b8ef85bfa627aca0b348",
+      "rule_id": "js/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 48
+    },
+    {
+      "fingerprint": "16f3433c445ed075f6428d629453001f690bf5c2c31af94b62163f05c340d7a1",
+      "rule_id": "js/taint-eval",
+      "file": "./tests/fixtures/realistic/express_api/routes.js",
+      "line": 55
+    },
+    {
+      "fingerprint": "47f00251e6ba64e934b2b681a8fdfd760a19d4721c1f1773a21f6f3ef7f22044",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/realistic/express_api/services.js",
+      "line": 17
+    },
+    {
+      "fingerprint": "be67a84e63b6d1bc02e7b8b906c79b96800458e84b91356efa32828b4658f045",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/realistic/express_api/services.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "d83473fa7da89efd57cdcaecd66edfe93e441a96c4463193f40500642a05e701",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 25
+    },
+    {
+      "fingerprint": "c705d75d8e2a4f2a75d970c02624d5ec8f9b287f7e1fcadaa2bd794a6a51d499",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 25
+    },
+    {
+      "fingerprint": "7bbe81a7e07a8af28f88f6d37b6e9aca5a554e4f01d7eb448eed3572ce071284",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "c3080f79ae305bfa3544bdb3343637b96309bb7eae45cf130f1c3d35c47c4d57",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "b0d25e779a500b106b175d193836042a035425b35dccfb4a9d953f731b3d47aa",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "fa2c3eb86e0aacddf06a4d2c101bfbacb1c36bf3363e3e6de60044c619f3f7db",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "defd76ee5d5ef8bc1f7bcc746a2f0d7a26131dd79c0a46c24efa57a823aff393",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 46
+    },
+    {
+      "fingerprint": "0eacd7a26d278a7d8f2cbfbde7b1f63929f6d466a6eac926519df0efb5b33ec1",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 46
+    },
+    {
+      "fingerprint": "f8c556bd871b6186fd968ecffd4254c56136c82648e3b96fb5ad28974029f290",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 54
+    },
+    {
+      "fingerprint": "599c1b57a85c7a4ae42ce5b28bfd6c1abba951a32813d5a4918a668cac523e88",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 54
+    },
+    {
+      "fingerprint": "27d3c2551aba9cfde2c8a840cb32be6f8f3e33ce626b394be40fa89b54f1dba6",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "9f8a6c83dc0d49bdef4cfb8ce7784540f2ebc5a1e0a7fb222fc8d31805facae2",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/express_app.js",
+      "line": 76
+    },
+    {
+      "fingerprint": "d4d2a2d7885a7f2ac8004d2c90f7c5f95dbbe0da0d030339757af7a1cf4a1c6c",
+      "rule_id": "js/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/express_chain/routes.js",
+      "line": 22
+    },
+    {
+      "fingerprint": "e84e3959cdc52d641414e441f416ceed22cb389e98e54594391ce73aeca202e6",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/realistic/express_chain/services.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "23ee99a1f2448dc04396953e19c63aa6ded7731d4d202414af17218cec6eddfb",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "0a43a76c832913f944f3fa209fea8bf5fa6efa68cfaba762a7ce9f41a01a21a5",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "6a03d1ef336ab813b007bdd2ff7b83f0f3a4e86db11a313136228b4ad548771a",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "f75deae007e799c54fd8479d2fc98a5508882785abdfaf92e37e1634c6e4733c",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "cc409213aa71a710963fb5104cd37d4fc84a4bf2a6f7da1c72fa47a67018e686",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "050d6e98b6fc32b13a969ea1ebb81d327560efc86769e42e8ed971c4d59230dc",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "4a207fef927768cbb5400b3a5d317df87c1bdfc50b8f7c572c920d921d722008",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "9aae5f9ba0e5d0077b7488141a0a177203214e11d0c768a49ab00632b20475f2",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/fastapi_app.py",
+      "line": 62
+    },
+    {
+      "fingerprint": "1a0f458916e8f9c812f8d3d165b26bf600c611de81340480b5cf21767b34dee9",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "23680e3011016423c49c6d40e6d176034ea553d88fc6e38a09118a08bdebc8b0",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "017cbe25db41c2649874219bc2f7783a504ed44aa38f25ab412adc1958f0cdcc",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "e451e0e11264bc73b80ae126ab147315730f15d4a734942a5aac7a801bbbeab3",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "384f6695e37447497755d0010b8a2f432b4018bdf0df99904ecb2bf0419bf621",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "b7e2fef1ed16266885d777ee4805b6edb532eae0b5769442fa989ff4d1431546",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "77a1e80661f793f22807ea15a3ba964c7df535e9283be4a5ad07af410e6f2432",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 64
+    },
+    {
+      "fingerprint": "acf0bf2c3da182d663a36fe66596c5d1fe2f74816a75a12c5fb431cb33343ca2",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 64
+    },
+    {
+      "fingerprint": "cee6cbc5e4582edd4b5db905457399a520240747779de4f09b4ca3b84c98f5bd",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 72
+    },
+    {
+      "fingerprint": "18efbcf175125eb790fa135c4beb985b86d9df893508488cfd2b715e2b42c27b",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 72
+    },
+    {
+      "fingerprint": "4d6dc632d7493e96b462508f2aa7faea260173b4f1c6c849959f1f1fce9beac2",
+      "rule_id": "py/taint-yaml-load",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "f7e8df6b066dea9bfc6067a3e20ec54f5596e3bc1609429a237c735f4027d485",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "00d4c3a8011079a5a04f421ef94a58221e6c6835a96ccc6bda95f5be4b0e21fe",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "fd9280915fb47ba185ac341300c6dd70ae3635aaf850d237a931fe5ba7f9dfad",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/realistic/flask_app.py",
+      "line": 104
+    },
+    {
+      "fingerprint": "dacf867fa312db2752389648640b4933c933987261c1d2671e6c33d05996ff11",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 36
+    },
+    {
+      "fingerprint": "09ad38c41d9f61fe547b8956cd21d7c7bf87cbae2c87b715034971c34e33a362",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 36
+    },
+    {
+      "fingerprint": "2d2acf277fbfa0fd7402b2f3d0579f1bb2668202725a8beef76415b0721b8c4d",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 47
+    },
+    {
+      "fingerprint": "64df56ab2870f55a83d162b8e9e0180201084aca81f5cb3face7861d445cee21",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 48
+    },
+    {
+      "fingerprint": "5d08bf519e176c40c59dcd5984c1cae6387f678559df2879d33febce99b87324",
+      "rule_id": "go/taint-ssrf",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "a41d6f63e5d45e1251d61e13edad028de30fed78948faed9753b82b4868ea331",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "8df91c9450c8be1f53fbed80f32a20117c575aa5e4c50ce9c90e54ccdb2f8e06",
+      "rule_id": "go/gin-no-trusted-proxies",
+      "file": "./tests/fixtures/realistic/gin_app.go",
+      "line": 73
+    },
+    {
+      "fingerprint": "1726a51960ec6dad8d52158e7127f0d1f4137462e4d6f6bca3e3a09f2897064d",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_chain/handlers.go",
+      "line": 24
+    },
+    {
+      "fingerprint": "3c76b6c4d09679b8a950aac73cd82671e7f0329890fce3a674b8a28a6435f7a7",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_chain/store.go",
+      "line": 14
+    },
+    {
+      "fingerprint": "ff36f0933645ea0eefb48ac9a6b6f0664d62578ccbee816aebcff93a73183ab8",
+      "rule_id": "go/taint-ssrf",
+      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 25
+    },
+    {
+      "fingerprint": "a40eeafa7812947b90f6b8dd5f44536abd432bce461e3ea3c49da0d61edc176a",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 25
+    },
+    {
+      "fingerprint": "2da7d54c6edf8eb95b95bfe3ea5ff72206287a02a1acfdd89c74385af088c05d",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 32
+    },
+    {
+      "fingerprint": "774d8db2fddbe4f6278dc3e0f954b9b2588ed377f01090d6d5c2df9fef2d545c",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "5a45e9a152902f93129eb07ce359dbf4dc42e1d741acf32e2ff5f79d6c6677f1",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "fd2bfa211f6eb3c6d3a34dc789b28687d12f6c89c4cd2e5b7ff675b9451255b7",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/realistic/gin_service/store.go",
+      "line": 15
+    },
+    {
+      "fingerprint": "a9f236844173d62d9293edd468c0ce33ce9e16decdf35f5e0cc103bebbf18dd9",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "5ed916018e216d4a2bc3fa8350e19c7c1a197c850eea5c9cc3e9cd97384c5765",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "f167ce08a2246ae7611bd94420506a0d079505a87a9af4c8ecb71c3d5c27668a",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 28
+    },
+    {
+      "fingerprint": "a619179153d5b260190c38acb8cc6430ca346e0ba01eb812f3753397531378d2",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 28
+    },
+    {
+      "fingerprint": "dcaf1f93cd1ebc250de3202c4e08cc6da49cb99bca968c785544deb0731b5673",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 37
+    },
+    {
+      "fingerprint": "feb313d86349964d68e35af502ad907869d917079e1ae1c709112ba178cc3d73",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 37
+    },
+    {
+      "fingerprint": "583e749df8722be17f1f6a272c175912d835f95c6732f8c86f54ac23c7fd8efb",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/hono_app.ts",
+      "line": 52
+    },
+    {
+      "fingerprint": "adb9e3fc2906e323443010e9c832f8d3794da3c6f001d06e6760be5322a0a142",
+      "rule_id": "js/no-command-injection",
+      "file": "./tests/fixtures/realistic/next_app/actions.ts",
+      "line": 15
+    },
+    {
+      "fingerprint": "b65e005f6c317f93e68d4338c2aea339d3c09841ba1c1aef2f7d50d93256f0e6",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/realistic/next_app/actions.ts",
+      "line": 15
+    },
+    {
+      "fingerprint": "b2d25ebee53a780a16d3ec1f55a94bb5be5fe5a82fa2c90922b1fad760c22442",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/realistic/next_app/actions.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "2f6f5d6d3021b464af8a9f7ca8b51dadc45d13555766de14a68bedc83f22c276",
+      "rule_id": "js/taint-sql-injection",
+      "file": "./tests/fixtures/realistic/next_app/route.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "e87be12708ae190783723422c63eb5f917e7ce66c3a2c67c2c391229b989ee2d",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/realistic/next_app/route.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "4a554e082efef15f9ac0d8926d970b82c670514ccd7bfe9c3f906ee2ae272de0",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 20
+    },
+    {
+      "fingerprint": "5369c7ecee4a23d3489c1e7c73a033fa2270bac17ed04a0d56a404fb5b79198a",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 20
+    },
+    {
+      "fingerprint": "ae9154e050bf5a86bca844bb9e08621a66e5eeea8607d4bf2c70ac024606e58a",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 27
+    },
+    {
+      "fingerprint": "c3d7692a5a64d857053a0ab412fe9ba97ecbb81611db102790f5cb344c4605d2",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 27
+    },
+    {
+      "fingerprint": "fb2b8c51e8702fc0ca4e18e6c35fbafe2067dde595c9eac851a3ebac8e966337",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 36
+    },
+    {
+      "fingerprint": "832e8892447811bba26aeb521f3598d66ebd59d8986c2645488b54e0ee4ccc69",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 36
+    },
+    {
+      "fingerprint": "2b6bc821cf86a484aab7c34fc2f46baba7707eba180bfcba25dd35b57699fcf2",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 51
+    },
+    {
+      "fingerprint": "f9bc9f1469886f3d6a93eaedd6337c3fa65a13f381bbc9b262ba058bf2cc4cdf",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/safe_cli_taint.py",
+      "line": 16
+    },
+    {
+      "fingerprint": "d74f67f5c832a417a7fcb23d40d436dcab81777af3912c54642fc2a1a87ccc42",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/safe_cli_taint.py",
+      "line": 20
+    },
+    {
+      "fingerprint": "529d1a6c519f6aaa982a6cd1057dd8032ae8d4ee60ac1a6b495d164f310c7a0c",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.java",
+      "line": 13
+    },
+    {
+      "fingerprint": "385e9addc1d4a58f820adda167318615a8bd7f2139de54988a5cf3b27988be00",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.java",
+      "line": 14
+    },
+    {
+      "fingerprint": "9c961071dd4355998b31eb5d4fe8135f09517960c5bff0b05f93c2a8731b9e42",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.java",
+      "line": 15
+    },
+    {
+      "fingerprint": "45204477c7ebeab58d4b68ef3e8b1005a08ca01c4485b3396c02aa68cdec3a0b",
+      "rule_id": "js/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "fb02a45953b261362e3e79a22556c9f654916238fb254d98fc727100cf475669",
+      "rule_id": "js/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.js",
+      "line": 13
+    },
+    {
+      "fingerprint": "b1ea34362456ca36fe295c9ab3cecf15f396519a4f307154c6995f20d3118c0e",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.py",
+      "line": 12
+    },
+    {
+      "fingerprint": "b9d5760902ee26078deb4792bbb8e6c3a561b95f183db3a3ef9e3e50643e5f83",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/safe_crypto_agility.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "c73fbf9549f563249f17f43a183bfbaba00941e12e27b9cc83703f611bb85c89",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_deno_taint.ts",
+      "line": 14
+    },
+    {
+      "fingerprint": "4fd6e1cfc22901a8f6bb44cd323eccb77c1d9fabae56494995ae8b36880ed7d8",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_deno_taint.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "dc2c8fc92b7de3cef70c6e165890395e32938fb159ad520637db5044c820f70c",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_django_taint.py",
+      "line": 12
+    },
+    {
+      "fingerprint": "a82efe88b066593cbbd3712f68fb6a723a622a07a3ef23e6747c98400b5f296d",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "b4be2e927d97d165a79ab27bff3ee66bcf48760f7224f2f26f1be5f7cbf1aad8",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/safe_django_taint.py",
+      "line": 26
+    },
+    {
+      "fingerprint": "dbb58fc0c323108764e974fe906107186963fe4ff946a818c5d04e8d4feb1b64",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/safe_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "c8840a320f7d662a709a024073d2e0fd662704196d165d226a8174b6b2ba0235",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_fastapi_taint.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "d47c125bddd1c367680849f04a9d61014fcab6975ad8ce8eb80cf42c7569ef92",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/safe_fastapi_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "e60bf521457ba6c8baff0008418c678e6ce06a2f51f8bfc48694b5b5997114e2",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/safe_go_taint.go",
+      "line": 27
+    },
+    {
+      "fingerprint": "635accf5fd57851535bc4746e9329462feab2b4bef9ac2c1040301d128500cf4",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/safe_go_taint.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "0704cbd72bf8bb0ee2dce048771537b5f302dbb6f91e5e839c6fa44d234f8cee",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/safe_go_taint.go",
+      "line": 73
+    },
+    {
+      "fingerprint": "285bc3dfa2bcf8a5a409c4effab0a573184afe11e5595a6822a0d49168f00273",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_hono_taint.ts",
+      "line": 8
+    },
+    {
+      "fingerprint": "9caec65fcadc40179b12f85245189ade3dc902147729d9b7ed03a303d5a867aa",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_hono_taint.ts",
+      "line": 17
+    },
+    {
+      "fingerprint": "8cabd934600adf8b7503e8b12e79ed187f645890abae52ddc1c9bd7969408415",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_hono_taint.ts",
+      "line": 25
+    },
+    {
+      "fingerprint": "34c4c00b5da59a0ba44f656e25b1ce10d13485d816a0971956c5d98397c0dce9",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "8f08d46c2c5afe617539b393e9ec4fd568c548c0be13336bd581b327b4c2fc55",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 22
+    },
+    {
+      "fingerprint": "7dcf207e3ae807957ca772935eff274fdff5e260677d5244213eb83fe2739244",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "249ebdc4f17462e1b473406bc32463e3953e61d82513216b87c52694c63c0841",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 42
+    },
+    {
+      "fingerprint": "3ab3632a25141ef152ca952bd01247e7552f7f3c945b9f230a55a0908780c15c",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 47
+    },
+    {
+      "fingerprint": "3c30f5f5cd9a7321c940db36c42a83d36e551202825f5ef4db3218af89b1d882",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 78
+    },
+    {
+      "fingerprint": "21808d395b4956d935dea9a8081bd5e79b0700c53f49c76d218344696c7f41fd",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 84
+    },
+    {
+      "fingerprint": "248083cf3f60c5b9370627ecafeeca24ec2f90430ecede9691eb2d68b19c9651",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 90
+    },
+    {
+      "fingerprint": "0bf189708ebe94ba0a9d0db9174bcf47ac0f929e8fd71dc4c8f422fcebae317e",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 96
+    },
+    {
+      "fingerprint": "33a72a0d43a7c3dbe3ba5bbc2701a84a270a4c1b02732d9b25c509f784e6c18f",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 103
+    },
+    {
+      "fingerprint": "8a7c1acf0afa577ec49aee0c00c4eb65fa291af7e1b121efd79bd98b7054bf57",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 109
+    },
+    {
+      "fingerprint": "92dcbcdb46a62d4b25ec9cae6488d4748d66f701f9429af6e0f59a9ebabfcbe2",
+      "rule_id": "js/no-command-injection",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 116
+    },
+    {
+      "fingerprint": "3fccb520c99dfce189662d19399be28c505300e8ab45a8e943bbd94bd2a226bb",
+      "rule_id": "js/no-command-injection",
+      "file": "./tests/fixtures/safe_js_taint.js",
+      "line": 122
+    },
+    {
+      "fingerprint": "4754eb64e2165343eae1e3a5342d1e76db29ffdf43d3d74ae8221e911d27ee10",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/safe_nextjs_taint.ts",
+      "line": 15
+    },
+    {
+      "fingerprint": "da95c527d87c27ead43e39c8cc6866f79eb59297a1f717aa93c18f8653e09158",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/safe_nextjs_taint.ts",
+      "line": 22
+    },
+    {
+      "fingerprint": "e8bc0974f085a2cf5acba664f93537bb12f670b52502755f5d16b901f0a6c7b8",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 16
+    },
+    {
+      "fingerprint": "df3ebd7fb092a0f5943aba323b985653c7a1bdfdcc2c19d5421c262bae5d27a8",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 23
+    },
+    {
+      "fingerprint": "d5a99b84a16cbfe634757ee24ced10e5d87d3e5af66c0cecc062811d826f310d",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "80318e93530a6897c6dd3f4d512145f693c63cbc9c842cdd5ec4e5e5329c810e",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 42
+    },
+    {
+      "fingerprint": "12e2d42419b53b8557091ecc1283718b21589146a89774c90ec92b82b1613d21",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "c41319ed9d619d958348b9781a53d8d29404672b9a5645e74e406e7e6d61b195",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "02013b57336871c1b5b67016a37e607ada3ee0e4576ed23e555a1b83c885c280",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "f932302764aa8e908b5275549a16abdb2dd9e285fd5e1611ce7e6d26cd386346",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 91
+    },
+    {
+      "fingerprint": "e6eb3d2a3df630ed16e05daadb0016b3cad0ef77b907f1dc527778cb9c26fc8b",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 104
+    },
+    {
+      "fingerprint": "46b05498f11ed5ca854befe357d102d3de48ce8507e1fd5abfae928d0a314fa9",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "bf02a1692c34ce5ef96048d7e1b1d878d9c66133370b90e6a2baaacac8becf53",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 165
+    },
+    {
+      "fingerprint": "3a8162f13e784c38f67d60f465a4c50e13ce3b40753ad820cd686d3a3d77833f",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "f829bc26fa60f7fedbe1cce28a25b410deea4477c39d840726aa0e82834af7ba",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 177
+    },
+    {
+      "fingerprint": "cff869332002907d588200f7ac550bc43d29223b6e97492be16a3e9a5a69b12b",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/safe_py_taint.py",
+      "line": 184
+    },
+    {
+      "fingerprint": "98d63f88f9d20aab2d576d6d32382e4d9b0783f7ee5358b414354c2d809e381c",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/semgrep_taint/safe_js_eval.js",
+      "line": 5
+    },
+    {
+      "fingerprint": "7b3b61073c8358ea8d3e06be268a1fbce830b01faf7810da0214d6e4a29f73a2",
+      "rule_id": "js/taint-log-injection",
+      "file": "./tests/fixtures/semgrep_taint/safe_js_eval.js",
+      "line": 9
+    },
+    {
+      "fingerprint": "3a8ef8ac6b3e355e933746fc06b4b528b51cb4877f7f8ec151487df7f4164252",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 13
+    },
+    {
+      "fingerprint": "6b678c72cf14d46f2e5c72e22f61fdfc6565aed65c61a42d932c846d1a9513eb",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 13
+    },
+    {
+      "fingerprint": "da3898f95c1d359391efb00371f45ccfbe11cdc2926253cd0cc143b5aca1eef8",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 19
+    },
+    {
+      "fingerprint": "e1d410772b0461744d45559e9da10ec9e32eb71d429774a2608f2909eb747c55",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 19
+    },
+    {
+      "fingerprint": "7f7dccec93ba5be73792e811e5c696b2031a468cd97ae28bfec078d18f4b4821",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 26
+    },
+    {
+      "fingerprint": "614510833df33d6bb94cda0c8c3c54447b1367ad6a384140cf50a75f58eb53c9",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 26
+    },
+    {
+      "fingerprint": "4f59c188f093a0858c61f3f9b4da53d670e3edb4c0ec92f034e72342618b890d",
+      "rule_id": "js/taint-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 6
+    },
+    {
+      "fingerprint": "3a9d01220355db492ae21a5a6877f38c2e2db87f627f5404288216358440407b",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 6
+    },
+    {
+      "fingerprint": "0530e62b789bc8b41f717ff8a95fb2585bc55a089d6e0680370f57aa5d4dc63b",
+      "rule_id": "js/taint-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "b2677eddc1a5d04791b600e448fdae12ef600a467cc3562cf2ba26ba70848f54",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "9b3d25090261c0bfedfd042cc4ae74c3d5c3a991befc2fd7623c101cfc6a86b7",
+      "rule_id": "js/taint-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "8e1d593a9ce58ebd6e3b78359fe7e59a7b89349bcdfe893d8a190ecf9a5bd91c",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "39636a75af5744cae453f6edd26b3a1b48e22189dc4da99e494ceb051a2e18b8",
+      "rule_id": "cs/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 21
+    },
+    {
+      "fingerprint": "e7ec1d3c92fa206e05ca4158a5dea3585f135069d7e60b6ff7a5447528da3828",
+      "rule_id": "cs/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 27
+    },
+    {
+      "fingerprint": "58a914553b4782066a2abe7785342fcef95eaa31684ec44d4703aaf19fd5ccb2",
+      "rule_id": "cs/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 33
+    },
+    {
+      "fingerprint": "ac6589982bdfe0098f949ab3c494b5d4aa8cf477bf01cf98b0292de2ed0ec7a7",
+      "rule_id": "cs/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 41
+    },
+    {
+      "fingerprint": "2639294d8133a8ac04911732c5256be043a589317e2e64ad6a4c9ea16081c3ca",
+      "rule_id": "cs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 47
+    },
+    {
+      "fingerprint": "5a7e27e6da18f274db22d07e5f305f0af1efae0ae73ba5bd45035f3e004bd3ea",
+      "rule_id": "cs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 48
+    },
+    {
+      "fingerprint": "005b6a6733bc77a91006b2ec52da5353c1a5ffe87ba19c4399f8a510bb02676b",
+      "rule_id": "cs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 49
+    },
+    {
+      "fingerprint": "aff62712e5f6ee9fbb791598faf84900f734b172f60c6e8d87c3cfcb472512e9",
+      "rule_id": "cs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 50
+    },
+    {
+      "fingerprint": "39906d30045704e3edb7e06f51a4ff17855e93507c7efabc4b9cba09653bef51",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 56
+    },
+    {
+      "fingerprint": "694f0bac8d5d07ecf87c2d1ecc65b49d2487ced41637e3c95510b1003571702a",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 57
+    },
+    {
+      "fingerprint": "0b6b5b00203a12b64f1cd2b0388f470ca4d094cb78dc2474797dfd44ac6eeb24",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 58
+    },
+    {
+      "fingerprint": "8e0f9dcc8c2705e32bc679d1754e2615a607bf3cf55aab1c56860110677d3cd6",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 64
+    },
+    {
+      "fingerprint": "69c15e694e1d6ff4e8050742690fbf7d9cb815a5dd5a2e4c6ba75c445e9c66aa",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 65
+    },
+    {
+      "fingerprint": "5b268236d1191a3f6148d38a7d340e5f52cebe623748e399ef68fe52e92cb503",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 66
+    },
+    {
+      "fingerprint": "407a6c2d1bd33880520bfe65276b32ea1d7fd3fa278cefb1c4eb3f026190e287",
+      "rule_id": "cs/no-xxe",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 72
+    },
+    {
+      "fingerprint": "abd4db8bf04bd5493e9f65b3ba7bd16e9fa09ad6873a70f3d06cda32a4fcddd8",
+      "rule_id": "cs/no-ldap-injection",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 80
+    },
+    {
+      "fingerprint": "5d53d1fd14ae84eaa32cb4f2662dec3e67d2a9651cb887cc80d2d45ea6b5eb18",
+      "rule_id": "cs/no-cors-star",
+      "file": "./tests/fixtures/vulnerable.cs",
+      "line": 90
+    },
+    {
+      "fingerprint": "a90f6a1b2cdad060707dc8a7698763bcd94e3747f86e107c9c41371520a8d39e",
+      "rule_id": "go/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 8
+    },
+    {
+      "fingerprint": "74465c45c1b76a7770cb659fed433179b37b73925e16c29ba5865e034e3d1c5e",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 21
+    },
+    {
+      "fingerprint": "434e9394ba4af425c9e9d719e28ed821b843acee3fca39edc00830e1c2f655bb",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 24
+    },
+    {
+      "fingerprint": "277485f44e9a94770d41166b3aac2cb9fbc1a1681ac1ccb6c51b188cc3720c44",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 27
+    },
+    {
+      "fingerprint": "e53bafc73d0f8ba1e5ebfccddf5d5792995e46864b47d22c0632144baaf93312",
+      "rule_id": "go/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 30
+    },
+    {
+      "fingerprint": "dc33c63fa7585987fb4fcd980d2528940794316bbc4c48721a1818e88b416f3d",
+      "rule_id": "go/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 33
+    },
+    {
+      "fingerprint": "d947b1daaf0207748f2bd7ce5f5618528d91478c4555de4d331455e748a8cadf",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 36
+    },
+    {
+      "fingerprint": "c10cf2fd2cc1e813f2bf7e4836bcee846475cd6b1845bdd6eb1cc967685db102",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 39
+    },
+    {
+      "fingerprint": "b2fabfb2533a76784f40a76c30b0b79c408f89bfa16cb1562cf545f9dfbfd0f6",
+      "rule_id": "go/net-http-no-timeout",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 42
+    },
+    {
+      "fingerprint": "101061eedb77c49e3ae4852d11f7de48e59e3d1a460876153be8a46d418649ab",
+      "rule_id": "go/insecure-tls-skip-verify",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 46
+    },
+    {
+      "fingerprint": "fa1b8c49a43927639a6e3acc33d17ec4d07d0cade6c7b24d6ad9693b14581b31",
+      "rule_id": "go/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 50
+    },
+    {
+      "fingerprint": "5405b945f1b7e6e9f043953b8452af773246cb84aa8fab3c92a53586c962eee9",
+      "rule_id": "go/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 54
+    },
+    {
+      "fingerprint": "1ae32b0236cff87744b5796a1cd67483f263462b742fc3a4198b21fbb4eef5c7",
+      "rule_id": "go/jwt-no-verify",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "5642df1510f823a3104a4bba7f56f54ced55544503436aaa4ecf30ccaec8baf2",
+      "rule_id": "go/jwt-no-verify",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "52dabf3c89bb926790f117104e269b612c6f4e8b504e2a81e70419019bfd2922",
+      "rule_id": "go/jwt-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.go",
+      "line": 63
+    },
+    {
+      "fingerprint": "b38dd555b3b949c5166cfc66656a965bdaf47384e96c4fbe2cd2c45493668381",
+      "rule_id": "java/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 13
+    },
+    {
+      "fingerprint": "248ba36b87cc1740c61807630c36d9b1ea93054e08adbbc5dc89563e31058b0b",
+      "rule_id": "java/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 14
+    },
+    {
+      "fingerprint": "1b407b09fd8266f0a1721b93fd39a35a0a7307d324ae3dd39bead2c4139663b2",
+      "rule_id": "java/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 19
+    },
+    {
+      "fingerprint": "29027be12af24cec202008546edbdcea01dd966d8e75d57caddf18fe3570b1e0",
+      "rule_id": "java/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 20
+    },
+    {
+      "fingerprint": "8a6bb2832eeca797abfb393a6cad9fc63255c6280cf4e95a7cbdc06618e75bad",
+      "rule_id": "java/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 26
+    },
+    {
+      "fingerprint": "a0373c94ce554a052095139c4fddefc2384e7b03a1087da0e53ff50446f6fc65",
+      "rule_id": "java/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 31
+    },
+    {
+      "fingerprint": "94c1d2b59bcaebda12f895561e998d2a0f43e554ec9a3dcfc824d86f2e315fbd",
+      "rule_id": "java/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 36
+    },
+    {
+      "fingerprint": "329456a86b29007be900d64b093c0e7e145b774cf8243c4e0424eb63894e40cf",
+      "rule_id": "java/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 37
+    },
+    {
+      "fingerprint": "1922c4d2a3e56bfddd7c608ff6c015151275ffad41b03f228a5fcf34cc17e37d",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 42
+    },
+    {
+      "fingerprint": "03292708d42c611073ab9fa8c3f0a895b91ec13a0c53a75ce6c1e99e57ebf1c7",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 43
+    },
+    {
+      "fingerprint": "be522348df16d6363e1df65dc13453d1904c214099ea46bd7eda0e500c17220b",
+      "rule_id": "java/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 44
+    },
+    {
+      "fingerprint": "7d2c4159356a0b73ac5c43e638a79199ff92cb95ad38b6c80ceb2de4f0523885",
+      "rule_id": "java/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 53
+    },
+    {
+      "fingerprint": "891514db7bc243174aab3274e79738ac763689e55ca9766bd453c9c73f7a2c30",
+      "rule_id": "java/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 54
+    },
+    {
+      "fingerprint": "19098cd77e85a30e3006e0ead33e5702d17ab2a65023d96f17d8ead374899cdc",
+      "rule_id": "java/no-xxe",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 58
+    },
+    {
+      "fingerprint": "47ba5ae61d04556a6ae102bf7c881549205e1191f715a4af639e215fc62f1d95",
+      "rule_id": "java/spring-csrf-disabled",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 63
+    },
+    {
+      "fingerprint": "8e7de29c280a39d9593aa552da0ddb2d49351d84d845873752449454c345e9a5",
+      "rule_id": "java/spring-cors-permissive",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 68
+    },
+    {
+      "fingerprint": "108ed94c541b75a7e18e152182dbe9c77ed83a1972a8d406e3e14a425e0be689",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 73
+    },
+    {
+      "fingerprint": "8706c333018d4ffe1bcb6050ef44312e782ee319c96dfebd62213d81a5c49373",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 74
+    },
+    {
+      "fingerprint": "fcf9fc00c2a2ea6c8f6b0bc23c581930bf0f17e0a3b267b27f7ce43fde17f13f",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 75
+    },
+    {
+      "fingerprint": "710e9e7028d27c409b63ca5380e8ac7ec5577d1d52ce4a7bc17208aecd229baa",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 76
+    },
+    {
+      "fingerprint": "87dac9feee0bc956bbd68f736adfe1c641ca5f55b4c4d75da6d6560bbbd0751b",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 78
+    },
+    {
+      "fingerprint": "37e5f5eb485f44d9776ae8a0b74ce7987bd091bed0b50ee0bfd04f757bc47e1e",
+      "rule_id": "java/no-xss",
+      "file": "./tests/fixtures/vulnerable.java",
+      "line": 79
+    },
+    {
+      "fingerprint": "f2a92c724162bab51e1febc8aea8a9217078873fe01ec16371b3157a9d9a1212",
+      "rule_id": "js/no-eval",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 9
+    },
+    {
+      "fingerprint": "75dc5956410372f4c3a4176dc92997664cb870bd56bfaa58a2710f80fef25310",
+      "rule_id": "js/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "5a22318c323547398893819cdc17eb7a4168c7d77f911dad2159e1e535736707",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "32059af89eb9a729a3942a3d663ae05c99f85ddf594e329840f0a96c9253c60d",
+      "rule_id": "js/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "5f65f7e7a4d0d144207cf7b617e477c590373231c6de298d752d1e2f357c180c",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 23
+    },
+    {
+      "fingerprint": "edeb1003d259f0555cd7dafba41dab91f080ad12eeec6000a06f7159d5b84440",
+      "rule_id": "js/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 26
+    },
+    {
+      "fingerprint": "687ffdcf905cec7945ee075a7a4d3876f8f9ddd15dd948a76c694a67afc47726",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 29
+    },
+    {
+      "fingerprint": "3630e58257f07120bb8152b3a9782bfdb7f4aebc7aa62b5ca995707f4119969e",
+      "rule_id": "js/no-open-redirect",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "00c226b2e657b9006fde7b98f8691a5dba592c330116f792f2c9e8c14d3e39ac",
+      "rule_id": "js/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 35
+    },
+    {
+      "fingerprint": "b9f176191bd9d573b789e9f94f45697b5f4fabe836eb2fd1c9ac221827227b9f",
+      "rule_id": "js/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 41
+    },
+    {
+      "fingerprint": "b1e121f8df80b0abcb44158bdbf6b5d21e850a717019876a2e87e1b0a2b91bde",
+      "rule_id": "js/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 44
+    },
+    {
+      "fingerprint": "90dd9d254a15175184bdb846806a182f7888ae603ef0a504aa8e74ca2e579f2d",
+      "rule_id": "js/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 47
+    },
+    {
+      "fingerprint": "889e436dd827a89a0f04de6a48d461ed29c0f3da7ac007ca3e6f009ff3845c05",
+      "rule_id": "js/no-prototype-pollution",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 53
+    },
+    {
+      "fingerprint": "ba4ebdca60098287c0d55212a53f8c8d40d827711e7c718fcbdc7b574c4c36b7",
+      "rule_id": "js/no-unsafe-regex",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 56
+    },
+    {
+      "fingerprint": "f997a291c4df65039469a60ab8abec4bbc4d18381689218f3114f5f407c1bbd4",
+      "rule_id": "js/no-cors-star",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 59
+    },
+    {
+      "fingerprint": "4568ea3b735fd6b5c0419285833b4e01e74f62cc4c63491988da4ecbf4327f00",
+      "rule_id": "js/express-no-hardcoded-session-secret",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 62
+    },
+    {
+      "fingerprint": "35f19c6530f3766c267a38661bf89ba623b4d9d9866c25e650b1763df6483c23",
+      "rule_id": "js/express-cookie-no-secure",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "e3a58fefbfa8bac20619be8d0b957a2c87dbf6bee5a1b0441d19110d40057109",
+      "rule_id": "js/express-cookie-no-httponly",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "6cef7a898595d3297f6e2aa6039a4060376c0e09995123d36d83165a45749c49",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "6ffc1a8520c03ead444f015fad6314a4c3e73b0f1de3bccaf71b45f2cec1e68b",
+      "rule_id": "js/express-cookie-no-httponly",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "ddef446999feb18d7b788a4f14f9465982d069a717a5c020034d0a942c2b4d01",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "a118826fb362161668663bbb10c852eb67b772a84321a1b5fd82263110bce39a",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "5ddb76434371b5dcdc20c20dc5b2548989a685cf59b081655d12d736016e26fe",
+      "rule_id": "js/express-session-saveuninitialized-true",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 74
+    },
+    {
+      "fingerprint": "5ab8f793de8a02c5e0efc8bab6e9d3969c72ccb2b24159e00b3126363a8b6a31",
+      "rule_id": "js/jwt-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 77
+    },
+    {
+      "fingerprint": "5f5b1ae23e3e42f3aa79a1b6e4d847ed86fc4ecbb106145134d86d6f62cb2151",
+      "rule_id": "js/jwt-none-algorithm",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 80
+    },
+    {
+      "fingerprint": "1cac932c771260d90ff775ff5b4e3de9d7c4fbd63c9257ae6be735de97a79d68",
+      "rule_id": "js/jwt-ignore-expiration",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 83
+    },
+    {
+      "fingerprint": "86331480a052aa965985d42c655a4dd7f38a8ca01b8237a643306110d17baf72",
+      "rule_id": "js/jwt-verify-missing-algorithms",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 83
+    },
+    {
+      "fingerprint": "2fe18e726e5cb3c953ad627a090e4e94fe9de2a7f6abde125757f6fae82ac151",
+      "rule_id": "js/jwt-decode-without-verify",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 86
+    },
+    {
+      "fingerprint": "67aa306bda034f3521172d90b61301dea0f78a4520038871cc623eccee513108",
+      "rule_id": "js/jwt-verify-missing-algorithms",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 89
+    },
+    {
+      "fingerprint": "3b294827ee4fa67aa97756b98d518edc141a4a23e47376b6501526bdc06f97d7",
+      "rule_id": "js/express-direct-response-write",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 93
+    },
+    {
+      "fingerprint": "fb25914ccc6270e833912b57f7ccb14019e04acc5b547dc4e8a1dc5f52e1332e",
+      "rule_id": "js/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 97
+    },
+    {
+      "fingerprint": "fef6cde290113df44138ddb3f04cddfe04cb0a6c45c0ace834099e5a5ab6a11b",
+      "rule_id": "js/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.js",
+      "line": 100
+    },
+    {
+      "fingerprint": "5f44d08fac3ea97e8d080ee932dcebd59c6e629c9b2ada0afcfeeb9d400f94d7",
+      "rule_id": "php/no-eval",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 5
+    },
+    {
+      "fingerprint": "1517ec2532610ee132490a94c617da5a367ef375be8a41bfddba12051429e746",
+      "rule_id": "php/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 8
+    },
+    {
+      "fingerprint": "819c4da4abe81d7560f2a68bbbca1859f1b4c184490a186ae237c7c2722ebfb2",
+      "rule_id": "php/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 9
+    },
+    {
+      "fingerprint": "1060a23bd968397509ecaef5421b32a69f7a354c536ce602ace887c9484f5532",
+      "rule_id": "php/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 10
+    },
+    {
+      "fingerprint": "67c8be6a8d23c713d9c41af7a772e037816093f8ea4142b2cccd9c8670391306",
+      "rule_id": "php/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 11
+    },
+    {
+      "fingerprint": "755decc32f95e672f1fc1d72a168ce2ed4a0f941a3e74d01d88917317d32ba65",
+      "rule_id": "php/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 12
+    },
+    {
+      "fingerprint": "6982b54a303c1d1aacf8c08db44e2628f115d549070e84f3372197a3346a8af5",
+      "rule_id": "php/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 15
+    },
+    {
+      "fingerprint": "ad95cabdd2fca1a6466c689631111709e8e4886a81e03e0eb0ecfb67c19f322e",
+      "rule_id": "php/no-unserialize",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 18
+    },
+    {
+      "fingerprint": "83ebcf9f8f73304563cd09d80ff7e9f9e000e4f2bdb5836b2a2222bfc8b2afd9",
+      "rule_id": "php/no-file-inclusion",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 21
+    },
+    {
+      "fingerprint": "861f62b769bcfbde6a9946aeb9f30e80429374779d1c25e0803ea12fcc8ebf10",
+      "rule_id": "php/no-file-inclusion",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 22
+    },
+    {
+      "fingerprint": "40ccd19ec0ef6323079a15c63afc96817656c2354234416765bfb39bf84dd9b5",
+      "rule_id": "php/no-file-inclusion",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 23
+    },
+    {
+      "fingerprint": "832dbc68a68e1e9020990bbb6bab770fe044d548e0bd343b75fab3647273c9de",
+      "rule_id": "php/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 26
+    },
+    {
+      "fingerprint": "2b4e8214a230e1c9815af48c30bf2c4049d3b3ea243e0f6e716abcdbce647692",
+      "rule_id": "php/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 27
+    },
+    {
+      "fingerprint": "e86a2f0c439e49e7ce8323a11a7a098bc31716bd2b84cbd06cede8e281964cef",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 30
+    },
+    {
+      "fingerprint": "b3332aba3853efccaf933b52e0751281bc5adfb4af01352a466023b86d796bf2",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 31
+    },
+    {
+      "fingerprint": "1ec7ffe2139d09ef5fcd3fe8f4ae3668e0a784539c87923e26f28d4357565319",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 32
+    },
+    {
+      "fingerprint": "3b447bef097c9ab250676b9acb514da9bdff88d0d5999c84fc7940cc58fae2c3",
+      "rule_id": "php/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 35
+    },
+    {
+      "fingerprint": "cabf2629f66c9dc7150a02417993d3b9c5a4d99a43dd40df52e19bcf38edf53d",
+      "rule_id": "php/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 36
+    },
+    {
+      "fingerprint": "f872b8e83fcf08d6ede116c0aaa5237bec3cb3be6f6d15add6bc669b984c9898",
+      "rule_id": "php/no-extract",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 39
+    },
+    {
+      "fingerprint": "68784234051bc875a03992fef411ab5dfba9e6298ee7015a728239f4ccce4e6a",
+      "rule_id": "php/no-preg-eval",
+      "file": "./tests/fixtures/vulnerable.php",
+      "line": 42
+    },
+    {
+      "fingerprint": "616c323374cfd6db8647ee569f3704c366b85dc9e625772d2f5dba930a682a71",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 11
+    },
+    {
+      "fingerprint": "4309adf3c561a0922e3470f8048ba47569e1bb09b01998c771f59221e00f3dc4",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "d9412a5d25312b9b967f7e9d8bc4b484379ce865203dbc67c38b4003235b5c54",
+      "rule_id": "py/django-secret-key-hardcoded",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "4b81f2070ee7ea6f0db94a2799ce2338943179e315decbc1e124aec77ffce67e",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "4cc4b4ab2897e7048aea390f690dabfffa0909a23ab0a2e905192b09b1db9b07",
+      "rule_id": "py/flask-secret-key-hardcoded",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "a40ddcf2574f7969543ac726dd14ae83172df0e1537f40401c277153c2c21ccf",
+      "rule_id": "py/session-cookie-secure-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "e649200b517f7cee4cd1206c707869d83d7a204b3d32b1aae0ff68dd38f1dcb3",
+      "rule_id": "py/session-cookie-httponly-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "f78899e5d38cecf138ca3ad1eeca4084c316f0d843989ca26390bbed18a2560f",
+      "rule_id": "py/session-cookie-samesite-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 27
+    },
+    {
+      "fingerprint": "8a0341a01cc27646526ee8c28e5aae5477bb403850ac1d99a9927b48da1a8490",
+      "rule_id": "py/csrf-cookie-secure-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "e497c102b2af320c583d221f8852ccd67b683ebb2669804de03e84e0a663e31f",
+      "rule_id": "py/csrf-cookie-httponly-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "c0e59d075b18358b06a8cc22d89e69d44f544ad3f7d812ab7c1ae2bb2d8dc514",
+      "rule_id": "py/csrf-cookie-samesite-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "edf9064a91dcf4be9dc2fef1f6b980f918f26e1600e107477b6b16612262f469",
+      "rule_id": "py/csrf-exempt",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 39
+    },
+    {
+      "fingerprint": "05c88e075e40c7ca5b57401003517fe15a3dc240f95fb4f21a84af34e89c5ff3",
+      "rule_id": "py/wtf-csrf-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 44
+    },
+    {
+      "fingerprint": "96bc4357e89e2c9bb8abe9bfab2e8f27cdd4964606e316780925f0959f5b8707",
+      "rule_id": "py/wtf-csrf-check-default-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 47
+    },
+    {
+      "fingerprint": "333d2637d9dd4e50cd2a47e6dd00ec6e994c40249c1e4c9cb6e7fe6768f907ff",
+      "rule_id": "py/django-allowed-hosts-wildcard",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 50
+    },
+    {
+      "fingerprint": "4923fcba183503e614a66f1e3e54ef4f69f2fce826916a0f2ef8778875fd7420",
+      "rule_id": "py/secure-ssl-redirect-disabled",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 53
+    },
+    {
+      "fingerprint": "e1240e6e0b7abed428444acca322433e403659b4188ff4b8ace93a5a097e9109",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "2089f0224994a711728553c5437954eb6670147d959b6bd5ff321c033726c4ed",
+      "rule_id": "py/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 59
+    },
+    {
+      "fingerprint": "20ea9454d908918855447faa18b1325a1a70ac139fb3a4ac4a0b7b687781d975",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "1f1e391744fd8d2a8cce8504b09fa709f84fb4f5dddc1891397a5f886cdd0ecd",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "f104dc01499621d0e7f2a89f7af41ff352b53d266af45fe2d1c48ebeba0d8204",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "3b6b043363aec47a459cf3284bbdd552a98776b012145dd1deb22810a80f25fc",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "5ae8a60c2bc1db028e98d1c0efddd12b9f02b3ad198ec66b65464d4477ac20bf",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 75
+    },
+    {
+      "fingerprint": "ebc3ae846883dbf95563712ef74acf5a54859746f7e04d6589eb43d5ea20dfd3",
+      "rule_id": "py/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "d0f060a57e1114d8d8a20a081448e1b4c09bd5af9bce91da9f50bf2fc83e9444",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 84
+    },
+    {
+      "fingerprint": "43bb8fc6a83b5a5ba08eb0b90778a69a46dfcb54f257748f13fbd189357e159c",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 92
+    },
+    {
+      "fingerprint": "427429b0914a38df4143bdd453f4ff8648db5ac623f656e9611cee4c1dc29dd0",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 96
+    },
+    {
+      "fingerprint": "74ca8317ea92f90baa2fe63ca6538843a11b1abc3dc8c7cddad5f9e30c5ab729",
+      "rule_id": "py/no-debug-true",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 99
+    },
+    {
+      "fingerprint": "1e9236cfc9040e9b66b7201959b78b7de69f8a863c32d54122c8f46ea8814a31",
+      "rule_id": "py/no-open-redirect",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 103
+    },
+    {
+      "fingerprint": "51d248d91617fcccf3aeadb2dd151075a856916025ffb17b6e04ff6b8a4b5c78",
+      "rule_id": "py/no-cors-star",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 106
+    },
+    {
+      "fingerprint": "4b642df947bf261ab0826fd1116a34849940863a9f02826922660e0cc9db71f1",
+      "rule_id": "py/flask-debug-mode",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 109
+    },
+    {
+      "fingerprint": "af04b0cadf2da37ef4794ec3185e111cf6a6cc0799ff0c00f381af8791c090dd",
+      "rule_id": "py/jwt-no-verify",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 113
+    },
+    {
+      "fingerprint": "66cc8f4e9a0ecb765b9b32781fa0c0697c049d62ae81f9d5273cbd9e83c1e66b",
+      "rule_id": "py/jwt-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 113
+    },
+    {
+      "fingerprint": "b24b414bced79b4509785f6692f43ef9f6bb4e6a71b8db9c584a97c76109c293",
+      "rule_id": "py/jwt-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "2eccdd2b65ac145d46088636df0793122306886bda653bec0bab7a02d9920d70",
+      "rule_id": "rb/no-eval",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 4
+    },
+    {
+      "fingerprint": "b7ad9e157e85ca8441b13cf8cc76edbc8b4a23ac921ee4116a9db6e99062df51",
+      "rule_id": "rb/no-eval",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 5
+    },
+    {
+      "fingerprint": "4e30ecc68c6a227204791bccc9cf34e547d41139ed6cbdd0962d46a931086490",
+      "rule_id": "rb/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 8
+    },
+    {
+      "fingerprint": "795e1abbe32bd987075c9b716f07fd2989fd13921fb2531e720e24ab20afb374",
+      "rule_id": "rb/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 9
+    },
+    {
+      "fingerprint": "b90308dcee51d7b98f1ed94ba1439dd60929cee6ea2e966f21a2edde44021697",
+      "rule_id": "rb/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 10
+    },
+    {
+      "fingerprint": "ec73b46ac977071b4f6bd23170120b1c4488c934cd65aaf0bc92d6eb058dde20",
+      "rule_id": "rb/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 13
+    },
+    {
+      "fingerprint": "3f662156fd32a125475f4fb5fb9150a96d9ecf15b9683bd465e869f0dd4a325d",
+      "rule_id": "rb/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 14
+    },
+    {
+      "fingerprint": "11679695b2a5247f46c502157031f518892751782a7a91b53e622c7077e67fc8",
+      "rule_id": "rb/no-mass-assignment",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 17
+    },
+    {
+      "fingerprint": "1f5fef9087cea9ad4ebb7a16cb9b0017855796797080fd12393d335f851c3520",
+      "rule_id": "rb/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 20
+    },
+    {
+      "fingerprint": "41958d07a3bbe4ebb214b4d1adfc2b43035b7ba0da16f296951002f1ab03f709",
+      "rule_id": "rb/no-unsafe-deserialization",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 21
+    },
+    {
+      "fingerprint": "64d3e3e911f3a53c37db321157f49b1af0ad9bdaa2cb7ea12d68ff5da712f04e",
+      "rule_id": "rb/no-open-redirect",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 24
+    },
+    {
+      "fingerprint": "1ba9b3628aa4a4961374e9083496440135983ea0c3683e92d199df3b92e32bef",
+      "rule_id": "rb/no-csrf-skip",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 27
+    },
+    {
+      "fingerprint": "0e5bf12afa1f3873a2ca155838a3aaa687d8a95bac8fba6cb8e417246c3122e9",
+      "rule_id": "rb/no-html-safe",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 30
+    },
+    {
+      "fingerprint": "e264b6902b2b775e90e46f43c67bec4abc9e5824ffcbf7048cc18b3dac5071c1",
+      "rule_id": "rb/no-html-safe",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 31
+    },
+    {
+      "fingerprint": "ed66a6bca22c18a4994bfd410f00c3230c3cc7e0a3b7fe71fa49d71762e7e8e6",
+      "rule_id": "rb/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 34
+    },
+    {
+      "fingerprint": "efd18eeea5c575e68fd5167395d4a28a5582e09e98a551634bd18bd850d4e34d",
+      "rule_id": "rb/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 35
+    },
+    {
+      "fingerprint": "39bd7fc1f89321c35e19dc09637a395afedd4e76c54eba0afec3d88080b897a2",
+      "rule_id": "rb/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 38
+    },
+    {
+      "fingerprint": "a4e4d4b7cfdbc045d616e09a9a79ba83587723fc3c4de494f7b23caee074591d",
+      "rule_id": "rb/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 39
+    },
+    {
+      "fingerprint": "0d08ad91336cab0e6f56300eebe64e25de2e03d103fe9307d3b82ffb1394594b",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 42
+    },
+    {
+      "fingerprint": "b678482ef20dc3425a3e2d775b4db840aefbcab09a57d35fc96691edc21e838f",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 43
+    },
+    {
+      "fingerprint": "09b85516da3bf99c03cb496bc375f634e247e119e5518a91921d53b1fdf90de0",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 44
+    },
+    {
+      "fingerprint": "9c96d290ec781e6bb2fe07e14c42c13f9b3667206ad5078d71b00f96f1ce2738",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 45
+    },
+    {
+      "fingerprint": "e889d988cb28fe7a6555b7db313d11ab0a82c4ad27d0bea586e26c7ac87b0562",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 46
+    },
+    {
+      "fingerprint": "55413cadb01932e7c43ab813cfbac2ed2f8df633a62b11929d211911fbb267fe",
+      "rule_id": "rb/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 47
+    },
+    {
+      "fingerprint": "14c600bd5cebb1a868f9bd1fb1280856de8938320c9497920245d0c0888e51c8",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 50
+    },
+    {
+      "fingerprint": "fddfbda2cebc3408bca81364a7ad0fc8ed5e1b7cf86534fbfe880de060aaa242",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 51
+    },
+    {
+      "fingerprint": "5b5bb63a5165fa31bbdc156fcd21b025b47c4381d9b0d402bf354e5de6b80f2b",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 52
+    },
+    {
+      "fingerprint": "10479c44db53f68cf88dcade8044d9e25dbdff874df2258026bb7e36cccdd60d",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 53
+    },
+    {
+      "fingerprint": "4412e60881814833ab78a3774fb37438940d05f3abba7314352053185b81314a",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 54
+    },
+    {
+      "fingerprint": "67d267f0a74276e31abad9bcdff6099ea2528ed93faeeb0fdc3c22a86ab4c4ba",
+      "rule_id": "rb/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rb",
+      "line": 55
+    },
+    {
+      "fingerprint": "3e900d933230cbe25716a6b49a039c6a70cdea0b3ec60cf202e43b86ce2de75e",
+      "rule_id": "rs/unsafe-block",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 7
+    },
+    {
+      "fingerprint": "9b8c72c6b400b12650c53a26c7804586fa13d8ad5f55caa346c4254b06418596",
+      "rule_id": "rs/unsafe-block",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 15
+    },
+    {
+      "fingerprint": "3ff69d35f102b8dfdcb35082866176bc04c3cdf112293a4de7096975c133d12d",
+      "rule_id": "rs/transmute-usage",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 15
+    },
+    {
+      "fingerprint": "61c1707e87a789ae6a42eff0112f921bb3cec7b55bf910cf88e847b802661926",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 20
+    },
+    {
+      "fingerprint": "5c1f1b4b685ecdfbb4480f483d4e8ad46acbead895ec8c93141deab13838562f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 20
+    },
+    {
+      "fingerprint": "f2687e40427cc172de9193e759a4c38e2db41b419d1c2e2af948a2b11cb80c0a",
+      "rule_id": "rs/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "00ad6427a28be977d26add72c2908c3cf0a05226490b48d6f859499b64d3c1e2",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "0bfdca2a99b11f493043d1b12b8262e835235db28fd4c69957466220aac1c768",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "ff143630503d4046f65de4d1c9fc6d62c8abbb4aa15b5b51c5264e673791fc63",
+      "rule_id": "rs/no-weak-hash",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "4f0c87ed3ed60f6c9e298c15d1a7729a2737d28dc0f2c9d6e90c6bda1a906789",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 36
+    },
+    {
+      "fingerprint": "c7227420123d4a3ba5a6a15e7b6ce1c4e3865efe08aa4dbba7fe241d7afa37a2",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 37
+    },
+    {
+      "fingerprint": "4bf2cd30e030297f02f5acd6b54270bc89d64d36714a652c2cb0214715857f2d",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 38
+    },
+    {
+      "fingerprint": "fcf63b4f6a1abcc60897f1b2faf27393350f8883f07d345099c34325a1da509f",
+      "rule_id": "rs/tls-verify-disabled",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "f6abdd3381876040fb6abc51d16e662036af84ea9274f9aca330d58e8f74ac36",
+      "rule_id": "rs/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 50
+    },
+    {
+      "fingerprint": "49b783e2e10e9e65ac9b28d2fcbc40174767a0064ee6ded793990c46efd97195",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 55
+    },
+    {
+      "fingerprint": "f57e005b26da608abc46482d8e30950877c37574309aaf3e230879b0f71accd9",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 56
+    },
+    {
+      "fingerprint": "efdd1fc1f85ef96b54c706cdcb8ff86dfd0c11027ec0c242506e8464343458d4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "3c74c46b926272979365d064f0aea2882f7c6b5a64475b28f1366298291cf5a3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/fixtures/vulnerable.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "09b698e78eecc0724a939bb4bcf86f7017a34f2a2c8c99fa178d5db927685a66",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 7
+    },
+    {
+      "fingerprint": "21392c80c454387b213f520834bbc26c49835be38cec278ec49a963c0283d165",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 8
+    },
+    {
+      "fingerprint": "ebc3621c136fbcbc217f184a2c774c1f8c7532b2b96821a4a4ab9e74b45cca1f",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 9
+    },
+    {
+      "fingerprint": "7f13aebeb1ac709fcd98a45e12c0b9d833230eb339e8dbf243125773ff2b76d1",
+      "rule_id": "swift/no-command-injection",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 13
+    },
+    {
+      "fingerprint": "dfa10a85ee3ffd80a221bd2274069884a72237f14b4fcf6356d782c8964d2841",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 22
+    },
+    {
+      "fingerprint": "54e959b3fdf21b3496e21020c7253f579213e0baaac90eb1d3163ddeb3acc533",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 23
+    },
+    {
+      "fingerprint": "6e3f806cdac6e032c00a9c761167f96550566f3ca98c3fa6ae001f3a024a01a1",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 24
+    },
+    {
+      "fingerprint": "ef82f881fb175e3a963c50a928f7353716ad2b4b1b7831b11351ec11aafae0dc",
+      "rule_id": "swift/no-insecure-transport",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 28
+    },
+    {
+      "fingerprint": "193a3be57a34245b3b65883fd95f41191277158079e77a21982fc0a67291af23",
+      "rule_id": "swift/no-insecure-transport",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 29
+    },
+    {
+      "fingerprint": "e6e124cde47085dad2efa187c721873fb8c57991a0a406039bc5da720a56a191",
+      "rule_id": "swift/no-eval-js",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 33
+    },
+    {
+      "fingerprint": "5dc355e4f327678089c2701f2651bf64d6392325a297a8d9343857589ec800aa",
+      "rule_id": "swift/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 40
+    },
+    {
+      "fingerprint": "aab05fedd8ef0d353eed397b66d17eb864801d879e561b90df90f6c025f5d17f",
+      "rule_id": "swift/no-insecure-keychain",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 48
+    },
+    {
+      "fingerprint": "657ee6e47596ef007e0392bb2a972114cc1a5ef93078b068fbcc22b51a7eb201",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 56
+    },
+    {
+      "fingerprint": "94baeae87ed4d0746b72d381c55aabdc67dad0e0ca2a0add7f52d432de20ac72",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 59
+    },
+    {
+      "fingerprint": "5cf8975b36e073916d45eb2338a8a6b1f14c9a251641bd87243a523342b3a8c8",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 60
+    },
+    {
+      "fingerprint": "de5d28e78af47f9de7723d955cdf1697d826e979302edc92adeda106d2027d21",
+      "rule_id": "swift/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 66
+    },
+    {
+      "fingerprint": "356c81ffb5307b0f8128a6bb9975fbd1ed86388d3154285edd7804c02269d24e",
+      "rule_id": "swift/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 67
+    },
+    {
+      "fingerprint": "46c7bdd4b08d887992114ce95b99ae9ee1a098b09ad380d93b46b64b984c579d",
+      "rule_id": "swift/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 72
+    },
+    {
+      "fingerprint": "c5866a672981062feee3d208ca4e66550de2b7c773f23d45ffb5702fc11f1ce9",
+      "rule_id": "swift/no-ssrf",
+      "file": "./tests/fixtures/vulnerable.swift",
+      "line": 73
+    },
+    {
+      "fingerprint": "938407e9f75481f2763b80a594c4437ac1f9ff522c04360ba21c38d4aa4e8134",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "e6dbde7bc53d4ec9d6728ebd00456c65069ddc81099968f4c988e11d835ef37a",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "61cd712ee758c6989aa38fc709709552e31a9aff8bbef6f57654451597e84efd",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "ac0e5a25b1116661f5968053efa8c621d01efe62019dfd72ba4786d11b7852fe",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 25
+    },
+    {
+      "fingerprint": "eb23729e16dbe006a0a2995d436a450ed17b2cc0cc65cd2d8503a293d1a940fa",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 25
+    },
+    {
+      "fingerprint": "2ca20eeed5b7f0a8738b68b572fe4ea46a81d3e9f647f3811693a670e260fa71",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "62794a8e9249801bce7e100d72e7ad62b57f92044ece5b1fa12493920e3f9bcc",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "e60acbd745596da01db2d51a7e83ee0207056775cf4aac3598e2d277f230d80a",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 37
+    },
+    {
+      "fingerprint": "0668a4b4adebc0acbf8c133050f18ac333b7ec5774098516156083c3ff770a2b",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_cli_taint.py",
+      "line": 37
+    },
+    {
+      "fingerprint": "57a2d8a0e8fdaa22cfa9d07ba2811e7bd041396e30a0897cd64ac610641a5dd0",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 10
+    },
+    {
+      "fingerprint": "bdc600670b9ab6338a3f5ee77f3a80307667ad79a6ee87707e35a0d5a8993629",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 10
+    },
+    {
+      "fingerprint": "46d130cbdec95bc73364d197f099188e8db7969bb2604e121dd2b349c10292d0",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 16
+    },
+    {
+      "fingerprint": "ed6906b27fc8d03643c497690e97bae5b9f44f7d3fc0c57de47ed9df09071feb",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 16
+    },
+    {
+      "fingerprint": "0c0e371358e1fb7d4ab164ee54d0e308dd3bfe5bbf65479b8d3e6c22ccde0c68",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "37d550e11011e7942c286fa689e051061d7f573d72a7f3a88b9feab4235759d0",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "deb3b802457a8215c098c50b2fb12b667728b0ab17da9f486a107c12048bd4dd",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "3bddb8dbda5f37eeede6524b241616596f4612fb70522f63454c163a43b24f34",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "691406323725c56d5ee335033fd5b2d808bfa55c9a2f4b668668a69e27cd01d4",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "7f05b85b4f83afa4efc1699b7aaa546bcc5fc162ff412f6cc2f88235604cb604",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "6e321813f808d5844302928f177ebbe445309857bc861266037b6f4ff2e31a76",
+      "rule_id": "py/taint-yaml-load",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "39db48daf71aa834c2b2e36dce24f2ec305ea837a99f7ae0ef86a557e1338ea2",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "4e2706e10cf3ce757551d21c962176493d5476a807b64b4dda2c95afbcc898d6",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "8eef3bbd4779ec929b5add3f1a71068ba75daa443309dd83180438d10d9c6344",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_django_taint.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "09a2814b6bc0328cd23c3f775ca6fb744f4eef3e2bd88d49b4d81cbe0c30fdfa",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "4099fefdf1277e490e0f380bf6884a7ee9f715848eaec1d75fb973a3a33268f6",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "b18ce7e7e6298299f1cf5af960e13d2be34df983f7cdfda51247f357c5a07db8",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 28
+    },
+    {
+      "fingerprint": "d7e5f1419b0ba5dc6b57fd92eebd33f2b67f6c5593c2a2b953075272a5221641",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 28
+    },
+    {
+      "fingerprint": "992ddea47cc0e92f25cd7f409d672c1b2c1c2a7316d4ee94714d11f17cd346b6",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "7fb44717ace75be76145cf0eb758b17fb547c596c659a74e779b86633bbaf4fc",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "34278f1b29974c90da1f6ee5475b91a3d119c01b7f8bb668a75efa8f70afcd3d",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 23
+    },
+    {
+      "fingerprint": "442cd72b9aa85e9f70df2f0b04ba30c0a1fea0caf03918f853733cf6e65cedb3",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 23
+    },
+    {
+      "fingerprint": "17a6b4229dfe3a452f8313c3e3700ee0e1f7c78d4a67a3e18ad4e4f7727a0477",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 29
+    },
+    {
+      "fingerprint": "0b3005e05f9cee70c87f7eef930cf1a34fa7a20862cd77809dea61e0d6352d34",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 29
+    },
+    {
+      "fingerprint": "cf9752cc7db68fbcb84eff1b8e0e0534885fcd5acdd19e6458420832c70b9fae",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 35
+    },
+    {
+      "fingerprint": "91f8277692df0785814e1db15ade1ceead9842ef0b2d9a74de7ecbad836c5cde",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 35
+    },
+    {
+      "fingerprint": "5432976d84574eef912e44971fb01d2d3bda2b95e5b558476c866db301db2043",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 42
+    },
+    {
+      "fingerprint": "3be2d01515abebdcdb70d07fd778d012815859fa2680955ddd05d24978596996",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 42
+    },
+    {
+      "fingerprint": "5997fa8a58725f9a5b89b373df7171c7e822c556bf264681537781a92868afb0",
+      "rule_id": "go/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 49
+    },
+    {
+      "fingerprint": "de0d8413af9a0feb4d63a45a748d0239a2a2bd8186dacbe502c79845ad303882",
+      "rule_id": "go/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 49
+    },
+    {
+      "fingerprint": "f896f7e219a12aa41699d651b4b66969781a06230071c9c5c3ab4a83134e5993",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "1886b6ffe4733837025e1f47064ee698797b0c943af5d373f8851ddd2f6eb363",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "caeaadb7eee9938e8ec5cbcd13bbc11aa80152e917c70d217bc97e81752987dc",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 63
+    },
+    {
+      "fingerprint": "8d25c60a007bfd39330f33bff7e2de33054bbd6067d03e7cb5e21c4bcc67947e",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 63
+    },
+    {
+      "fingerprint": "6a9e25fa804b45dd61eef56b29a309c95a253725204f75683c1b453728c57224",
+      "rule_id": "go/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 69
+    },
+    {
+      "fingerprint": "bc3a10637ee03dec630c2781e817add31a5554a3fa5d364c65220db682d380e1",
+      "rule_id": "go/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 69
+    },
+    {
+      "fingerprint": "3f87e0ca29d03d4c0720da18916905ca635be6c8d20811068c19a47b4e8056b9",
+      "rule_id": "go/taint-ssti",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 78
+    },
+    {
+      "fingerprint": "a050b044036dc8422b6358b9fb6392152b5ff569fa4ffa78c7afe78a26946c9b",
+      "rule_id": "go/taint-xpath-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 86
+    },
+    {
+      "fingerprint": "7cce932343804a93c1c6b6dbe063f5277a3d69bab95bf7b8871ac8347768ff1e",
+      "rule_id": "go/taint-ldap-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 94
+    },
+    {
+      "fingerprint": "aec35d6f51b12559ef1e9b493ac7e98b7ee396601a78258d6262179f131d3e01",
+      "rule_id": "go/taint-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 102
+    },
+    {
+      "fingerprint": "c3d7153f3032f5802d782ae9ac4d397e874e6f57d02e291009106b441cfd27f9",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 102
+    },
+    {
+      "fingerprint": "f75373f6375eff90f6885bceeb510827691356c1ebf2258a2befc1c3584c395a",
+      "rule_id": "go/taint-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 108
+    },
+    {
+      "fingerprint": "c5a5f0a60890661744812bac1ba7dc474c35f6fecfd4cc52cf2bada1e53f5e36",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 108
+    },
+    {
+      "fingerprint": "e5937358112dab6a8878a50ba30799d2371371e76ca478debd07324ce399df04",
+      "rule_id": "go/taint-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 114
+    },
+    {
+      "fingerprint": "5237e28e877ba3c128ac87818876f7478cf09f3691c583fbba4a0502cab82bb5",
+      "rule_id": "go/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 114
+    },
+    {
+      "fingerprint": "0ea7d987264d159446531fe90ff2bfa22f1ce90fa05543d4d208cd71dfad941b",
+      "rule_id": "go/taint-log-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 122
+    },
+    {
+      "fingerprint": "2ef29b9a12db61d831cc31a5dc15118257fe765f07d720d4b6b389c1e2d937aa",
+      "rule_id": "go/taint-nosql-injection",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 130
+    },
+    {
+      "fingerprint": "48dafdbd0d9088f76a0b12c0e9d7a4bc891869ed52af2f162c952a0a8ed6edea",
+      "rule_id": "go/taint-path-traversal",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 138
+    },
+    {
+      "fingerprint": "afefe819684cd315048776f043cb8b3830619448bf022efbf506b18156d57cc9",
+      "rule_id": "go/taint-path-traversal",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 144
+    },
+    {
+      "fingerprint": "fe2f83d81b68d424305bfc02ebff7d1b96933968815bc25f0f8657f3e9deaa49",
+      "rule_id": "go/taint-path-traversal",
+      "file": "./tests/fixtures/vulnerable_go_taint.go",
+      "line": 150
+    },
+    {
+      "fingerprint": "aee8c7a0a7c7d3ad94ef60c099f0f380964d5887a46229f8462953204e5b91fc",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 11
+    },
+    {
+      "fingerprint": "672a8b192148268b91593d20ac6aea06e19a53f0940adc9b45b40f4f002909c9",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 11
+    },
+    {
+      "fingerprint": "97d708fde22434e1d5c89aac55f15216952aafb1ea4538ad8c1a8df07ad1e8bd",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 18
+    },
+    {
+      "fingerprint": "cce2c9a65a3af3496752010c03fe3e9f1ce17753142cad171b263bbec451b909",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 18
+    },
+    {
+      "fingerprint": "dcc7a86874daed6c107b9179af442d175a86e5e7b59932e7a77caf3a87c215e6",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "2a01684eac5f43ef1e223e44669930fa6c82e805de4c47b5694acd4e86162c86",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "502c8b19dd490e6e9548b73fabe898240cc190266ae4388417120f19e9bd21a7",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "b7bb362d379236042296a32d09e32e59e7c7d20a4bc70650974788c00c81cebe",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "548a3052fd5ddf5b3067ca3d4663f29475e7d6540294dfceb8a0ab29ba786c39",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 21
+    },
+    {
+      "fingerprint": "cba9b775eafda48ce27c2b85561fc3d52d6a44b877c4f8467a1a259eafc78d15",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 21
+    },
+    {
+      "fingerprint": "e3dcbc0f83d6211b468211c26e621076c418edae338629310c3d0e1df7ec87c4",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 27
+    },
+    {
+      "fingerprint": "8fdcc04648ad9644984596cc736c72260bbb0a2a826f0dab04af9fe1c7695244",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 27
+    },
+    {
+      "fingerprint": "734d3c8c82d565d6fd395449ae88513cdb9271f51830435bd90c4ee750ba839f",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 34
+    },
+    {
+      "fingerprint": "fcde00a8e1526c1d77109150e314e86e82dd8c791c439f65755332512bca106a",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 34
+    },
+    {
+      "fingerprint": "f658db3a6bf683d9176544caf0fae93aed5fadbdfc9f942fbb77d8e44acb32b2",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "3f983b960308aa3c0285a453297bcc7b68444d3c1e492362f29284dc81f44025",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "aed9d090a24746964c5b624918935d49be87b6615579b5da1fd0ca22ddc218bc",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 51
+    },
+    {
+      "fingerprint": "f4750b94e8e36566ec4137e9cba290a4f8437d0cb514abcdbfaf50cff01d91e9",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 51
+    },
+    {
+      "fingerprint": "0297b1618ef57868af77884f93fe35a4f7b6089ea3f7ca41491e803c27b8c60f",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 58
+    },
+    {
+      "fingerprint": "0979a2d91f5620d7ed740378b5a17da4eb4371f905d312d27c82ae760f65449c",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 58
+    },
+    {
+      "fingerprint": "31605f9b469a54c48d1baf601c3ff45fd0cafaa74ecaa9c739889667eac86960",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "84b842f94ce69a5c91d0087a4a827dd80612705b06b6d9fb8743658b21194fc1",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "ced013e6204b95dd026693fec69cc333b34f6e645e9b920699e6c64a7eb5693d",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "08df18e510a1ed7b9728dde15a3e06c99787d8cc256ed115b148b75fce5d90a1",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "625989600a36f6a02f8aba5cc9edcfd94f2c27f18d11012de2495ddbb547df7f",
+      "rule_id": "js/taint-log-injection",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 77
+    },
+    {
+      "fingerprint": "1c6467fd691c651ec13f3e4debb553c150f19bd43d1421f1217d9bdd2834264c",
+      "rule_id": "js/taint-xxe",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 84
+    },
+    {
+      "fingerprint": "07d1501a3e52f2d0d061dfada428546cc3d990c7c817d0a1f02df465bd388a54",
+      "rule_id": "js/taint-nosql-injection",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 91
+    },
+    {
+      "fingerprint": "74dd65aa13e0ddf26e67ae189883e726377e88f9bf6751206b60ae52a50f88b5",
+      "rule_id": "js/taint-ldap-injection",
+      "file": "./tests/fixtures/vulnerable_js_taint.js",
+      "line": 97
+    },
+    {
+      "fingerprint": "17168ffebd7c94753856d1ae7d42107cb2a93f0f5db851196cbd0375afb624ad",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 13
+    },
+    {
+      "fingerprint": "db8beb68b0452f183fbce0506fd6584fe12762dcb408bf61eea2083dcaa2ad27",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 13
+    },
+    {
+      "fingerprint": "97c0cedb0bfb65d8a84244a500462ec6eb732c81c9661bf6c4aa503121cc5d39",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 19
+    },
+    {
+      "fingerprint": "8cd9a0af2a9ececfe26a79eb9cd557149364a491cfc4017425a97ffcb28f80e7",
+      "rule_id": "js/no-document-write",
+      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 19
+    },
+    {
+      "fingerprint": "290bba758d154f3c5df4e26d6504099f03e4c8d0a368f80c5f6d739caef460a4",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "7d6434fb04b3ce13554b635b5b8b979ede0fbff9bad7bf65a7ae57d01fbb7c50",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "c7fd304bedaebded3a505fc93adba7d91819c6dae76c63ed0e73a4c922d457a1",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "c2d5b0bcd786bf9c597fff525b3e85ed6737a2f4d0b002171e24ebb7168ecf60",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 39
+    },
+    {
+      "fingerprint": "ca542da6fbfc5da5710d266e2f60b6c9719c804778a3c809638976aa36838f0d",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 44
+    },
+    {
+      "fingerprint": "ec11e1413989c1f5f51e08373ac8a2467d740904905b7be20d79e62431e68ba1",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 47
+    },
+    {
+      "fingerprint": "2c53f75bc29d021b5225a8b63f3a39b8110c849ae77e16025b169246f49216c8",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "3c4d7f0fe1c0c9de707ed0ec94b79229a996df31d4e1a82dd9f8c22250a6d614",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "18784d317d6d6ecb2c696196a9e3698885fad566dde0a6af95783ac1edfac1f4",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 58
+    },
+    {
+      "fingerprint": "ce856f1c98ce94bd1423b5002d2a08e842c721c838d4e250598b0234798b5a0b",
+      "rule_id": "py/no-weak-crypto",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "232398c18b163759c914ed071423a030be117d059e635326226ed3041121292b",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 66
+    },
+    {
+      "fingerprint": "bd64c22bf42e25e5fe07b4657e774210d915b85b67032e8fb7641658485031c5",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 69
+    },
+    {
+      "fingerprint": "30f8fa40e9c490ba055e4f2196a0668dcde15515c6658f3ba23127e2eee9c456",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 74
+    },
+    {
+      "fingerprint": "152ab55c66fb214b802c2088dfd43c4aa3bf04540fe534c649b70be85fbedf0a",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "b9ea7136567395039accfa3a2645cebfdaa551a890912983c7552f3cdfbbb70e",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 80
+    },
+    {
+      "fingerprint": "b109cd0c412f9f689e95ae03418a61f8dd376e374417468bc062453d758d3077",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 83
+    },
+    {
+      "fingerprint": "276bcd3d9f920db115afb161c49b8d8902403734f37bc04df818efbd98b13721",
+      "rule_id": "py/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "926eac6475e4bac72319e29ca516594f9d71d0cdf0a6ddfae475fa0f0961310c",
+      "rule_id": "py/no-path-traversal",
+      "file": "./tests/fixtures/vulnerable_py_aliases.py",
+      "line": 93
+    },
+    {
+      "fingerprint": "5a637c0e96db22e430b2f63cdc0fb2c90ce6ceca970db9aaa729f896a116d334",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 15
+    },
+    {
+      "fingerprint": "165a909e8b5bf446eadaf29a2ed60e03792ff8ff7c905f45f553d0944ea45afd",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 15
+    },
+    {
+      "fingerprint": "f212ac81d71d1a94cbe3915c0e0ddca221e19da63069822d4b12bdcf0c2b487d",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "e02eaf92bad537935a9828c8fc8c4381c36dd27254f0ad3af2d69e564958c9cc",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "cfbc507a920ae78810efbd9eb3031a49cf003a14ae2f834392c1a31d74ff2a6c",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 29
+    },
+    {
+      "fingerprint": "1744c4cd2ad2444bb8e4bb5bdee5f7f576c150e70b4a1e599dd0620f7706f05a",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 29
+    },
+    {
+      "fingerprint": "72c616c4e26823e3047ee644e508bc986ee6ec01e964e65d095074f01fd2ba32",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "b14b1dd6262df6b609ee761aa1316cf1c8735421f5909305ed1c82be75274459",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "dbe81fd9197ee87734c165f735b5391eb3f6cfddc441bc71fdc0f126e105a720",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "45ec25cc4dfb96abe3bd6ea53196fce9a366ff18244c44cea9c14b4993d6d557",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "68ff8f53047570c3a2dc1adc97fa1bef1b0730a9d76059dd80d4ebb59928a081",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "655026c18fbc3d2b2cf5c608f835de8383c49319f8f8ad68d47a77f9b2bf98a5",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "593afa6992ed7ebca6a4193d8a133f214ce9bcd53d7e53e80124e3f29df1a271",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 54
+    },
+    {
+      "fingerprint": "db37e63e19bd1347b84292c2d2ba6cbb1941b1bd00ff1078c0de9de461c478a1",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 54
+    },
+    {
+      "fingerprint": "6128591974e0e0f43c1d50a4a1d7f332032f33e6bd8e36361ea345d224898c53",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 60
+    },
+    {
+      "fingerprint": "4b77211abac65fe1d0daee29b4b4379659ca05897b07709de57415a4fc3e9824",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 60
+    },
+    {
+      "fingerprint": "678960e65414288b74c97fd1ad91aa5606d1713e9de618c5d2e41e1db9e297af",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "5c21838df0ac2c0d46b0d574886e09c565ac2a726103fa1ac43c464bfadb6343",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "c96591d58fe9ba21538e62f8a5cea0e51051a4358a2e8cd9b72712a2f0156c47",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "d2aa9e1739319be4e434af18308c3da5c6413958291546e41a227701fb042536",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "6b64c1ff8e72d434dd2f6b6767d00c3650079be4152287a9b09d909bd814b3d6",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 76
+    },
+    {
+      "fingerprint": "59bb0c7cc34ee8bfc45e1e85eaf2cddd571319b695f3d061f95d7a7bc26729ce",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 76
+    },
+    {
+      "fingerprint": "cdf5f5703ee814b47fad7ecb74d10229c5bfd8903aac775eee37680ae71f94a0",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 82
+    },
+    {
+      "fingerprint": "552f610c0346cf2408a7c6ef3102d203598780adb430db7555d99fbaf0ff9e0a",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 82
+    },
+    {
+      "fingerprint": "8c016c28b19ef9d3447c256944adb985ba24ad3cfdd9add4b290c5a48e06dc29",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "406c38e3972040090636106d40c4f085f0207f6719c72cc3d303ebb5645e5711",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "96d84ae452ed7ae579b8ab2c04ae5cb691f0ef359be6bd3e97ad601bf795cf1a",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 94
+    },
+    {
+      "fingerprint": "6b0c8e0d7d020d4f146bf6ada6bf89dfc2165ff06fedf94c1d294f8f55964894",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 94
+    },
+    {
+      "fingerprint": "66d1f5575afdaafb45b411d61b052183f950e2836986c3450e3f379686623863",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 108
+    },
+    {
+      "fingerprint": "d2fcd562eb237f6ffa43e1cdd7cfd5c868a44a491bf6e533897bddf959333113",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 108
+    },
+    {
+      "fingerprint": "a28e4283046ca623baef24f58b781c2cb5a3ff57b41899cd3375e29690a6030e",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "29dfd8f8608c28998d8c63b8b4d9e1aa77cf1393e45263b3f83a256e7fcde2f9",
+      "rule_id": "py/no-pickle",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "c1266bd2a12c1365cbf1a1d511c3f1ad8465d4a040d300c1156d1b7b70420d46",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 131
+    },
+    {
+      "fingerprint": "328dad2535807d567a8863c071b20eeada791e343681f9a4f4357ebac0ff8ccb",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 131
+    },
+    {
+      "fingerprint": "a11cb2d06968cbb06e2263fca964cc5953aea390d7a6fd6b21cc2946995cde98",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 137
+    },
+    {
+      "fingerprint": "d53bb858c68ce684ecfbff7545b607ace534425421addb34143f61a11c3c6114",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 137
+    },
+    {
+      "fingerprint": "d7ef323fe07b6af8f182ffaf3caa586728fa0ea40dd94bed04ce0d0b6dcd82b6",
+      "rule_id": "py/taint-ssrf",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 143
+    },
+    {
+      "fingerprint": "b52279dde9c5d99f3dffa7a0dcbc77a1d27d3811e917e6add2528da38b2ff79f",
+      "rule_id": "py/no-ssrf",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 143
+    },
+    {
+      "fingerprint": "6846f4ee2c70b9d893eebe1016af041b77c1424efc463ed5cbdc6e1f65a6eb33",
+      "rule_id": "py/taint-yaml-load",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 149
+    },
+    {
+      "fingerprint": "a14cce64bc2deabedda9d6b2f4e623baebadeb8e7ec8d044a28786318eb8d85d",
+      "rule_id": "py/no-yaml-load",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 149
+    },
+    {
+      "fingerprint": "3a197a581fc79e8fcf671460811e698ec3764aada43eede830f15f355a952b59",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 159
+    },
+    {
+      "fingerprint": "b26b10621fbe1b3035151f99ad9aa40d747a165b47d5329797a0c92a3d9b030d",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 162
+    },
+    {
+      "fingerprint": "fda792b84b94e8d0c4224ceb2df485c29279dfcd23e33b965de2d55269818d99",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "bec4ec63d1d38aab0bb5ded21a2da2728489e3126d2363c599e0ef214c16ada6",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "5ea5c85eacae49a9108b3e82ee0332ec4e05e4291a581402038c9f8050b7d4f3",
+      "rule_id": "py/taint-eval",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 176
+    },
+    {
+      "fingerprint": "8b58c9e15ece1e1fdfb6f334d89451a70c6433cf6e8385d0432a473f5de28bac",
+      "rule_id": "py/no-eval",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 176
+    },
+    {
+      "fingerprint": "b5f23103c730b06656f719766c7495c7944e3895c9f346046274ed075fee97f2",
+      "rule_id": "py/taint-sql-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
       "line": 185
     },
     {
-      "fingerprint": "622697b648053162a483841286b7406ebc612753dc6d14f6c4524c3ff7b52973",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
+      "fingerprint": "d4d63692463d827c4bbcd49e3867ea391222edd26810fea5aa017a1ebf791e17",
+      "rule_id": "py/no-sql-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 185
+    },
+    {
+      "fingerprint": "fe3552491070df38f5d50070080ee8c7256e40fe1889ae733d259740479476f8",
+      "rule_id": "py/taint-ssti",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 195
+    },
+    {
+      "fingerprint": "87c505b1a4040ca75470c3fb5161baebc89368da956e2fbc18486cd53b885c13",
+      "rule_id": "py/taint-xpath-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 205
+    },
+    {
+      "fingerprint": "a23dd1a0b2d467ff93efb2fe328499bae08c0a5f36c229802f61a229f8153965",
+      "rule_id": "py/taint-ldap-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
       "line": 215
     },
     {
-      "fingerprint": "fca29ade62c33ec75b9954c18f19101d9ffc381d00a82bfd5f48181de316047e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
+      "fingerprint": "5306493339080768d0a8d10167134d9b94a154a4dcbab064c9eec6855a9e9ac7",
+      "rule_id": "py/taint-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 221
+    },
+    {
+      "fingerprint": "e8c69ca4f1e68bfc3f02699b37df1e8a753e8755fb48e0afbd6c8dece7ab031c",
+      "rule_id": "py/no-command-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 221
+    },
+    {
+      "fingerprint": "0b3cdda4719606bef1159104fcfcf4054352bc5aef45787add2aef8d061ee93b",
+      "rule_id": "py/taint-log-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 229
+    },
+    {
+      "fingerprint": "28340fc3a23614efd580771d6fe9bb9cb954b2f6af2a7d6bcf5f72226d9fe029",
+      "rule_id": "py/taint-xxe",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
+      "line": 237
+    },
+    {
+      "fingerprint": "dc102932c135cd46b401a0c30fc71331bbf1d8101f33bab6e6ba166d0df92bec",
+      "rule_id": "py/taint-nosql-injection",
+      "file": "./tests/fixtures/vulnerable_py_taint.py",
       "line": 247
     },
     {
-      "fingerprint": "6a64a01b9c17a15e79ef084048d4e84749b9439f940bf50e06f1d96d91556cad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 280
-    },
-    {
-      "fingerprint": "e3af6665b3a6e37e8b1bd8337b592a90dbc6bb3c091a72a3eb53bfb135d17a0f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 313
-    },
-    {
-      "fingerprint": "522d0f591b997b51c28d57cf071fcfea161bef6ad62cd78e3a141c5ca5ce247f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_java.rs",
-      "line": 342
-    },
-    {
-      "fingerprint": "0e93783bb0b2b7f2d956679423ee00362ec1b2075ca463032b12e2a8fc31fed5",
+      "fingerprint": "e497082d69e4e6981c56929e79a6a97f515f6cd9dde212fd79df058b879fa04a",
       "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 24
+      "file": "./tests/integration.rs",
+      "line": 7
     },
     {
-      "fingerprint": "8b0b056bb273c030aa72b53f92b3b6cc659f7fcea4c42f941b81d423d0194faf",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_javascript.rs",
+      "fingerprint": "eba0076130649dfbfdcb55929928d284379365b01967ef861dab28133e666416",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 11
+    },
+    {
+      "fingerprint": "44f56c40eb8aa3144e74a06c4fb69cc60e80a1831fe2ec9a4ef80c5a653ddea1",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 11
+    },
+    {
+      "fingerprint": "96625d420933d7e71b01a8862aaf0c48c2861a27bfa2ac7e06b8ef676ef2048f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
       "line": 32
     },
     {
-      "fingerprint": "1d09ac42b0eeb78ff0d1d03cdc98644bbc2da214a2c8574d8767ba614d9d9dbb",
+      "fingerprint": "2279f3ccf706007cfadd9f74e986759a93b84eebe61fd06a6620d75101ea9a97",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 42
+      "file": "./tests/integration.rs",
+      "line": 41
     },
     {
-      "fingerprint": "a9729b44da3a30b3b3e02d9a2b329790d7635cbd3c69acb0c457a498b26a880c",
+      "fingerprint": "802f09e5510bc22b071858f4e3684be96bddb451404d6fcda00c6a7feb474943",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "a0926c8f8384ae2d450c50aaa84fa9fe0358eccef7c19c27a383a115c6ce31f2",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/semgrep_parity_javascript.rs",
+      "file": "./tests/integration.rs",
       "line": 49
     },
     {
-      "fingerprint": "9f92d3ddecbdb551a9143f1e5d3e5e59faf0ac0364adf5bc2c999e9727736171",
+      "fingerprint": "b08dd553c50973f9e90853924316fad44eaef9443c15419c57ba87303b78e9d9",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 63
+      "file": "./tests/integration.rs",
+      "line": 51
     },
     {
-      "fingerprint": "d7e01b1ddccd4e13ea71584788b3c686335c1085aa957c43aded9af1792d5428",
+      "fingerprint": "9e1ca5639334e07b9d8aabf33d6c4f96a0b04da87f2257c3f05eb7619c9158a9",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 64
+      "file": "./tests/integration.rs",
+      "line": 56
     },
     {
-      "fingerprint": "3f0ebe0df07b51cee1a74fe6f1d5530928756db331337bffd5d13db63015debb",
+      "fingerprint": "39ab6f3e5a9c27563a2a6497359a32e64268a87b920816073a1f8681d207e1cb",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
+      "file": "./tests/integration.rs",
+      "line": 58
+    },
+    {
+      "fingerprint": "0d95f74b3a8efe1908c348ae0b69108e98e71de7f40c2492a41ed0f021e3b642",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 67
+    },
+    {
+      "fingerprint": "7be0adb8f28ec4a03f3f65bf5384009c47a8383a7b9749cde3d67e965132e6a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 76
+    },
+    {
+      "fingerprint": "85f70baafaa4ceef33a55b98237c44db7f7437c8ff4ef574a801fa9625b2761c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 78
+    },
+    {
+      "fingerprint": "57605c0a005c748111449834412b74a672fddf2e13bd66e1df07d7d6a6df4d05",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 86
+    },
+    {
+      "fingerprint": "3fda8137364c71876cc84929e6987e70f8bdf7abaf02d53c869d58b16f380cb1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "108c4678e646a9e550d5a8cc8fa86699a928481978ccbd3883ef900924af52d4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 99
+    },
+    {
+      "fingerprint": "20f790288961648aeb8a27c5c5945d93c14bbbe3dfacec2dd0f8353769bf68ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 107
+    },
+    {
+      "fingerprint": "d0fa914616aa5f0adbbdb7c4d7285096098e54bbd91dbfc68783fb6ea0fa1966",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 169
+    },
+    {
+      "fingerprint": "f95537b328c225a2386c7a932633f3d16747df5b1577a28b8dfe28cbacd28ee9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 177
+    },
+    {
+      "fingerprint": "cb56c3a453945b5517dd410f7a2b7daea812918464a2810f98765216aa288276",
+      "rule_id": "rs/no-ssrf",
+      "file": "./tests/integration.rs",
+      "line": 205
+    },
+    {
+      "fingerprint": "1f4aa10013d792548b60e73362b0640920ea13a7c6d2a69a65c0d4e66491a33c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 221
+    },
+    {
+      "fingerprint": "f3b0990b86891fe353f11dc9b0c226071cf4327f0965d67ea7a559fb31467867",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 229
+    },
+    {
+      "fingerprint": "fbbbe342fe1fa22420416b77b50598ad0da3638637b0fa4c777ecc050008a9f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 316
+    },
+    {
+      "fingerprint": "017a7ec825efa13ce9315b489448eb955f71ce904ce40f9e46192ac46908335a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 322
+    },
+    {
+      "fingerprint": "9befda8b2e3b72d9113c1009425520c2d01fced57a0e157e38c1e8f232c1e9d7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 355
+    },
+    {
+      "fingerprint": "7da0522d42d6f5f6a27de7d1d9657e42bddf0771cc0f584814d15fd613d26edb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 363
+    },
+    {
+      "fingerprint": "4ead2a1911333c69bc385a715e81d781dec82bf75e20dcf95e4a8c571ed34dcd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 393
+    },
+    {
+      "fingerprint": "22ec07fcc12417ab645630ed2065559af255f029d05df80109bf480acd5c188b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 399
+    },
+    {
+      "fingerprint": "f68d69d25c380357f08c1f747560fdba0caf4f35f306cfabe40305db08ee1d88",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 426
+    },
+    {
+      "fingerprint": "ba79a9aadf8bf519c9479e2b50a465441473a4709ee162fb601e8172d533d7da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 434
+    },
+    {
+      "fingerprint": "8202a0ae0b1c4a12bb2e1cce0bc1d1217a7cecf008e4de9dc7cb734e071d61aa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 461
+    },
+    {
+      "fingerprint": "c06e51832f7621cabfce6de82be31c839e648d9f0766a73b3a51c4052f640e86",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 467
+    },
+    {
+      "fingerprint": "2e1324d8d98f2994f0e69f16155b03bb4e8c210d224c98f961ea214b1fdef77f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 496
+    },
+    {
+      "fingerprint": "5c23313a655eabe21085bb4997d66000ea0dbd56a189a66309c57332a19c2bd0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 504
+    },
+    {
+      "fingerprint": "ba4bbbe50356e0129434da4dde6090365219adc440a31c297a5efd2c2b430840",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 530
+    },
+    {
+      "fingerprint": "76e7de0212b7aae5cc69413db3430716becee02fb6bff01e9c6ec50cce359f45",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 536
+    },
+    {
+      "fingerprint": "1b6a00207a08e25990709cf77eec95e66f9576b5e33aec607c095f1d60496f3e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 564
+    },
+    {
+      "fingerprint": "e2f5406796ba20348b9f3fd1f61e32c4ad5e82da5e3095b764e26bdef4c1f6d4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 575
+    },
+    {
+      "fingerprint": "3357c11175836c2ca195415da056daec851e666d78e9a391a0e419ccb63ad266",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 587
+    },
+    {
+      "fingerprint": "971fdcf303600602c663b12a6ea4d6f209322c47e844b8c3553c46f94f82d13f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 595
+    },
+    {
+      "fingerprint": "ef4421238db6fa208149274aa8a80ff719622f9dbb9cf21e872ed473f302f9cb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 608
+    },
+    {
+      "fingerprint": "d438d503160df6ad76a7dbd531e96e3a52736345cf7b8358b0547dcf669a3b14",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 619
+    },
+    {
+      "fingerprint": "a09866b4f6e0c635f65093470a51d3318fe00306e603fb668902d58979f056a2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 676
+    },
+    {
+      "fingerprint": "d82bd0f3fb91ad23077f89e4da8909d4acf1929eac0e88500aafc4c5362c91ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 684
+    },
+    {
+      "fingerprint": "819b519afcea25d5c9a37e95b79ece920d7eff58d4a96f8b288c734e394a70b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 732
+    },
+    {
+      "fingerprint": "87134c37d40718c60b7b35b49d03de53764c686aff62ad2a9b3f0c9a0307aee4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 738
+    },
+    {
+      "fingerprint": "689c34feb04f94542d8a856690d04648d461bf46528d95d49f554a994548c949",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 764
+    },
+    {
+      "fingerprint": "8cb3c98d249d42a257d02d6ccc4eaea082602b6894b7ee13a92252d4c5806367",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 772
+    },
+    {
+      "fingerprint": "4ebd9d05a7f7aba85345dad9a94af1d0a1192da13cc190388ee2ad922ee80a4f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 787
+    },
+    {
+      "fingerprint": "8cffeda86fc9115deeda2a12980aea4e232367be183b4faf57300ab3a1b0a1f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 793
+    },
+    {
+      "fingerprint": "578c334c77357f798f863755943eaf5fba67f68fdf352d4448aa1aa4727badb0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 811
+    },
+    {
+      "fingerprint": "e57e494d0db1e627409fabce5cad7cbca09c84f0b239f25d9dadfee836abeffa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 819
+    },
+    {
+      "fingerprint": "ae0333eb3d4b3cdd30f3e01b2e907e38b9f9f67cca75af63ec7d6b959583393b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 834
+    },
+    {
+      "fingerprint": "96a9bbd30dd5883729e433b6dedcddf4535b99d4fa1dbb34f1bccdc40f87bc2f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 840
+    },
+    {
+      "fingerprint": "170d16fde3584cffd0ff6ee0030b6916f340f0d9a6521c0c45225dfd08d43d2f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 858
+    },
+    {
+      "fingerprint": "7aa73a02413fcfd523aa5906983b2cdf9e9dccd25faefd5921792578384b6075",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 866
+    },
+    {
+      "fingerprint": "511c2d596820d2ec3f18df8acc32e808f5e2c3b1c9ad1c4acbde545b41fc7cdd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 881
+    },
+    {
+      "fingerprint": "c5c2a0b790c155965e86ddfdabdc03631c605394dd6f2464baef5841a2db6e46",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 887
+    },
+    {
+      "fingerprint": "cdd5ef457e82f380dd17e4e3f0aad33f56baa5e24efdeeb8d5dfd5a97078b6c1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 902
+    },
+    {
+      "fingerprint": "503643e7540562f7d59945392d4af04fb748dd53ee6dfea50f98634e8492e63b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 910
+    },
+    {
+      "fingerprint": "311f91872819317f8ade870833e3a7aa8e7ba43f07e130d49c02d9a8ef08a465",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 923
+    },
+    {
+      "fingerprint": "0a1cffea9ba86950bb8952077458b89514bc658b5f1be7394b1093df4a3128f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 931
+    },
+    {
+      "fingerprint": "c83227a68e49c0689805f84c9850b4c4e7e83b56b8b676b586c581f6c6e17fcf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 971
+    },
+    {
+      "fingerprint": "a2ae5ed5e8611e7974368caf6c6e3b673500d47813c043c7341c64fa2b7a94ee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 979
+    },
+    {
+      "fingerprint": "e3f40b80a93879a7fdeadaa711aa0ed761e86c5c5eb27daf4bb1356b2ae8facf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1042
+    },
+    {
+      "fingerprint": "e759ffb15b021681e74a89807e8a78a714748b0f14bb6dde5e0553ddd5f864da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1048
+    },
+    {
+      "fingerprint": "b4d205b03ed4b9ace062c2af95083aac16088567026e1eed12bbd4156d8dc547",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1075
+    },
+    {
+      "fingerprint": "5a674d03c81491b702f1cff14b83c07efde69746f27a0d355930c7255b7e50a6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1083
+    },
+    {
+      "fingerprint": "48575e6fcaa8a54ca0fed9d65d5a077f503c552e3fe041852b1a03ade22d7695",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1096
+    },
+    {
+      "fingerprint": "c06fd0a0ab0f9d78befa785631254a57d3111e5bda9a9d00bdf93d26e2e4d757",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1104
+    },
+    {
+      "fingerprint": "cb0fecf62464cdff9314662c30e36713adf0139466f63d89b01caf45e064219c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1140
+    },
+    {
+      "fingerprint": "9e168ae113c8a144df028a29a404d3cff61aa4df97b64dc4039fe20fd9677c86",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1162
+    },
+    {
+      "fingerprint": "bb67e77961cf94a62c6aaadacadc0403930c95c527250d2d9af434d943262a18",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1164
+    },
+    {
+      "fingerprint": "860452d2ed29dd3fe7b62149fb3b8d1c6e5c6ef16fc5ec4c0aebcce4ba7b4cac",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/integration.rs",
+      "line": 1170
+    },
+    {
+      "fingerprint": "f5329f0b137afe8fa61cf79e31e6b058c2e9e793ac69c34cc6506b28718cf127",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1171
+    },
+    {
+      "fingerprint": "7553496015df48b54ed6631aeb2e3a59397f30ba2f0ae1b382c876b8297182f7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1172
+    },
+    {
+      "fingerprint": "73436d268dc120e33c44563235b4104288b1d306c09a740761bb3f852c0ab418",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1174
+    },
+    {
+      "fingerprint": "76c872a3561da87c7a6b848b6176b97274fc794e476e67c03bac59b1d49d8447",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1175
+    },
+    {
+      "fingerprint": "348ae9aa0a49e7d1acf974c7d092fecd934dfc95391ea565ef0b7b09f6dd8bae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1240
+    },
+    {
+      "fingerprint": "417b4578f67d0c585e44004ea5ca0074e00d049d3a445bab1769cd0693446056",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1248
+    },
+    {
+      "fingerprint": "52ebf1365467ccc32c992cd854c270585a8d85351899ce7335ad0d2c00f843db",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1288
+    },
+    {
+      "fingerprint": "9e9754f71c6bf09d5974458dca9342facf43c006d0bd99f038e7fa8bb7686c85",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1296
+    },
+    {
+      "fingerprint": "c0bf4760937e317bb8e909308fafb68d9ca877aa2de263cc38651270799c2a42",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1332
+    },
+    {
+      "fingerprint": "ca073c6fb8771f1ca8d68a03dde1281cdfd7f4569a4aed474307ba995ad30c95",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1360
+    },
+    {
+      "fingerprint": "a4f7203cee0d452935a6090fb8e56c9163c9c2415e7e3df5f31c1717a588cd38",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1368
+    },
+    {
+      "fingerprint": "f671773c8a6e5d5ed7cd8a72f431e3fc278a3856d71926a9b318f732fc09fe86",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1408
+    },
+    {
+      "fingerprint": "bd7f0726a0d946c998fd61362db673ff29d0b5d70a73aa3e3918ef06bdb7ce95",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1416
+    },
+    {
+      "fingerprint": "0afcd0917d676d3f05c24063af6f0f0f7793c885df8ca610f390ac6cd4ccb5d9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1456
+    },
+    {
+      "fingerprint": "5f4b87084c0b6fc6b1807093e97b08a6871aeccfea587067e8af70c76f608562",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1464
+    },
+    {
+      "fingerprint": "42d6bc646c5233b03d741d9809ccf4b6d6ca23a59ab53b0de8c5ea43abd2dc3a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1508
+    },
+    {
+      "fingerprint": "4f151277c08bcc19ba5c85e7c8a4e9a8506b3022515b523238b6acefe85e293e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1516
+    },
+    {
+      "fingerprint": "2f39d14fc611e1419c6244589cded61cbde428ec025ea6320b73b173377f5663",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1545
+    },
+    {
+      "fingerprint": "9facf80601436f22b30ac16dbbb2c1b02517a0dcbe4d7d758c85a91a57b5556f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1558
+    },
+    {
+      "fingerprint": "326a60a97a142a42c3aab9beca6a9272e061339e2bdc431f34dccbac36d91cc2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1587
+    },
+    {
+      "fingerprint": "488d2368f5d9ab6f31adef9c47b3a63e350e2c0c6b9b9ad303604d9c72e29fe5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1600
+    },
+    {
+      "fingerprint": "dba2dfde8073af359ab0c3064ff002d2087edbaf3924a717e39c52dd6471bbfa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1621
+    },
+    {
+      "fingerprint": "066901e51f7929890eb0087295a70ae78244d727cca89a228233a50724654ff6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1634
+    },
+    {
+      "fingerprint": "37eb3f99ae51bf1ac69d7ca645d2d861eb8b0c4a57226b961d9524c4c7e401cd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1653
+    },
+    {
+      "fingerprint": "956815821e733b6dde65c9018776826c6b0faa9db9d0e13276b8cb44620bd34a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1666
+    },
+    {
+      "fingerprint": "8a71be9fc50a95fb1f11fab1fa588938761741b4acdffeba918efc80fda97d91",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1685
+    },
+    {
+      "fingerprint": "ba7eb9bb3e2ac45edea6dd06ea895f09ddf0ff7df0e00ed6054b7c65cd801568",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1698
+    },
+    {
+      "fingerprint": "dffebf546b82856418b830a4a15445927795f36543378b7346026105a43015c3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1717
+    },
+    {
+      "fingerprint": "a6d00b9a32bf9e925d900cfbb44e1ccde17fb56f0de1a9ec31dfd2e3cf986147",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1730
+    },
+    {
+      "fingerprint": "b187cdd08f1b7de7d463fd4ab041e7899bc15d04b9c7070d193f583163f60a1f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1749
+    },
+    {
+      "fingerprint": "f1ec013a3610d5b3df24e4d1b11c39ce6179dfb00d32bd10b638c1c72adcf64f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1762
+    },
+    {
+      "fingerprint": "d747043303e5791d1f5ed550a5679e3236a9cda2f1d5eb5e6bef9aacf5ae3a7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1781
+    },
+    {
+      "fingerprint": "e0c62397c39fc4c42b99cee5b781185e053573f81e63312966ad657bf68257e6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1794
+    },
+    {
+      "fingerprint": "3be52beaf921263d0cc8044a96da745cad410b83fdee7cabe0411b90335a171b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1816
+    },
+    {
+      "fingerprint": "bcd09c83fd3598921fce4b9b59eb004242b9e49013719be343bb6a299341e9a1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1822
+    },
+    {
+      "fingerprint": "c05bc9f986f4a0cc7b792499c7b921ce308271fd73701929b7e4f4a60fe46098",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1842
+    },
+    {
+      "fingerprint": "600e1daa026f8961aced9196c7ed699eb334d048e9a3b94daffd853d0c2e3175",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1848
+    },
+    {
+      "fingerprint": "eb0ff5e5cf7275a4177323363d611bb5118c73a824169b6e366c27c6261c17de",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1854
+    },
+    {
+      "fingerprint": "97d3f09c9e14d481102290d28f5c35daecd66f6842fefe248f1ad22df079e1a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1868
+    },
+    {
+      "fingerprint": "f8baf22ef313cb49ec6b55637e7d27f0ef9ed3a730e69fbe86084d0eb5e44f6c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1888
+    },
+    {
+      "fingerprint": "6d523ae67a3c73e46de38e44b9a39d1b8fce15c1181da3624115fb2dc46827f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1904
+    },
+    {
+      "fingerprint": "6803111737c87d6b8f77b5debf530c24680ffdc28ec7981f596759cd79a2adec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1911
+    },
+    {
+      "fingerprint": "4bfe59307db674513064fa6c755c5a47fcf249a195c2c4ae18eb0c0d92b9223a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1929
+    },
+    {
+      "fingerprint": "d7ad816c3e10299ddda2b6dac61458e9f6b63766bbc3d5947bb803fc1644d3e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1939
+    },
+    {
+      "fingerprint": "e8902ff2e3c42f38fec150bab3ce261ee9da4555c9ee0e25b6309f04bf964302",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1944
+    },
+    {
+      "fingerprint": "2c0ed37dcc7f7dd9b611f8caeffdf3b401f17748db20ae1f9fc9dd75e720db55",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1945
+    },
+    {
+      "fingerprint": "a855f92525d87aa1161f1ee27b1c2de0328ab3599e65dbbb1b435d9cc93fe82c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1961
+    },
+    {
+      "fingerprint": "725d0db73ac2feca0c5e07f904c0f632325e79c19da94f4f40ed047827d175f5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1973
+    },
+    {
+      "fingerprint": "062d1c7bb062c3aee0b0c9f602c9e854e3b2c6ffd09890fba7459448c0d6dfe5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1986
+    },
+    {
+      "fingerprint": "e436c525820c3dd6f86431823fa988955c2b191929dd987140376fadf42509ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1989
+    },
+    {
+      "fingerprint": "6728a43b739f32b36db617570191c4907c8f8a3a427ee1af0fac7f707f675f35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1992
+    },
+    {
+      "fingerprint": "ca449472d928aa4aaa09757df4ab037e58aa4fdb7c7368742e477f3a26e59d4a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1994
+    },
+    {
+      "fingerprint": "4e7dc12c09095e29ed024ea7749848ab880d618b94a2b77ba7edbe57664be0c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 1998
+    },
+    {
+      "fingerprint": "e0deae22f2baa25d7646ef9b4aec411598e9c6a84508aa97619ab2c11b482ce2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2009
+    },
+    {
+      "fingerprint": "200d5b78bd00f5fceb291a46003051d911869d779ba06f33727b67d6b2e2e506",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2011
+    },
+    {
+      "fingerprint": "80e29fbbb08d706e20d6f6612787075d093186627c2dff198b7625c01e23781a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2015
+    },
+    {
+      "fingerprint": "c0a92b3efc16cdcc60a748ba018798ec203562af328f644ccbf6946fd3e052e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2026
+    },
+    {
+      "fingerprint": "df95223e644f43d926718d663243098298fdae464fb16066331e29ff09feaf71",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2032
+    },
+    {
+      "fingerprint": "4803054674c5409931a4c7380b2463b1620dc8e38d8056fb20ad52a7bac88a89",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2033
+    },
+    {
+      "fingerprint": "08b99e6dc636d7e6c55400158567b96c8e80cf54db643392406a4355d68725ff",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2040
+    },
+    {
+      "fingerprint": "d959aebc546a59529bd5323a5148ea05595636c20c8e564596926e94d23fa3df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2040
+    },
+    {
+      "fingerprint": "049f5929566562c32e562264921d0bd179abd4583c9cdbc35e2a979d9a4cf2a1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2043
+    },
+    {
+      "fingerprint": "96bdd420cf1c253526c013c241f39e8a6a1f9c25ea55346c894000e79b82609d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2050
+    },
+    {
+      "fingerprint": "76b5a89c9171a38e4c9d9657a85377833aa1a23d0ba06e0ff81599a0ffa52e7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2066
+    },
+    {
+      "fingerprint": "764b2d45686236b9e490a06ce33bbaf15d94af6116ad1d08d866e0323d5f5e5a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2078
+    },
+    {
+      "fingerprint": "e095ae7c96f825dd67a93eab502c86765e30b572fdaa4b54ef49c9b19190b654",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2088
+    },
+    {
+      "fingerprint": "706c6134de793addd0c95c96b8355eea3910965f42089451aa248ff1270d104a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2096
+    },
+    {
+      "fingerprint": "5b6461d7e5db4f343b6b4e2780507d926e3484f09e4c4cd8e203f82e36828c83",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2103
+    },
+    {
+      "fingerprint": "2ecb90fa7ddb63402d9b70c066cd8ec4e02f5983865cfd17195512df4816b018",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2122
+    },
+    {
+      "fingerprint": "bf1522afaaad8d19637b5ed3c6a2c849db26451896712d693ae1ceab8f8fdd06",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2126
+    },
+    {
+      "fingerprint": "a36b311b707c791b68ffa54804827f477e48b804b8a7b28960203d9baade57f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2132
+    },
+    {
+      "fingerprint": "03e702878349bfbe89f7d8db147980581bdc0dff2e4134f6ff99fdfa989fb0fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2146
+    },
+    {
+      "fingerprint": "676ead43ab2c48527b3838e34ec226a489175332f7d42ba7102842337c31c5b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2153
+    },
+    {
+      "fingerprint": "4e8c2dfd4d860ee8f2643263813c0f698caced47e513a36c9d6ac2f2bb230189",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2168
+    },
+    {
+      "fingerprint": "c6eb75d65d4ce1b6dd78bb096f1818016b22b8b4f5e339c4e5a0d482b902806a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2178
+    },
+    {
+      "fingerprint": "1727e2f165bbefa0f6f0beece00d8d8ab072d24c170ab24db62dbde4dea9ea6b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2185
+    },
+    {
+      "fingerprint": "a67fdefa3c36a679d7d11f60f9d1ae78e5486d93d11ee776892160f14bd496b1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2208
+    },
+    {
+      "fingerprint": "aa770e8863c68cfc32ddd992fd79502a01839ba07473da0095ee7df24ae5c08e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2216
+    },
+    {
+      "fingerprint": "98d430d3be617d87ba3d9f0e6c813813bf30b0fed06d129a9ed8a367654f57ef",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2238
+    },
+    {
+      "fingerprint": "926700ce25b63be73b7351067b395c3cdf9b36fd03f336552872c79ec758b724",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2249
+    },
+    {
+      "fingerprint": "b540a166e4f318323ec4cbee9a262db042499bdc1ecfbef751e3c898cf82fe14",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2250
+    },
+    {
+      "fingerprint": "da8dc12c14c1bee5ab0935ab32144509d453b390c1f9317029212ce85716d595",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2252
+    },
+    {
+      "fingerprint": "fee256a0f12e11685eea2e49fec2827839bd4c894f3006e252da93fc1591d7df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2259
+    },
+    {
+      "fingerprint": "589033dd849f0fd408945481942d95cba8eeead758d83182ce291d2906087b25",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2285
+    },
+    {
+      "fingerprint": "2439c743587590ddf3a5af240bad0ffca68f4115917ca1127bf3ba820f2c253a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2286
+    },
+    {
+      "fingerprint": "4cd9fc4ec57cdfb286af8961da5425af6a781993f920003a55f2a846bb518e4a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2287
+    },
+    {
+      "fingerprint": "e551a57d90c48058a7b7755e9e3cb05da71044cb67e4c98590a2845f396db57f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2288
+    },
+    {
+      "fingerprint": "2b2d6779958cc68dc708b6c88bd2b9885f415d998e13d63b0e887aae28ff0a94",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2290
+    },
+    {
+      "fingerprint": "dfc7a8b1d15077ac5af7696dc59486d29a8644aa644f9bbb8b475bc8a3a740bf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2296
+    },
+    {
+      "fingerprint": "b9e022ed9b459bec46319410a97ec0e83a4900dd8904b36fdb9e88523d171383",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2308
+    },
+    {
+      "fingerprint": "53a4e886aa53444dc0c6dbab82f2568fda863ff84a93c53b6ee28cd1595bdc35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2324
+    },
+    {
+      "fingerprint": "24fec50094d1f13ba7a3c24ef9dcb1a7b94d81432907befbfa16e8a5bc4a0b05",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2325
+    },
+    {
+      "fingerprint": "0e7be4ad15c5fa1c0b1482f9aefc8393a7bed0d8b9a43d3e20c4e59e1d9fc921",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2327
+    },
+    {
+      "fingerprint": "e323f9bfcfb69f320f0bf9d40c989ea678ce91443db29ef28a58ae01046c2357",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2329
+    },
+    {
+      "fingerprint": "05ac11d2dd290525fa71b412aff35653829a96e2a5d70d8c20615a97863e5aea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2335
+    },
+    {
+      "fingerprint": "57c814e68ae7561337228caf741be235faf1989741c9bf17d338d544ca263104",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2341
+    },
+    {
+      "fingerprint": "23f40e8f53d569932d305fa91d6a5c8d6498a1e8f84b27e0a0f511b9164d8e13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2360
+    },
+    {
+      "fingerprint": "5727f3a80fc3beb74d95b9de01ea9bb595fb2583781a72fd75d5641fbf52bcab",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2378
+    },
+    {
+      "fingerprint": "350cc728e6391241eebe701b346078fd701a1f6d76342a9a5dbccda8119b41b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2379
+    },
+    {
+      "fingerprint": "9c254404df01765057fbbb13953e8e6bfabed51e56ffaa11b67a92e906847dd4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2381
+    },
+    {
+      "fingerprint": "900a54640c149af187671ada70996076e2406a2f2437571e757752db364eca69",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2382
+    },
+    {
+      "fingerprint": "9ba3233f8f9566ef70d5971ad643a40a8b35ba601f1ee4ca6d7b43535c4a55d9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2390
+    },
+    {
+      "fingerprint": "ce339041f0490161e7b27f234ea8ef49b90d5a4d0cfaf69aff18f16f178837c3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2416
+    },
+    {
+      "fingerprint": "0cffb8e60f9daea6248dc5030bbcd7d36edee77daaddb8be2341f6a4caa433d5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2418
+    },
+    {
+      "fingerprint": "56b8fd59ff9448a924470842ff35d3567bfded00f48f3f77163b7943a11a88e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2424
+    },
+    {
+      "fingerprint": "782389b05195dd05878ae9327f3704b3202a4403836f8fe1d02b72d98fe88c78",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2425
+    },
+    {
+      "fingerprint": "610b3e332d164595818c1532181364109729a308624a126e7a87c4bf8b777ddb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2435
+    },
+    {
+      "fingerprint": "aa9d5d9e683636fceb74ea2114b613f3ace2bb4e8a3a598ba462d29f77c3e1f4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2444
+    },
+    {
+      "fingerprint": "ce200629df76cd5cf1ea4a5a0e6b3ea7883e9741df34067cb5bf7afe28d0ccad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2446
+    },
+    {
+      "fingerprint": "6e163f4be253311db2da087592067ff2d8a395a2d27b3d5e05cb7154728b693b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2449
+    },
+    {
+      "fingerprint": "968a5938b2ab7be9b3fe19cbe82a1503150cc4f9378220ff41e4e4b70cfe4f77",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2450
+    },
+    {
+      "fingerprint": "c3d09b4c18213346a80c09b6aceb3923e9d523fbeae97360a7e8c9311f7cbabe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2460
+    },
+    {
+      "fingerprint": "3d5addcaf9241844a4f0b45281676a59b0b540d80f0a525898623e5fe964bce2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2469
+    },
+    {
+      "fingerprint": "4734b4fcabed4d33e8a3bd85806a29245a4c411f29808586a1a14da6a1f9ea5c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2471
+    },
+    {
+      "fingerprint": "25d1b384169ce1f495693061aa01cd1381b6d6aeeaf4863ab6d36e483461ae80",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2477
+    },
+    {
+      "fingerprint": "ef0a999c3b7d5405e30ae1bdb724c78af75e260ad10c3ac427ce58b8b3abd376",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2478
+    },
+    {
+      "fingerprint": "4dd8719b185ee246c6f22cdec6835152acb60e252adcd01561c56f31f24f4669",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2488
+    },
+    {
+      "fingerprint": "c996494ae0ff41014b43ed7d5f4b5d86358324694d0097c31da4b3e82958d44f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2495
+    },
+    {
+      "fingerprint": "9a26a68c36d1eb8f438089578a88633732b508d253a4fec4aa96a58ad453dd34",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2497
+    },
+    {
+      "fingerprint": "5d3e177fffffc25c7e949e4632f80937a1363366a5f70bc6906e99db3e79630c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2503
+    },
+    {
+      "fingerprint": "dfc380d0f1a0cffdd4d93e08cc29b27c27bac453d683c304fc0bf1a01584bf43",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2504
+    },
+    {
+      "fingerprint": "27b4b14d9e045e60ec3a1b8c2dd3d732f8237eef05af6a8067c7ffd40b1483fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2514
+    },
+    {
+      "fingerprint": "77ed62063282aef350fa4ae331704940b82066c3ded782cef0747a19832e1f6e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2520
+    },
+    {
+      "fingerprint": "decc0d600615311c869facca3120cd85a8bc621b14391a2dc51ad09fafb39f37",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2522
+    },
+    {
+      "fingerprint": "01c54ec16f75eaceb7a3a484b5561858198e9f844222f2b2dcbaa9b43639f489",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2528
+    },
+    {
+      "fingerprint": "c37f70299eaff1ba64f338370628066adb5d30c98ed260a1941cbcc81001d785",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2529
+    },
+    {
+      "fingerprint": "34bcba7c41a449056d5b19ced5a7a5d02f3fb214c9cc2bbd418db99f9f2b3fcf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2539
+    },
+    {
+      "fingerprint": "77bcbb7d448557d54dd760e4eb0d53a557716bcff97994714085b1c1009f78e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2550
+    },
+    {
+      "fingerprint": "d3e48602ca58e27a1ab872a35e27d3612601db2fcd263d5fcaf96fcc3ed9b8ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2556
+    },
+    {
+      "fingerprint": "2c2c30796ad64ef61003033c60b65bdcff06d32dbf8bed6287f7064fc07c39ea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2568
+    },
+    {
+      "fingerprint": "aa80aaa84597337146f30cd082e318876c1d819463c8c3de55960f5c6013676c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2582
+    },
+    {
+      "fingerprint": "58aa8099a3b21f0a9f24415cc67b45332c852d331782a444f4800f57dc0d70d3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2606
+    },
+    {
+      "fingerprint": "2b045342d387769ebb811e0d99bb8a0c462fc89cfea32dda99806f96acba784c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2617
+    },
+    {
+      "fingerprint": "e090a1adb93fc289c09c3bf570d60bf2703f75f7aab3a746ac3041a23934c136",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2638
+    },
+    {
+      "fingerprint": "85685971d8750254f5d0c4db9a1e7623fb0558701c833502e8fb4bf8bca752f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2646
+    },
+    {
+      "fingerprint": "18568b009e72415e058db3be2b512e56675eaf426879ee774e3db01e589614f8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2661
+    },
+    {
+      "fingerprint": "67d407677a6d5a713411ec9a3e27b4eb77cb3f714cba661d237c6710ecf3dde4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2671
+    },
+    {
+      "fingerprint": "0e01eeffdded6f6558188b8fe332bf6b4738e5d8ae0639c0d27fb29f4c7b58d1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2679
+    },
+    {
+      "fingerprint": "5e93b93c66252ff75a1eab4fb281bc4fa5c0b3395f50502ca5cbb806be790d63",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2691
+    },
+    {
+      "fingerprint": "10b3a9b0906c837b8deb64e182157825f67fab21d163129748a5c38bf15a376b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2702
+    },
+    {
+      "fingerprint": "9261bb6b8e20c00d6dcbe5808d3cfc1f7b6604b9e6a89c2469f3abde4c3fbab7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2716
+    },
+    {
+      "fingerprint": "c3d256d2ce4e9d0bca9092a1e4a10965fb4a1904b8261ec7729991cddffb3c6e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2720
+    },
+    {
+      "fingerprint": "79a58c150943914a42ecfc8ea361219eae7b28de298eebbb2fcea90030dba318",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2727
+    },
+    {
+      "fingerprint": "bd4d125c9ed3cb9b87dca71661132c351202077bbea2edbdc4a6bfe27c8299ba",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2730
+    },
+    {
+      "fingerprint": "218b8ec275b3cd63a2dafdc988701ef7c34c6a2eddd806b7bf3a26261dca84a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2733
+    },
+    {
+      "fingerprint": "a4421cdbb059195c856ea04ffeac195a60251135a88215847247e966f4f32664",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2746
+    },
+    {
+      "fingerprint": "e4684778d8e21b972d2e697973ee11f67a909f9c3207db2f7cac47d01de94521",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2785
+    },
+    {
+      "fingerprint": "97d73e942d09ebf9711bfd37639aa26236178fac5a8b77c51359e6254d91d004",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2791
+    },
+    {
+      "fingerprint": "4205294e27bd9e8a3afc189c977f5a54ecaacc1d188eb19af13416113f834143",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2803
+    },
+    {
+      "fingerprint": "0843203eda9e042485786237730b54e43b220bfc5c6082d4439b7c12bada2346",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2815
+    },
+    {
+      "fingerprint": "53cfd0b13ac2256ddf528574d5363ed85112bd54238d1c88f8338f58d24ec892",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2818
+    },
+    {
+      "fingerprint": "5db97cc7971e6888d45e9de12b9b7646909a0a295747edd491d78aed10786503",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2821
+    },
+    {
+      "fingerprint": "eba251fa16a99c4cdc828b32a0387074a0fdb0e56d881a73ce21b58194765afb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2831
+    },
+    {
+      "fingerprint": "0e597ab73ebc43022090935daefe3cfc4fc6d94f87d7e10d9d8419c5abfe9d0e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2841
+    },
+    {
+      "fingerprint": "1c42925121975fe474e9d517e2c60a640d05b5551cb4644dbe0dc6220012439b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2845
+    },
+    {
+      "fingerprint": "7a22fdca9c0456d493ac91d8aa35e6adcd569dfb31f7cd79d8ac85feb8dbb72e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2848
+    },
+    {
+      "fingerprint": "2d2448ecba28181a0bb1dd8240854dd699f3a15d6e0d1de9549125723882eb34",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2852
+    },
+    {
+      "fingerprint": "4e22595c51a82e928d49fba02b6261fad63ba920ef29db7d5844314d4aaa7f46",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2863
+    },
+    {
+      "fingerprint": "699321562a56385c57a3ab46de17277d5500c0479e432c95382e8f6f93445aa2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2866
+    },
+    {
+      "fingerprint": "b863ad5b3d6032e9c23d993a6a1bfd971fb0725a40026f1988da9947e9e597b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2870
+    },
+    {
+      "fingerprint": "b78a3c107567f1443f23f7b32944221014237ebad886235b3da05b588d270c6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2881
+    },
+    {
+      "fingerprint": "1ba2b2ac9c2cb537f0368b1706eb6e65942c639ce5cbae643fb3e10f50832817",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2889
+    },
+    {
+      "fingerprint": "a214235d1360a89e4b090e4251e7490635b52f238e1803b0cc8cf410af0a77a0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2902
+    },
+    {
+      "fingerprint": "7ffb8cc6315732e37c7c6444bb39705036e66533c67754c4eb5e4f1205cbd11b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2905
+    },
+    {
+      "fingerprint": "8a0fe123742306d9f235e3f944d1a3e5a484adab5bec45616b4272f2e9601a6a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2908
+    },
+    {
+      "fingerprint": "79ec03273494d7bc3ea34ba60b9396f3d93962c5330e9dbe49d66db68ee9a57d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2916
+    },
+    {
+      "fingerprint": "9c719f70ac0981f64b59a5a1850e0a676ea1cab39ffd9c55b02ae569a86c271b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2919
+    },
+    {
+      "fingerprint": "975ff7055ac0fa3bade8e5306bb627328e9dca6ffa0e559c4e8a00efedaabb92",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2934
+    },
+    {
+      "fingerprint": "1d65010ebd3ac09d2f100007fb8bf1facdeabe3d7ee60cb8dbea0d435e2d7a00",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2938
+    },
+    {
+      "fingerprint": "39357e0dc89ceb8c7131697da1646c1a45431d3805e428b67c8168dc6194e2e7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2943
+    },
+    {
+      "fingerprint": "2b0b0d3535f7e06d0c3ad81609d914b3ebcef37cca63dbc57768075b5292e5c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2956
+    },
+    {
+      "fingerprint": "cb82d3b7e4e4534c604dd8075f119af8edeba0fcd16001d538118bb3839db2b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2969
+    },
+    {
+      "fingerprint": "d86817d10ee01e2ce5df598359bf756662028dd3cebfa929f1cd54fa54e4e74b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2972
+    },
+    {
+      "fingerprint": "72eee8955046d8019e764f4ed34a01ef99c376eb1dcc1937ea3773f3a1e5e08b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2972
+    },
+    {
+      "fingerprint": "c2bb07d98dc0c9761cb37ad3271b1bb128a865781038439090f585e71c21f9ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2974
+    },
+    {
+      "fingerprint": "86e90603c80a032cccd5769f626b102739431c64f289c465d0f6ed9ed2a9979f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2976
+    },
+    {
+      "fingerprint": "2bdb4a5a545590031e774a78fe73696a579886ce245d2f5386826dba282f9f5d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2980
+    },
+    {
+      "fingerprint": "c1585d266a87de16baa8ad859e34b974b49a61b198501de78790ed1f56b2e393",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2981
+    },
+    {
+      "fingerprint": "684dab6e5ad82ac2a9defbe73a465c8fb0a7ca1159b78c9e70c948e926436656",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 2994
+    },
+    {
+      "fingerprint": "fe8f0810dabbf05da7c58438c49bf9562592734a2527a5d6dceeb531f87f7fb3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3000
+    },
+    {
+      "fingerprint": "4483573c60a8c6b6c1c59cb3801db1e2ce29fba78906007c5216feb418f4bbd1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3003
+    },
+    {
+      "fingerprint": "2945e165fbcf9170aa3a279458814e662c3f9fce3b8ec026c51f0d3c99f948de",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3008
+    },
+    {
+      "fingerprint": "276f8927aee296e51e6c58c7f6349b5522bab5c84b3b1e04b91fdc5a60dd88e0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3021
+    },
+    {
+      "fingerprint": "918f8652040ebead244fa4db33f954c58d68f8eb93bc9645d1f29e14d900d68a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3038
+    },
+    {
+      "fingerprint": "a98934280dc51320d6456b73b36df7e6ab54cb88c8c373940a1a2947f5c6eb7b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3047
+    },
+    {
+      "fingerprint": "df5693410d5998032261f327f3fa3eb9937d645092f662a69061e8acfa33fd99",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3052
+    },
+    {
+      "fingerprint": "31d3ba99e75b5c9c4dec6bf77faabfc2183963e39879bfcace2344b4037d0069",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3066
+    },
+    {
+      "fingerprint": "17f6d1eb27c8e24a24a276471da727f9335cdc00f540bc8ebe853dd0891822d8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3076
+    },
+    {
+      "fingerprint": "5cb5d038d1b42b72e7ce50822018fcd54cb08e857f3d39c8d071267ddbe06b28",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3101
+    },
+    {
+      "fingerprint": "498752858e0f2c3b3b01c33024ea563e452d7fc52af28b5fcd673d7e058c7ee9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3121
+    },
+    {
+      "fingerprint": "a3689c26fcc6b840606757ab3d23481df3e540c70a83f72fd5ae5337e7111676",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3132
+    },
+    {
+      "fingerprint": "ccf50eaf6524fd972bba22b46f7a8f6daeb19f16b3898a30e3abeec31a37a962",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3186
+    },
+    {
+      "fingerprint": "b766c2b6f0e6200109b24264ec51341419a7d082efcc47c488427fed308639f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3197
+    },
+    {
+      "fingerprint": "16048b20a3469030460bd73431a403f9311c03f53bf4fa7fd93ac38a286f5ee4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3241
+    },
+    {
+      "fingerprint": "719dc5aea1547a006998c71a7993ec33f005956017de735f7b9899bb65e32e7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3247
+    },
+    {
+      "fingerprint": "0c49ecb49cc8a00a2c42c3c6e647dcf81454888f3ef1cc18dc06c454a38a69b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3249
+    },
+    {
+      "fingerprint": "68d266f53740a474f2ab04cd4c3eb99e9a2b493592d4be07220259882c787af2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3270
+    },
+    {
+      "fingerprint": "1bf66705fc0951ed831144a5e3cb68d0834bcf3e5d503769196d91f1a1bf8ecb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3287
+    },
+    {
+      "fingerprint": "75650acd757c024469eae2946f588a98f11f9237c1c518965de889431726596f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3306
+    },
+    {
+      "fingerprint": "940e7ce6c87ae40bef7f0d4bfd60547bc1b7a146c117875c3112ed4d86305b03",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3309
+    },
+    {
+      "fingerprint": "34c14b2eb9b3d5a700207685d699d0611b06fdddc896e4f7308053a082eb9172",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3327
+    },
+    {
+      "fingerprint": "db1708755da22585b64fffc76e1ba0d5520c4273e6deb96c4325e3fe832dd525",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3335
+    },
+    {
+      "fingerprint": "2d78560e942d0b20943a69df6fd9a611205bef202e7c4d21726f89834192fbaa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3351
+    },
+    {
+      "fingerprint": "01d7f4b7d65dc06aac2ff572337e469df1690488bae086ff06faec6ee603a94d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3359
+    },
+    {
+      "fingerprint": "c4afb535a9c728ffd702ae0aef69fc720ff17659ae94213831c745ad0362ad60",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3375
+    },
+    {
+      "fingerprint": "630b578ca75f0cb31d78f22444e7a7013ccf13405fdd3eb70ed8d6b1b805ae3e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3383
+    },
+    {
+      "fingerprint": "8496a00b959109807ca295a3869e3f00c9d9430a37a7acd12f100f2ae47ad86e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3406
+    },
+    {
+      "fingerprint": "5d9f9786737598867f5b1d7bfd47d8e2fb87f231664795935447493176dd02b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3420
+    },
+    {
+      "fingerprint": "91b41f7f20bb2252dfce85164cb74dd9913a037f05e8556e8b8c1871ef7ac0ec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3423
+    },
+    {
+      "fingerprint": "20595d6298c64a6e391e04566bd93c7ec4b2bac5bf2b034f856325eaab3cf521",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3434
+    },
+    {
+      "fingerprint": "3396bcbff5cf4dceac3355abbd131270e2f7cbc6f79940d0fef8fe064c5797f4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3461
+    },
+    {
+      "fingerprint": "cddfb5cb79ba898ca4fd9a7fa1c4e84346bc9380f2320c8d0020be852bd44be4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3462
+    },
+    {
+      "fingerprint": "be72cb58a4f5625eb5cd799ab19d2015a760df160260321fe70f16593181499d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3470
+    },
+    {
+      "fingerprint": "a45fe6f0d954d34fc93b5e9aee13bbf02fc7d4d23d173a2455265fb38694e55d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3502
+    },
+    {
+      "fingerprint": "c0f256f1f88063d5d80ed6c2942f76bfac1053e5b51e69fc4ebc6cfd1c6ffe8a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3731
+    },
+    {
+      "fingerprint": "96ca411dc5cedbdb11b00f5e9ff08931561e3368e54306f2dd3f8ca14125e015",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3737
+    },
+    {
+      "fingerprint": "d03bf90d6664bc3adf282cde51ccebcf0cfaf56b4545c9bbd2a1e55606112b4b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3744
+    },
+    {
+      "fingerprint": "040421b5574505a38c36f90fae5dc90237bd465059817e7cbb54226405cefdb4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3754
+    },
+    {
+      "fingerprint": "be53da2d3a2995c206e424ffbc4f0fd8db8482c992ad2b0ea9734e0ef3c131b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3779
+    },
+    {
+      "fingerprint": "e64ac6b3b29f18983070ed80011d73c9727a04126ff8d5c67f354d529cd08c21",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3785
+    },
+    {
+      "fingerprint": "7978491cf73c3c4a001fda73f911dce85fadbafed648d224567ff009848de6e2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3806
+    },
+    {
+      "fingerprint": "44d4e37d8fa33d602a18fce2bf599bce1813461cad74fe1f66bbade765f06756",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/integration.rs",
+      "line": 3814
+    },
+    {
+      "fingerprint": "60e663fee1e63ad1bdcf39aaa401b4dfe0f6cffc73327d5cb8dbf1431e2b7b6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 22
+    },
+    {
+      "fingerprint": "d5101529968f39a448fdda960f2c4c105e118b6f19a17bd54b82388f747971af",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 22
+    },
+    {
+      "fingerprint": "18af09a91f23077fae58672240f10433129465743618e16a4e8640d3dcec33e9",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 22
+    },
+    {
+      "fingerprint": "f5bbf241d2d197ee49e3aae118f2cb5f2f683033727f9026cf861fee349b1912",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "216c6c02ccf6e09aed543b655146ea88d7b31ac754ed2e2a7c878eaeed264024",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "ba66ddc00c467d16ebb3406353f564a5e44ae8b8ccb3efe4c6525e14b7d4d659",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "a65bc4c9f3563b2e613fff8a9c5e56dc46fd754a3eff97fd317afa5502bf8bcd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "e911a98373c91bac64557749ad6b20e83aea957846d7f98e93903ead6257ccc5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 6
+    },
+    {
+      "fingerprint": "0aaec3a1e8f7bdf9d988debd56eaf5d55ba15a3168c408f204448e8d1911a6a6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 7
+    },
+    {
+      "fingerprint": "552ed5e37c0c6b2c828e54fc0557de05bac5925df37e0c08279e45a8aa94d00d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 8
+    },
+    {
+      "fingerprint": "17e990a2cce34cccbc0c4c18185c4ec2de1247d53b771a618247ebaf7984f9dd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 11
+    },
+    {
+      "fingerprint": "c45fe349f388d2c573d02f5b91d642341fe54468261c6fcf7aaebc366c2dc618",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 12
+    },
+    {
+      "fingerprint": "e9210cfc3b2b215afd9bd86738c6a0751c461c7e331fdc2db4ded79ad9892f54",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "86de3783e6ae51bd5b3141c2c731ba58719fa1b570d53ed31a8abcf7cec33b98",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "7be52fc9175041aea127006d2f0e0ffd88edaf7b80fc848f9ff3fda10fb351e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "40577488ec8557ef68b9b41cd5ef0d8da5b6cc414f72618a6425d3d88810272a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "bb18c813f4f6084b9d9e9900eb6e7979a08c07e65117e289ebd5ff2fbd2c8aa3",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/mcp_server.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "1ee5f80607a93456e7fe7b0b8d9558ca040173caffee449c9740b861cd5d1355",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "181d9acb16d6d79f0312548e3988ea941b1497085f655b008358f4b0d5d5dd96",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 37
+    },
+    {
+      "fingerprint": "7c69568c3a70fec7d0f46eaf4d3b3d5beef33ea48d4c71987f4fa29e30faf8f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 38
+    },
+    {
+      "fingerprint": "a8ab1ec165de5b7d879dc4274549bacce37507e1c391d8e96ed7f467b74242e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "ace9e0de409f2cec19834cc139fd1b9a2a7d432afbc8ac4ad33d41c692c3cdc1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "e382bab26719cb7abfc0dbed310a18ad4c7a5fa6b8f3c13f7d94635a665bb32e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/mcp_server.rs",
+      "line": 101
+    },
+    {
+      "fingerprint": "f1affc21b0a9bc0122ecc67380e932ca65d50b073726ee74b91df5862d6b36a1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 101
+    },
+    {
+      "fingerprint": "6e6f1d0f73ad1cce46c759bebd591b3f82543f218dda24fd293d9af3746e55d1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 123
+    },
+    {
+      "fingerprint": "b9852e9f14262ca6732d53dd76e7b74f2a1e090ed95e4e177ff833f153b19463",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "306f441deaf6990385aed4976b2e0744ba56a17083f35411db37afc0d4e69f54",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "21d4b625db31f88605d480f0fcc0de1a518f2b348374d555518580f290466208",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 131
+    },
+    {
+      "fingerprint": "5e267a96c9932b0143a86490a0ecb9ea9761e842f9a05b574b14858158febe70",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/mcp_server.rs",
+      "line": 169
+    },
+    {
+      "fingerprint": "0a590bac30c65045e08e290568fb9294f6ad51f65b6d3fb753b4bd0354b58f27",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 169
+    },
+    {
+      "fingerprint": "f5e9e14ff12e50f044827d03eec0f7353474e1fb585da3e57575d21f69faf190",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 176
+    },
+    {
+      "fingerprint": "dcaefadd7bfdc8c465dd1f4354cc43253a98f8d4770e34a54b8fb71806df3c30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 177
+    },
+    {
+      "fingerprint": "1c2d888c87c6b585a46f55660f7cc152bff50bd253e082885087f75bab9a2099",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/mcp_server.rs",
+      "line": 196
+    },
+    {
+      "fingerprint": "33057f76f04ad85dc02fd3edcab1affe37adb97d9b0fef68c20fd1d52d5e13ab",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 196
+    },
+    {
+      "fingerprint": "f120702f1bf70b2a45fada6f8d1a555dc0ca632de4646e37a2160827770302ae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 218
+    },
+    {
+      "fingerprint": "1d45ec9fe5d23a8d4f7f6c8bc753ef10c8cd2442f1b8477dc093e23f1a10f5d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "c1baffdfe285212db641d876534a6489ab446f22e2f19382bed004d5fd242a82",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "b7f250156fbff74e361f9c584352b6dbae293864b997ce74d18f13f2a2c18252",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/mcp_server.rs",
+      "line": 229
+    },
+    {
+      "fingerprint": "c86a5b91506abddb44adcd2d5eb4346eee5883d8586d5c285bb427f0286515c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 229
+    },
+    {
+      "fingerprint": "cd910faacb84b8f17fbea4739e4e3a46dfc8a55cc45e07f0cfc1d1a694673671",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 236
+    },
+    {
+      "fingerprint": "3a27bc880ace9b8b2c7f70df00c6532323fea47e991805f7cc0cbdff6061e227",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/mcp_server.rs",
+      "line": 237
+    },
+    {
+      "fingerprint": "246b4477067601a06217565bf7181ed6882bb37eb8911b6c428d488ce631d43b",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/realistic_fixtures.rs",
+      "line": 19
+    },
+    {
+      "fingerprint": "2c11b4dcd17dadc929afb7e10b7b612e461e69821486bb59b2db3a88628cbf03",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/realistic_fixtures.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "1e843e5429fa6f3e4600b5fb2f3e54d52156dad3e1e9abbecf4501781a7ea8ff",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/realistic_fixtures.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "9f0e534ff7d27a1bc5a5defd2f36b81ccc092bb2b181cd67be0cc2088c693b5b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/realistic_fixtures.rs",
+      "line": 39
+    },
+    {
+      "fingerprint": "6c09a468ee461508ad2e8550e259cfd5cc9d1322d42e130bcfdd4312126fe956",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/rule_inventory.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "d86b8eb73a80448edfbfef22b452a8528fe273a278981657bb02ded65aee175c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/rule_inventory.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "31980b1dd164b5f5406880018e506b0919818246e934654c3991b6ac683dab00",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/rule_inventory.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "65401b390401892e518d4a85119752dea453875fe7b6c460a3168f566ee2fd58",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/rule_inventory.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "523ef60f48fa5f279217dc42c93aea6bba8290f58f6f8d1488b49c7b1ff64350",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/rule_inventory.rs",
+      "line": 35
+    },
+    {
+      "fingerprint": "c54622784b8207282f27211ddd927d34569cc2f121906ec11952c266ef1acb03",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 13
+    },
+    {
+      "fingerprint": "325a8bcda9d69f3b4d36f565873e0398b53e3d6a7a371bbf6528633621653a09",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "7a6ed60263c0b6f279ea510c54986014671b500f10673c3e55d99fbd6bb87bcb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "021e1b7e8d39027a7b84eee00bffb0226b450c9be0e2e73facb06a5cc4652bc4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "abcf29d53ea393a5bf0edd2d3e6146f46a72cc0dad61a50b58b50b698df3727b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "bc7b67ce9f85d63c5463e3a410a8b785a88de85c65b1e0245b29f68553f9c10c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "ae64d1b9e532208a9ec16aba81be5e551aec51c29bd2e017de5c3d4ceea7d9df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "3ef755e3fba843ce3843e8a712e3fb7abc726d523842c662461e8079bad6356d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 56
+    },
+    {
+      "fingerprint": "122f26718d49dc5d320dc174dc708c0574f0e094a61fa42d20e92185093b382c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 60
+    },
+    {
+      "fingerprint": "2a5a1d44d219f6c7f84db2ab2dd8e3f4acbc5906dbf2fb84f237e59554565746",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
       "line": 72
     },
     {
-      "fingerprint": "15bd1c2c446ca6ae78b8658dfc9c4cd8777fc54b95d870e28c4699c661ee5005",
+      "fingerprint": "9384fdacbed6d09511f00c70bac768049cba3aa70c1ff8193f23007fa3e9fc0a",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 77
+      "file": "./tests/semgrep_integration.rs",
+      "line": 76
     },
     {
-      "fingerprint": "0adb3d23104e261e70fce919a050238cab5c4bfa6749f81948abcfb2e0d4b82c",
+      "fingerprint": "3cd40dd99c7c09acea265572b6a843253f4914c6d2f4b8328cd2c775c2306a36",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 80
+      "file": "./tests/semgrep_integration.rs",
+      "line": 88
     },
     {
-      "fingerprint": "be49ea88fd7c2d268dba787222a3ce3bc35a92ad6bf9d73cb4c5002318a71fb5",
+      "fingerprint": "8a40f181d7b3d61ac1e32590cd90652221e73dc64f076e24a63019e688ab500b",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
+      "file": "./tests/semgrep_integration.rs",
       "line": 91
     },
     {
-      "fingerprint": "d2e2cbcc06d78dddd007195c4779e5e025deaabd67ae03e9914e17e7dcf288a2",
+      "fingerprint": "2dfc268d7d7b49469330b93e26c8d19939153e38c86634c3866fa49e5de63399",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 92
+      "file": "./tests/semgrep_integration.rs",
+      "line": 103
     },
     {
-      "fingerprint": "b7ccd4e60adf7a68d638e6e098f94633585217776858c7e14e52d14b6e3c3d3d",
+      "fingerprint": "a8f18f921460120a2b673cbac0948575020a09699176a134db64999f988e40a3",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 100
+      "file": "./tests/semgrep_integration.rs",
+      "line": 113
     },
     {
-      "fingerprint": "2b58439f25aa49688d77865ce623adb64a9d6f16b5d39e746e7bfbfd68b42ad7",
+      "fingerprint": "01c894ec817828aaabfe7c418f9b17e35d00e14c5619c2e47acdab3c3a21ff51",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 105
+      "file": "./tests/semgrep_integration.rs",
+      "line": 114
     },
     {
-      "fingerprint": "f4aef8f5572a542619e6dd7b1ad95ea69163c404bc230a694ae2ccd32f5c9314",
+      "fingerprint": "0c9105afae26d2bcd1d47179b331b6ee044c318ff907cc0efcb68293535103f1",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 108
+      "file": "./tests/semgrep_integration.rs",
+      "line": 126
     },
     {
-      "fingerprint": "a1383f2c75599dd39ac8300ff8460a0481ac57e5822f3794d7c50974fe04ef88",
+      "fingerprint": "779bf25e029c06953422ecb46ef45712bb5f330ba0d86b9aad9dbdfea0f7d79c",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 119
+      "file": "./tests/semgrep_integration.rs",
+      "line": 127
     },
     {
-      "fingerprint": "e7a1d869608261febc9c649deff8608db04b8ab9a6eb85a5a0647b431563c93c",
+      "fingerprint": "6bc659818b159af7abbf4ec0f58525aa77fce4ce930bb3f3419182489915a053",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 124
+      "file": "./tests/semgrep_integration.rs",
+      "line": 128
     },
     {
-      "fingerprint": "1098715b5c6efe79ad4eb4f49c7d964b88d08f220184e61c0da5f05b885f737e",
+      "fingerprint": "8cba22217eef498ba9e88999566799a9a924e4ba171c1b4dfb524e58cae80cbd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "971966926fcdffa0da9ebd699891bdd6597117966dd7154f8d6bf8cf853d5541",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 138
+    },
+    {
+      "fingerprint": "1299b6fbb6b81dd433edb4d1ada7d64189f74c9e68bafbc73aa97bad2d7a7101",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 152
+    },
+    {
+      "fingerprint": "729d225af5e454aa63d921b2ef8ee2d9653abbbb85640a13e2d31a72fcb92bfb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 153
+    },
+    {
+      "fingerprint": "677db1c684c7119d9d5c7bca071a9796d781971dc9801c16d1d70052ea38f1d8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 154
+    },
+    {
+      "fingerprint": "efefe909d683f7d6ffabfcfa31c43396f3bf44d5e88622b02efb71cfd895f30b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 163
+    },
+    {
+      "fingerprint": "2f1cbb0b2f4d1f1dfd6271199943d2227eab1813bc7d17455e75e337ef21d362",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 164
+    },
+    {
+      "fingerprint": "903152930d7d0f639806295da19e9fb36ec66ae5559af47ff7634c1fa7a3af0a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 181
+    },
+    {
+      "fingerprint": "dccf2c493cfdb894304baff834e1354d84e380d44b1b467cf4fd79121a560973",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 191
+    },
+    {
+      "fingerprint": "fa604130a27a1433a814d3ffecc0d12aa61d8e4f4d62a9ecf990e5c6fbce439a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 192
+    },
+    {
+      "fingerprint": "bee31e6fed34096f02d8ece509d7307e37b07903e6dc64e6b71297b2b3a1d3fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 208
+    },
+    {
+      "fingerprint": "82d0798e9bf1e0449e4e89f8ad87886b17957c219a21a92a49af572dc1d3dc1a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 210
+    },
+    {
+      "fingerprint": "8210d7fe285289f8a4ffb0ed7ddd022d855956d750a7c8da3546c9a802f60e9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 223
+    },
+    {
+      "fingerprint": "8b3e8bced90c33693687c770f5aa7fb9d06cfd27786e195545256589228d2ee4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 224
+    },
+    {
+      "fingerprint": "27966e87cd9ce6b3b4f5e51b5d90e947e7cda3a0972f1d6930037e585c9ed01e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 241
+    },
+    {
+      "fingerprint": "895b5e3199a94adfee49e35e77d92c353accdff5194365be8513e7400972b3f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_integration.rs",
+      "line": 242
+    },
+    {
+      "fingerprint": "93b397b6ba98daaaaf76e9348293ba0a97a9307155651aa10c28ae5f232d029a",
       "rule_id": "rs/no-command-injection",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 142
+      "file": "./tests/semgrep_parity.rs",
+      "line": 15
     },
     {
-      "fingerprint": "0e1952598db1489b9f7acb465583517825348da6bd5f291f8b0906dbd9657e44",
+      "fingerprint": "3066caf3df6598bdcabde436caf345fa5147dd0a0c41a5a1f112cf5786b6dddf",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "f4fdeeec0b3a43449c6d38fd150d1358d04409a5e5e827f56e92c55ac771af16",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 142
+      "file": "./tests/semgrep_parity.rs",
+      "line": 33
     },
     {
-      "fingerprint": "d28b32f3624bf19078bef446b0fa9aa078f4bf8ecd505268a1c3e9c345e243c4",
+      "fingerprint": "2604aa9a1ba8f85012de990c7fb029b8cdfa5832722868af57bfebcfa59fd9b3",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 146
+      "file": "./tests/semgrep_parity.rs",
+      "line": 35
     },
     {
-      "fingerprint": "b22b61f1f2cbe56b286c945b6fd869e4ddcc01ec755cdd716fc55abf4f32fc51",
+      "fingerprint": "487d800ac1268b7e79542c6336b1994fdaa2ae7827c8bc1eec46b878e5e9fce5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "7d0914f6ffbd60dce55da0032f81cfc2fc6b9f23438066941a19c0ac0e9aa281",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 185
+      "file": "./tests/semgrep_parity.rs",
+      "line": 55
     },
     {
-      "fingerprint": "fb7629a12bd0a19f74b744d1a5a0e94b001b44c4fd09b8118dd392255f0946af",
+      "fingerprint": "5ac948416915fa2f2d10122f103f5365c086b0460944f7a31b4a92d9acb1d0f0",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 215
+      "file": "./tests/semgrep_parity.rs",
+      "line": 60
     },
     {
-      "fingerprint": "ac1a282547130c3b4512560669bd7eba5ed50e5bbca8b376b4da565980dd28fb",
+      "fingerprint": "5d3a61b43be4f19bcdefdafa4f0a878ba273ad05dde870387b116539e84ebd0a",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 251
+      "file": "./tests/semgrep_parity.rs",
+      "line": 65
     },
     {
-      "fingerprint": "cf914fc332093c4de1558f53988c125188650df5ad7e43a0f07afa0f994dca62",
+      "fingerprint": "9bd948ba3d84fde96c4a2eff3329a5d7bc3a4dbf530a322a49f1afeabbdea19b",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 284
+      "file": "./tests/semgrep_parity.rs",
+      "line": 68
     },
     {
-      "fingerprint": "cde7bbc86478dca9e0f1880457dbec0cc9c86f9d64be6cf5870b1e5823311d87",
+      "fingerprint": "94514df72c5c3e753c2a2f42fe9e72ff12877aa80ebe6437797523c88861a7a8",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 317
+      "file": "./tests/semgrep_parity.rs",
+      "line": 79
     },
     {
-      "fingerprint": "291a93a59f25fdc97ff00b074489e44d27630ac0b257fb470adb4c610298a7a2",
+      "fingerprint": "a24e3fe622db034f80f1637298b1bc804b5f5041dc88961062e7e78dcde47be1",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/semgrep_parity_javascript.rs",
-      "line": 346
+      "file": "./tests/semgrep_parity.rs",
+      "line": 80
     },
     {
-      "fingerprint": "224d0c1c89c1a1a564ff5499a97f91ad4a5a1b8fd1dafc7ff304faaf91d9d505",
+      "fingerprint": "bfd31fcea992396eed0e71586fedc028674ad2f6ae5a8c25444041b2938faaf7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "d71b05bedfb2e905f00b1769f4984c9385bb22071e6dadc939af2aa35ea5119d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 93
+    },
+    {
+      "fingerprint": "67d6ac361f48f6c695b0fe6256677ee51787afad82d990666390a4ad7f79cfe0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 96
+    },
+    {
+      "fingerprint": "b33f0664c1954688ca9243a678f30b8d952e601fefb9a01cb23ec2275d10df7a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 107
+    },
+    {
+      "fingerprint": "f29ce56777b580450658671acaf2f5f83bd10a14ca01ea5b07fca60c922c1ee7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 112
+    },
+    {
+      "fingerprint": "529782c4bf5824bf03cd4ba0d785892afd5f75cac3fc79f274ec5829b1002e13",
+      "rule_id": "rs/no-command-injection",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 130
+    },
+    {
+      "fingerprint": "4c6ed0ea72587422d25989ad58aa031f5bd8c5942559a1914396cee84ae9ff65",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 130
+    },
+    {
+      "fingerprint": "1568fdd3fda7212fd313b83fb0be0e25dcd69735ed2b558332ad9c9a2eefd012",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 134
+    },
+    {
+      "fingerprint": "f1d2ba5a552a068c666956d7f42008b4b10726a948788f360329a9f53aa26826",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 173
+    },
+    {
+      "fingerprint": "87e83bdd576b4ee1c7c9955e877853c1ba9f110f897758a53eedea2c9f92627a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 203
+    },
+    {
+      "fingerprint": "6251309c28e3c2cd3d60e26940b4d42f3392943769ef55870ece39b0d7484387",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 235
+    },
+    {
+      "fingerprint": "f5a678dc56977164f569f66abfcfa06ca421bc12aabd4b1558fedf8ebd5f9b0f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 267
+    },
+    {
+      "fingerprint": "ad30c7a839d2e7b3e4d6b00ea7b9c96959a36e21f9e8a9683f47c3ddad6a43c1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 299
+    },
+    {
+      "fingerprint": "52a561f380cf7a0238f7b5a0b2390a89025856be2bbe808964673dc92783d023",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "./tests/semgrep_parity.rs",
+      "line": 328
+    },
+    {
+      "fingerprint": "56e07b4339a62164ecbff21e94eafbaf1ca97d6e99b56300e4b14acda6318444",
       "rule_id": "js/no-command-injection",
-      "file": "vscode-extension/src/extension.ts",
+      "file": "./vscode-extension/src/extension.ts",
       "line": 263
     },
     {
-      "fingerprint": "a18b59c82157ee6d3a33694ece494dee42849140a323024433bd56cf5b1c0dda",
+      "fingerprint": "4cf1c478a2c49176af7c1f72f0f07ee70372ce79a946079bdb42dbf5b83d28b1",
       "rule_id": "js/no-command-injection",
-      "file": "vscode-extension/src/extension.ts",
+      "file": "./vscode-extension/src/extension.ts",
       "line": 368
     }
   ]

--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -2,9741 +2,10137 @@
   "version": 1,
   "entries": [
     {
-      "fingerprint": "9a7440e5c644a0cdb4f6d69e23205eb5f2c495a8417aa3d58b128155ba8c4112",
-      "rule_id": "py/no-command-injection",
-      "file": "./benchmarks/compare_versions.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "019fc5cea1d33056d86f604fe21791816648da00392cacc2af37c92a6d19f012",
-      "rule_id": "py/no-command-injection",
-      "file": "./benchmarks/parity/parity.py",
-      "line": 386
-    },
-    {
-      "fingerprint": "53be29858a62396a2f4b3de998950bd3738aea5a5ddb60553d0b8b5330311576",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "d9fd343536591d1c5b1d7d5b7fb74a74c487d9a3510770589d95e2277b672268",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 81
-    },
-    {
-      "fingerprint": "719134e5400b669c776cec249587dfd2561b8d35fc12082d3cc864ea4531a28e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 111
-    },
-    {
-      "fingerprint": "6f5d7ff55ae29f677d7f719aa91af4d31259f999ba0c0910794f4f60c122f59b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "8211afcb787bec135464d53a130c1c1f6b386afeab36953c9afea5b7f03bf0bc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 123
-    },
-    {
-      "fingerprint": "47e4937c89a8e5b9e16559fe67278cbae1a2fc5ca291cc6825029aca957da8cc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "eb327a4137d65f3c19d23f7d707788548547a8f017211d9c961e10c3661ba36d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 182
-    },
-    {
-      "fingerprint": "316cdb60585599a8850997d83df3922147130af0f0aca7e97e480ba32cf995b6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 218
-    },
-    {
-      "fingerprint": "43c24b7023a0e2a12409d6c5e8364b70612c133f4fb68851d5e431bf6e53a152",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "35f3ac989962c8c99467e7049d25e330c9bd16afb8b2c510e4b4a3db2d0c7a01",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 248
-    },
-    {
-      "fingerprint": "8d89e132f85ec9a4118e7e0ba393ea2ed7791641b09e6c3c709ab527c2c845c9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 295
-    },
-    {
-      "fingerprint": "bb30619cefea91460ed1ad8b4bca7a8d8a944f2360f0fe5586987a04bbe5f5ea",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 300
-    },
-    {
-      "fingerprint": "ff2fed6862f21ee241e2c08cfefa1bf1b929b56be3da155d49c3e929b10a9633",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 333
-    },
-    {
-      "fingerprint": "f7eb077a2ec8f0a3650d65167d84647c7e8766e74c8e3201cbba218f9dace766",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 334
-    },
-    {
-      "fingerprint": "b11d72619c56700f37094728c2ef7c47a86bcdec5072bb58e71177266ed6ecc2",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 337
-    },
-    {
-      "fingerprint": "638ff22d664033f5faa5dde62c13101676318ae5e353dff8101fa79e7c02a196",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 368
-    },
-    {
-      "fingerprint": "a2ba3d1c30b0a463e194b259c2324b286d12e48edff4d2e0fddeb6ec27c5deaa",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 373
-    },
-    {
-      "fingerprint": "e03218dee09a24e89589371d11e30d14cf8afce155c4a586e904fa810fca49be",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 389
-    },
-    {
-      "fingerprint": "0a9fa4ceb8b9454eeef2f2ec55e0cdc7bfcd3e46a02676bfea79575f93ab7d74",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 390
-    },
-    {
-      "fingerprint": "c699d1ff098b00f876ee1053358ee771aa708f618e7d2e4a4163923fe396974d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 407
-    },
-    {
-      "fingerprint": "5a20c48a2a229a6c0ba1b8066431ead348f217bffe63a693bb8516f07811db03",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 691
-    },
-    {
-      "fingerprint": "464b2a44e09f3c9b86a3d3ca1a45d9ae5912d023241f41d64ac78e9ebb1b35ac",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 701
-    },
-    {
-      "fingerprint": "aa5da5fbb6412d5c3cda9d9d343e176c56e0d71ca0c2870351eb4c1aaeb38aa5",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 709
-    },
-    {
-      "fingerprint": "5c1c624463ca2b01f2d4a4f0b0ee7f8f068377b10345089950c05dedf41c55c6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/app.rs",
-      "line": 733
-    },
-    {
-      "fingerprint": "a6375cbdbd5cbba53415d3e770a783cde01bed49815174cd5043206f579285ae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/baseline.rs",
-      "line": 283
-    },
-    {
-      "fingerprint": "29cc2e1fe4c490fa72200d67522d28e416f37a7c359e4b49935f9a1d36ce9fef",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/baseline.rs",
-      "line": 292
-    },
-    {
-      "fingerprint": "2a7ce3ec116c39712fffea815738fb702ffaf904f40cea403e229e90398ad897",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/baseline.rs",
-      "line": 292
-    },
-    {
-      "fingerprint": "88455cee0fd75ad67d3853e90fcced358838a55b5633d73754a7c93e70351e8f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/baseline.rs",
-      "line": 317
-    },
-    {
-      "fingerprint": "c9c79d3aea84968de8434417f1ef2ba55a7dda79032960ae75859edc44bce086",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/bin/foxguard_github_app.rs",
-      "line": 1037
-    },
-    {
-      "fingerprint": "f4a983952a195ecc73b7edd86a5ee3c9b05eab89fc975cb50b083ee1aeaf6427",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/bin/foxguard_github_app.rs",
-      "line": 1081
-    },
-    {
-      "fingerprint": "ba86c559eff463a1bfba7e82a8792af7f8bc70dca6c8f6fa692cc27bf771f002",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/bin/foxguard_mcp.rs",
-      "line": 157
-    },
-    {
-      "fingerprint": "cab611422684277c954b61edcbc4a2b1dd5235f7e805a018d5fa4f67f30113ca",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/bin/foxguard_mcp.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "6a8e9b5592e678759ab14934f0a1721ac626f3b306705be551bb2e08a6ef5b4b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/config.rs",
-      "line": 463
-    },
-    {
-      "fingerprint": "cba5c7136b5b982c18ece49edb03741293120412dbbf5511e18c72b9b1aba391",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/config.rs",
-      "line": 911
-    },
-    {
-      "fingerprint": "6ce4ad2d8afc368e382b897e2a1183ece52511cafc809bdb74f2dbc8728bd755",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/config.rs",
-      "line": 948
-    },
-    {
-      "fingerprint": "0621a3b8015655b666ea28849daaa10ac207fc0ca0f94fbd3123a94cca27a414",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/config.rs",
-      "line": 949
-    },
-    {
-      "fingerprint": "f5854874b779735acd5376a8fa8499e3f84723b4ec7944c43bd70c1b213c21e5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 990
-    },
-    {
-      "fingerprint": "5e83f6b5aaea585a7d98be0057eed08b0975d53f8763314b4ac6351b07280661",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 992
-    },
-    {
-      "fingerprint": "ebb74ffa8b47a7805ecbf6bb0c275ee2c1aab1dbb7f185113166d65321acc507",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1026
-    },
-    {
-      "fingerprint": "f57ba72b98c8abebf4dd0bbf3d564e96c066796ed0e6aaf7cb863b29f350a96a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1044
-    },
-    {
-      "fingerprint": "097dffce2427b23ef430d4fc2d37a871fe724b6689d903b4428e590068ba7ec5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1045
-    },
-    {
-      "fingerprint": "9ddc75d3b90e826ae2f40b6c13b376bab15c138a6cac2d426001161029989feb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1047
-    },
-    {
-      "fingerprint": "d61fe0876d1fe74fdd68b557592d4a2b193d44fafbb96d1c63ad72454bbdc660",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1063
-    },
-    {
-      "fingerprint": "3b7adec2b449c328dd5db1f70ae0f42a241f448602e254b11a82a5f48194125f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1064
-    },
-    {
-      "fingerprint": "07bf0e26da2b07738924777eb1bb96c6a904acbb19b34ff5324fac3758235da8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1066
-    },
-    {
-      "fingerprint": "439f2490efcf16e8794870129a3091adf0a5d72c64165e08bf3867348a2b7000",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1067
-    },
-    {
-      "fingerprint": "88604b0835795c18c7d6f852733bf5940fcc879774c50fb40bbd4b72f0459ab2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1083
-    },
-    {
-      "fingerprint": "f9e092492e1ca8b6e4c4570dcb2d0bd239abee1b1125bd657ef046cf82904e14",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1084
-    },
-    {
-      "fingerprint": "3f366dc702cd44ecb6cd06b21878558748e72688d03def8bef9b37c4f7dfaca6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "8bfea5e457ec20c96e5b9e6f8e9b16f3a9f0b45afaf6e2598f9363c81aff9176",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "5ba5be7e7c71d477f644e492a4a4052b00ba103d80b5614bda41c2c0c7f99261",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1091
-    },
-    {
-      "fingerprint": "5d0ef69c5f4cbe65286b0afcc4805a14be7b9cf43db18b4187eab5bace9414b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1105
-    },
-    {
-      "fingerprint": "a6be5cd52850cac5cd712c7686687d60fbb4738f1d60afa9fdbf7074ce3247db",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1112
-    },
-    {
-      "fingerprint": "dd33e0999b25b98fbfa657097de45490f008117d37edabefb1422d7925c8c142",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1112
-    },
-    {
-      "fingerprint": "bc5aef0558da2ff0e8f2d4765d933a620cf811264ba5899ede2f611799c83ce4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1125
-    },
-    {
-      "fingerprint": "4d20f152a119ca341b44d587fbb6b53d5df47330643e29561955d601aecf9ad4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1128
-    },
-    {
-      "fingerprint": "6167adea82c5a47fb5c51ce8a6af096498aea82a0294dc842d7de451cdf3b92e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1128
-    },
-    {
-      "fingerprint": "3b3ffadaa406d177ef0ff6e15247838f9875450567ded290fa9ec1a37161f37e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1141
-    },
-    {
-      "fingerprint": "aba48a76a1a00b28c6f7fe6e7a090a3e88e85590d5a07121325b0843564935f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1148
-    },
-    {
-      "fingerprint": "71a9ed2e0c888958a8b5740abd388910330e9a426819e4215da2ff8b69f82ae6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1148
-    },
-    {
-      "fingerprint": "a78606ca8deca620139f259358c097790523aaf83ba35da2e4cb94a017920476",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1157
-    },
-    {
-      "fingerprint": "7bd044602c90f223c76b078463de66f2dd2821cd97b91593d763a123c0f8f83e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1160
-    },
-    {
-      "fingerprint": "4c7cd6350dce5edda52c9028d55d377d4117cde7acb7d7d7f7eef72615582875",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1160
-    },
-    {
-      "fingerprint": "08bff8d2c0a43cd014adfa786eef74e5d0e112c52323cf6141a3ecd592c212b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1169
-    },
-    {
-      "fingerprint": "586e57dff77ae37b11872bedfbf4d08bb19697b8cf81b0fc1654766c730dfd78",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1176
-    },
-    {
-      "fingerprint": "f04a4cc8dba4d73ed5e7c7bdd728ba04beab26dfb47c1f5c59d4df9f0bbc5b67",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1176
-    },
-    {
-      "fingerprint": "9c0ab59fd99da2a90092613c18f0a67befc6b058e71860486b3341bd44d5d34d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1189
-    },
-    {
-      "fingerprint": "5d3371be89277723356e5c978a53f8d397340b66cf099fb8a005a3d045294b75",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1193
-    },
-    {
-      "fingerprint": "a7b8855787b4a4c826ab916b2387c856649ac928c23a3b520fb39cbbd12bd640",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1197
-    },
-    {
-      "fingerprint": "c2060b6ba5b99337076cc435d562c2f40bcb1d8f3682b045ead78f0a8c0a9363",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1197
-    },
-    {
-      "fingerprint": "e4b386b089f140ce5db39bf03a2bc5f9f2c3b3943e3c7e44a9ca150d91465138",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1207
-    },
-    {
-      "fingerprint": "abfb20e10ce518c120516f8edcec0806de116cb081e932701e6fd391be70ecd7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1213
-    },
-    {
-      "fingerprint": "b296594c5508876f7ef38bf8626766d4a812524978b02c6708451751f8fb7bba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1226
-    },
-    {
-      "fingerprint": "d7f7bcb8f13b7856941aade041fdfbf7de333bfea8d178f38113b6dfaaaa4772",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1230
-    },
-    {
-      "fingerprint": "74e327340795b53d86777b19e5dace805a3895838aff276f5a179795df3a9ae1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1231
-    },
-    {
-      "fingerprint": "7dc8176b0b100e6bd16084cc4436dca8b4fa2ddce235f367311a8bee7e6cfad2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1232
-    },
-    {
-      "fingerprint": "31d3def95832a47b84ffa3700e7cf51c3e6020dace3c7b8a5083bdc4808e6739",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1242
-    },
-    {
-      "fingerprint": "c4fc2ed17046b86cb66ea6310d2cd059d4bea6520754e7fcc95c9f98ee5d259f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1256
-    },
-    {
-      "fingerprint": "a2b48faf389c2659f13de31f9c721481f5f72496d860225278faaf3716716136",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1259
-    },
-    {
-      "fingerprint": "30d2133c2ed42670df0f116a1519fc72e2afbdf18f5ff11b6a18e6aad790ea5d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1264
-    },
-    {
-      "fingerprint": "ab4fa611b8d36302e2fb72ec94ecf2c6e4a6cd1b881916f3008b9ce1ff956231",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1264
-    },
-    {
-      "fingerprint": "9d779e0ca1a65be9d7d39fd234fd61f919e0f7c2d5daf8daaaf6c3c31a4925f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1269
-    },
-    {
-      "fingerprint": "2b39fb31d7dc10c609eeb779ad61366d153a542ec6ac198711f201b305193979",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1304
-    },
-    {
-      "fingerprint": "2456e2d3425d0d49d276ea5efbc2088ec63f2ba31391beb9d3d700493c8074fb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1310
-    },
-    {
-      "fingerprint": "9e550c45c46c09e3a114e6a29ace646727bf21c9331a6e0ff02e4f81690b8c7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1310
-    },
-    {
-      "fingerprint": "96033cbbebd59cf03dfcfffeadcb29caef078b6e9349d6da70cbe7732ef7e624",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1336
-    },
-    {
-      "fingerprint": "8fbda6c13a9d8eae9f22f50e64667c4552e209df5426d30e797180aaf0be4e34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1342
-    },
-    {
-      "fingerprint": "eea683c7675bbcef882ef90954503e3c6493756b9716ba7461abf6721ce20208",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1342
-    },
-    {
-      "fingerprint": "ef9c23d362516a8afb1a714afa10a21f8a219087fe10e8076911d094887a1ffb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1365
-    },
-    {
-      "fingerprint": "f7b37aaa520fd8fe7b661f07abe53a924b9a91470c09c484b56b5fa5fd65cb9c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1371
-    },
-    {
-      "fingerprint": "b9dce12a6658f69015af4aa4ebedc0a1a367a6d35512c46072210e34e2d5cd66",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1371
-    },
-    {
-      "fingerprint": "1165f57a77a7899c44fece95a78d3d9e8ed814affbc421614613cea66bcf3dce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1391
-    },
-    {
-      "fingerprint": "6d9b30011a7e51849b02e09905e0ebe672975ba7059651d957a8312b97e31de2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1397
-    },
-    {
-      "fingerprint": "b5ca8e7cb09f477a6773e335c22477202d46110ff24b4014099951b00471e4ec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1397
-    },
-    {
-      "fingerprint": "54b5b697ffae1daf095ad7c802708c54ec8486e7a842c56df77aaaaa0ce6d0f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1422
-    },
-    {
-      "fingerprint": "04d3804fec24e255508832606a169f698864826feddd6b3d665c697bfc4d34cf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1437
-    },
-    {
-      "fingerprint": "cc131e39ce1dd4ec8bfd50c82e839d65ff946cba92549782719d75540253763d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1439
-    },
-    {
-      "fingerprint": "39c3f8915d458cf112bab04b3222ebd26d3867f7cc31f64cfe92a6f40c779595",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1439
-    },
-    {
-      "fingerprint": "7865f1da0f60224b569d4af5f07633949823537194a8001202810ae9b4feefde",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1449
-    },
-    {
-      "fingerprint": "1d887512c28fccec5a8bcf27971b61e982c402d03c6e93673ce972ea213fe3f2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1451
-    },
-    {
-      "fingerprint": "7c201fa9d0ad522cbb3a9828ba31785ac1b011a0ca558f07dc8c57247eff4822",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1451
-    },
-    {
-      "fingerprint": "40f6cbab2bfcd488a9bc2d463425bda2c069a294a0f552e96650c4f0f19a0510",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1461
-    },
-    {
-      "fingerprint": "607cb5e9ab11fed42325a8ad51720f899fd9081f2c34f7061210b0edc3562154",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1467
-    },
-    {
-      "fingerprint": "12b0f975a5bb1e246dd0cf457c7efcde23bec135624ee1934ff35a2749513f1e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1467
-    },
-    {
-      "fingerprint": "18d209db7d59c8d0e9354b4a4a73dcd23db4aaded435519fcdaf5d1acb9116ae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1475
-    },
-    {
-      "fingerprint": "49c340715f083808c70e18cc79375fc3b794edd58c24620119e107d61d87f50e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "09a3641c7e2b00b153c18ff3623dceb4fabbfa1b104b6a8fafc3a28cc6430ce1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "983e3f4c90bcf33acb983c2adabfe96b251deb33022403878850f0e422f3bcdc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1489
-    },
-    {
-      "fingerprint": "399801a1c8c6e49c2fd6cd7b067471bcdd928574b50f96afe8a538b8490b7619",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "ca3de25b7dcf5ff2c5b2144066c82a1d0917a7b085585b739dd09209c8bfdd12",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "51fe4d38706559dff475f0333380ee6fa35ad9c57932d731643e088c8403a4ea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1503
-    },
-    {
-      "fingerprint": "3ad825cc7e7b605a5cfa3834bb25e1f7b9f521060e47f588fbc67327469b14a8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1515
-    },
-    {
-      "fingerprint": "c6a8fed008841756a9ee8249503f2ea1f6ee15c9407b3b742a81946cc6c32cae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1527
-    },
-    {
-      "fingerprint": "af0ac191d3fcaae79578c4eb18dddb2d270f757be81ad01c6c9381aa426fe702",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1541
-    },
-    {
-      "fingerprint": "84d73e25bd4546166f6d65e58736dce323c3d688380773bca169df95f2ed1135",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1563
-    },
-    {
-      "fingerprint": "652451dc979587e03705c6c80ba9b9f49d2ff72483eb4343c31a7d60834eaf8f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1569
-    },
-    {
-      "fingerprint": "b26e6733abc475214d208baac38cfc9f063705defddae8a600af46e7fa21ad25",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1569
-    },
-    {
-      "fingerprint": "d7883f2956cc8b5ae4f885d41d8459d9aa54d4eb8d659406fb7bef3f262cc215",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1577
-    },
-    {
-      "fingerprint": "d4453a9f822f6141a8c3c75511e4e9912212a996747b12969f11155171a28e8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1583
-    },
-    {
-      "fingerprint": "9db6fa37f59794eba3eaf2fc51540eaf64710f74dcc6eea90e6547e9e11fa47c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1583
-    },
-    {
-      "fingerprint": "82c6cec03f3384f6ddd77b0689345893406c9c7f4274eea8c3b064d9b3b2bd02",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1594
-    },
-    {
-      "fingerprint": "fd956bbda061f067929a8d41e16351594d808dede2a0d9f21886e49ad7867c3c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1597
-    },
-    {
-      "fingerprint": "52722e6870e3b41ff4757ac6272e8895956b95428da5d8eb75c011ad8c7ab07d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1602
-    },
-    {
-      "fingerprint": "d47de7e5618bef5ab6abafeaaeda315223b8d43e1d2d177e0c309f147164bc85",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1602
-    },
-    {
-      "fingerprint": "c4c474d4b47b945b960dd6c56757dc637d95f731e61ba0231b67d5f44d6d9d9d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1612
-    },
-    {
-      "fingerprint": "a1767e432c1ce29ad9bbf4199626fe14873f37e04b79624672c327dcde0d48ee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "38a1879a3c771e18c15419017980bb4bf66bf01f9f34cc8d2763552a3b536d03",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "f6d9a6d6b6e172e3349c7b80a13c6a8aac4b0491510341d4186865972bed6fcf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1627
-    },
-    {
-      "fingerprint": "e0c4e885620b72a2d1b56c457bbed2cf9a698080599f3798d10bdd7be3996846",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1628
-    },
-    {
-      "fingerprint": "86988ffc7f1a6325f8b1fbdab5a627c5362e97161837ac55a29850d38c7c1a7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1632
-    },
-    {
-      "fingerprint": "5dbaf94700c487d9e0100b2909f3aa5d49954dce102e5b719f0b194e59066a45",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1642
-    },
-    {
-      "fingerprint": "115aeb1830b26c657f60715a6c8171b7d6cd810241cf4713ee8fdf6aeb2fa4c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1663
-    },
-    {
-      "fingerprint": "b994d544d14bb64a7d0cf5417d78aab7d8bebbbbcd9dd8af3ad5e7eb452264fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1666
-    },
-    {
-      "fingerprint": "085aeef61a5f750565dc38594b6e7ab1b9c29542b416bdf4db4cc5da929706f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1670
-    },
-    {
-      "fingerprint": "3f01cdff7ffbba012b8b475498c3c5fbc89d88e94677bb33d5d9fa9e5c0896e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1670
-    },
-    {
-      "fingerprint": "8c8009e5a30dbcae2fe3e3d8f7561efe1f4ca943650ffc3508d6f2ffee855d96",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1677
-    },
-    {
-      "fingerprint": "7f82a7d964c79d0bf25018892d30eb9f6cde2853e1edfde6bf3437cfd64cec20",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1683
-    },
-    {
-      "fingerprint": "528f594cb61519024af7b6e80814b91073003774e30e26733e619d8c2c7eedc9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1700
-    },
-    {
-      "fingerprint": "38bc857891b2aab8aeb43a07cd14c265b630596e52149f17624f9ba095db1129",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1709
-    },
-    {
-      "fingerprint": "e545d5f9ef20a4d1f1740e3ec63b1557c244f2577a4606f7f4713c422331caa5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1715
-    },
-    {
-      "fingerprint": "3a9ad6ea19e7a8d3396cd9fa1cad2f6ecdf546f1d2bb33673e9e2221dd557032",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1715
-    },
-    {
-      "fingerprint": "da78f9308ea84d445ba518c82d2d2d1f1bcec42b39558f6b6eea4bd2b77c0401",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1729
-    },
-    {
-      "fingerprint": "c80f84a558a63524310cfb422215d44db0c09b2b2d3b913cfac6bddbe2021de4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1731
-    },
-    {
-      "fingerprint": "51e4d0fcf81d7bf79653c354a98b20e8db0bd7e16bb7ba8cbf7b88082cbb3e71",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/config.rs",
-      "line": 1731
-    },
-    {
-      "fingerprint": "6d48181ec2ae6d943bcc158159927d90ef733eeab361627f79a9de04d8b398b1",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/diff.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "3f553800635c144cf3989fbd06b6312547006cb8900e380297fb78585c2027f6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/diff.rs",
-      "line": 217
-    },
-    {
-      "fingerprint": "7d14dcb7d64feaea50eb5500a4cc386436216566f56e244dbdc9ae564a77c4c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 487
-    },
-    {
-      "fingerprint": "2449424a85be12a3f1ad2f920abc7bc960a45e100b90e47a8cd1575142086c72",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 492
-    },
-    {
-      "fingerprint": "04687d1ab8a35a03f9e2354cd90ad60b7bfca0cd0df2ebf966b17a910d424ff9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 511
-    },
-    {
-      "fingerprint": "84fb95b372befb7ac9c8f4d27102bcf9539ca290b281ece147075d804fcbef51",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 682
-    },
-    {
-      "fingerprint": "2b99addb7d4d492ce140a9d6e37560a0a106bcf0257ea5083095e4ce4872eb61",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 686
-    },
-    {
-      "fingerprint": "48f2bc40fbc5248d6aa084aa2617341a18987067bcb7fd1b01034c29bf07d02b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 719
-    },
-    {
-      "fingerprint": "f9957e0eed18e2a76b3c57d2d382aca7a79501fa3e85dfc8b8b9b42e155f7974",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
+      "fingerprint": "26e527eb940b7550d95d0ef9887b9e2e26d4b72d800f843ac0d8c0798ef92200",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
       "line": 720
     },
     {
-      "fingerprint": "9959c40bccdb7bb00e2bd0d465a6d5532943b3b031a6e6d2aa0636af062dded2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 737
+      "fingerprint": "17fc1654f4c266705e49c624e81b4669c5ca852c4a2fc4c49b0c804f8d101abe",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 979
     },
     {
-      "fingerprint": "ce9530b71e4e9cb5adfd0323386ecbb5ddcd9fd9dac4d4c158f817bc23e0af72",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 747
+      "fingerprint": "e3e15f8f215e93e43ba4609a129e8e71a12532ed7cafde0578560f3ddd238370",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 1787
     },
     {
-      "fingerprint": "3defc145327ae2e81d9698c27c3181728c6721140eb306bd699800afe9702505",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 748
+      "fingerprint": "2b5fc90ae2b308c2f5862470b4a88b49747eb00290c7400e29c1b86fe4082a3d",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 1807
     },
     {
-      "fingerprint": "609a40845f75fcc460ec98837c4f30c8da66b02ce991d64215cf86b0b66f246f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 776
+      "fingerprint": "ac07bdea788e7c42f23235279b6a96602b6c45b087312da4d86bf2624ed46cfd",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 2054
     },
     {
-      "fingerprint": "6b015fc465856bd61e676b0075faa6d826edb0fc3daa50b8e9f31a0d67515bbe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 787
+      "fingerprint": "9d89e941020b035ec13fd6d29483a543eedc6c1a9ef5202cd4c9041846e191be",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 2146
     },
     {
-      "fingerprint": "ac4277eaae31c54125152d7780207a406e08da74e1a646edc0a274895994b614",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 789
-    },
-    {
-      "fingerprint": "25cb230008b1aff0e3dad389443be800fceef1adbd8f6287a17f40bc0a687b08",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 809
-    },
-    {
-      "fingerprint": "2f490b999af03925d5fdc38afe67d4d9453cdc0b50fc2acf3abcac6398c08c3e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/coccinelle.rs",
-      "line": 811
-    },
-    {
-      "fingerprint": "9c4e3238e5ae54e0471a1c46795966590b3e67d45ad721964fde3121b41efdd6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 272
-    },
-    {
-      "fingerprint": "b4f7add89898fd79ebe2512d7efb287965a0c3fb483cd563fa08dd150da2591b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 304
-    },
-    {
-      "fingerprint": "cf9815b2675bf63c4a5e9706c24e17392f75d0ad231370832ffd8ebe58874e48",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/codeql.rs",
-      "line": 677
-    },
-    {
-      "fingerprint": "6555ba87a662f26007c672af75cdd78250b62a12c8b51e48863d12ec8d883bbc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/codeql.rs",
-      "line": 681
-    },
-    {
-      "fingerprint": "554380c0ca41efd3bba68644b4036be17cc49205632745e2bcb9fd9bdeacd1f8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 865
-    },
-    {
-      "fingerprint": "237a85a427ecaa45b7b190389fd7ccebdb9ba5c70b2ebd164b27833cc823c169",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 866
-    },
-    {
-      "fingerprint": "1160e68fe392fa26c53cd901c3ee6d3a1421d7c41c80b803562edd8a0a8ad6af",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 903
-    },
-    {
-      "fingerprint": "fdf3f74c146d6ab82189d1be53889818b972196ec214cc918087c384bc7f6cb5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 904
-    },
-    {
-      "fingerprint": "4782aea160e978c197229b657d83a37b704efe0c9c441a96fa359d067a9a8268",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 921
-    },
-    {
-      "fingerprint": "258fc44c52d49294d468f83e1728975da4d91b6e1826f76292dc0f06ee4addca",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 922
-    },
-    {
-      "fingerprint": "c00143365defd5913e299dcefd8628f9e355336dbc559df171caa9dae95dc788",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 930
-    },
-    {
-      "fingerprint": "30f760699079ea1ee4f0fb0a99e9794b944c1f2d9764136949ca5817c5208ba1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 931
-    },
-    {
-      "fingerprint": "aeca8dc2fa106c4d7ae02eeccfb2c06dc79073495d47deea0189c726b262016a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 932
-    },
-    {
-      "fingerprint": "994785d11730f283f50fd056e4565a0405200e15197a43589c1a577311ceba70",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 933
-    },
-    {
-      "fingerprint": "36658baa298ea2199d6630f7758fe7272ba56b96259fae0791d2002228a7cb2d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 949
-    },
-    {
-      "fingerprint": "5fea9229033eed2390d615b70aceca6a80acb7e7fa5b0c884d8c37e8e6e2d534",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 950
-    },
-    {
-      "fingerprint": "8ab9e5e62ae7a28254883944f2ec89f6d53ce4340fdf48631d8c530469641976",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 956
-    },
-    {
-      "fingerprint": "b71b35b1367c46d76fb15c15a52ff6ed3ea5799690023f8a5e387857a92dabee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/codeql.rs",
-      "line": 958
-    },
-    {
-      "fingerprint": "d626ba63206a27704b615f3dba2a165e4f527a4db405c243723252c443053e82",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/parser.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "f37e0c37709e26191e571b65d6d182b146d970e39aba5aa341115cc0586015c9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/parser.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "8fc5fad156acbd664d02df020b8ba019cf0c9c5cc2957b061a4e5fab9d88b23a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/scanner.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "e0ad33bc921f61fafd3c2676c46a53c6a8ca1cfa97c2ef12e90a3ce6593a857a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/engine/scanner.rs",
-      "line": 371
-    },
-    {
-      "fingerprint": "2187d20ce4c0c82ad929fa420028727e3ab0133e19a0d7a7e24339b3d9ae7e8c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 553
-    },
-    {
-      "fingerprint": "7abbad0deacc2fdd963fe06da2d81e0b792e5ebfd66e7e6d1d4392d7d6f28d77",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 561
-    },
-    {
-      "fingerprint": "c45f990c7345e601544c43eb851a86cfff153f704c2b2624aa3bfa4687655e18",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 568
-    },
-    {
-      "fingerprint": "a58b6ebc5cbb6e4f3bc8b4bea02165fe652ba9614c9df8e8db7875555624e63a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1002
-    },
-    {
-      "fingerprint": "cb7543fdd3a56842a5ecc57c16c12560d3370d6a5af6d1d7eef8c3d74a27b2ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1010
-    },
-    {
-      "fingerprint": "d1a7166982dd6017aa45e6d78c53a91075f75f41e1a932b2ca4fd85e0d9f1f7a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1027
-    },
-    {
-      "fingerprint": "cda66952259f0b9be2dcf6338cfb9bdf7cb4fefd3140e0845a806108446fc72d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1034
-    },
-    {
-      "fingerprint": "e124c84fb196b01df9d8d4a90796fff106305b68c8aee1d37a5478ac1d396d9f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1056
-    },
-    {
-      "fingerprint": "1e55d65e309c4adad91a84f089db66e3b04c25ef6e013366d725da53624b04e3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1065
-    },
-    {
-      "fingerprint": "16aa8ad9c75222eaa41e743f8f1efc55999835675edfb65479d14b2fa65712bd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1074
-    },
-    {
-      "fingerprint": "985a1766c68a3628289871a0b8b211476cad4251918393c75581c47f3378bfd7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1430
-    },
-    {
-      "fingerprint": "cd17f127021f0ce17919b66bfa31c0227bdff7d4e115d94f6d47a8e4f17ec2da",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1464
-    },
-    {
-      "fingerprint": "150563578d03dfff5137ee5c2ba994aa231f48aadda5e4c8e7976c92f7ac7f02",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1472
-    },
-    {
-      "fingerprint": "ba4b123d9d7a121123ba1ce67b913779de7cd0e5bf6fa421fd32a73512abbc3d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1481
-    },
-    {
-      "fingerprint": "5836fe14fd9f173590274b95f3cb4bd36964be4a5dc46bbea20f8a05a7ee14f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1507
-    },
-    {
-      "fingerprint": "f88351c0676e803bb60fb5e994406bb1456f585eae6d8030d7ba5552fc9863cf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1518
-    },
-    {
-      "fingerprint": "2347950730c1ca4dbef1e6baf71f16fbf95ff066370eb386e48b27c8d373fcfd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1519
-    },
-    {
-      "fingerprint": "7ede18a0b1bb7cdd5b07e755bd36747b194100cde32fb6c3ec14565b5f8922c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1521
-    },
-    {
-      "fingerprint": "199ecc3c5e07be69ac1f9ab2653113fa851a4c58bc177d7196d0c25526497d1a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1523
-    },
-    {
-      "fingerprint": "6286f96d3771805066bd899e37f1c5974b17f4f6a4db78179104a10bb2667af1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1527
-    },
-    {
-      "fingerprint": "0eeef7b8f254218ed40dcffbe791c9c2b18cb8c54a2285c85c4198b8123fd279",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1529
-    },
-    {
-      "fingerprint": "652aa932f03b1e0cc195ba5c06f1459a5fd7045c98bcf9dd9d7bd94ddd10bd65",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1546
-    },
-    {
-      "fingerprint": "a73f9a2f4608f4a8f0336033a2da1b0cb247b70c767ea0056b8fcac175321a1f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1547
-    },
-    {
-      "fingerprint": "20390813d44833ed233a8abe1e432f08595b04c1577dc977794c987d326d9ec7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1549
-    },
-    {
-      "fingerprint": "6ed2088751260dad5a1cef2425da9f0f968fd80bc336547966aad6e80b6cd101",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/engine/scanner.rs",
-      "line": 1553
-    },
-    {
-      "fingerprint": "219a0836f42e060e80aad57d641de8560a8d44f9de16fb691b33dd2fab54ab69",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/command_injection.rs",
-      "line": 311
-    },
-    {
-      "fingerprint": "e101af24af4a5b5c67a48c5cff6b4800668958c7d24128e163b6a86f69c7fe4d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/command_injection.rs",
-      "line": 312
-    },
-    {
-      "fingerprint": "51eda003da502fdce2cf159910ec6609bca9496584a58063ee3e2180a242a9a8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/command_injection.rs",
-      "line": 323
-    },
-    {
-      "fingerprint": "f39a46315cdabf73b5ebb3e8e3f26f98141e6cf4e4ca02300ebe41993664a43c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/command_injection.rs",
-      "line": 324
-    },
-    {
-      "fingerprint": "36b1406c8cf224e3d3e4ec5d82412d4d527c0a920ad1c574d149ae6a4acf8fb9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/fix/mod.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "cd6cabd79f991d0bbc8d204451a940345df6017df3c138d7ac978ac52b6c3ac6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 445
-    },
-    {
-      "fingerprint": "0c7ad33728a18681c062ebb19c61aa8066e4cf297716de094d53f28497452a53",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 447
-    },
-    {
-      "fingerprint": "e6e0e7935d7bfacdf34201e553faab131db03615f6c0d9475a780055e52a1a55",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 458
-    },
-    {
-      "fingerprint": "eb4bae085bb091f2a20c5de13a5208aa5b461d4017591f3e5d69c033d17bac47",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 459
-    },
-    {
-      "fingerprint": "ce61af43963edd759895f5e470b024bf444bcb9dd642bf1379a821eadc3bf9b0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 470
-    },
-    {
-      "fingerprint": "4d112f335f02cea66624c6e4ef338e3456dd5989da25b5ad272dbb03937f9b35",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "aa8f8ed9382c4b11f6bb533fbf9c676133112d4ff430cddb59968566bfff8d23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 482
-    },
-    {
-      "fingerprint": "07c411ed0ad46e102b6ca093366a8858144c3fa27d98ba740974ca33de9798a4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 483
-    },
-    {
-      "fingerprint": "7fff0ac20b77f343a31f1664bd1ca1815aff3e3f3a6ec0cf0fa89506e0ab2e3c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/sql_injection.rs",
-      "line": 494
-    },
-    {
-      "fingerprint": "9bd01ffdb9d477afa299abeb2d48f56fd41f387deac98147ad33747470df66d4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/xss.rs",
-      "line": 121
-    },
-    {
-      "fingerprint": "2a3fe10dd384278e1c8cbfbcc2ef7008111798a3a5fd91a1d8cfcc29d4f5de94",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/xss.rs",
-      "line": 123
-    },
-    {
-      "fingerprint": "d9832c024c4eff83b387a3e2bf91470627be483963a5e30e80e691fd8ecad9b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/xss.rs",
-      "line": 131
-    },
-    {
-      "fingerprint": "22d6836689a5d38ce2cb21fd1482882bf512254050061e5a93a0feef4073a844",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/xss.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "d1fd440c7258eb63cd81268a69dc3894717097f8f96e9f667280ee6e9c0104ec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/fix/xss.rs",
-      "line": 140
-    },
-    {
-      "fingerprint": "46c6d713d6c5b06cddc9235bea1d00bdb8b7afb0f091428260f4351201384c5c",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/git.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "2a374954584f87965d64b37ba350f6d2699b9283b7038943ab2d19b5c0b44da8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/github_app/review.rs",
-      "line": 823
-    },
-    {
-      "fingerprint": "7689fad892785279654365885518d4f40cd2daa04ae02de4d9aa231195adf8f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/github_app/review.rs",
-      "line": 850
-    },
-    {
-      "fingerprint": "0531955a71fadf236b41c9c2650749b529bce1a1f5d92ac23472f35692bf70b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/github_app/review.rs",
-      "line": 879
-    },
-    {
-      "fingerprint": "decb4beafb728418d54bbbe2756aca05dd3edb94bdf976b90ae4b5db992f6d86",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/main.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "4fbff6f0946265958e65666370ce1dc5cff614640eb4334cbde055dad98e050a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/main.rs",
-      "line": 141
-    },
-    {
-      "fingerprint": "04097e2b99c7ea6913af7332e17d94a258945a79b486be2ae8522b5014fadcfa",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/main.rs",
-      "line": 146
-    },
-    {
-      "fingerprint": "c50cdb479b0d1325057c272e5edb423107711724e31eca7681292f677ca77bfc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/main.rs",
-      "line": 274
-    },
-    {
-      "fingerprint": "47a08326c2021b11bbb21dcb23e1a4fb9aa81587d741d114b05a1e0a0ccbddb7",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/output/mod.rs",
-      "line": 140
-    },
-    {
-      "fingerprint": "320640e419b0fd11a4a15160f978598ad68e09949ba2b2d4b0552e8666c308f6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/output/mod.rs",
-      "line": 181
-    },
-    {
-      "fingerprint": "f87a752e8b475c6be28af7b20ef52deaa1c166a1e416c7dfe3e617826ad761bf",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/output/mod.rs",
-      "line": 185
-    },
-    {
-      "fingerprint": "d9dcf7281be18630ffc5f58efccffdcd78818ed3307589979fe6f85d8d05f595",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/output/mod.rs",
-      "line": 230
-    },
-    {
-      "fingerprint": "f30a724b683367a30b47782d44ddb1c95fdadf2597c72f7b91a3233748e9e94b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/path_identity.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "9ae3305efaf2c5eb731c47f752da09a3887f19f0b48a6c16325430b73a79e908",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/path_identity.rs",
-      "line": 75
-    },
-    {
-      "fingerprint": "a8fa99c557a4c74d48e2436ef16b24b85b3960487922cbcd6e5966369b736bb2",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/path_identity.rs",
-      "line": 112
-    },
-    {
-      "fingerprint": "598066b5176b9a4726b848934532af21667e2fe170bd16ccca03124a602b9caf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/path_identity.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "14ffe5d42103618471d434f50f995004c3028b758308c6d29c789194794dea23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/path_identity.rs",
-      "line": 186
-    },
-    {
-      "fingerprint": "dc3c3e243e938327e1e1b8f35ca199fe198cefbfd2477a2066dcc2342bf8b863",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 271
-    },
-    {
-      "fingerprint": "0035f4e44b4a3af654f53cd0d06adf68db62311bbf93e8891ee1890c4d37fbba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "f52e7b4642015a92b65dee8636569e49a249cebfc57cbd0b5582358080c9562d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 614
-    },
-    {
-      "fingerprint": "48b95b4b7e515958d21d26e790b50968a7262f02fd46fbe053b69ebcb9a39436",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 639
-    },
-    {
-      "fingerprint": "5e005b4c112eddb47bef857a3025122e2ac8281ba5fca9bf237f2fff74a71464",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 647
-    },
-    {
-      "fingerprint": "8df7d7972c0357ad88e2c94cf9e02ae432fb2e533a3139f9398b01fbf9baedbf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 650
-    },
-    {
-      "fingerprint": "ad68ec8435c20b775a3981bbd2969b9caef20682a22f01f3262d1214ac28e4d0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 653
-    },
-    {
-      "fingerprint": "5c13205e7fe92b0a604bad1683d1b37c206c70617bde1bb9bd2298324fe0698f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 665
-    },
-    {
-      "fingerprint": "dc446739fc5a263d66466a8b329430002037d9a881944c5416910aa5be7d78d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 669
-    },
-    {
-      "fingerprint": "b5ee239ef18b8cfd5e68d8e473d91933ca7b9bb407457f052a879ff140a664be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 684
-    },
-    {
-      "fingerprint": "1bb6a3abfb814b93aadf5c272fe6af628ae86f07868dd6883d52e6cc40f0bca2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 694
-    },
-    {
-      "fingerprint": "6ddc77933ba3ac2b42514dd8cfefcdfe793217fd0e8cd92c869259ba51bed91e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 707
-    },
-    {
-      "fingerprint": "9088691f51dcb4ff2df8294900ef8d1c4cf99624401b6f854adc48fc0311f35a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 714
-    },
-    {
-      "fingerprint": "09a6d7c63a5a9662b9c40b479afcb2cf577f42a20103a9f9e3a74e4169330376",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 739
-    },
-    {
-      "fingerprint": "7849ad2ebafd7bfd058cddeea7b0cabd028576d558cf6979ca926ebd5a81185c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 758
-    },
-    {
-      "fingerprint": "91ea3b13543749ee87fc5db965193eb6b09c41b6ceb2af0fb2e9bb8fc39157ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/cbom.rs",
-      "line": 765
-    },
-    {
-      "fingerprint": "18ccb41e7b139b5938fd96c12c17ebdf823ee97bbd774d57588f930cf97e08b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/json.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "20182102e5495e7042eccc37b55d1096ec0d40a7b6636aff23e1d10f020f0a56",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/sarif.rs",
-      "line": 341
-    },
-    {
-      "fingerprint": "5f6d3c27f126c52bc227085d910aef9404833d8443b28715fed002a1600fe318",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/report/terminal.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "7791472b4e480d45b313149a6ab61cbdd07d19679518a91853b4c63de453dacc",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/report/terminal.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "2983c8ba4418d36f980fe995e752223bffd6014961a78a2f67c1f18e96854a56",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/report/terminal.rs",
-      "line": 126
-    },
-    {
-      "fingerprint": "ebc99d48f661ce597a75c231fa245797aea11d0c89bb7c8335c599ec4a67e2f0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/common.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "381462dbf3c516654d35d305dafd9c11852f90a8dd7f46a5ed2a15b962de0edc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/common.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "109ed1859e2cced77cabfadb2b6a6014be25e466b418bcbb9982a3f442942478",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/common.rs",
-      "line": 407
-    },
-    {
-      "fingerprint": "78e839a06d5a2cb412c1c512f3a30a0dca41b75e85222a715bc6257d481b146b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/common.rs",
-      "line": 408
-    },
-    {
-      "fingerprint": "c7c142467e1cfb8ea99f8962a87e158707fad7dda57d4a07c336a715ecd8979c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "8a8570a54c45ff882124aebe07e70cf87bb90c280098f8e52e45f3b48a4e840a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "8d5f218a36ec02822bed7ba0ff1b55a40f0bb9232349adedb65b19bf609423c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "7a62ed4eb5b1d718db009ca24564253bce02b3bf0dfd0d76af550d149125797d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 47
-    },
-    {
-      "fingerprint": "8fbd5e6bd58d24fa890d74e32d2b49649c84b7685e4ff8f3020f800b04f4e1ec",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 54
-    },
-    {
-      "fingerprint": "559ada4f664692de3b02a04928e51499a48ed907b3283f654b90d89cd1b241b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "89b9b51ba08d99b0337f8968d2b6489cfb2e6a4826fba18a74448b14a4bd6777",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 69
-    },
-    {
-      "fingerprint": "90ba7b88a968419e4fc8052e43f796bb3118b9f382ff6989773fa4c5f35d622e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "6f927a18b7b1a16dfe0633ae71a788caf6e8ce1cf15a4e7ea2ea2a10256990f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "3af3ccfa03f975dfb43b66200be741feb918a6212c7fa9c87e76e4792cc818fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/config.rs",
-      "line": 94
-    },
-    {
-      "fingerprint": "c0d7082e85c1c48f9df490a838fc92d71b7b27527a0b05848cb8257c6254b58a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/csharp.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "6bddb626b48038130f01122c8cfab2274da96b64627e6a38590cbd0f14eec21e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/go_taint.rs",
-      "line": 1324
-    },
-    {
-      "fingerprint": "7f0d0d48a8609033ca68ad2d295daf5a76dabeb6e9ec9e23ff3ecf1e3d142a65",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/go_taint.rs",
-      "line": 1702
-    },
-    {
-      "fingerprint": "23aeaf1a3580ee8dd092efb9ec5ea1950e68256c1793c3c7f6f6184514c8b741",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "661d2383bee064a98159fc1807d0244c0b49969499626ade86069db41135facf",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./src/rules/java.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "906d4936ca242f9ca6bc911d9570661df50a97ee3e8f84f3c403722ec358ce34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "c578a8bba1d0779ee0402b641a1367d8460b2c7fae526de2679864cd5d040ba9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "b0b3594f25948c53b98ebad97277f198749bb87b6ac43c020671770b2c01e045",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "224895a7e14317c657a602a6c106df39185aa89a5366222a4118992f91ddc49a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 49
-    },
-    {
-      "fingerprint": "90d96de49c43adb4b9a44c3646f2c6146454ef0d34383d11b54fcd98a1bc229d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/java.rs",
-      "line": 57
-    },
-    {
-      "fingerprint": "9db9a87fe6e5a248692b84e13b6fb87b683eadf66dad9a299ae9a9410b2719b1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "dbd1d2fa4afe6c0961264fc0154dfa07a4cd36825127e1371d0ab7655e7668db",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript.rs",
-      "line": 28
-    },
-    {
-      "fingerprint": "7cde115ad13f1453d314de353e97383d154d73c267e27eb64d4dfe559c894198",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript.rs",
-      "line": 36
-    },
-    {
-      "fingerprint": "ac8c31aeaff45a43595f820314dec47a94d38fa2fbaa9b8706542d9228f25dde",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "a83295abbbf267891e4000c5907f1dca02de49dd5ca1b51602c660cb51e292e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2121
-    },
-    {
-      "fingerprint": "0c59708c32e88c5a17fb9622d6fec9e798016632c56f3d1b0ca57e186b542b79",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2278
-    },
-    {
-      "fingerprint": "cddbb9333bfd6f320f508f2f902a294175bc3cdafa9c661b19ee624f1ff39e98",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2300
-    },
-    {
-      "fingerprint": "eaaa237072f768a5514771c7098b7b7258b62142f4abfe2879d94d59c307a3ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2309
-    },
-    {
-      "fingerprint": "a7df27fed900a8595f2bd564c48c929982e82e38285c87f28da4d2ebb0b59690",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2318
-    },
-    {
-      "fingerprint": "182a1e8c22ab4fbd81f04f11778ee83aec5507e56bd6f003e40dc2f508e7b0c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2514
-    },
-    {
-      "fingerprint": "03be16b312741ffdf3ce755c85210e3baaab3ee1734f8667743d33a05049c6bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2534
-    },
-    {
-      "fingerprint": "a250d13cf7f19bdfa1fdb6dab7d77c2c0eea5e60a930b6c442a2b757f3fb03e6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2550
-    },
-    {
-      "fingerprint": "c2d907ec76ca2de7b432213f9d93cab8c717a334f609e01653269e3c5c0db878",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2568
-    },
-    {
-      "fingerprint": "9b16e12241a576d65274ad9fc8ecc6f8bc83f4aceb89d362a0e7729916a6638c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2584
-    },
-    {
-      "fingerprint": "9b387451eae2fa3d4a34552ae2e76909c5c31c921be9ff84f59de84da010cc16",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2601
-    },
-    {
-      "fingerprint": "c5d306313427906d220844426fda57faf7337088e47581a7eb4dc3446909693c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2621
-    },
-    {
-      "fingerprint": "db6b50e0939a1081fb30d76ff798ab96186f47750ece53209f708e22b5b97e15",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2637
-    },
-    {
-      "fingerprint": "68c838bfec1c1b22938301e7662113dc51f4f03d92f361e278fc32d18b920af1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2656
-    },
-    {
-      "fingerprint": "b46ddb8e65eca9153fcc6f7099584d9dc25a6d654c67ec9697a5a9c2625576f8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2681
-    },
-    {
-      "fingerprint": "f10dbdb3d07747981ceab5287b386cf455e51cfdb0fd60a684bc7adb2afda658",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2700
-    },
-    {
-      "fingerprint": "8bd81c3109bc94c7dd84cd46ece7b836550b64bc9f92eb51573e3dc6b4d4c0bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2709
-    },
-    {
-      "fingerprint": "c900f1a54bf4434b19674608817ccc6bb029c7b8150660ca4245b009d243d69a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2729
-    },
-    {
-      "fingerprint": "de9e18b10676daf40cd11bdbead52fa7bc28b2c7ee597114e49fa2ebb25f5595",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2749
-    },
-    {
-      "fingerprint": "9158d24e9f916f7278b0c99f8dee8ad68b87762f18c9ae8ae8b27dcfbff7dbf7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2766
-    },
-    {
-      "fingerprint": "60b4e5d7594008015783bd8c2039693354c0b77cfa2dc5358c88347cb5935476",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2787
-    },
-    {
-      "fingerprint": "5e592d9f2ad2611aec8cc9bed5524359efaf507a47cad1f9731db549a84a7968",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2811
-    },
-    {
-      "fingerprint": "2f48e1ff6e61e56d730c7d7536decd7114f6c10d664cca43d8fe25dc5b538c1c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2837
-    },
-    {
-      "fingerprint": "cecf4d756198c7803b891133c0436af7ec800a3cb9b34b49eec3c2e32ba0d3f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/javascript_taint.rs",
-      "line": 2856
-    },
-    {
-      "fingerprint": "3f1cf078e348f67cc395c0123c44b8504a1f4f83bf6b91287d4e3a729cb13f5b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "258571289adc9f12c07840d9b6d098c04dd3b4abc6bc7f08c842cdb01da839ad",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./src/rules/kotlin.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "137eedfaa8903838fa0a8fffa2390c6d1571425800df0b020f2c50caea3148c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "0584cbd5029fc225030c56eda19d82819583173dcfec900ef59b2cc97b0cd4a0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "a0161a584645792846932a038e665d590bca0c5b70930c52f0736c24227d28f7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "915d7b6dd549cb9debcdddabcbe4d6f397b4ab12207be7021d4d1fb2c8a044b8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 49
-    },
-    {
-      "fingerprint": "38991c253723ca46d8165ecd51b17a9dd81c77d69595b4a7bb497e9057063729",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin.rs",
-      "line": 1031
-    },
-    {
-      "fingerprint": "4978b57909641c62821d3cf60238cf5ff94f2ceff7b43f7c7a021f95b3aa3009",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/kotlin_taint.rs",
-      "line": 766
-    },
-    {
-      "fingerprint": "bb562e6bd569d8a4a4b4f203138104c4ebd124b35dc2783de45b22da0c95d995",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/manifest.rs",
-      "line": 489
-    },
-    {
-      "fingerprint": "59ce4fe823c738fdc1cd1db6c4faddecf8d45261eaf66ee678a5de277980ffc4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/manifest.rs",
-      "line": 533
-    },
-    {
-      "fingerprint": "7b154cc5237ec9b3170fe58afeeebc0e7cef4c450f6e500db63301776e95f5b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/manifest.rs",
-      "line": 755
-    },
-    {
-      "fingerprint": "94546272e664eb626ab31042c41b2fcc35f5e9f08dbaeba4c7d9830faab1c0ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/mod.rs",
-      "line": 976
-    },
-    {
-      "fingerprint": "abecf3bbbb68c6c98c11e61a727a817b8a2fbcc379db6066ac77e1c5dd982c2b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/mod.rs",
-      "line": 986
-    },
-    {
-      "fingerprint": "034fe7f5541e45fdb3c716084728abcb8bad48fc07de39f74cba80bcdccc5083",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/mod.rs",
-      "line": 994
-    },
-    {
-      "fingerprint": "3442fc2ee763d5213f008e493a8c39d1a317ae607011f2b42a8f9800be53ca3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/php.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "ba287edfdb414f3a39018546f11f3774e2cd73368f8f37980e5de09043f97a56",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/python.rs",
-      "line": 19
-    },
-    {
-      "fingerprint": "5f6662f4717da5fcb3674901505bc993aca6b350e7668fe4eff11e30d22ec7c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/python_aliases.rs",
-      "line": 316
-    },
-    {
-      "fingerprint": "cdcb2b999f7272c358f83911942d9b9a6515d6f7b33cd16f235e2d6f3374ab94",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/python_taint.rs",
-      "line": 1495
-    },
-    {
-      "fingerprint": "add03796c534a27767975a3b95af65d9abc2d817a2b4c9f63a913fca4da81fce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/python_taint.rs",
-      "line": 1685
-    },
-    {
-      "fingerprint": "c0b40c5fd90b926e5977fee798ebea348aec18c5ce5d44f37e8e894319bf3917",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/ruby.rs",
-      "line": 836
-    },
-    {
-      "fingerprint": "fd7f41c8e17e2cdb0217b3577721b8071b0aa3f08091349be93c837605fc5f67",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/ruby.rs",
-      "line": 839
-    },
-    {
-      "fingerprint": "637fac132cd3d2616daf5836e5947dbb28ba9b0d8b963fcac4f225221fe1b598",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/rust_lang.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "7615674b9a0002fa246b1421b14dae7d01462aeabeae3a99a2c3d1770cf0dc7a",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./src/rules/rust_lang.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "676ade54160679929bc3ba6bc0b9d06b4ec7552588b5ddf37f4e5779ed2a5f73",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/rust_lang.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "3f4bcde0ed7c4527e0465a249838e40b00157d47dda9617ec5bb56ab5764c97e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 347
-    },
-    {
-      "fingerprint": "3742a4e9950972a8bd8a54aee9544d05d1124d2bfd2d4856af6cb2f3772d8c47",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 353
-    },
-    {
-      "fingerprint": "c220c1a76c6efc2a0e44fd152b4ded06094408f253460d07eebdc769855c9ea2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1060
-    },
-    {
-      "fingerprint": "9e24a9d6b6943c2ac491bf6e37eddfc3f922146fb2fb5fba93d09f878edd7ef4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1348
-    },
-    {
-      "fingerprint": "1c05a7181b60adad6250ac49036854d1fe52392228b86ef502f808be3dfeaf1e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1349
-    },
-    {
-      "fingerprint": "9ad32cf893790458b8d7749b2f270d003340bc456f98e7d21c4254a494a895ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1364
-    },
-    {
-      "fingerprint": "86b81c6c7572f12d3e63f4d29a66739a6f46adafe93e88c11cd76f975a346c4c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1408
-    },
-    {
-      "fingerprint": "4279ac09d6d8fa6552fd036fc3fbe91ebfeef18ca67c244660c46e275993157f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1409
-    },
-    {
-      "fingerprint": "3b86e843dc57a3dc05414170e35f8865766a69aad288de0643e2b3ccfe2e8421",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1433
-    },
-    {
-      "fingerprint": "6f58029432c01495dc42bfbb471a15da14bd6b71ccbcc0ba7d01f3be60616f8f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1448
-    },
-    {
-      "fingerprint": "a434f6056ef9554264dcaa29a952a5acebd7d6fef838e5bb01bf20f8247ecec3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1474
-    },
-    {
-      "fingerprint": "6e4d3cf0dcb8de954bbb58dda698c873dc2e92af517d8d39df8499b07702b50a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1477
-    },
-    {
-      "fingerprint": "19a7bd9a5c0973750a67c02c69c05e7a4926ba100ddec9195cf730eec2e187ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1497
-    },
-    {
-      "fingerprint": "0049b3bd8ab37bfc464ed7e1ecd79c3b6a76abe003c5722835eb11ead1f9f3ac",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1500
-    },
-    {
-      "fingerprint": "1a50759342b0a29295c7aeaf13b28cd486a7441d82b8d307ad4696f164a38714",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1517
-    },
-    {
-      "fingerprint": "d274f199d7aaf7fbc46fe3abf36b6e4f5a59597e88b3752159c5535e4c4f165f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1520
-    },
-    {
-      "fingerprint": "19473493c11dddf262440d7bc095b3ced1ff813cf1a3ce40d8c416a10506e79a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1537
-    },
-    {
-      "fingerprint": "4bf4f269653c21fe70992bb986be366254a3033109b466a45d4ddc8965e89dd4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1540
-    },
-    {
-      "fingerprint": "8cadfcb00d3c77a2de3de7dec8569d18083ebed94a6f295f0721fc5803f1b7a9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1557
-    },
-    {
-      "fingerprint": "45467e078e8e969e9c7287b0d66608ae53401fa146207641ce86ccd8fe2db25e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1560
-    },
-    {
-      "fingerprint": "562da2e8ceb8f39b25dc3c842f293d0a7d54120b5e720de6c399aed0372e5f48",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1579
-    },
-    {
-      "fingerprint": "aeca5cf26f7969c5881ef499fd66650fa5a933225ee8546bcfabd878ab13db96",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1582
-    },
-    {
-      "fingerprint": "1413fca54f0a6f5388fcd0cb85df0ff8be87bdce8ae2c481040536765a50889c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1603
-    },
-    {
-      "fingerprint": "6e2a01616bf8eb49cee49c7cab00df577d073e25e100addd3ca2b1e9b61b4540",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1606
-    },
-    {
-      "fingerprint": "f0a627c3441242f214961e956fa06850b362944a408d1fd3f6aee660009c571c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1627
-    },
-    {
-      "fingerprint": "7b3a44d6840cc5a49ffc6ba7bba517d96eb9af53211188ed35b025324820e279",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_compat.rs",
-      "line": 1630
-    },
-    {
-      "fingerprint": "38aaf8680ae46a00eed92771c777e85e1df7fc9286517bf6abd42728046d0e04",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 548
-    },
-    {
-      "fingerprint": "61dfd6858b20545616e6d82b1dff47e2d63860eb6a0df6f33e298fcd9a4a0bc8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 648
-    },
-    {
-      "fingerprint": "76b8f7eb3675ca03beb4690ebfd151117f9426d9e795848c7e548f6e73d597ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 731
-    },
-    {
-      "fingerprint": "725f5caddc515a29f3aa54ff9242a53ed8b59f355475d1ae10070eab5d8964aa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 743
-    },
-    {
-      "fingerprint": "49a8d5e0a567976d2a78bf966d4097163034e339159c162efc6d67cb714f940b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 755
-    },
-    {
-      "fingerprint": "3612d852e62ea8af07ca77f5ba43d41ebce179fbe388658ecb90e2f131b33397",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 764
-    },
-    {
-      "fingerprint": "1c2670f2f4b8241bda6aa7edde7cbadaa85abc4cba13952f28aaab9f92c32e1f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 773
-    },
-    {
-      "fingerprint": "dfabdccaeda351e8c6506a1111e3ed94f043e8a3026407b47d093b6abb38e650",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 782
-    },
-    {
-      "fingerprint": "1267cdb32e45836e0026abc58c2c030b4fadf6ede2d0eeea921bcdffedd222b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 819
-    },
-    {
-      "fingerprint": "f8249bad1fbdbb3f06507843cd0bb8d89ae24307c35706e3707616244d7aafb9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 842
-    },
-    {
-      "fingerprint": "4283f0f61af6e7bbdee0bfa9ac8626dbb5d3dec03d56b884e6ab3078e19bfeb0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 857
-    },
-    {
-      "fingerprint": "c5a8b7869f3e314ac6ec111435fd4971829b1701c9ad9d9b666f572b63cd0c0b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 872
-    },
-    {
-      "fingerprint": "303bd6904d2719f1b6e9203a86e84a07814a0b77d4d1854bc76cc7370c9a2551",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 895
-    },
-    {
-      "fingerprint": "6dbd206c8deaa2adf3df85a3756553e6295494c79673d4b90d794582eb3f20d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 914
-    },
-    {
-      "fingerprint": "d6b7b9e6c39c59e83118271bf98325104a1ea19aa981d272880baadb7ff8db72",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 927
-    },
-    {
-      "fingerprint": "85bb3803dc4446b4d5e28bc785a36265f4cc53b0dfab117b98d7ad7c36ab961a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1060
-    },
-    {
-      "fingerprint": "2b11eac46c1b74270aea7a005bf3ba6f532bd4430fde2aded9dfda6bf5172e73",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1109
-    },
-    {
-      "fingerprint": "acfa49d62f48d69c2f01e6f3fe745d38a0909ca6b578f6e5899410c53060cabc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/semgrep_taint.rs",
-      "line": 1126
-    },
-    {
-      "fingerprint": "ac3bb3687277b4880789a5741167360f041b19722675145b0144f7a695874409",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./src/rules/swift.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "0945f5c890be7de33946cf68b7c65066d35525b561cdd5a8327a90ca46b6d511",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "7a6528d216c0b12d01d0b91fe6ac80e4bedd180c1975395754baddcc8494f17d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "440450b487f36c09b028540ea87848478437a2f7b5aa4c5a08ac7ca57e717ddc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "608f4d44cc902b8e0ce9c0d5a9d2451ea4748108a72a13ff8b5214c000284622",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 41
-    },
-    {
-      "fingerprint": "84218aabdaa35021816f2d05ff35f8fd3cde7e3fb656141bafd60080bfcd231f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 51
-    },
-    {
-      "fingerprint": "2240b65f4c5365d111833ed3f57f02958b9f17aa7a6ccbc16caa7c00237ff4ed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 59
-    },
-    {
-      "fingerprint": "1294407a2d1ecce062332fc3a09a8145bbb1964c13e91ac11b7ca80ce1bd62b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 67
-    },
-    {
-      "fingerprint": "fefc4623c5698cd8baf3dfc3e4a3e15583c7a34edcb789fb55cee800b70be7be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/swift.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "85c62a5896cbd9a5de228e47eaf1d468c1aeff032be9dcf2d36bd7759f63e662",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/taint_engine.rs",
-      "line": 814
-    },
-    {
-      "fingerprint": "707377de73b3e48499863e79a2a79f467b9d312e8f648c22f2973be1b56f5159",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/rules/taint_engine.rs",
-      "line": 839
-    },
-    {
-      "fingerprint": "00c010f9d5b52be7b7f62eb7aa83821675698e70068300b44cf3a35eb02c0183",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/secrets.rs",
-      "line": 189
-    },
-    {
-      "fingerprint": "d820b72d039fb9582b8433ed84ae2161203c47d6e5be90fa786d81fe3672a1bb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/input.rs",
-      "line": 354
-    },
-    {
-      "fingerprint": "aedf3a8c627c9f5fcbce2e3ac5eed2537516cafa1163232e95b801c509a38060",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/input.rs",
-      "line": 357
-    },
-    {
-      "fingerprint": "1b359a274b077cc3fa694b4cfd98c09ca18bf570d4d311aad3d2368e02e37708",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/input.rs",
-      "line": 361
-    },
-    {
-      "fingerprint": "04ccfd4304fb80250f02504fa200395a07064c35b237163e5f3ac0eb612ab31e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 434
-    },
-    {
-      "fingerprint": "0c0107b4296fe5bb170cac10cf8174dfeac179bc4363c0916afa38f674cce2c2",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 461
-    },
-    {
-      "fingerprint": "d7bc0a95b149f5c538fa651f38e0f873c99a74078670f8a51c65f670c7a98ad4",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 642
-    },
-    {
-      "fingerprint": "c5feb22afca62581c9c88efbbdfd1e12bafe51a9e688ed22fa21432365138e86",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 646
-    },
-    {
-      "fingerprint": "67a755197f33eb90773e475c4abdb5242c2b50460c1557255263668d8276ebf6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 666
-    },
-    {
-      "fingerprint": "24e3d312875fbde397c0b4c03bd6d6486b1f5712379f942a59a3e1a8bb510688",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 687
-    },
-    {
-      "fingerprint": "bb9070dcd4aaad87d6f113bc74c3d77404647b72ea8d2b08785a8eb9d9395032",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 716
-    },
-    {
-      "fingerprint": "e3e3954227ec06076e34c36ef394610b53a8f4a50a162b7fc4e7485a0feb0125",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 752
-    },
-    {
-      "fingerprint": "28ef043cfcb11f076e0304620e56e9e02eba73899b818acbdc2ed2877e4fa10d",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/input.rs",
-      "line": 828
-    },
-    {
-      "fingerprint": "8057ec702926ff34e8d01850067c450254093fa31f85f82a2d9c24dc028e02d3",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "d020af31678b12cb6a247932790eada972c30a9bf32fcd80628d5198348c6fc5",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "cb9a1a358c05f93a24c913d4dafa67d0a4d1916adfeeffd01e9329b2024646be",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "9e978c2a2fdf3c908681f1caed6682c1780e58d8be1335aeb460a387852186ba",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "593e03b6f9414af4c616a5da4a2b3d085320d934e925508eb73e6e09bb98580b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 319
-    },
-    {
-      "fingerprint": "07a7e6453c02d8573514dab6226f94db0365ed1c4bdce10cc64289f3d055dce3",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 338
-    },
-    {
-      "fingerprint": "173daac9df8e3061b2e58b46e437bc37c54ba90aef42a3d1f3bcc044e14b518e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/mod.rs",
-      "line": 350
-    },
-    {
-      "fingerprint": "45fadfde12770e4394da5204892402d970acc8f956726e4be855902e120254e7",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 391
-    },
-    {
-      "fingerprint": "9f1ae2ddea463248a92d929db0db4ab8e4944198f035048b03c4c62470d35df8",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 395
-    },
-    {
-      "fingerprint": "4378fe2f0bf56aafb4d785b825337bc12d47617c8942da210c9c5ab1e306940a",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 401
-    },
-    {
-      "fingerprint": "772c86a89a184d7e9166e3f117609b603621cbe02043a3d9d39b766b7c6f22bf",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 406
-    },
-    {
-      "fingerprint": "6ad81bb180fec1ba099873a269b4ffe0998d0254fa3dd9887ae37fe042f3bd18",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 414
-    },
-    {
-      "fingerprint": "7461437daac9da136eeb75959421b5f52d6fef3368545458272d75230aaf27ee",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 416
-    },
-    {
-      "fingerprint": "bd9fed9153940e5b677166e1e9b1b77845fb576d5dcf06e3cf17fc284f2abae7",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 427
-    },
-    {
-      "fingerprint": "3697d5e2e739247bfad9ece792be03b9f37657529eea5918ec1f648d995ac7c4",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 427
-    },
-    {
-      "fingerprint": "8cd0472914f53d6064a35db1da105de30b21aedf762602ead20218dbdd00d443",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/state.rs",
-      "line": 428
-    },
-    {
-      "fingerprint": "81005764c289184dc0ca768dad9db3fa4f7e95c5f8071b208dbad7b8043ae915",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 135
-    },
-    {
-      "fingerprint": "6d3dc65fa18ff4c45257fc70b00cbefe31c3bbc1bdee5cd812fa4e4a06aade1e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "74b581d9cc611d9ead123ac5574460408e540ff9aa19f3bbc7cea7a180ad43a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "1ebb58865f82cced352e5c083b51d30235d69ba3be1c0d2212691f857db4b1ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 189
-    },
-    {
-      "fingerprint": "07decf885bb0e63ee6392486683ac6003376265cce91c679ebdcfdbe3a4cc5cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 201
-    },
-    {
-      "fingerprint": "5928e5c11cbcb500cf5d07d7a45e2f22f110506d275925e35064c275c8d2a762",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 217
-    },
-    {
-      "fingerprint": "e6f8d3c8cb4753ca1b4dfee656e4b9f09df4bf9cde35510a111312d9527b2e3c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 243
-    },
-    {
-      "fingerprint": "f7b5861f37540f03ba0c796b0b9f020605f166473c4b612d90ff824f2d48a8b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 704
-    },
-    {
-      "fingerprint": "6575cf0a2d38a7b0c32b73643fd46423522409b512dece8a09c53529949143ed",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 744
-    },
-    {
-      "fingerprint": "07847fbedad3b5ab1bf298e87bc0573a4f9d7b1f5c5d22cefd8b7ebdc0e84b21",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 784
-    },
-    {
-      "fingerprint": "1c5537394ece1bbc023e8654d1ba6b4af648dad2dbe926ef9a02f345738b84f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 824
-    },
-    {
-      "fingerprint": "8a6be895e15d177bfdd411c478d76b7de7158c7600e314834167a5fe450bfb14",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 838
-    },
-    {
-      "fingerprint": "222782497219482ef5595b2057922d131e5c52352580c974117479bdf510cfa6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 840
-    },
-    {
-      "fingerprint": "f3c67c1d9b7f2e4033a39e517902f74c09d9ac22cd44ae8e90123745edcf36bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 841
-    },
-    {
-      "fingerprint": "857411b32e7f8481ac66e2b424246db496442404971292f23ba4bbaa9c80033b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 866
-    },
-    {
-      "fingerprint": "016ab901ddaf3034f2e3eda1192731ca2362b229ed8238e94960cdbd40e64583",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 868
-    },
-    {
-      "fingerprint": "fb378ded04629057a1e764b7ad0facb7c5bffabab769c0751404180627d56026",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 869
-    },
-    {
-      "fingerprint": "bf1d28f12d722e449d83b27569845b61e0156e914a07cb519a49e312e8b78078",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 881
-    },
-    {
-      "fingerprint": "96a75bf5e963098324997124a62f2f32d3223bae7c6b65952a06bff0b15d9bd3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 898
-    },
-    {
-      "fingerprint": "76790f2881765d84f89eae3297c7705da3b82b128a8cac996b60104c8b242cd3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 916
-    },
-    {
-      "fingerprint": "81eac1c4565d01ed719d9460e5f23cb2f6979209a102f2f0f580a02cd527dcde",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 920
-    },
-    {
-      "fingerprint": "e84925e8d242d60820f8bf7309e665f4e72effab126e2895403c82740ffb9304",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 934
-    },
-    {
-      "fingerprint": "91d941844d1154c6648f4706acf9ffdba5d3d24b87638be647a02c78b9e1e491",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1365
-    },
-    {
-      "fingerprint": "851605796b854b9b5575113609df6d32cc2ed58596a450ce49c406820fd2da80",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1479
-    },
-    {
-      "fingerprint": "41a7227550e539888d880d9306e32da88d83469623b51dec882f1eb8179ae78f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1742
-    },
-    {
-      "fingerprint": "ff37a47d5572f8b155eda49e554c2ab9e77494440968e77cc3e9fda87006011b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1749
-    },
-    {
-      "fingerprint": "4feed9070c9e0610ee17b7ea16dc4a4a2b3dd49185df1923477de2b760fab14a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1801
-    },
-    {
-      "fingerprint": "47a917ae3a627c497883e08da3bcafaad4d054015ead5b9d37fe1976228e8355",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1813
-    },
-    {
-      "fingerprint": "7703e215ff4100bcc0c93eecc3276cf5e35adda3edefc47251f56ead53d1b769",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1865
-    },
-    {
-      "fingerprint": "596a02c3fb88bedeea0d6d91632e9f6b7691db330f187cdd32848918daefe6b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 1873
-    },
-    {
-      "fingerprint": "8016a3f2954870904ccce085c7f66b1716afe341999feb7c49d8be993a8e2dca",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2111
-    },
-    {
-      "fingerprint": "b9a5f8abf3f7ac4db14c0ac7d757d0e95506976a2ab7a0f417dde0133d936052",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2112
-    },
-    {
-      "fingerprint": "8b0915b23223245390646653b0dab7fe5c3c446b6864ac6679340becd4d150fc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2195
-    },
-    {
-      "fingerprint": "408412e3455a72486933aafc1a9f8f60d21d24050f275f7940fbf207878fc77c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2224
-    },
-    {
-      "fingerprint": "21508f5400199ad08a623c9ae5e49149d49ff167d473e252b87bb536e1a5c269",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2230
-    },
-    {
-      "fingerprint": "3493e45778c172aa930aa914f0ab993beacf9defbb589a71544b1d1ea8d48510",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./src/tui/tests.rs",
-      "line": 2246
-    },
-    {
-      "fingerprint": "aaa22e0722896b2c1f112bc92a64a0f9ab4c976d464cc30c144b2fdae1e29b55",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/widgets.rs",
-      "line": 1108
-    },
-    {
-      "fingerprint": "ecc083c6c881632de48bd5167dfbeca0389e061666ab8eab4e45949f16b7b62f",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/widgets.rs",
-      "line": 1108
-    },
-    {
-      "fingerprint": "10c4c5bacef78892ca4e4fbc198d439d6b0185a618dd32522a5b7ac41748d172",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/widgets.rs",
-      "line": 1123
-    },
-    {
-      "fingerprint": "ffefe06fc8b1b21468a8f4adb3d41415b62611f018dd8c9143f9b28d8b6fd541",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./src/tui/widgets.rs",
-      "line": 1123
-    },
-    {
-      "fingerprint": "021a59a8d6ae0ac58287cf6c364f36fcbe3e87df25183e72857e9ee241459c5f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/ast_rule_batch_bench.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "a0028135f49795103ab8253beb1ed824842ab16767694bd1913962e0f9c565ba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/ast_rule_batch_bench.rs",
-      "line": 26
-    },
-    {
-      "fingerprint": "1ec2fdc22d140e8577e2eeb783d775980348191d89a76c65ab28c9b14e655892",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/ast_rule_batch_bench.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "92655c580fc99f7fee01caa43151595d68f75569798393801a32b12b25a8f038",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/ast_rule_batch_bench.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "446854433cfd47fcdb01e1b2806729e420401f89c4091709dcae23ac126c67eb",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "0bc2ef7c099371ed84298fe8280908f909593da81de80224cf0c9dd982e70ed6",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "7182fa8ea9637574b7f15f1f3b8ee00001222b86d19ada86f74eed8d5c46daba",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "9ef5e49846e219e2652c152d1374c06eb7198294daac55b176a043b8185836cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "23ebe41662cffe2f56a7b690bed49665c49531adcd7b142ae7893984f552625f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 106
-    },
-    {
-      "fingerprint": "41144be0527977afc369182ef3df71b4dd36b515a73ee9231e21ddccedd6e119",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "60495d629546af9551ead15bb7f65be67cd81a5bb2b49bfca3e7f52adc5caaef",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 195
-    },
-    {
-      "fingerprint": "1f0fd2687febe70a864be829c103bcb0bdf9a71706e7a4feeae85543e266ebf3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "bbb638193c7a03d49c2be87d5a86f2ff4d400107a3d1e2244ef999dfc7b42e34",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cnsa2_compliance.rs",
-      "line": 244
-    },
-    {
-      "fingerprint": "e0fd39f99f662aca1eb02cb7f111e3f01c6a78ee2b3f8945213befab9967bbfd",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 10
-    },
-    {
-      "fingerprint": "f063feab00bf40d5a2371209175bde440350ab6c526c6bc034173a1871376924",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 14
-    },
-    {
-      "fingerprint": "24a9a1031cc248b4c9a50555d6fa9dd9b07889ed0913d4dbc1d37315f3cdbc91",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 14
-    },
-    {
-      "fingerprint": "65f80f63c90678f4dea3cbdfcab519595a53fddd5509b4744b2f649f8197100c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "b14a447431c44b4fe625b3f471b581aabfc8261322d283ee7fce39f54ff87213",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "bdf383e70fd4aa3fd773981ac298f85d4ef4b7aac0e60c48691ef808de6cd4c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 46
-    },
-    {
-      "fingerprint": "04e6ba737f3c5322f05f6d576f508b62e11442cd3a4c2c22614ec1037556a35b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 51
-    },
-    {
-      "fingerprint": "d0d5ab8dce98522d3820eb080ca04881b3ea22805b399c6e084d7994cbc77068",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 52
-    },
-    {
-      "fingerprint": "b5a7a098c07768e038f19b878833e3e245839a8a3b116b11153916e7e2dcfae3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 61
-    },
-    {
-      "fingerprint": "1a428d7708caea27cf9a3d1ed59d2d2d3b96d9e9345601b3773e3d16f307c4d3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "bfdd0d0fe67402c1192d3343e25232c9b085613ef2fccd4b263e9374c86d94e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 74
-    },
-    {
-      "fingerprint": "ab441a0e9ae2ac754eb7530932a56c7f678750e91db25b345b9db2d8612f45e4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 78
-    },
-    {
-      "fingerprint": "f5d1f9a61c716c5fbbf33efa6a98fbcc0bcdfe3234c8102f2c010aba9ee7e7c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "fc2731f2c2e0dec7ea582865d118eb47a78985c154717c13680b24e9c81c721a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 129
-    },
-    {
-      "fingerprint": "62597eecf44ce129db9fe409b88629359bad8cfce1df54715cbbb31e3418e521",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/coccinelle_integration.rs",
-      "line": 138
-    },
-    {
-      "fingerprint": "14b486fde8157ff6090b43e1026054122fbd765d581878ed165204d7d271b186",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "9fef00879031a1151ae09fa3948c280bf5178976d4cb0f34d176d254a7b363c1",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 235
-    },
-    {
-      "fingerprint": "1a7ba04cf57c32d9fb674b63b2a5391b4517dc4c3838a55bdfcb9eb69de2023b",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 235
-    },
-    {
-      "fingerprint": "39f6d5ae5a64d1409a33a857e1df75f2ef028b1314b40e7b04045482d9d4ac7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 295
-    },
-    {
-      "fingerprint": "3ffaead40e10cde753444ac8e6592b4b8e7372933ed50dfe2cee409c24bf1ee4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 301
-    },
-    {
-      "fingerprint": "76bf3b6f577c9aad6d75b746d0c5be27b4c7bb613603c3087e145f91a5f075e3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 310
-    },
-    {
-      "fingerprint": "57e64d3bc31a8c818046a109a8c8fe9359f0e61aabd077b81ef6680361094160",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 317
-    },
-    {
-      "fingerprint": "842205b094237fe061f2351381585261bad391a31a6abd9bc4c52a19f1d3c9f8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 348
-    },
-    {
-      "fingerprint": "59fcb8606eae721a11f57bd46e4813e82f84d8b94a91e8cdc071fff698ec993d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 440
-    },
-    {
-      "fingerprint": "a8606921676ce0fcb6b034148f170f3c17ca049352d5c65244beecba146d9072",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 442
-    },
-    {
-      "fingerprint": "1a025802b570094d40f474029284f9ca2597d30636ffe3ac030ff29267a5a535",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 505
-    },
-    {
-      "fingerprint": "a710c2a8c13d55bf1223f631d447458cefd5c9ee63204ab9a6fd467c3a3a2a74",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 508
-    },
-    {
-      "fingerprint": "e7665b295cbd96162f25e7969cda48890cb45490c758d7ba7e4015e8c31a9640",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 511
-    },
-    {
-      "fingerprint": "44dccbf753d1da60c94c26148998bb1797ac52da75fdf9a955d9b96d3305eefe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 514
-    },
-    {
-      "fingerprint": "b46dd1c974603e40e2316f97d22db81b46685e10d23ce19fa9bf8a650b14e3fa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 516
-    },
-    {
-      "fingerprint": "7376a46590d3b2cf1c10004ff01ecaa379cf65d41e96b8f6fcc956f8f38cd5f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 547
-    },
-    {
-      "fingerprint": "28caf2644977f809ad0b4b9e3c5c96e85ec89a84a41f8d0825e820ddf33dea62",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 550
-    },
-    {
-      "fingerprint": "63ede03332e86b21c11ca51603c6c42a3698d68349bf3bba9b66884fe6162f4e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 571
-    },
-    {
-      "fingerprint": "7a1051438ee0e86ed1f8493d45f5552d66b18df65b5c73af215df85abeb567de",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 575
-    },
-    {
-      "fingerprint": "4a20a63bd7ce34e4080e63e6423e9794217ae6fdb2ae95375a6ae7e79ae37b5e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/cross_language_matrix.rs",
-      "line": 617
-    },
-    {
-      "fingerprint": "4a209776a3e7761ab74111288af55ee22e648562b71cd1de503b72f66abeb137",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "31bdb4677402461813bc5151258065f4f2b5b4d236839a5eb4bb3642a81ab119",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "f23ea9eb3ce17e933042e1701c2e2d7eb3aceb348947490d8b95c5c685a5b384",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "14085aa68d17ead0005ad9f29b8cc4d7171022f4fe4a524e80e5f126ef26a2e4",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "5ade42bf57f329dd9eedff00ae05a230d886361b7b92cc2695da22213106fb6d",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "c7a74a1f579eec452755f5fe7ee21cfb78867089f9597bc0bf04bedbae408258",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "9012d4dd59031f6775d2f8d39de4683eaf21c7246f1d86181cf5c6a62062db88",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "ce0460cb2be4f1757065bbea251f8713a7f1d80a7b916b07bc9b9296fec758c1",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "6703ad8bbc6f1706965cd59ee76d3eda6990a3fca7f02a23d312a1cac4ea757e",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/cli_tool.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "4ffbf43f954fd0b2a4aae715a35c838645b0466c8276f58a817d3c29367c0168",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/realistic/django_chain/queries.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "8a694f47d13c005e27ca1389f411ec495466eec0f55451f06cfc820a8889607a",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/django_chain/views.py",
-      "line": 22
-    },
-    {
-      "fingerprint": "4661d4bf045626c13f97e28751d4097d6afd9cc2c881de265e8715139d29104f",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/realistic/django_shop/queries.py",
-      "line": 20
-    },
-    {
-      "fingerprint": "8e1c6c15d5fe088a702bf0f33ddd9d209d0294eeec879733fb009f4a8a6586ac",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/realistic/django_shop/queries.py",
-      "line": 27
-    },
-    {
-      "fingerprint": "a00e8e971717aaf1d525f60ead8e85689f5be1f4a7c3d65cebabc02b3e7c3749",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "d0583a017292c4ca49be171e50d8cc0caeecc63b6b540d57a7a3becf5ee1b3a4",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "6b2be3216a76c2b8e32374fb45979dbd66b9da5c0d9e33a9ab568d7e8caaf364",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "f7cb0739f6df6d8ed47ca61c6f1bfffe1264e978d84c6d24155413bd4e3ca851",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "6847dd99d3b048dffb156bb8d388d615be7c3ff5cf48fe1ed1ea6df803809dd3",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "b792ac40617bd592df636cc40ae1b722c34e4dd2d16da353c2bbbd200ef99389",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/realistic/django_shop/views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "e8c71844162df36ace093aca3bd1c779a056eae4c1c3250febc6d04a96aa8a5a",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "f327d0583d87e628d5eb14871c68ff41efcf42c11f45a9e1df124773f86ac183",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "7633558ddd927396ab56cb307ff502a3ef5506e4874a5c3e6c49fec544fb6779",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "47fd0251f66834ddef6be467375b9e040f52cfe853f28144829c157b88dacc5c",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 40
-    },
-    {
-      "fingerprint": "18eabf5f16f80eb8617b75c3f900b9391c54d05f8f7cf2a39aab0126aba23e2f",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "19df579e1f9c30b810008132aa95d986f26a6061512c49e285011642c1b0f9f2",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "9ba8d442f67676f5e070389da4cedddba329fbe15d5fcebc4166b1a34fb1e86f",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "53efc244f8e8d2c117c91d0b26dd5695bd22f53c997a68fd7980f8909315b2bf",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "27a11374ecb1751bf92cc18df667d563c688c1b4b8f6b7e01f6e7949bba2df92",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/realistic/django_views.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "e4f5091ab56d0e18f16579d706bd1135b1fd2262512d716ce65a93d63198c246",
-      "rule_id": "js/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "588dc3e0f8a294f585a1f6945f6c17bed75db7592930bcf42095dc604fb47a94",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "ef7bc31cddb427fe670a7368d0eb24487dade939ab1f960bc1120022d348baba",
-      "rule_id": "js/taint-command-injection",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "3b9c82ed9775020ad78e855752aa9f97bc3973bdd3487fef7ae0f8615756b29d",
-      "rule_id": "js/no-command-injection",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "039d787c9cb2fefa4cf0a28fd270fdbc9199bd689fb0c04568b3cfb17f303e4d",
-      "rule_id": "js/taint-eval",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 40
-    },
-    {
-      "fingerprint": "f948a7a6ef251b66e30361496079f721e3ab7861821ecf07e80a26a6e093a4aa",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 40
-    },
-    {
-      "fingerprint": "09753d7ee415a1a792c143bf89ae399467ca71dca009b8ef85bfa627aca0b348",
-      "rule_id": "js/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 48
-    },
-    {
-      "fingerprint": "16f3433c445ed075f6428d629453001f690bf5c2c31af94b62163f05c340d7a1",
-      "rule_id": "js/taint-eval",
-      "file": "./tests/fixtures/realistic/express_api/routes.js",
-      "line": 55
-    },
-    {
-      "fingerprint": "47f00251e6ba64e934b2b681a8fdfd760a19d4721c1f1773a21f6f3ef7f22044",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/realistic/express_api/services.js",
-      "line": 17
-    },
-    {
-      "fingerprint": "be67a84e63b6d1bc02e7b8b906c79b96800458e84b91356efa32828b4658f045",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/realistic/express_api/services.js",
-      "line": 24
-    },
-    {
-      "fingerprint": "d83473fa7da89efd57cdcaecd66edfe93e441a96c4463193f40500642a05e701",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 25
-    },
-    {
-      "fingerprint": "c705d75d8e2a4f2a75d970c02624d5ec8f9b287f7e1fcadaa2bd794a6a51d499",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 25
-    },
-    {
-      "fingerprint": "7bbe81a7e07a8af28f88f6d37b6e9aca5a554e4f01d7eb448eed3572ce071284",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "c3080f79ae305bfa3544bdb3343637b96309bb7eae45cf130f1c3d35c47c4d57",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "b0d25e779a500b106b175d193836042a035425b35dccfb4a9d953f731b3d47aa",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "fa2c3eb86e0aacddf06a4d2c101bfbacb1c36bf3363e3e6de60044c619f3f7db",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "defd76ee5d5ef8bc1f7bcc746a2f0d7a26131dd79c0a46c24efa57a823aff393",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 46
-    },
-    {
-      "fingerprint": "0eacd7a26d278a7d8f2cbfbde7b1f63929f6d466a6eac926519df0efb5b33ec1",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 46
-    },
-    {
-      "fingerprint": "f8c556bd871b6186fd968ecffd4254c56136c82648e3b96fb5ad28974029f290",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 54
-    },
-    {
-      "fingerprint": "599c1b57a85c7a4ae42ce5b28bfd6c1abba951a32813d5a4918a668cac523e88",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 54
-    },
-    {
-      "fingerprint": "27d3c2551aba9cfde2c8a840cb32be6f8f3e33ce626b394be40fa89b54f1dba6",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "9f8a6c83dc0d49bdef4cfb8ce7784540f2ebc5a1e0a7fb222fc8d31805facae2",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/express_app.js",
-      "line": 76
-    },
-    {
-      "fingerprint": "d4d2a2d7885a7f2ac8004d2c90f7c5f95dbbe0da0d030339757af7a1cf4a1c6c",
-      "rule_id": "js/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/express_chain/routes.js",
-      "line": 22
-    },
-    {
-      "fingerprint": "e84e3959cdc52d641414e441f416ceed22cb389e98e54594391ce73aeca202e6",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/realistic/express_chain/services.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "23ee99a1f2448dc04396953e19c63aa6ded7731d4d202414af17218cec6eddfb",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "0a43a76c832913f944f3fa209fea8bf5fa6efa68cfaba762a7ce9f41a01a21a5",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 34
-    },
-    {
-      "fingerprint": "6a03d1ef336ab813b007bdd2ff7b83f0f3a4e86db11a313136228b4ad548771a",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "f75deae007e799c54fd8479d2fc98a5508882785abdfaf92e37e1634c6e4733c",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "cc409213aa71a710963fb5104cd37d4fc84a4bf2a6f7da1c72fa47a67018e686",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "050d6e98b6fc32b13a969ea1ebb81d327560efc86769e42e8ed971c4d59230dc",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "4a207fef927768cbb5400b3a5d317df87c1bdfc50b8f7c572c920d921d722008",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "9aae5f9ba0e5d0077b7488141a0a177203214e11d0c768a49ab00632b20475f2",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/fastapi_app.py",
-      "line": 62
-    },
-    {
-      "fingerprint": "1a0f458916e8f9c812f8d3d165b26bf600c611de81340480b5cf21767b34dee9",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "23680e3011016423c49c6d40e6d176034ea553d88fc6e38a09118a08bdebc8b0",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "017cbe25db41c2649874219bc2f7783a504ed44aa38f25ab412adc1958f0cdcc",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "e451e0e11264bc73b80ae126ab147315730f15d4a734942a5aac7a801bbbeab3",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 48
-    },
-    {
-      "fingerprint": "384f6695e37447497755d0010b8a2f432b4018bdf0df99904ecb2bf0419bf621",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "b7e2fef1ed16266885d777ee4805b6edb532eae0b5769442fa989ff4d1431546",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "77a1e80661f793f22807ea15a3ba964c7df535e9283be4a5ad07af410e6f2432",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 64
-    },
-    {
-      "fingerprint": "acf0bf2c3da182d663a36fe66596c5d1fe2f74816a75a12c5fb431cb33343ca2",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 64
-    },
-    {
-      "fingerprint": "cee6cbc5e4582edd4b5db905457399a520240747779de4f09b4ca3b84c98f5bd",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 72
-    },
-    {
-      "fingerprint": "18efbcf175125eb790fa135c4beb985b86d9df893508488cfd2b715e2b42c27b",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 72
-    },
-    {
-      "fingerprint": "4d6dc632d7493e96b462508f2aa7faea260173b4f1c6c849959f1f1fce9beac2",
-      "rule_id": "py/taint-yaml-load",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "f7e8df6b066dea9bfc6067a3e20ec54f5596e3bc1609429a237c735f4027d485",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "00d4c3a8011079a5a04f421ef94a58221e6c6835a96ccc6bda95f5be4b0e21fe",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "fd9280915fb47ba185ac341300c6dd70ae3635aaf850d237a931fe5ba7f9dfad",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/realistic/flask_app.py",
-      "line": 104
-    },
-    {
-      "fingerprint": "dacf867fa312db2752389648640b4933c933987261c1d2671e6c33d05996ff11",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 36
-    },
-    {
-      "fingerprint": "09ad38c41d9f61fe547b8956cd21d7c7bf87cbae2c87b715034971c34e33a362",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 36
-    },
-    {
-      "fingerprint": "2d2acf277fbfa0fd7402b2f3d0579f1bb2668202725a8beef76415b0721b8c4d",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 47
-    },
-    {
-      "fingerprint": "64df56ab2870f55a83d162b8e9e0180201084aca81f5cb3face7861d445cee21",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 48
-    },
-    {
-      "fingerprint": "5d08bf519e176c40c59dcd5984c1cae6387f678559df2879d33febce99b87324",
-      "rule_id": "go/taint-ssrf",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "a41d6f63e5d45e1251d61e13edad028de30fed78948faed9753b82b4868ea331",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "8df91c9450c8be1f53fbed80f32a20117c575aa5e4c50ce9c90e54ccdb2f8e06",
-      "rule_id": "go/gin-no-trusted-proxies",
-      "file": "./tests/fixtures/realistic/gin_app.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "1726a51960ec6dad8d52158e7127f0d1f4137462e4d6f6bca3e3a09f2897064d",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_chain/handlers.go",
-      "line": 24
-    },
-    {
-      "fingerprint": "3c76b6c4d09679b8a950aac73cd82671e7f0329890fce3a674b8a28a6435f7a7",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_chain/store.go",
-      "line": 14
-    },
-    {
-      "fingerprint": "ff36f0933645ea0eefb48ac9a6b6f0664d62578ccbee816aebcff93a73183ab8",
-      "rule_id": "go/taint-ssrf",
-      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "a40eeafa7812947b90f6b8dd5f44536abd432bce461e3ea3c49da0d61edc176a",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "2da7d54c6edf8eb95b95bfe3ea5ff72206287a02a1acfdd89c74385af088c05d",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 32
-    },
-    {
-      "fingerprint": "774d8db2fddbe4f6278dc3e0f954b9b2588ed377f01090d6d5c2df9fef2d545c",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "5a45e9a152902f93129eb07ce359dbf4dc42e1d741acf32e2ff5f79d6c6677f1",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/realistic/gin_service/handlers.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "fd2bfa211f6eb3c6d3a34dc789b28687d12f6c89c4cd2e5b7ff675b9451255b7",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/realistic/gin_service/store.go",
-      "line": 15
-    },
-    {
-      "fingerprint": "a9f236844173d62d9293edd468c0ce33ce9e16decdf35f5e0cc103bebbf18dd9",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "5ed916018e216d4a2bc3fa8350e19c7c1a197c850eea5c9cc3e9cd97384c5765",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "f167ce08a2246ae7611bd94420506a0d079505a87a9af4c8ecb71c3d5c27668a",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 28
-    },
-    {
-      "fingerprint": "a619179153d5b260190c38acb8cc6430ca346e0ba01eb812f3753397531378d2",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 28
-    },
-    {
-      "fingerprint": "dcaf1f93cd1ebc250de3202c4e08cc6da49cb99bca968c785544deb0731b5673",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 37
-    },
-    {
-      "fingerprint": "feb313d86349964d68e35af502ad907869d917079e1ae1c709112ba178cc3d73",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 37
-    },
-    {
-      "fingerprint": "583e749df8722be17f1f6a272c175912d835f95c6732f8c86f54ac23c7fd8efb",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/hono_app.ts",
-      "line": 52
-    },
-    {
-      "fingerprint": "adb9e3fc2906e323443010e9c832f8d3794da3c6f001d06e6760be5322a0a142",
-      "rule_id": "js/no-command-injection",
-      "file": "./tests/fixtures/realistic/next_app/actions.ts",
-      "line": 15
-    },
-    {
-      "fingerprint": "b65e005f6c317f93e68d4338c2aea339d3c09841ba1c1aef2f7d50d93256f0e6",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/realistic/next_app/actions.ts",
-      "line": 15
-    },
-    {
-      "fingerprint": "b2d25ebee53a780a16d3ec1f55a94bb5be5fe5a82fa2c90922b1fad760c22442",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/realistic/next_app/actions.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "2f6f5d6d3021b464af8a9f7ca8b51dadc45d13555766de14a68bedc83f22c276",
-      "rule_id": "js/taint-sql-injection",
-      "file": "./tests/fixtures/realistic/next_app/route.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "e87be12708ae190783723422c63eb5f917e7ce66c3a2c67c2c391229b989ee2d",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/realistic/next_app/route.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "4a554e082efef15f9ac0d8926d970b82c670514ccd7bfe9c3f906ee2ae272de0",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 20
-    },
-    {
-      "fingerprint": "5369c7ecee4a23d3489c1e7c73a033fa2270bac17ed04a0d56a404fb5b79198a",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 20
-    },
-    {
-      "fingerprint": "ae9154e050bf5a86bca844bb9e08621a66e5eeea8607d4bf2c70ac024606e58a",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 27
-    },
-    {
-      "fingerprint": "c3d7692a5a64d857053a0ab412fe9ba97ecbb81611db102790f5cb344c4605d2",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 27
-    },
-    {
-      "fingerprint": "fb2b8c51e8702fc0ca4e18e6c35fbafe2067dde595c9eac851a3ebac8e966337",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 36
-    },
-    {
-      "fingerprint": "832e8892447811bba26aeb521f3598d66ebd59d8986c2645488b54e0ee4ccc69",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 36
-    },
-    {
-      "fingerprint": "2b6bc821cf86a484aab7c34fc2f46baba7707eba180bfcba25dd35b57699fcf2",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/realistic/nextjs_handlers.ts",
-      "line": 51
-    },
-    {
-      "fingerprint": "f9bc9f1469886f3d6a93eaedd6337c3fa65a13f381bbc9b262ba058bf2cc4cdf",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/safe_cli_taint.py",
-      "line": 16
-    },
-    {
-      "fingerprint": "d74f67f5c832a417a7fcb23d40d436dcab81777af3912c54642fc2a1a87ccc42",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/safe_cli_taint.py",
-      "line": 20
-    },
-    {
-      "fingerprint": "529d1a6c519f6aaa982a6cd1057dd8032ae8d4ee60ac1a6b495d164f310c7a0c",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.java",
-      "line": 13
-    },
-    {
-      "fingerprint": "385e9addc1d4a58f820adda167318615a8bd7f2139de54988a5cf3b27988be00",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.java",
-      "line": 14
-    },
-    {
-      "fingerprint": "9c961071dd4355998b31eb5d4fe8135f09517960c5bff0b05f93c2a8731b9e42",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.java",
-      "line": 15
-    },
-    {
-      "fingerprint": "45204477c7ebeab58d4b68ef3e8b1005a08ca01c4485b3396c02aa68cdec3a0b",
-      "rule_id": "js/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "fb02a45953b261362e3e79a22556c9f654916238fb254d98fc727100cf475669",
-      "rule_id": "js/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.js",
-      "line": 13
-    },
-    {
-      "fingerprint": "b1ea34362456ca36fe295c9ab3cecf15f396519a4f307154c6995f20d3118c0e",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.py",
-      "line": 12
-    },
-    {
-      "fingerprint": "b9d5760902ee26078deb4792bbb8e6c3a561b95f183db3a3ef9e3e50643e5f83",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/safe_crypto_agility.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "c73fbf9549f563249f17f43a183bfbaba00941e12e27b9cc83703f611bb85c89",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_deno_taint.ts",
-      "line": 14
-    },
-    {
-      "fingerprint": "4fd6e1cfc22901a8f6bb44cd323eccb77c1d9fabae56494995ae8b36880ed7d8",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_deno_taint.ts",
-      "line": 21
-    },
-    {
-      "fingerprint": "dc2c8fc92b7de3cef70c6e165890395e32938fb159ad520637db5044c820f70c",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_django_taint.py",
-      "line": 12
-    },
-    {
-      "fingerprint": "a82efe88b066593cbbd3712f68fb6a723a622a07a3ef23e6747c98400b5f296d",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "b4be2e927d97d165a79ab27bff3ee66bcf48760f7224f2f26f1be5f7cbf1aad8",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/safe_django_taint.py",
-      "line": 26
-    },
-    {
-      "fingerprint": "dbb58fc0c323108764e974fe906107186963fe4ff946a818c5d04e8d4feb1b64",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/safe_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "c8840a320f7d662a709a024073d2e0fd662704196d165d226a8174b6b2ba0235",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_fastapi_taint.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "d47c125bddd1c367680849f04a9d61014fcab6975ad8ce8eb80cf42c7569ef92",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/safe_fastapi_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "e60bf521457ba6c8baff0008418c678e6ce06a2f51f8bfc48694b5b5997114e2",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/safe_go_taint.go",
-      "line": 27
-    },
-    {
-      "fingerprint": "635accf5fd57851535bc4746e9329462feab2b4bef9ac2c1040301d128500cf4",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/safe_go_taint.go",
-      "line": 41
-    },
-    {
-      "fingerprint": "0704cbd72bf8bb0ee2dce048771537b5f302dbb6f91e5e839c6fa44d234f8cee",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/safe_go_taint.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "285bc3dfa2bcf8a5a409c4effab0a573184afe11e5595a6822a0d49168f00273",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_hono_taint.ts",
-      "line": 8
-    },
-    {
-      "fingerprint": "9caec65fcadc40179b12f85245189ade3dc902147729d9b7ed03a303d5a867aa",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_hono_taint.ts",
-      "line": 17
-    },
-    {
-      "fingerprint": "8cabd934600adf8b7503e8b12e79ed187f645890abae52ddc1c9bd7969408415",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_hono_taint.ts",
-      "line": 25
-    },
-    {
-      "fingerprint": "34c4c00b5da59a0ba44f656e25b1ce10d13485d816a0971956c5d98397c0dce9",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "8f08d46c2c5afe617539b393e9ec4fd568c548c0be13336bd581b327b4c2fc55",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 22
-    },
-    {
-      "fingerprint": "7dcf207e3ae807957ca772935eff274fdff5e260677d5244213eb83fe2739244",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "249ebdc4f17462e1b473406bc32463e3953e61d82513216b87c52694c63c0841",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 42
-    },
-    {
-      "fingerprint": "3ab3632a25141ef152ca952bd01247e7552f7f3c945b9f230a55a0908780c15c",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 47
-    },
-    {
-      "fingerprint": "3c30f5f5cd9a7321c940db36c42a83d36e551202825f5ef4db3218af89b1d882",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 78
-    },
-    {
-      "fingerprint": "21808d395b4956d935dea9a8081bd5e79b0700c53f49c76d218344696c7f41fd",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 84
-    },
-    {
-      "fingerprint": "248083cf3f60c5b9370627ecafeeca24ec2f90430ecede9691eb2d68b19c9651",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 90
-    },
-    {
-      "fingerprint": "0bf189708ebe94ba0a9d0db9174bcf47ac0f929e8fd71dc4c8f422fcebae317e",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 96
-    },
-    {
-      "fingerprint": "33a72a0d43a7c3dbe3ba5bbc2701a84a270a4c1b02732d9b25c509f784e6c18f",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 103
-    },
-    {
-      "fingerprint": "8a7c1acf0afa577ec49aee0c00c4eb65fa291af7e1b121efd79bd98b7054bf57",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 109
-    },
-    {
-      "fingerprint": "92dcbcdb46a62d4b25ec9cae6488d4748d66f701f9429af6e0f59a9ebabfcbe2",
-      "rule_id": "js/no-command-injection",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 116
-    },
-    {
-      "fingerprint": "3fccb520c99dfce189662d19399be28c505300e8ab45a8e943bbd94bd2a226bb",
-      "rule_id": "js/no-command-injection",
-      "file": "./tests/fixtures/safe_js_taint.js",
-      "line": 122
-    },
-    {
-      "fingerprint": "4754eb64e2165343eae1e3a5342d1e76db29ffdf43d3d74ae8221e911d27ee10",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/safe_nextjs_taint.ts",
-      "line": 15
-    },
-    {
-      "fingerprint": "da95c527d87c27ead43e39c8cc6866f79eb59297a1f717aa93c18f8653e09158",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/safe_nextjs_taint.ts",
-      "line": 22
-    },
-    {
-      "fingerprint": "e8bc0974f085a2cf5acba664f93537bb12f670b52502755f5d16b901f0a6c7b8",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 16
-    },
-    {
-      "fingerprint": "df3ebd7fb092a0f5943aba323b985653c7a1bdfdcc2c19d5421c262bae5d27a8",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 23
-    },
-    {
-      "fingerprint": "d5a99b84a16cbfe634757ee24ced10e5d87d3e5af66c0cecc062811d826f310d",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "80318e93530a6897c6dd3f4d512145f693c63cbc9c842cdd5ec4e5e5329c810e",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 42
-    },
-    {
-      "fingerprint": "12e2d42419b53b8557091ecc1283718b21589146a89774c90ec92b82b1613d21",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "c41319ed9d619d958348b9781a53d8d29404672b9a5645e74e406e7e6d61b195",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "02013b57336871c1b5b67016a37e607ada3ee0e4576ed23e555a1b83c885c280",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "f932302764aa8e908b5275549a16abdb2dd9e285fd5e1611ce7e6d26cd386346",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 91
-    },
-    {
-      "fingerprint": "e6eb3d2a3df630ed16e05daadb0016b3cad0ef77b907f1dc527778cb9c26fc8b",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 104
-    },
-    {
-      "fingerprint": "46b05498f11ed5ca854befe357d102d3de48ce8507e1fd5abfae928d0a314fa9",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "bf02a1692c34ce5ef96048d7e1b1d878d9c66133370b90e6a2baaacac8becf53",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 165
-    },
-    {
-      "fingerprint": "3a8162f13e784c38f67d60f465a4c50e13ce3b40753ad820cd686d3a3d77833f",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "f829bc26fa60f7fedbe1cce28a25b410deea4477c39d840726aa0e82834af7ba",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 177
-    },
-    {
-      "fingerprint": "cff869332002907d588200f7ac550bc43d29223b6e97492be16a3e9a5a69b12b",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/safe_py_taint.py",
-      "line": 184
-    },
-    {
-      "fingerprint": "98d63f88f9d20aab2d576d6d32382e4d9b0783f7ee5358b414354c2d809e381c",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/semgrep_taint/safe_js_eval.js",
-      "line": 5
-    },
-    {
-      "fingerprint": "7b3b61073c8358ea8d3e06be268a1fbce830b01faf7810da0214d6e4a29f73a2",
-      "rule_id": "js/taint-log-injection",
-      "file": "./tests/fixtures/semgrep_taint/safe_js_eval.js",
-      "line": 9
-    },
-    {
-      "fingerprint": "3a8ef8ac6b3e355e933746fc06b4b528b51cb4877f7f8ec151487df7f4164252",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 13
-    },
-    {
-      "fingerprint": "6b678c72cf14d46f2e5c72e22f61fdfc6565aed65c61a42d932c846d1a9513eb",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 13
-    },
-    {
-      "fingerprint": "da3898f95c1d359391efb00371f45ccfbe11cdc2926253cd0cc143b5aca1eef8",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 19
-    },
-    {
-      "fingerprint": "e1d410772b0461744d45559e9da10ec9e32eb71d429774a2608f2909eb747c55",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 19
-    },
-    {
-      "fingerprint": "7f7dccec93ba5be73792e811e5c696b2031a468cd97ae28bfec078d18f4b4821",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 26
-    },
-    {
-      "fingerprint": "614510833df33d6bb94cda0c8c3c54447b1367ad6a384140cf50a75f58eb53c9",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
-      "line": 26
-    },
-    {
-      "fingerprint": "4f59c188f093a0858c61f3f9b4da53d670e3edb4c0ec92f034e72342618b890d",
-      "rule_id": "js/taint-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 6
-    },
-    {
-      "fingerprint": "3a9d01220355db492ae21a5a6877f38c2e2db87f627f5404288216358440407b",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 6
-    },
-    {
-      "fingerprint": "0530e62b789bc8b41f717ff8a95fb2585bc55a089d6e0680370f57aa5d4dc63b",
-      "rule_id": "js/taint-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "b2677eddc1a5d04791b600e448fdae12ef600a467cc3562cf2ba26ba70848f54",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "9b3d25090261c0bfedfd042cc4ae74c3d5c3a991befc2fd7623c101cfc6a86b7",
-      "rule_id": "js/taint-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "8e1d593a9ce58ebd6e3b78359fe7e59a7b89349bcdfe893d8a190ecf9a5bd91c",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "39636a75af5744cae453f6edd26b3a1b48e22189dc4da99e494ceb051a2e18b8",
-      "rule_id": "cs/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 21
-    },
-    {
-      "fingerprint": "e7ec1d3c92fa206e05ca4158a5dea3585f135069d7e60b6ff7a5447528da3828",
-      "rule_id": "cs/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 27
-    },
-    {
-      "fingerprint": "58a914553b4782066a2abe7785342fcef95eaa31684ec44d4703aaf19fd5ccb2",
-      "rule_id": "cs/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 33
-    },
-    {
-      "fingerprint": "ac6589982bdfe0098f949ab3c494b5d4aa8cf477bf01cf98b0292de2ed0ec7a7",
-      "rule_id": "cs/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 41
-    },
-    {
-      "fingerprint": "2639294d8133a8ac04911732c5256be043a589317e2e64ad6a4c9ea16081c3ca",
-      "rule_id": "cs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 47
-    },
-    {
-      "fingerprint": "5a7e27e6da18f274db22d07e5f305f0af1efae0ae73ba5bd45035f3e004bd3ea",
-      "rule_id": "cs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 48
-    },
-    {
-      "fingerprint": "005b6a6733bc77a91006b2ec52da5353c1a5ffe87ba19c4399f8a510bb02676b",
-      "rule_id": "cs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 49
-    },
-    {
-      "fingerprint": "aff62712e5f6ee9fbb791598faf84900f734b172f60c6e8d87c3cfcb472512e9",
-      "rule_id": "cs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 50
-    },
-    {
-      "fingerprint": "39906d30045704e3edb7e06f51a4ff17855e93507c7efabc4b9cba09653bef51",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 56
-    },
-    {
-      "fingerprint": "694f0bac8d5d07ecf87c2d1ecc65b49d2487ced41637e3c95510b1003571702a",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 57
-    },
-    {
-      "fingerprint": "0b6b5b00203a12b64f1cd2b0388f470ca4d094cb78dc2474797dfd44ac6eeb24",
-      "rule_id": "cs/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 58
-    },
-    {
-      "fingerprint": "8e0f9dcc8c2705e32bc679d1754e2615a607bf3cf55aab1c56860110677d3cd6",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 64
-    },
-    {
-      "fingerprint": "69c15e694e1d6ff4e8050742690fbf7d9cb815a5dd5a2e4c6ba75c445e9c66aa",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 65
-    },
-    {
-      "fingerprint": "5b268236d1191a3f6148d38a7d340e5f52cebe623748e399ef68fe52e92cb503",
-      "rule_id": "cs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 66
-    },
-    {
-      "fingerprint": "407a6c2d1bd33880520bfe65276b32ea1d7fd3fa278cefb1c4eb3f026190e287",
-      "rule_id": "cs/no-xxe",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 72
-    },
-    {
-      "fingerprint": "abd4db8bf04bd5493e9f65b3ba7bd16e9fa09ad6873a70f3d06cda32a4fcddd8",
-      "rule_id": "cs/no-ldap-injection",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 80
-    },
-    {
-      "fingerprint": "5d53d1fd14ae84eaa32cb4f2662dec3e67d2a9651cb887cc80d2d45ea6b5eb18",
-      "rule_id": "cs/no-cors-star",
-      "file": "./tests/fixtures/vulnerable.cs",
-      "line": 90
-    },
-    {
-      "fingerprint": "a90f6a1b2cdad060707dc8a7698763bcd94e3747f86e107c9c41371520a8d39e",
-      "rule_id": "go/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 8
-    },
-    {
-      "fingerprint": "c2d5af79edd7908572c6b03b759bb873f558248f8421cdbe3e1c3438e510aa6a",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 22
-    },
-    {
-      "fingerprint": "fb35ec2d5ddb2bc197812688882372ec0752993a1d9e97e39a06ebdf3e2eb0d7",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 25
-    },
-    {
-      "fingerprint": "4043ca72a392ac65be8437de09de401d5f34ee8cd140af7669fec087c584bc30",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 28
-    },
-    {
-      "fingerprint": "71ee7d46b3502a9ade3137bff6d1fd66217957833cfb979123cca09706f3b857",
-      "rule_id": "go/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 31
-    },
-    {
-      "fingerprint": "ade056cabb35cb3484e860229cec4cec6f7c57b683001fc8216432a2eed2badb",
-      "rule_id": "go/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 34
-    },
-    {
-      "fingerprint": "f2af9ae23084eefb6b3c063af170738a4ed4ba893954477ba22aee9d5d4818ed",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 37
-    },
-    {
-      "fingerprint": "9977d9afc10f750b67bb911c1004f53486d5d03019a34f17aba0d99d4960729c",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 40
-    },
-    {
-      "fingerprint": "1d557a90238594cb75a3c9689d5bc507817653eff54f6d2140e65109aae3ff1a",
-      "rule_id": "go/net-http-no-timeout",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 43
-    },
-    {
-      "fingerprint": "4bc336d7d30621af4881b29af5d89e7fbdbbfc12801eba23737f6ec9fefaff27",
-      "rule_id": "go/insecure-tls-skip-verify",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 47
-    },
-    {
-      "fingerprint": "12c6b9f4afd48d4f696d34b7117677528ab370a9bb5e35e812c845eb59f8c82e",
-      "rule_id": "go/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 60
-    },
-    {
-      "fingerprint": "ecb8464262a2912f597a022b4af17ecd4eb1398fe8fe165ae31d0f35e426b834",
-      "rule_id": "go/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 64
-    },
-    {
-      "fingerprint": "b6ea1c741925ab17341b4f54e2779cc0fa5feaac0542f24206c64039a8c6df63",
-      "rule_id": "go/jwt-no-verify",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 67
-    },
-    {
-      "fingerprint": "91b5bf7d47dd23e9dfee7588dc4b0ac70063f257a9e92b39c20b4ef5df24da61",
-      "rule_id": "go/jwt-no-verify",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 70
-    },
-    {
-      "fingerprint": "563c1c447e4d4f97373ea8b655c1d8abdd8c1ee0d9df72f8e417f395d61a8f33",
-      "rule_id": "go/jwt-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.go",
-      "line": 73
-    },
-    {
-      "fingerprint": "b38dd555b3b949c5166cfc66656a965bdaf47384e96c4fbe2cd2c45493668381",
-      "rule_id": "java/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 13
-    },
-    {
-      "fingerprint": "248ba36b87cc1740c61807630c36d9b1ea93054e08adbbc5dc89563e31058b0b",
-      "rule_id": "java/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 14
-    },
-    {
-      "fingerprint": "1b407b09fd8266f0a1721b93fd39a35a0a7307d324ae3dd39bead2c4139663b2",
-      "rule_id": "java/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 19
-    },
-    {
-      "fingerprint": "29027be12af24cec202008546edbdcea01dd966d8e75d57caddf18fe3570b1e0",
-      "rule_id": "java/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 20
-    },
-    {
-      "fingerprint": "8a6bb2832eeca797abfb393a6cad9fc63255c6280cf4e95a7cbdc06618e75bad",
-      "rule_id": "java/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 26
-    },
-    {
-      "fingerprint": "a0373c94ce554a052095139c4fddefc2384e7b03a1087da0e53ff50446f6fc65",
-      "rule_id": "java/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 31
-    },
-    {
-      "fingerprint": "94c1d2b59bcaebda12f895561e998d2a0f43e554ec9a3dcfc824d86f2e315fbd",
-      "rule_id": "java/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 36
-    },
-    {
-      "fingerprint": "329456a86b29007be900d64b093c0e7e145b774cf8243c4e0424eb63894e40cf",
-      "rule_id": "java/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 37
-    },
-    {
-      "fingerprint": "1922c4d2a3e56bfddd7c608ff6c015151275ffad41b03f228a5fcf34cc17e37d",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 42
-    },
-    {
-      "fingerprint": "03292708d42c611073ab9fa8c3f0a895b91ec13a0c53a75ce6c1e99e57ebf1c7",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 43
-    },
-    {
-      "fingerprint": "be522348df16d6363e1df65dc13453d1904c214099ea46bd7eda0e500c17220b",
-      "rule_id": "java/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 44
-    },
-    {
-      "fingerprint": "7d2c4159356a0b73ac5c43e638a79199ff92cb95ad38b6c80ceb2de4f0523885",
-      "rule_id": "java/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 53
-    },
-    {
-      "fingerprint": "891514db7bc243174aab3274e79738ac763689e55ca9766bd453c9c73f7a2c30",
-      "rule_id": "java/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 54
-    },
-    {
-      "fingerprint": "19098cd77e85a30e3006e0ead33e5702d17ab2a65023d96f17d8ead374899cdc",
-      "rule_id": "java/no-xxe",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 58
-    },
-    {
-      "fingerprint": "47ba5ae61d04556a6ae102bf7c881549205e1191f715a4af639e215fc62f1d95",
-      "rule_id": "java/spring-csrf-disabled",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 63
-    },
-    {
-      "fingerprint": "8e7de29c280a39d9593aa552da0ddb2d49351d84d845873752449454c345e9a5",
-      "rule_id": "java/spring-cors-permissive",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 68
-    },
-    {
-      "fingerprint": "108ed94c541b75a7e18e152182dbe9c77ed83a1972a8d406e3e14a425e0be689",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 73
-    },
-    {
-      "fingerprint": "8706c333018d4ffe1bcb6050ef44312e782ee319c96dfebd62213d81a5c49373",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 74
-    },
-    {
-      "fingerprint": "fcf9fc00c2a2ea6c8f6b0bc23c581930bf0f17e0a3b267b27f7ce43fde17f13f",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 75
-    },
-    {
-      "fingerprint": "710e9e7028d27c409b63ca5380e8ac7ec5577d1d52ce4a7bc17208aecd229baa",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 76
-    },
-    {
-      "fingerprint": "87dac9feee0bc956bbd68f736adfe1c641ca5f55b4c4d75da6d6560bbbd0751b",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 78
-    },
-    {
-      "fingerprint": "37e5f5eb485f44d9776ae8a0b74ce7987bd091bed0b50ee0bfd04f757bc47e1e",
-      "rule_id": "java/no-xss",
-      "file": "./tests/fixtures/vulnerable.java",
-      "line": 79
-    },
-    {
-      "fingerprint": "f2a92c724162bab51e1febc8aea8a9217078873fe01ec16371b3157a9d9a1212",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 9
-    },
-    {
-      "fingerprint": "75dc5956410372f4c3a4176dc92997664cb870bd56bfaa58a2710f80fef25310",
-      "rule_id": "js/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 12
-    },
-    {
-      "fingerprint": "5a22318c323547398893819cdc17eb7a4168c7d77f911dad2159e1e535736707",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "32059af89eb9a729a3942a3d663ae05c99f85ddf594e329840f0a96c9253c60d",
-      "rule_id": "js/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 19
-    },
-    {
-      "fingerprint": "5f65f7e7a4d0d144207cf7b617e477c590373231c6de298d752d1e2f357c180c",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 23
-    },
-    {
-      "fingerprint": "edeb1003d259f0555cd7dafba41dab91f080ad12eeec6000a06f7159d5b84440",
-      "rule_id": "js/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 26
-    },
-    {
-      "fingerprint": "687ffdcf905cec7945ee075a7a4d3876f8f9ddd15dd948a76c694a67afc47726",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 29
-    },
-    {
-      "fingerprint": "3630e58257f07120bb8152b3a9782bfdb7f4aebc7aa62b5ca995707f4119969e",
-      "rule_id": "js/no-open-redirect",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 32
-    },
-    {
-      "fingerprint": "00c226b2e657b9006fde7b98f8691a5dba592c330116f792f2c9e8c14d3e39ac",
-      "rule_id": "js/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 35
-    },
-    {
-      "fingerprint": "b9f176191bd9d573b789e9f94f45697b5f4fabe836eb2fd1c9ac221827227b9f",
-      "rule_id": "js/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 41
-    },
-    {
-      "fingerprint": "b1e121f8df80b0abcb44158bdbf6b5d21e850a717019876a2e87e1b0a2b91bde",
-      "rule_id": "js/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 44
-    },
-    {
-      "fingerprint": "90dd9d254a15175184bdb846806a182f7888ae603ef0a504aa8e74ca2e579f2d",
-      "rule_id": "js/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 47
-    },
-    {
-      "fingerprint": "889e436dd827a89a0f04de6a48d461ed29c0f3da7ac007ca3e6f009ff3845c05",
-      "rule_id": "js/no-prototype-pollution",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 53
-    },
-    {
-      "fingerprint": "ba4ebdca60098287c0d55212a53f8c8d40d827711e7c718fcbdc7b574c4c36b7",
-      "rule_id": "js/no-unsafe-regex",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 56
-    },
-    {
-      "fingerprint": "f997a291c4df65039469a60ab8abec4bbc4d18381689218f3114f5f407c1bbd4",
-      "rule_id": "js/no-cors-star",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 59
-    },
-    {
-      "fingerprint": "4568ea3b735fd6b5c0419285833b4e01e74f62cc4c63491988da4ecbf4327f00",
-      "rule_id": "js/express-no-hardcoded-session-secret",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 62
-    },
-    {
-      "fingerprint": "35f19c6530f3766c267a38661bf89ba623b4d9d9866c25e650b1763df6483c23",
-      "rule_id": "js/express-cookie-no-secure",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "e3a58fefbfa8bac20619be8d0b957a2c87dbf6bee5a1b0441d19110d40057109",
-      "rule_id": "js/express-cookie-no-httponly",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "6cef7a898595d3297f6e2aa6039a4060376c0e09995123d36d83165a45749c49",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "6ffc1a8520c03ead444f015fad6314a4c3e73b0f1de3bccaf71b45f2cec1e68b",
-      "rule_id": "js/express-cookie-no-httponly",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "ddef446999feb18d7b788a4f14f9465982d069a717a5c020034d0a942c2b4d01",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 68
-    },
-    {
-      "fingerprint": "a118826fb362161668663bbb10c852eb67b772a84321a1b5fd82263110bce39a",
-      "rule_id": "js/express-cookie-no-samesite",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "5ddb76434371b5dcdc20c20dc5b2548989a685cf59b081655d12d736016e26fe",
-      "rule_id": "js/express-session-saveuninitialized-true",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 74
-    },
-    {
-      "fingerprint": "5ab8f793de8a02c5e0efc8bab6e9d3969c72ccb2b24159e00b3126363a8b6a31",
-      "rule_id": "js/jwt-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 77
-    },
-    {
-      "fingerprint": "5f5b1ae23e3e42f3aa79a1b6e4d847ed86fc4ecbb106145134d86d6f62cb2151",
-      "rule_id": "js/jwt-none-algorithm",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 80
-    },
-    {
-      "fingerprint": "1cac932c771260d90ff775ff5b4e3de9d7c4fbd63c9257ae6be735de97a79d68",
-      "rule_id": "js/jwt-ignore-expiration",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 83
-    },
-    {
-      "fingerprint": "86331480a052aa965985d42c655a4dd7f38a8ca01b8237a643306110d17baf72",
-      "rule_id": "js/jwt-verify-missing-algorithms",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 83
-    },
-    {
-      "fingerprint": "2fe18e726e5cb3c953ad627a090e4e94fe9de2a7f6abde125757f6fae82ac151",
-      "rule_id": "js/jwt-decode-without-verify",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 86
-    },
-    {
-      "fingerprint": "67aa306bda034f3521172d90b61301dea0f78a4520038871cc623eccee513108",
-      "rule_id": "js/jwt-verify-missing-algorithms",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 89
-    },
-    {
-      "fingerprint": "3b294827ee4fa67aa97756b98d518edc141a4a23e47376b6501526bdc06f97d7",
-      "rule_id": "js/express-direct-response-write",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 93
-    },
-    {
-      "fingerprint": "fb25914ccc6270e833912b57f7ccb14019e04acc5b547dc4e8a1dc5f52e1332e",
-      "rule_id": "js/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 97
-    },
-    {
-      "fingerprint": "fef6cde290113df44138ddb3f04cddfe04cb0a6c45c0ace834099e5a5ab6a11b",
-      "rule_id": "js/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.js",
-      "line": 100
-    },
-    {
-      "fingerprint": "5e045bf4d14eb91903ea7c64d44277237573c7eac5ba86c3f52f564fd026754d",
-      "rule_id": "kt/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 7
-    },
-    {
-      "fingerprint": "9546631540531fd5966676c5fa14668d7930754e6b877348cbf1c7e6c78c52e7",
-      "rule_id": "kt/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 11
-    },
-    {
-      "fingerprint": "ca7c818abc6b601e1791badbe89a2186b583de3775e127da0d774f4b8dd18337",
-      "rule_id": "kt/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 12
-    },
-    {
-      "fingerprint": "3bd3f312e9280a1ab0603230daa1171e40ca96423be09ecbf187fd4265498303",
-      "rule_id": "kt/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 17
-    },
-    {
-      "fingerprint": "961522c93064601cd1b6315ba50e25865fd5f8c078ecbaa71b24ba0637aff77d",
-      "rule_id": "kt/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 21
-    },
-    {
-      "fingerprint": "8d164219679484edc9d6b88a9cbf60b1928055c5f732c24ccb6c738e0a382ba3",
-      "rule_id": "kt/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 25
-    },
-    {
-      "fingerprint": "3ea363e54f7831afa51fc05cc81c20f4e4b00a4c798892a8b7c57a9d513b6035",
-      "rule_id": "kt/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 33
-    },
-    {
-      "fingerprint": "22af00a5b95673d45e051e3fd838e569e66e68851e5e62395e787d9b32606e2b",
-      "rule_id": "kt/no-xxe",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 38
-    },
-    {
-      "fingerprint": "e45b9b64b44c2d3b337f14e091c3af054bcb485be62a7afc06ec3108a71e564e",
-      "rule_id": "kt/no-cors-star",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 44
-    },
-    {
-      "fingerprint": "03290c914e8c9f3661a983c3a3d36dc00cdbb684a7f9584d95beedfdeb6580c2",
-      "rule_id": "kt/no-eval",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 48
-    },
-    {
-      "fingerprint": "30124d5b33f337a0932be9ba10be01ea33188736b9bdc538aed5aad741ca5980",
-      "rule_id": "kt/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 53
-    },
-    {
-      "fingerprint": "96fb44f931d97a858576f2b1cf962fb6162b3f7e8d3295ad000e685f5ed721ce",
-      "rule_id": "kt/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable.kt",
-      "line": 53
-    },
-    {
-      "fingerprint": "5f44d08fac3ea97e8d080ee932dcebd59c6e629c9b2ada0afcfeeb9d400f94d7",
-      "rule_id": "php/no-eval",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 5
-    },
-    {
-      "fingerprint": "1517ec2532610ee132490a94c617da5a367ef375be8a41bfddba12051429e746",
-      "rule_id": "php/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 8
-    },
-    {
-      "fingerprint": "819c4da4abe81d7560f2a68bbbca1859f1b4c184490a186ae237c7c2722ebfb2",
-      "rule_id": "php/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 9
-    },
-    {
-      "fingerprint": "1060a23bd968397509ecaef5421b32a69f7a354c536ce602ace887c9484f5532",
-      "rule_id": "php/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 10
-    },
-    {
-      "fingerprint": "67c8be6a8d23c713d9c41af7a772e037816093f8ea4142b2cccd9c8670391306",
-      "rule_id": "php/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 11
-    },
-    {
-      "fingerprint": "755decc32f95e672f1fc1d72a168ce2ed4a0f941a3e74d01d88917317d32ba65",
-      "rule_id": "php/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 12
-    },
-    {
-      "fingerprint": "6982b54a303c1d1aacf8c08db44e2628f115d549070e84f3372197a3346a8af5",
-      "rule_id": "php/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 15
-    },
-    {
-      "fingerprint": "ad95cabdd2fca1a6466c689631111709e8e4886a81e03e0eb0ecfb67c19f322e",
-      "rule_id": "php/no-unserialize",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 18
-    },
-    {
-      "fingerprint": "83ebcf9f8f73304563cd09d80ff7e9f9e000e4f2bdb5836b2a2222bfc8b2afd9",
-      "rule_id": "php/no-file-inclusion",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 21
-    },
-    {
-      "fingerprint": "861f62b769bcfbde6a9946aeb9f30e80429374779d1c25e0803ea12fcc8ebf10",
-      "rule_id": "php/no-file-inclusion",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 22
-    },
-    {
-      "fingerprint": "40ccd19ec0ef6323079a15c63afc96817656c2354234416765bfb39bf84dd9b5",
-      "rule_id": "php/no-file-inclusion",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 23
-    },
-    {
-      "fingerprint": "832dbc68a68e1e9020990bbb6bab770fe044d548e0bd343b75fab3647273c9de",
-      "rule_id": "php/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 26
-    },
-    {
-      "fingerprint": "2b4e8214a230e1c9815af48c30bf2c4049d3b3ea243e0f6e716abcdbce647692",
-      "rule_id": "php/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 27
-    },
-    {
-      "fingerprint": "e86a2f0c439e49e7ce8323a11a7a098bc31716bd2b84cbd06cede8e281964cef",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 30
-    },
-    {
-      "fingerprint": "b3332aba3853efccaf933b52e0751281bc5adfb4af01352a466023b86d796bf2",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 31
-    },
-    {
-      "fingerprint": "1ec7ffe2139d09ef5fcd3fe8f4ae3668e0a784539c87923e26f28d4357565319",
-      "rule_id": "php/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 32
-    },
-    {
-      "fingerprint": "3b447bef097c9ab250676b9acb514da9bdff88d0d5999c84fc7940cc58fae2c3",
-      "rule_id": "php/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 35
-    },
-    {
-      "fingerprint": "cabf2629f66c9dc7150a02417993d3b9c5a4d99a43dd40df52e19bcf38edf53d",
-      "rule_id": "php/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 36
-    },
-    {
-      "fingerprint": "f872b8e83fcf08d6ede116c0aaa5237bec3cb3be6f6d15add6bc669b984c9898",
-      "rule_id": "php/no-extract",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 39
-    },
-    {
-      "fingerprint": "68784234051bc875a03992fef411ab5dfba9e6298ee7015a728239f4ccce4e6a",
-      "rule_id": "php/no-preg-eval",
-      "file": "./tests/fixtures/vulnerable.php",
-      "line": 42
-    },
-    {
-      "fingerprint": "616c323374cfd6db8647ee569f3704c366b85dc9e625772d2f5dba930a682a71",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 11
-    },
-    {
-      "fingerprint": "4309adf3c561a0922e3470f8048ba47569e1bb09b01998c771f59221e00f3dc4",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "d9412a5d25312b9b967f7e9d8bc4b484379ce865203dbc67c38b4003235b5c54",
-      "rule_id": "py/django-secret-key-hardcoded",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 14
-    },
-    {
-      "fingerprint": "4b81f2070ee7ea6f0db94a2799ce2338943179e315decbc1e124aec77ffce67e",
-      "rule_id": "py/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "4cc4b4ab2897e7048aea390f690dabfffa0909a23ab0a2e905192b09b1db9b07",
-      "rule_id": "py/flask-secret-key-hardcoded",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "a40ddcf2574f7969543ac726dd14ae83172df0e1537f40401c277153c2c21ccf",
-      "rule_id": "py/session-cookie-secure-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "e649200b517f7cee4cd1206c707869d83d7a204b3d32b1aae0ff68dd38f1dcb3",
-      "rule_id": "py/session-cookie-httponly-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "f78899e5d38cecf138ca3ad1eeca4084c316f0d843989ca26390bbed18a2560f",
-      "rule_id": "py/session-cookie-samesite-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 27
-    },
-    {
-      "fingerprint": "8a0341a01cc27646526ee8c28e5aae5477bb403850ac1d99a9927b48da1a8490",
-      "rule_id": "py/csrf-cookie-secure-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "e497c102b2af320c583d221f8852ccd67b683ebb2669804de03e84e0a663e31f",
-      "rule_id": "py/csrf-cookie-httponly-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "c0e59d075b18358b06a8cc22d89e69d44f544ad3f7d812ab7c1ae2bb2d8dc514",
-      "rule_id": "py/csrf-cookie-samesite-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "edf9064a91dcf4be9dc2fef1f6b980f918f26e1600e107477b6b16612262f469",
-      "rule_id": "py/csrf-exempt",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 39
-    },
-    {
-      "fingerprint": "05c88e075e40c7ca5b57401003517fe15a3dc240f95fb4f21a84af34e89c5ff3",
-      "rule_id": "py/wtf-csrf-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 44
-    },
-    {
-      "fingerprint": "96bc4357e89e2c9bb8abe9bfab2e8f27cdd4964606e316780925f0959f5b8707",
-      "rule_id": "py/wtf-csrf-check-default-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 47
-    },
-    {
-      "fingerprint": "333d2637d9dd4e50cd2a47e6dd00ec6e994c40249c1e4c9cb6e7fe6768f907ff",
-      "rule_id": "py/django-allowed-hosts-wildcard",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 50
-    },
-    {
-      "fingerprint": "4923fcba183503e614a66f1e3e54ef4f69f2fce826916a0f2ef8778875fd7420",
-      "rule_id": "py/secure-ssl-redirect-disabled",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 53
-    },
-    {
-      "fingerprint": "e1240e6e0b7abed428444acca322433e403659b4188ff4b8ace93a5a097e9109",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 56
-    },
-    {
-      "fingerprint": "2089f0224994a711728553c5437954eb6670147d959b6bd5ff321c033726c4ed",
-      "rule_id": "py/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 59
-    },
-    {
-      "fingerprint": "20ea9454d908918855447faa18b1325a1a70ac139fb3a4ac4a0b7b687781d975",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "1f1e391744fd8d2a8cce8504b09fa709f84fb4f5dddc1891397a5f886cdd0ecd",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "f104dc01499621d0e7f2a89f7af41ff352b53d266af45fe2d1c48ebeba0d8204",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 70
-    },
-    {
-      "fingerprint": "3b6b043363aec47a459cf3284bbdd552a98776b012145dd1deb22810a80f25fc",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "5ae8a60c2bc1db028e98d1c0efddd12b9f02b3ad198ec66b65464d4477ac20bf",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 75
-    },
-    {
-      "fingerprint": "ebc3ae846883dbf95563712ef74acf5a54859746f7e04d6589eb43d5ea20dfd3",
-      "rule_id": "py/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 79
-    },
-    {
-      "fingerprint": "d0f060a57e1114d8d8a20a081448e1b4c09bd5af9bce91da9f50bf2fc83e9444",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 84
-    },
-    {
-      "fingerprint": "43bb8fc6a83b5a5ba08eb0b90778a69a46dfcb54f257748f13fbd189357e159c",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 92
-    },
-    {
-      "fingerprint": "427429b0914a38df4143bdd453f4ff8648db5ac623f656e9611cee4c1dc29dd0",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 96
-    },
-    {
-      "fingerprint": "74ca8317ea92f90baa2fe63ca6538843a11b1abc3dc8c7cddad5f9e30c5ab729",
-      "rule_id": "py/no-debug-true",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 99
-    },
-    {
-      "fingerprint": "1e9236cfc9040e9b66b7201959b78b7de69f8a863c32d54122c8f46ea8814a31",
-      "rule_id": "py/no-open-redirect",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 103
-    },
-    {
-      "fingerprint": "51d248d91617fcccf3aeadb2dd151075a856916025ffb17b6e04ff6b8a4b5c78",
-      "rule_id": "py/no-cors-star",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 106
-    },
-    {
-      "fingerprint": "4b642df947bf261ab0826fd1116a34849940863a9f02826922660e0cc9db71f1",
-      "rule_id": "py/flask-debug-mode",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 109
-    },
-    {
-      "fingerprint": "af04b0cadf2da37ef4794ec3185e111cf6a6cc0799ff0c00f381af8791c090dd",
-      "rule_id": "py/jwt-no-verify",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 113
-    },
-    {
-      "fingerprint": "66cc8f4e9a0ecb765b9b32781fa0c0697c049d62ae81f9d5273cbd9e83c1e66b",
-      "rule_id": "py/jwt-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 113
-    },
-    {
-      "fingerprint": "b24b414bced79b4509785f6692f43ef9f6bb4e6a71b8db9c584a97c76109c293",
-      "rule_id": "py/jwt-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "2eccdd2b65ac145d46088636df0793122306886bda653bec0bab7a02d9920d70",
-      "rule_id": "rb/no-eval",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 4
-    },
-    {
-      "fingerprint": "b7ad9e157e85ca8441b13cf8cc76edbc8b4a23ac921ee4116a9db6e99062df51",
-      "rule_id": "rb/no-eval",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 5
-    },
-    {
-      "fingerprint": "4e30ecc68c6a227204791bccc9cf34e547d41139ed6cbdd0962d46a931086490",
-      "rule_id": "rb/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 8
-    },
-    {
-      "fingerprint": "795e1abbe32bd987075c9b716f07fd2989fd13921fb2531e720e24ab20afb374",
-      "rule_id": "rb/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 9
-    },
-    {
-      "fingerprint": "b90308dcee51d7b98f1ed94ba1439dd60929cee6ea2e966f21a2edde44021697",
-      "rule_id": "rb/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 10
-    },
-    {
-      "fingerprint": "ec73b46ac977071b4f6bd23170120b1c4488c934cd65aaf0bc92d6eb058dde20",
-      "rule_id": "rb/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 13
-    },
-    {
-      "fingerprint": "3f662156fd32a125475f4fb5fb9150a96d9ecf15b9683bd465e869f0dd4a325d",
-      "rule_id": "rb/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 14
-    },
-    {
-      "fingerprint": "11679695b2a5247f46c502157031f518892751782a7a91b53e622c7077e67fc8",
-      "rule_id": "rb/no-mass-assignment",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 17
-    },
-    {
-      "fingerprint": "1f5fef9087cea9ad4ebb7a16cb9b0017855796797080fd12393d335f851c3520",
-      "rule_id": "rb/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 20
-    },
-    {
-      "fingerprint": "41958d07a3bbe4ebb214b4d1adfc2b43035b7ba0da16f296951002f1ab03f709",
-      "rule_id": "rb/no-unsafe-deserialization",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 21
-    },
-    {
-      "fingerprint": "64d3e3e911f3a53c37db321157f49b1af0ad9bdaa2cb7ea12d68ff5da712f04e",
-      "rule_id": "rb/no-open-redirect",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 24
-    },
-    {
-      "fingerprint": "1ba9b3628aa4a4961374e9083496440135983ea0c3683e92d199df3b92e32bef",
-      "rule_id": "rb/no-csrf-skip",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 27
-    },
-    {
-      "fingerprint": "0e5bf12afa1f3873a2ca155838a3aaa687d8a95bac8fba6cb8e417246c3122e9",
-      "rule_id": "rb/no-html-safe",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 30
-    },
-    {
-      "fingerprint": "e264b6902b2b775e90e46f43c67bec4abc9e5824ffcbf7048cc18b3dac5071c1",
-      "rule_id": "rb/no-html-safe",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 31
-    },
-    {
-      "fingerprint": "ed66a6bca22c18a4994bfd410f00c3230c3cc7e0a3b7fe71fa49d71762e7e8e6",
-      "rule_id": "rb/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 34
-    },
-    {
-      "fingerprint": "efd18eeea5c575e68fd5167395d4a28a5582e09e98a551634bd18bd850d4e34d",
-      "rule_id": "rb/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 35
-    },
-    {
-      "fingerprint": "39bd7fc1f89321c35e19dc09637a395afedd4e76c54eba0afec3d88080b897a2",
-      "rule_id": "rb/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 38
-    },
-    {
-      "fingerprint": "a4e4d4b7cfdbc045d616e09a9a79ba83587723fc3c4de494f7b23caee074591d",
-      "rule_id": "rb/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 39
-    },
-    {
-      "fingerprint": "0d08ad91336cab0e6f56300eebe64e25de2e03d103fe9307d3b82ffb1394594b",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 42
-    },
-    {
-      "fingerprint": "b678482ef20dc3425a3e2d775b4db840aefbcab09a57d35fc96691edc21e838f",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 43
-    },
-    {
-      "fingerprint": "09b85516da3bf99c03cb496bc375f634e247e119e5518a91921d53b1fdf90de0",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 44
-    },
-    {
-      "fingerprint": "9c96d290ec781e6bb2fe07e14c42c13f9b3667206ad5078d71b00f96f1ce2738",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 45
-    },
-    {
-      "fingerprint": "e889d988cb28fe7a6555b7db313d11ab0a82c4ad27d0bea586e26c7ac87b0562",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 46
-    },
-    {
-      "fingerprint": "55413cadb01932e7c43ab813cfbac2ed2f8df633a62b11929d211911fbb267fe",
-      "rule_id": "rb/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 47
-    },
-    {
-      "fingerprint": "14c600bd5cebb1a868f9bd1fb1280856de8938320c9497920245d0c0888e51c8",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 50
-    },
-    {
-      "fingerprint": "fddfbda2cebc3408bca81364a7ad0fc8ed5e1b7cf86534fbfe880de060aaa242",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 51
-    },
-    {
-      "fingerprint": "5b5bb63a5165fa31bbdc156fcd21b025b47c4381d9b0d402bf354e5de6b80f2b",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 52
-    },
-    {
-      "fingerprint": "10479c44db53f68cf88dcade8044d9e25dbdff874df2258026bb7e36cccdd60d",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 53
-    },
-    {
-      "fingerprint": "4412e60881814833ab78a3774fb37438940d05f3abba7314352053185b81314a",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 54
-    },
-    {
-      "fingerprint": "67d267f0a74276e31abad9bcdff6099ea2528ed93faeeb0fdc3c22a86ab4c4ba",
-      "rule_id": "rb/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rb",
-      "line": 55
-    },
-    {
-      "fingerprint": "3e900d933230cbe25716a6b49a039c6a70cdea0b3ec60cf202e43b86ce2de75e",
-      "rule_id": "rs/unsafe-block",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 7
-    },
-    {
-      "fingerprint": "9b8c72c6b400b12650c53a26c7804586fa13d8ad5f55caa346c4254b06418596",
-      "rule_id": "rs/unsafe-block",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "3ff69d35f102b8dfdcb35082866176bc04c3cdf112293a4de7096975c133d12d",
-      "rule_id": "rs/transmute-usage",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "61c1707e87a789ae6a42eff0112f921bb3cec7b55bf910cf88e847b802661926",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 20
-    },
-    {
-      "fingerprint": "5c1f1b4b685ecdfbb4480f483d4e8ad46acbead895ec8c93141deab13838562f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 20
-    },
-    {
-      "fingerprint": "f2687e40427cc172de9193e759a4c38e2db41b419d1c2e2af948a2b11cb80c0a",
-      "rule_id": "rs/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 25
-    },
-    {
-      "fingerprint": "00ad6427a28be977d26add72c2908c3cf0a05226490b48d6f859499b64d3c1e2",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "0bfdca2a99b11f493043d1b12b8262e835235db28fd4c69957466220aac1c768",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "ff143630503d4046f65de4d1c9fc6d62c8abbb4aa15b5b51c5264e673791fc63",
-      "rule_id": "rs/no-weak-hash",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "4f0c87ed3ed60f6c9e298c15d1a7729a2737d28dc0f2c9d6e90c6bda1a906789",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 36
-    },
-    {
-      "fingerprint": "c7227420123d4a3ba5a6a15e7b6ce1c4e3865efe08aa4dbba7fe241d7afa37a2",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 37
-    },
-    {
-      "fingerprint": "4bf2cd30e030297f02f5acd6b54270bc89d64d36714a652c2cb0214715857f2d",
-      "rule_id": "rs/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 38
-    },
-    {
-      "fingerprint": "fcf63b4f6a1abcc60897f1b2faf27393350f8883f07d345099c34325a1da509f",
-      "rule_id": "rs/tls-verify-disabled",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "f6abdd3381876040fb6abc51d16e662036af84ea9274f9aca330d58e8f74ac36",
-      "rule_id": "rs/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 50
-    },
-    {
-      "fingerprint": "49b783e2e10e9e65ac9b28d2fcbc40174767a0064ee6ded793990c46efd97195",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "f57e005b26da608abc46482d8e30950877c37574309aaf3e230879b0f71accd9",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 56
-    },
-    {
-      "fingerprint": "efdd1fc1f85ef96b54c706cdcb8ff86dfd0c11027ec0c242506e8464343458d4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "3c74c46b926272979365d064f0aea2882f7c6b5a64475b28f1366298291cf5a3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/fixtures/vulnerable.rs",
-      "line": 63
-    },
-    {
-      "fingerprint": "09b698e78eecc0724a939bb4bcf86f7017a34f2a2c8c99fa178d5db927685a66",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 7
-    },
-    {
-      "fingerprint": "21392c80c454387b213f520834bbc26c49835be38cec278ec49a963c0283d165",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 8
-    },
-    {
-      "fingerprint": "ebc3621c136fbcbc217f184a2c774c1f8c7532b2b96821a4a4ab9e74b45cca1f",
-      "rule_id": "swift/no-hardcoded-secret",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 9
-    },
-    {
-      "fingerprint": "7f13aebeb1ac709fcd98a45e12c0b9d833230eb339e8dbf243125773ff2b76d1",
-      "rule_id": "swift/no-command-injection",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 13
-    },
-    {
-      "fingerprint": "dfa10a85ee3ffd80a221bd2274069884a72237f14b4fcf6356d782c8964d2841",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 22
-    },
-    {
-      "fingerprint": "54e959b3fdf21b3496e21020c7253f579213e0baaac90eb1d3163ddeb3acc533",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 23
-    },
-    {
-      "fingerprint": "6e3f806cdac6e032c00a9c761167f96550566f3ca98c3fa6ae001f3a024a01a1",
-      "rule_id": "swift/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 24
-    },
-    {
-      "fingerprint": "ef82f881fb175e3a963c50a928f7353716ad2b4b1b7831b11351ec11aafae0dc",
-      "rule_id": "swift/no-insecure-transport",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 28
-    },
-    {
-      "fingerprint": "193a3be57a34245b3b65883fd95f41191277158079e77a21982fc0a67291af23",
-      "rule_id": "swift/no-insecure-transport",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 29
-    },
-    {
-      "fingerprint": "e6e124cde47085dad2efa187c721873fb8c57991a0a406039bc5da720a56a191",
-      "rule_id": "swift/no-eval-js",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 33
-    },
-    {
-      "fingerprint": "5dc355e4f327678089c2701f2651bf64d6392325a297a8d9343857589ec800aa",
-      "rule_id": "swift/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 40
-    },
-    {
-      "fingerprint": "aab05fedd8ef0d353eed397b66d17eb864801d879e561b90df90f6c025f5d17f",
-      "rule_id": "swift/no-insecure-keychain",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 48
-    },
-    {
-      "fingerprint": "657ee6e47596ef007e0392bb2a972114cc1a5ef93078b068fbcc22b51a7eb201",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 56
-    },
-    {
-      "fingerprint": "94baeae87ed4d0746b72d381c55aabdc67dad0e0ca2a0add7f52d432de20ac72",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 59
-    },
-    {
-      "fingerprint": "5cf8975b36e073916d45eb2338a8a6b1f14c9a251641bd87243a523342b3a8c8",
-      "rule_id": "swift/no-tls-disabled",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 60
-    },
-    {
-      "fingerprint": "de5d28e78af47f9de7723d955cdf1697d826e979302edc92adeda106d2027d21",
-      "rule_id": "swift/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 66
-    },
-    {
-      "fingerprint": "356c81ffb5307b0f8128a6bb9975fbd1ed86388d3154285edd7804c02269d24e",
-      "rule_id": "swift/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 67
-    },
-    {
-      "fingerprint": "46c7bdd4b08d887992114ce95b99ae9ee1a098b09ad380d93b46b64b984c579d",
-      "rule_id": "swift/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 72
-    },
-    {
-      "fingerprint": "c5866a672981062feee3d208ca4e66550de2b7c773f23d45ffb5702fc11f1ce9",
-      "rule_id": "swift/no-ssrf",
-      "file": "./tests/fixtures/vulnerable.swift",
-      "line": 73
-    },
-    {
-      "fingerprint": "938407e9f75481f2763b80a594c4437ac1f9ff522c04360ba21c38d4aa4e8134",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 13
-    },
-    {
-      "fingerprint": "e6dbde7bc53d4ec9d6728ebd00456c65069ddc81099968f4c988e11d835ef37a",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "61cd712ee758c6989aa38fc709709552e31a9aff8bbef6f57654451597e84efd",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "ac0e5a25b1116661f5968053efa8c621d01efe62019dfd72ba4786d11b7852fe",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 25
-    },
-    {
-      "fingerprint": "eb23729e16dbe006a0a2995d436a450ed17b2cc0cc65cd2d8503a293d1a940fa",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 25
-    },
-    {
-      "fingerprint": "2ca20eeed5b7f0a8738b68b572fe4ea46a81d3e9f647f3811693a670e260fa71",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "62794a8e9249801bce7e100d72e7ad62b57f92044ece5b1fa12493920e3f9bcc",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 31
-    },
-    {
-      "fingerprint": "e60acbd745596da01db2d51a7e83ee0207056775cf4aac3598e2d277f230d80a",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 37
-    },
-    {
-      "fingerprint": "0668a4b4adebc0acbf8c133050f18ac333b7ec5774098516156083c3ff770a2b",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_cli_taint.py",
-      "line": 37
-    },
-    {
-      "fingerprint": "57a2d8a0e8fdaa22cfa9d07ba2811e7bd041396e30a0897cd64ac610641a5dd0",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 10
-    },
-    {
-      "fingerprint": "bdc600670b9ab6338a3f5ee77f3a80307667ad79a6ee87707e35a0d5a8993629",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 10
-    },
-    {
-      "fingerprint": "46d130cbdec95bc73364d197f099188e8db7969bb2604e121dd2b349c10292d0",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 16
-    },
-    {
-      "fingerprint": "ed6906b27fc8d03643c497690e97bae5b9f44f7d3fc0c57de47ed9df09071feb",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_deno_taint.ts",
-      "line": 16
-    },
-    {
-      "fingerprint": "0c0e371358e1fb7d4ab164ee54d0e308dd3bfe5bbf65479b8d3e6c22ccde0c68",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "37d550e11011e7942c286fa689e051061d7f573d72a7f3a88b9feab4235759d0",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 18
-    },
-    {
-      "fingerprint": "deb3b802457a8215c098c50b2fb12b667728b0ab17da9f486a107c12048bd4dd",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "3bddb8dbda5f37eeede6524b241616596f4612fb70522f63454c163a43b24f34",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 24
-    },
-    {
-      "fingerprint": "691406323725c56d5ee335033fd5b2d808bfa55c9a2f4b668668a69e27cd01d4",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "7f05b85b4f83afa4efc1699b7aaa546bcc5fc162ff412f6cc2f88235604cb604",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "6e321813f808d5844302928f177ebbe445309857bc861266037b6f4ff2e31a76",
-      "rule_id": "py/taint-yaml-load",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "39db48daf71aa834c2b2e36dce24f2ec305ea837a99f7ae0ef86a557e1338ea2",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "4e2706e10cf3ce757551d21c962176493d5476a807b64b4dda2c95afbcc898d6",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "8eef3bbd4779ec929b5add3f1a71068ba75daa443309dd83180438d10d9c6344",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_django_taint.py",
-      "line": 43
-    },
-    {
-      "fingerprint": "09a2814b6bc0328cd23c3f775ca6fb744f4eef3e2bd88d49b4d81cbe0c30fdfa",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "4099fefdf1277e490e0f380bf6884a7ee9f715848eaec1d75fb973a3a33268f6",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 19
-    },
-    {
-      "fingerprint": "b18ce7e7e6298299f1cf5af960e13d2be34df983f7cdfda51247f357c5a07db8",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 28
-    },
-    {
-      "fingerprint": "d7e5f1419b0ba5dc6b57fd92eebd33f2b67f6c5593c2a2b953075272a5221641",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 28
-    },
-    {
-      "fingerprint": "992ddea47cc0e92f25cd7f409d672c1b2c1c2a7316d4ee94714d11f17cd346b6",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "7fb44717ace75be76145cf0eb758b17fb547c596c659a74e779b86633bbaf4fc",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_fastapi_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "34278f1b29974c90da1f6ee5475b91a3d119c01b7f8bb668a75efa8f70afcd3d",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 23
-    },
-    {
-      "fingerprint": "442cd72b9aa85e9f70df2f0b04ba30c0a1fea0caf03918f853733cf6e65cedb3",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 23
-    },
-    {
-      "fingerprint": "17a6b4229dfe3a452f8313c3e3700ee0e1f7c78d4a67a3e18ad4e4f7727a0477",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 29
-    },
-    {
-      "fingerprint": "0b3005e05f9cee70c87f7eef930cf1a34fa7a20862cd77809dea61e0d6352d34",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 29
-    },
-    {
-      "fingerprint": "cf9752cc7db68fbcb84eff1b8e0e0534885fcd5acdd19e6458420832c70b9fae",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 35
-    },
-    {
-      "fingerprint": "91f8277692df0785814e1db15ade1ceead9842ef0b2d9a74de7ecbad836c5cde",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 35
-    },
-    {
-      "fingerprint": "5432976d84574eef912e44971fb01d2d3bda2b95e5b558476c866db301db2043",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 42
-    },
-    {
-      "fingerprint": "3be2d01515abebdcdb70d07fd778d012815859fa2680955ddd05d24978596996",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 42
-    },
-    {
-      "fingerprint": "5997fa8a58725f9a5b89b373df7171c7e822c556bf264681537781a92868afb0",
-      "rule_id": "go/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 49
-    },
-    {
-      "fingerprint": "de0d8413af9a0feb4d63a45a748d0239a2a2bd8186dacbe502c79845ad303882",
-      "rule_id": "go/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 49
-    },
-    {
-      "fingerprint": "f896f7e219a12aa41699d651b4b66969781a06230071c9c5c3ab4a83134e5993",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "1886b6ffe4733837025e1f47064ee698797b0c943af5d373f8851ddd2f6eb363",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 57
-    },
-    {
-      "fingerprint": "caeaadb7eee9938e8ec5cbcd13bbc11aa80152e917c70d217bc97e81752987dc",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 63
-    },
-    {
-      "fingerprint": "8d25c60a007bfd39330f33bff7e2de33054bbd6067d03e7cb5e21c4bcc67947e",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 63
-    },
-    {
-      "fingerprint": "6a9e25fa804b45dd61eef56b29a309c95a253725204f75683c1b453728c57224",
-      "rule_id": "go/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 69
-    },
-    {
-      "fingerprint": "bc3a10637ee03dec630c2781e817add31a5554a3fa5d364c65220db682d380e1",
-      "rule_id": "go/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 69
-    },
-    {
-      "fingerprint": "3f87e0ca29d03d4c0720da18916905ca635be6c8d20811068c19a47b4e8056b9",
-      "rule_id": "go/taint-ssti",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 78
-    },
-    {
-      "fingerprint": "a050b044036dc8422b6358b9fb6392152b5ff569fa4ffa78c7afe78a26946c9b",
-      "rule_id": "go/taint-xpath-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 86
-    },
-    {
-      "fingerprint": "7cce932343804a93c1c6b6dbe063f5277a3d69bab95bf7b8871ac8347768ff1e",
-      "rule_id": "go/taint-ldap-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 94
-    },
-    {
-      "fingerprint": "aec35d6f51b12559ef1e9b493ac7e98b7ee396601a78258d6262179f131d3e01",
-      "rule_id": "go/taint-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 102
-    },
-    {
-      "fingerprint": "c3d7153f3032f5802d782ae9ac4d397e874e6f57d02e291009106b441cfd27f9",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 102
-    },
-    {
-      "fingerprint": "f75373f6375eff90f6885bceeb510827691356c1ebf2258a2befc1c3584c395a",
-      "rule_id": "go/taint-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 108
-    },
-    {
-      "fingerprint": "c5a5f0a60890661744812bac1ba7dc474c35f6fecfd4cc52cf2bada1e53f5e36",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 108
-    },
-    {
-      "fingerprint": "e5937358112dab6a8878a50ba30799d2371371e76ca478debd07324ce399df04",
-      "rule_id": "go/taint-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 114
-    },
-    {
-      "fingerprint": "5237e28e877ba3c128ac87818876f7478cf09f3691c583fbba4a0502cab82bb5",
-      "rule_id": "go/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 114
-    },
-    {
-      "fingerprint": "0ea7d987264d159446531fe90ff2bfa22f1ce90fa05543d4d208cd71dfad941b",
-      "rule_id": "go/taint-log-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 122
-    },
-    {
-      "fingerprint": "2ef29b9a12db61d831cc31a5dc15118257fe765f07d720d4b6b389c1e2d937aa",
-      "rule_id": "go/taint-nosql-injection",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 130
-    },
-    {
-      "fingerprint": "48dafdbd0d9088f76a0b12c0e9d7a4bc891869ed52af2f162c952a0a8ed6edea",
-      "rule_id": "go/taint-path-traversal",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 138
-    },
-    {
-      "fingerprint": "afefe819684cd315048776f043cb8b3830619448bf022efbf506b18156d57cc9",
-      "rule_id": "go/taint-path-traversal",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 144
-    },
-    {
-      "fingerprint": "fe2f83d81b68d424305bfc02ebff7d1b96933968815bc25f0f8657f3e9deaa49",
-      "rule_id": "go/taint-path-traversal",
-      "file": "./tests/fixtures/vulnerable_go_taint.go",
-      "line": 150
-    },
-    {
-      "fingerprint": "aee8c7a0a7c7d3ad94ef60c099f0f380964d5887a46229f8462953204e5b91fc",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 11
-    },
-    {
-      "fingerprint": "672a8b192148268b91593d20ac6aea06e19a53f0940adc9b45b40f4f002909c9",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 11
-    },
-    {
-      "fingerprint": "97d708fde22434e1d5c89aac55f15216952aafb1ea4538ad8c1a8df07ad1e8bd",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 18
-    },
-    {
-      "fingerprint": "cce2c9a65a3af3496752010c03fe3e9f1ce17753142cad171b263bbec451b909",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_hono_taint.ts",
-      "line": 18
-    },
-    {
-      "fingerprint": "dcc7a86874daed6c107b9179af442d175a86e5e7b59932e7a77caf3a87c215e6",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "2a01684eac5f43ef1e223e44669930fa6c82e805de4c47b5694acd4e86162c86",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 10
-    },
-    {
-      "fingerprint": "502c8b19dd490e6e9548b73fabe898240cc190266ae4388417120f19e9bd21a7",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "b7bb362d379236042296a32d09e32e59e7c7d20a4bc70650974788c00c81cebe",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 16
-    },
-    {
-      "fingerprint": "548a3052fd5ddf5b3067ca3d4663f29475e7d6540294dfceb8a0ab29ba786c39",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 21
-    },
-    {
-      "fingerprint": "cba9b775eafda48ce27c2b85561fc3d52d6a44b877c4f8467a1a259eafc78d15",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 21
-    },
-    {
-      "fingerprint": "e3dcbc0f83d6211b468211c26e621076c418edae338629310c3d0e1df7ec87c4",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 27
-    },
-    {
-      "fingerprint": "8fdcc04648ad9644984596cc736c72260bbb0a2a826f0dab04af9fe1c7695244",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 27
-    },
-    {
-      "fingerprint": "734d3c8c82d565d6fd395449ae88513cdb9271f51830435bd90c4ee750ba839f",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 34
-    },
-    {
-      "fingerprint": "fcde00a8e1526c1d77109150e314e86e82dd8c791c439f65755332512bca106a",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 34
-    },
-    {
-      "fingerprint": "f658db3a6bf683d9176544caf0fae93aed5fadbdfc9f942fbb77d8e44acb32b2",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "3f983b960308aa3c0285a453297bcc7b68444d3c1e492362f29284dc81f44025",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 39
-    },
-    {
-      "fingerprint": "aed9d090a24746964c5b624918935d49be87b6615579b5da1fd0ca22ddc218bc",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 51
-    },
-    {
-      "fingerprint": "f4750b94e8e36566ec4137e9cba290a4f8437d0cb514abcdbfaf50cff01d91e9",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 51
-    },
-    {
-      "fingerprint": "0297b1618ef57868af77884f93fe35a4f7b6089ea3f7ca41491e803c27b8c60f",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 58
-    },
-    {
-      "fingerprint": "0979a2d91f5620d7ed740378b5a17da4eb4371f905d312d27c82ae760f65449c",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 58
-    },
-    {
-      "fingerprint": "31605f9b469a54c48d1baf601c3ff45fd0cafaa74ecaa9c739889667eac86960",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "84b842f94ce69a5c91d0087a4a827dd80612705b06b6d9fb8743658b21194fc1",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 65
-    },
-    {
-      "fingerprint": "ced013e6204b95dd026693fec69cc333b34f6e645e9b920699e6c64a7eb5693d",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "08df18e510a1ed7b9728dde15a3e06c99787d8cc256ed115b148b75fce5d90a1",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 71
-    },
-    {
-      "fingerprint": "625989600a36f6a02f8aba5cc9edcfd94f2c27f18d11012de2495ddbb547df7f",
-      "rule_id": "js/taint-log-injection",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 77
-    },
-    {
-      "fingerprint": "1c6467fd691c651ec13f3e4debb553c150f19bd43d1421f1217d9bdd2834264c",
-      "rule_id": "js/taint-xxe",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 84
-    },
-    {
-      "fingerprint": "07d1501a3e52f2d0d061dfada428546cc3d990c7c817d0a1f02df465bd388a54",
-      "rule_id": "js/taint-nosql-injection",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 91
-    },
-    {
-      "fingerprint": "74dd65aa13e0ddf26e67ae189883e726377e88f9bf6751206b60ae52a50f88b5",
-      "rule_id": "js/taint-ldap-injection",
-      "file": "./tests/fixtures/vulnerable_js_taint.js",
-      "line": 97
-    },
-    {
-      "fingerprint": "17168ffebd7c94753856d1ae7d42107cb2a93f0f5db851196cbd0375afb624ad",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 13
-    },
-    {
-      "fingerprint": "db8beb68b0452f183fbce0506fd6584fe12762dcb408bf61eea2083dcaa2ad27",
-      "rule_id": "js/no-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 13
-    },
-    {
-      "fingerprint": "97c0cedb0bfb65d8a84244a500462ec6eb732c81c9661bf6c4aa503121cc5d39",
-      "rule_id": "js/taint-xss-innerhtml",
-      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 19
-    },
-    {
-      "fingerprint": "8cd9a0af2a9ececfe26a79eb9cd557149364a491cfc4017425a97ffcb28f80e7",
-      "rule_id": "js/no-document-write",
-      "file": "./tests/fixtures/vulnerable_nextjs_taint.ts",
-      "line": 19
-    },
-    {
-      "fingerprint": "290bba758d154f3c5df4e26d6504099f03e4c8d0a368f80c5f6d739caef460a4",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 30
-    },
-    {
-      "fingerprint": "7d6434fb04b3ce13554b635b5b8b979ede0fbff9bad7bf65a7ae57d01fbb7c50",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 33
-    },
-    {
-      "fingerprint": "c7fd304bedaebded3a505fc93adba7d91819c6dae76c63ed0e73a4c922d457a1",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 36
-    },
-    {
-      "fingerprint": "c2d5b0bcd786bf9c597fff525b3e85ed6737a2f4d0b002171e24ebb7168ecf60",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 39
-    },
-    {
-      "fingerprint": "ca542da6fbfc5da5710d266e2f60b6c9719c804778a3c809638976aa36838f0d",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 44
-    },
-    {
-      "fingerprint": "ec11e1413989c1f5f51e08373ac8a2467d740904905b7be20d79e62431e68ba1",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 47
-    },
-    {
-      "fingerprint": "2c53f75bc29d021b5225a8b63f3a39b8110c849ae77e16025b169246f49216c8",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 52
-    },
-    {
-      "fingerprint": "3c4d7f0fe1c0c9de707ed0ec94b79229a996df31d4e1a82dd9f8c22250a6d614",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 55
-    },
-    {
-      "fingerprint": "18784d317d6d6ecb2c696196a9e3698885fad566dde0a6af95783ac1edfac1f4",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 58
-    },
-    {
-      "fingerprint": "ce856f1c98ce94bd1423b5002d2a08e842c721c838d4e250598b0234798b5a0b",
-      "rule_id": "py/no-weak-crypto",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 61
-    },
-    {
-      "fingerprint": "232398c18b163759c914ed071423a030be117d059e635326226ed3041121292b",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 66
-    },
-    {
-      "fingerprint": "bd64c22bf42e25e5fe07b4657e774210d915b85b67032e8fb7641658485031c5",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 69
-    },
-    {
-      "fingerprint": "30f8fa40e9c490ba055e4f2196a0668dcde15515c6658f3ba23127e2eee9c456",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 74
-    },
-    {
-      "fingerprint": "152ab55c66fb214b802c2088dfd43c4aa3bf04540fe534c649b70be85fbedf0a",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 77
-    },
-    {
-      "fingerprint": "b9ea7136567395039accfa3a2645cebfdaa551a890912983c7552f3cdfbbb70e",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 80
-    },
-    {
-      "fingerprint": "b109cd0c412f9f689e95ae03418a61f8dd376e374417468bc062453d758d3077",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 83
-    },
-    {
-      "fingerprint": "276bcd3d9f920db115afb161c49b8d8902403734f37bc04df818efbd98b13721",
-      "rule_id": "py/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "926eac6475e4bac72319e29ca516594f9d71d0cdf0a6ddfae475fa0f0961310c",
-      "rule_id": "py/no-path-traversal",
-      "file": "./tests/fixtures/vulnerable_py_aliases.py",
-      "line": 93
-    },
-    {
-      "fingerprint": "5a637c0e96db22e430b2f63cdc0fb2c90ce6ceca970db9aaa729f896a116d334",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 15
-    },
-    {
-      "fingerprint": "165a909e8b5bf446eadaf29a2ed60e03792ff8ff7c905f45f553d0944ea45afd",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 15
-    },
-    {
-      "fingerprint": "f212ac81d71d1a94cbe3915c0e0ddca221e19da63069822d4b12bdcf0c2b487d",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "e02eaf92bad537935a9828c8fc8c4381c36dd27254f0ad3af2d69e564958c9cc",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 21
-    },
-    {
-      "fingerprint": "cfbc507a920ae78810efbd9eb3031a49cf003a14ae2f834392c1a31d74ff2a6c",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 29
-    },
-    {
-      "fingerprint": "1744c4cd2ad2444bb8e4bb5bdee5f7f576c150e70b4a1e599dd0620f7706f05a",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 29
-    },
-    {
-      "fingerprint": "72c616c4e26823e3047ee644e508bc986ee6ec01e964e65d095074f01fd2ba32",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "b14b1dd6262df6b609ee761aa1316cf1c8735421f5909305ed1c82be75274459",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 35
-    },
-    {
-      "fingerprint": "dbe81fd9197ee87734c165f735b5391eb3f6cfddc441bc71fdc0f126e105a720",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "45ec25cc4dfb96abe3bd6ea53196fce9a366ff18244c44cea9c14b4993d6d557",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 41
-    },
-    {
-      "fingerprint": "68ff8f53047570c3a2dc1adc97fa1bef1b0730a9d76059dd80d4ebb59928a081",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "655026c18fbc3d2b2cf5c608f835de8383c49319f8f8ad68d47a77f9b2bf98a5",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 46
-    },
-    {
-      "fingerprint": "593afa6992ed7ebca6a4193d8a133f214ce9bcd53d7e53e80124e3f29df1a271",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 54
-    },
-    {
-      "fingerprint": "db37e63e19bd1347b84292c2d2ba6cbb1941b1bd00ff1078c0de9de461c478a1",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 54
-    },
-    {
-      "fingerprint": "6128591974e0e0f43c1d50a4a1d7f332032f33e6bd8e36361ea345d224898c53",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 60
-    },
-    {
-      "fingerprint": "4b77211abac65fe1d0daee29b4b4379659ca05897b07709de57415a4fc3e9824",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 60
-    },
-    {
-      "fingerprint": "678960e65414288b74c97fd1ad91aa5606d1713e9de618c5d2e41e1db9e297af",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "5c21838df0ac2c0d46b0d574886e09c565ac2a726103fa1ac43c464bfadb6343",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 65
-    },
-    {
-      "fingerprint": "c96591d58fe9ba21538e62f8a5cea0e51051a4358a2e8cd9b72712a2f0156c47",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "d2aa9e1739319be4e434af18308c3da5c6413958291546e41a227701fb042536",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 71
-    },
-    {
-      "fingerprint": "6b64c1ff8e72d434dd2f6b6767d00c3650079be4152287a9b09d909bd814b3d6",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 76
-    },
-    {
-      "fingerprint": "59bb0c7cc34ee8bfc45e1e85eaf2cddd571319b695f3d061f95d7a7bc26729ce",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 76
-    },
-    {
-      "fingerprint": "cdf5f5703ee814b47fad7ecb74d10229c5bfd8903aac775eee37680ae71f94a0",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 82
-    },
-    {
-      "fingerprint": "552f610c0346cf2408a7c6ef3102d203598780adb430db7555d99fbaf0ff9e0a",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 82
-    },
-    {
-      "fingerprint": "8c016c28b19ef9d3447c256944adb985ba24ad3cfdd9add4b290c5a48e06dc29",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "406c38e3972040090636106d40c4f085f0207f6719c72cc3d303ebb5645e5711",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 88
-    },
-    {
-      "fingerprint": "96d84ae452ed7ae579b8ab2c04ae5cb691f0ef359be6bd3e97ad601bf795cf1a",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 94
-    },
-    {
-      "fingerprint": "6b0c8e0d7d020d4f146bf6ada6bf89dfc2165ff06fedf94c1d294f8f55964894",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 94
-    },
-    {
-      "fingerprint": "66d1f5575afdaafb45b411d61b052183f950e2836986c3450e3f379686623863",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 108
-    },
-    {
-      "fingerprint": "d2fcd562eb237f6ffa43e1cdd7cfd5c868a44a491bf6e533897bddf959333113",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 108
-    },
-    {
-      "fingerprint": "a28e4283046ca623baef24f58b781c2cb5a3ff57b41899cd3375e29690a6030e",
-      "rule_id": "py/taint-pickle-deserialization",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "29dfd8f8608c28998d8c63b8b4d9e1aa77cf1393e45263b3f83a256e7fcde2f9",
-      "rule_id": "py/no-pickle",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 116
-    },
-    {
-      "fingerprint": "c1266bd2a12c1365cbf1a1d511c3f1ad8465d4a040d300c1156d1b7b70420d46",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 131
-    },
-    {
-      "fingerprint": "328dad2535807d567a8863c071b20eeada791e343681f9a4f4357ebac0ff8ccb",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 131
-    },
-    {
-      "fingerprint": "a11cb2d06968cbb06e2263fca964cc5953aea390d7a6fd6b21cc2946995cde98",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 137
-    },
-    {
-      "fingerprint": "d53bb858c68ce684ecfbff7545b607ace534425421addb34143f61a11c3c6114",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 137
-    },
-    {
-      "fingerprint": "d7ef323fe07b6af8f182ffaf3caa586728fa0ea40dd94bed04ce0d0b6dcd82b6",
-      "rule_id": "py/taint-ssrf",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 143
-    },
-    {
-      "fingerprint": "b52279dde9c5d99f3dffa7a0dcbc77a1d27d3811e917e6add2528da38b2ff79f",
-      "rule_id": "py/no-ssrf",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 143
-    },
-    {
-      "fingerprint": "6846f4ee2c70b9d893eebe1016af041b77c1424efc463ed5cbdc6e1f65a6eb33",
-      "rule_id": "py/taint-yaml-load",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 149
-    },
-    {
-      "fingerprint": "a14cce64bc2deabedda9d6b2f4e623baebadeb8e7ec8d044a28786318eb8d85d",
-      "rule_id": "py/no-yaml-load",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 149
-    },
-    {
-      "fingerprint": "3a197a581fc79e8fcf671460811e698ec3764aada43eede830f15f355a952b59",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 159
-    },
-    {
-      "fingerprint": "b26b10621fbe1b3035151f99ad9aa40d747a165b47d5329797a0c92a3d9b030d",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 162
-    },
-    {
-      "fingerprint": "fda792b84b94e8d0c4224ceb2df485c29279dfcd23e33b965de2d55269818d99",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "bec4ec63d1d38aab0bb5ded21a2da2728489e3126d2363c599e0ef214c16ada6",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 171
-    },
-    {
-      "fingerprint": "5ea5c85eacae49a9108b3e82ee0332ec4e05e4291a581402038c9f8050b7d4f3",
-      "rule_id": "py/taint-eval",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 176
-    },
-    {
-      "fingerprint": "8b58c9e15ece1e1fdfb6f334d89451a70c6433cf6e8385d0432a473f5de28bac",
-      "rule_id": "py/no-eval",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 176
-    },
-    {
-      "fingerprint": "b5f23103c730b06656f719766c7495c7944e3895c9f346046274ed075fee97f2",
-      "rule_id": "py/taint-sql-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 185
-    },
-    {
-      "fingerprint": "d4d63692463d827c4bbcd49e3867ea391222edd26810fea5aa017a1ebf791e17",
-      "rule_id": "py/no-sql-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 185
-    },
-    {
-      "fingerprint": "fe3552491070df38f5d50070080ee8c7256e40fe1889ae733d259740479476f8",
-      "rule_id": "py/taint-ssti",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 195
-    },
-    {
-      "fingerprint": "87c505b1a4040ca75470c3fb5161baebc89368da956e2fbc18486cd53b885c13",
-      "rule_id": "py/taint-xpath-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 205
-    },
-    {
-      "fingerprint": "a23dd1a0b2d467ff93efb2fe328499bae08c0a5f36c229802f61a229f8153965",
-      "rule_id": "py/taint-ldap-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 215
-    },
-    {
-      "fingerprint": "5306493339080768d0a8d10167134d9b94a154a4dcbab064c9eec6855a9e9ac7",
-      "rule_id": "py/taint-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 221
-    },
-    {
-      "fingerprint": "e8c69ca4f1e68bfc3f02699b37df1e8a753e8755fb48e0afbd6c8dece7ab031c",
-      "rule_id": "py/no-command-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 221
-    },
-    {
-      "fingerprint": "0b3cdda4719606bef1159104fcfcf4054352bc5aef45787add2aef8d061ee93b",
-      "rule_id": "py/taint-log-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 229
-    },
-    {
-      "fingerprint": "28340fc3a23614efd580771d6fe9bb9cb954b2f6af2a7d6bcf5f72226d9fe029",
-      "rule_id": "py/taint-xxe",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 237
-    },
-    {
-      "fingerprint": "dc102932c135cd46b401a0c30fc71331bbf1d8101f33bab6e6ba166d0df92bec",
-      "rule_id": "py/taint-nosql-injection",
-      "file": "./tests/fixtures/vulnerable_py_taint.py",
-      "line": 247
-    },
-    {
-      "fingerprint": "d84099aec001886ec3df5c83d5adb4b6818a5056e4b0b7c591920996e16e0204",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/vulnerable_tsx.tsx",
-      "line": 6
-    },
-    {
-      "fingerprint": "7c3ea0dd7f616c615fa72809209bebab94b3513ec00566e7d0b984da4239b23d",
-      "rule_id": "js/no-eval",
-      "file": "./tests/fixtures/vulnerable_typescript.ts",
-      "line": 6
-    },
-    {
-      "fingerprint": "bc90f5aa427a302e745274d93b3be7777f06a3288de04614f4f06a2ceb7035e0",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/integration.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "95df077c0c1bedc808babcaa9c536f76010f3efefa6eb0a651a8e79074c21230",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "0e9eb77a577dbe76ad5687daf355026450f2b47d9432f0dad7e3d1c223fcdadf",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 62
-    },
-    {
-      "fingerprint": "2c7aff86903ac0bc4aa8a32bbe95334e0b182329badb1329d95b786eab4db4a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 83
-    },
-    {
-      "fingerprint": "90b694a33960ce615cfe2307fc7c32431afc9e0d5eaaa2291534574e64592450",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 92
-    },
-    {
-      "fingerprint": "f27fbaa3a098f9411e97a0ed7cb2c60dde47c54f13765bd4f641257d201f49fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "6e60b7e0b87c0f05b649cd4f8b849f4e98355b7bad49030c541f004fd2868b94",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 102
-    },
-    {
-      "fingerprint": "17c9d0d7226850d5c08041a7993c2d9c0a174ed33464959bfcfe408b3176c58d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 107
-    },
-    {
-      "fingerprint": "ec4995de741c90095be06e9537cd41f9c68920c658b1fa6af35be632e0694b98",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 109
-    },
-    {
-      "fingerprint": "b238a2805c993d45d7435b08c4759ed5ef7c00b371348b482d62cb72b98a648a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 118
-    },
-    {
-      "fingerprint": "2b22f8efba0d3ef360e49fe7559b4875d8b93dee0d1efa628b5bc81cd6a4cf45",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "e32cc12e60ab8cfed51fd43312641fc089cc989e89f21a121bbe8b593965959b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 129
-    },
-    {
-      "fingerprint": "1c83512bbc17b697a596d90b760f07833e72393ebb03d6bca73f6656a22a5b35",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "ced0be284e22c20893d1829004a6e10e3db4cc3af7cf7e48aacf6828557c8d63",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 139
-    },
-    {
-      "fingerprint": "f425f50be1fd20f80decf58b39da5920b36a5edcb25d55414f4ac7dc1aab20e0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "6d37eeccfd284e57eb54dd9dbee3cf46565870bf4bf6095761fa2233f7cef9b8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "aa7d572f0230073d6791221ae5bcccc39069c5a7bc51f3dcab41f76da6a2904f",
-      "rule_id": "rs/no-ssrf",
-      "file": "./tests/integration.rs",
-      "line": 254
-    },
-    {
-      "fingerprint": "2ab1074d6f247c1e1072e3547adccfa2feabb0fb5722c6b69b6270209aa23a10",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 270
-    },
-    {
-      "fingerprint": "866af0177c239120cbd953896faee84256b608abf44052c68fb9e18ae8fcb9c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 364
-    },
-    {
-      "fingerprint": "0c6f255a0290d5e95c9f8f80a3aed591a17e87c965b1845deee2f0e74c61c564",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 402
-    },
-    {
-      "fingerprint": "419fdd8279a7364b127168006685ee6cd5736dab471016f294dfe6ecee6179a8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 439
-    },
-    {
-      "fingerprint": "3ee028825510bfb9862675864be7b065ffe5ff243d4ae7d1fccaf0fdca89f124",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 471
-    },
-    {
-      "fingerprint": "03ea6cdd56bb875542651bf547de514f1d50c757b98450888897c5bc917d5fe8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 505
-    },
-    {
-      "fingerprint": "9f317da3114ef837c9c6d52b64209172e2de5f0a10b487ac2f2241b420626710",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 539
-    },
-    {
-      "fingerprint": "ecb66c3e02e681b77c24e3ed7d9e4a930625ba1cf535fe633562d2ec7a4e610b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 572
-    },
-    {
-      "fingerprint": "b1e79987cc390071818805d70ecd8cfd9f9d2ccf13750f03b3c06ce2ab03a6e1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 605
-    },
-    {
-      "fingerprint": "7932ebba7cbe8362b474597f872e563a3b0b6e7c789ac709a0b03baa2e9ab984",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 627
-    },
-    {
-      "fingerprint": "21a3da8e3712d92b1b3c12aac5500bbf5555f840fffe987447fe60c0b5fde1b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 647
-    },
-    {
-      "fingerprint": "9c49e172e279c4f78a02aef465403718891bab358852abc62d0c6daacf16fc8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 714
-    },
-    {
-      "fingerprint": "269c0a519b02a56719bc79f09c79dee336f584b840df5989e588d943ea302f12",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 769
-    },
-    {
-      "fingerprint": "82d0727f2767f3624d9a614b7a4af93e1a38c71649a9acc13db66e6969838701",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 800
-    },
-    {
-      "fingerprint": "b57ef8f6fe143a41acd357205b348a4748ed1edea604f434e27b7480c23af2df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 822
-    },
-    {
-      "fingerprint": "36b0737d4f990108c5ce7bccfa1777aef8ca393c97d8600ce65e2ee9210d0663",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 848
-    },
-    {
-      "fingerprint": "7b2109f2e91e17fa21b25a6263ec35edb4a0a80d34e8cfa148270d14dbb5161a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 871
-    },
-    {
-      "fingerprint": "0739fb3a0d29304af6209c1e88902040b2e2b9f19c51fd37c771b6b7257e9082",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 894
-    },
-    {
-      "fingerprint": "da1049afabfa8e105e51377c19999fe43042acd010fd2eae649e05260b2c521f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 916
-    },
-    {
-      "fingerprint": "c6e7ae54a0eec50fb577ba8f89249f5a7c77a4887351b7ae171fe86f2f1d687c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 939
-    },
-    {
-      "fingerprint": "cbc54e74ddaf5edc7f19367620f8cd8f7c8efdf46914002e8567613ffb0cb4b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 961
-    },
-    {
-      "fingerprint": "4f7a527e7378db03b20fd7438772fdee013e211c622eaa7db3f4bb2055f82409",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 981
-    },
-    {
-      "fingerprint": "993c306af4d72e89b8332628258d7d68503e6c5c08b6b5aa5e416c0b92ec0055",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1001
-    },
-    {
-      "fingerprint": "580110671d092fcfced7c6d963651d66569f1f344b694f7754d73626e4208bcc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1052
-    },
-    {
-      "fingerprint": "a947ee7247c4d13cfe5d6e67ad0dcb76a299c709c9cce8a14dc8e681395e69f6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1122
-    },
-    {
-      "fingerprint": "7dba6ea15dabd29e3ee7d0988bc390545217ccefd9fb7982bd27df11cb09e51a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1154
-    },
-    {
-      "fingerprint": "73436d268dc120e33c44563235b4104288b1d306c09a740761bb3f852c0ab418",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1174
-    },
-    {
-      "fingerprint": "10ad8c707d09b5db71ff80379ab5db7aa576abc8a3aef5e4f90608db17c255f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1217
-    },
-    {
-      "fingerprint": "b7dab2ed0bc0d913ee5583284686d8a6c24ac421c596c2abe6793f36bb6e48aa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1239
-    },
-    {
-      "fingerprint": "5b4325917ee3964bec723fd69b4906b07258c11777e4ccfbdf6049a5bd0279f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1241
-    },
-    {
-      "fingerprint": "5dad17ed053ab5b2e883c540d9359c10b7a75990f3081453f9da12c129a8ebae",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 1247
-    },
-    {
-      "fingerprint": "bb45748960a0da6900779d79ecba4283a026bcebcd1232fa8bebfcebb24af94d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1248
-    },
-    {
-      "fingerprint": "b933a46b64bc6bffb81288862a5604b8c96660cd2c62ffcedb8f0ad163c2ac23",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1249
-    },
-    {
-      "fingerprint": "bb898278b6c4cc97c11918a576f29c6120145a820d17f5c46e6d3d962384e190",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1251
-    },
-    {
-      "fingerprint": "8b133d144e3dd77d0cc42d5ad5a72909ca3c6f2e11fddc51846279985ca7f982",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1252
-    },
-    {
-      "fingerprint": "56c3f5564e784ec88174dce53c99030b46b0b79fb1400676eaa313d7da35a42b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1317
-    },
-    {
-      "fingerprint": "dcfa2124f4476f966cc59d98d3a5e24f98e0778d854c5c3099655f3ea57b72fd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1364
-    },
-    {
-      "fingerprint": "51b280b1f382a0fdf82cbdcf17ef47403dad00a31e48d128c5022d3b83d145c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1407
-    },
-    {
-      "fingerprint": "005e3f9d75bd01760262f1f69047a98ee646ac28fb04eb5723aeb0da86a3d304",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1435
-    },
-    {
-      "fingerprint": "d6976c5f294e651725ee3960af209aa5fda14bdab183651755d4b2c21bd05a55",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1482
-    },
-    {
-      "fingerprint": "84c57520f95a7dc67b1ad3df2b8230e6f1b07c052c21dba34cad12ff528e94de",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1529
-    },
-    {
-      "fingerprint": "ad18ff3d3d239c7aad072bbdd4fe5acf410bbd75842b45ecd6c80565a2299569",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1580
-    },
-    {
-      "fingerprint": "de81287a0e0bcf7e3d3f1b80336e17b85864a29705aad3fd82e6758f2c0cf147",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1616
-    },
-    {
-      "fingerprint": "6c131d2c7f0f16903097a5e91e95d088bada1f33afa008619a10bb7a4ca9e19a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1657
-    },
-    {
-      "fingerprint": "e2a83cb443a4b8310ff7aa7144aabb07c3734a2a6667913b8dea01b34fd014e2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1690
-    },
-    {
-      "fingerprint": "21ad1ba8ee586ac86a8860193a9c31ac836b51577070be8a31017d8a7ffe6ab3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1721
-    },
-    {
-      "fingerprint": "60c221b082aca844b8ac560ddb5619e72f7c314d3cdeb2fa0c15ef387708a2b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1752
-    },
-    {
-      "fingerprint": "5b8cd46da7bd04fc0b721406edd5f76304733a05c68c5044cccbd000395081ca",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1783
-    },
-    {
-      "fingerprint": "4c03c869478011f034f7ffbe53caf5b1359c5bd788efddb0c7d11d7882ba0880",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1814
-    },
-    {
-      "fingerprint": "60fc46169cbd4f98cd3271d9d788775550c2fbb2617f6bc0cd078fbd5036e834",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1845
-    },
-    {
-      "fingerprint": "ee692466e2ab3b23ef22f2a1d5d802c265e23d5b5fc8e606314c7972de85e604",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1879
-    },
-    {
-      "fingerprint": "436b3a7e74b57585e0c9485ce14e517800508f2f64064d499de3fc6a6515aeee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1885
-    },
-    {
-      "fingerprint": "a6038d607b83af13a03dc4f97d9283cc4b35044325910fd708c61326b279fdb5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1925
-    },
-    {
-      "fingerprint": "5cfb29f36347ced482dfa34335179ba1d137af51e1a7849503b982bb9ced81c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1928
-    },
-    {
-      "fingerprint": "ceb1f4e79390d953a70b65997a72324ce5eb488dfe8a8240da139c29efd0e0c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1934
-    },
-    {
-      "fingerprint": "55857625660dc19d0b68e51424e7f175cba2db465c8e2be1fa9da1f62c8195dc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1949
-    },
-    {
-      "fingerprint": "74fb956bf38011e148c882719e1b4c4327521b8a3f264985d0ba6e01af40a3bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1962
-    },
-    {
-      "fingerprint": "6f4fa0151e12e86e8e461b75e8e5b484f0caaff6640fdfe1dd8847a7ff01c05e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1965
-    },
-    {
-      "fingerprint": "a3302c0fcc8f5e050c4ae32b612447dff60327dd2a2688a430ae04a2f85a5620",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1971
-    },
-    {
-      "fingerprint": "ca3ca195ae9e4184fd3c86fa99219cc0f82565e7c7a5428d23547c14357bf51e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1985
-    },
-    {
-      "fingerprint": "e70abdf8fe9268cd84525029505e51e4c0be0608c1093e6aaf435487fd1d5743",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 1986
-    },
-    {
-      "fingerprint": "1c0a535faf9e887efb2480884dc60ec324684ee1dbdc103d87c4af229d105b20",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2000
-    },
-    {
-      "fingerprint": "0d0b3aadaccf64e1943811a0255cb9c61e18644c26d200f5d2a72478a8fffb24",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2003
-    },
-    {
-      "fingerprint": "251658636980ec11b5d2352beac0ecba12564fdb6a213a521d6f5948aefaa2ff",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2009
-    },
-    {
-      "fingerprint": "e493591f29b5ef6d6f1024f107d235ebb21137a3eba4506ec12ae3c096b510b5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2023
-    },
-    {
-      "fingerprint": "b5f2510ea7ccf8ba2c0144c91e01a2e130a569c3b830ec2d0e041b1423aed4fb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2024
-    },
-    {
-      "fingerprint": "d26b46af3c7696341f34d07e78efba18383c6524b9db23a7f79a19894686993e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2038
-    },
-    {
-      "fingerprint": "e906d7f2a5b2078fc62dff3f6932ea1deaa7b92e531930c8720159306fb9e31a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2042
-    },
-    {
-      "fingerprint": "011eba29f96bd012475fe4d7d28982388aacefe09f30a6cfbc9186e9d7538164",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2045
-    },
-    {
-      "fingerprint": "4070ae273ab8367c820b715befe22f1f1fda98b6405e1ee54e0c4bb5665ed0b4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2049
-    },
-    {
-      "fingerprint": "376b74e6aaefd9c737a2056dcba5628e6f996e0371b5f53a61a1151a73d5e55a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2064
-    },
-    {
-      "fingerprint": "c35fb10121c6c6847f37d0194aea88db9e74b384017e4e0b081f4bd262fd646a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2077
-    },
-    {
-      "fingerprint": "a85563aef154c81d56ce12df2d35a36b2db9cb8f40942d598d9a16a0d29c30e3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2078
-    },
-    {
-      "fingerprint": "410b6781a39a1da08347583ab46c6295ff2a1e9fa24b442140e27219caacaa01",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2083
-    },
-    {
-      "fingerprint": "12a51cba6e0aa44aa109b5c354f269574d8d7143fda0ed53657c6d1bd53450a0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2085
-    },
-    {
-      "fingerprint": "7d9717cab5c2dad1ab6bb894e9ea2e725551afbadecc349b084e42e585a24e0e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2090
-    },
-    {
-      "fingerprint": "b38242344d061106dea36e8749df0b358e7ac79fc816e7b0ea108680c8817b07",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2103
-    },
-    {
-      "fingerprint": "901ce45a52223a98c2f1b92cdb5efa3cc8eedd98426c03b988d40e17a9a2747a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2110
-    },
-    {
-      "fingerprint": "70e47ce52d3c3570f2c35ee12b0ee135086a4509301a9f2d93717d43737a7eae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2119
-    },
-    {
-      "fingerprint": "389ce240f0d0fe6313f95493cde38489ed621915869ccb0d50139257f2b4451f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2134
-    },
-    {
-      "fingerprint": "92eeef747818ea17d4bac57df6d8eecb554d1d6a5c0970ed4f5f2784c5e370d4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2148
-    },
-    {
-      "fingerprint": "74eebff52327445146926bb6fe9583c2f4600ebbf13e10c7df3d1289f20dbcd4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2153
-    },
-    {
-      "fingerprint": "bdbf59e92efb0168506b4b7658a43247e03330097553b0e757d71dc0c25348b6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2157
-    },
-    {
-      "fingerprint": "d45a30656d28c64229f8804eb252b9f3732c77d68c3c13303f2717fd0b65b460",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2166
-    },
-    {
-      "fingerprint": "4d8d8aa5e68ecef57f51c7d24f899ecb2cd86185cf1a9d35c13f6cb97ed99950",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2169
-    },
-    {
-      "fingerprint": "617f8df8b3b1b8f28ebc777b5efe3b11c4f3604c0c30dc090de64d13bf6c9806",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2171
-    },
-    {
-      "fingerprint": "ee4d077702f59571585ca5193241916d173a3041146c17a25dc6fe3a0b9e945f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
+      "fingerprint": "87950f94106e530c523090b0538791f4019e828c840676da7046724d1510cc1f",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
       "line": 2182
     },
     {
-      "fingerprint": "349a089f130d68b590e24da6a03bc43c03a65dc850fa72c35ac079819ba6a3d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2183
+      "fingerprint": "d2ac05f4d9c2cfdd2daec32b2087087d246c0b267b120e0704a68166a8cbb74c",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 2209
     },
     {
-      "fingerprint": "42e385d86c6e95382178196b01df6f53f1267575475134e82c6af0d3450b5caa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2188
+      "fingerprint": "b07a1397a2ee6134afed32fbd5f28488a989867458487d83f2f88569c037c5b0",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "Cargo.lock",
+      "line": 2794
     },
     {
-      "fingerprint": "8239bb936ab1b4caeb8b6fb9953518a1b3505c3d532bb54c1f30cb5b18b6294d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2190
+      "fingerprint": "2a2713cee642b38f6ff0cd88156299b89d9208775e60069c7146a46976dd5602",
+      "rule_id": "py/no-command-injection",
+      "file": "benchmarks/compare_versions.py",
+      "line": 36
     },
     {
-      "fingerprint": "e3eb51205fed2d02aa02da82cdfd6e77dd9575f5059f358e19a37110f4fdf173",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2195
+      "fingerprint": "6963ef2200eb99a3c2d61fb2419a2634a8c963dd1d9550cea04375dadaf1c873",
+      "rule_id": "py/no-command-injection",
+      "file": "benchmarks/parity/parity.py",
+      "line": 386
     },
     {
-      "fingerprint": "b157a59dfb69ef4e06d4c83aa695c6efc4e443b508ad316efc9587101c991bd2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2208
-    },
-    {
-      "fingerprint": "8be1913088b20d1781190473ea19c883ce708f09d2841c773a2e4c5b9114d8ba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2215
-    },
-    {
-      "fingerprint": "5414b4024d28ef898b5a8dc0331bcafda4e071f5374ac17f41e13d2b3ff308ea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2222
-    },
-    {
-      "fingerprint": "d584bc53a3619e0dbef516504dbec23988bcec5302c35e6870237ac88509a679",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2234
-    },
-    {
-      "fingerprint": "048aafe647068d18ea783bee6e8592dea2a15be1cf98bac4261828cfaefafd1d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2240
-    },
-    {
-      "fingerprint": "aea5213c5c7f7a2fc3c6540b5255ca2d59a6ea7396da706ef1f3ace654670a7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2246
-    },
-    {
-      "fingerprint": "c9d47788d463549852261211816a79655c2ca6ae2ff2f9cc1be4069fde650a26",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2251
-    },
-    {
-      "fingerprint": "b31423c5bf39fba2af77a7152ceac959ffddae741badc6174556bd636cbbc940",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2257
-    },
-    {
-      "fingerprint": "96084e4d60d2c5211c4f41fcdd56f3bb8c5d2c15737fd976db1ee47c999f2f09",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2265
-    },
-    {
-      "fingerprint": "b05d3a5d49c5f2396e0d86c1dcb6a40ed21b2aa817fa9562607f6e6778f763c5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2293
-    },
-    {
-      "fingerprint": "3a4cc46385ae6db281f8621b78a61ee8c7abc129f31f049e1d8851f673fa724b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2294
-    },
-    {
-      "fingerprint": "ab19125ae6f46a256c9c61f5a612590b461d5449c86a072611abd414705e6963",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2299
-    },
-    {
-      "fingerprint": "2bbd87dc88431e647de8082bf4c97216559a034bc42448c4856a1f9671033ff8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2301
-    },
-    {
-      "fingerprint": "b53441a772f2df9c35fb8a3ac548c624219883848f924ecf51c6c927d609df71",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2306
-    },
-    {
-      "fingerprint": "3d3c5ba11dcf213da555ddcbe0078a41e3a7a9df6b06420f3420c85f0dcd53b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2319
-    },
-    {
-      "fingerprint": "afdd856ec3aad16269817fd7f9b9c7be0a4b15cc75c992569f231de3dc1e6983",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2328
-    },
-    {
-      "fingerprint": "e819d4ab21cc5511cef15e099e14e66afc3288aabe8929b77af1f671817dc707",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2329
-    },
-    {
-      "fingerprint": "8b078a8654e42403030add9319a23596b3f098e5f4eae4e8cc78421e2c6b14ba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2335
-    },
-    {
-      "fingerprint": "0c79d7af476475b58b52b0b86d9fe17f6eb85476d2cbe97f39827f4a80f53eae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2337
-    },
-    {
-      "fingerprint": "869b0a33edf735b9aa922e017ae5a1a490075f4422658c0a3f15d0f5fee0a998",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2342
-    },
-    {
-      "fingerprint": "2e30e3f078bdbe9c8dd7c8a630845bde140bbadb0248c028581249d8f1e391d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2356
-    },
-    {
-      "fingerprint": "7ff9763c94c0eff614d693fcd6b289923c4c208830283697c316e826ce4d29b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2358
-    },
-    {
-      "fingerprint": "a6b80d8c51902f5f4c95b43b0599ee6fe99526105c855d6048bf8199b7c11a41",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2364
-    },
-    {
-      "fingerprint": "f0c15be388e107d6999346ecaebbab3641c899e7936258a8e6194bc208c765b7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2366
-    },
-    {
-      "fingerprint": "ff173ba0ce8320567a50880cb46106ce74c2bcaa1483dcd35684cd14f7f3585b",
+      "fingerprint": "5ae8cd6bd2645f05402f640240c152a686837b3c63378c749d443995a2fc2dd8",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 2373
+      "file": "src/app.rs",
+      "line": 74
     },
     {
-      "fingerprint": "b21762bf9cfcf1762612309830b3fad293f7e8d1779dda07e4a671735d83ab84",
+      "fingerprint": "b7cc8f59f0de3ccf8cb756a378c6a0c718d2fc4e40980aedcbd370cbb0788dce",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/integration.rs",
-      "line": 2376
+      "file": "src/app.rs",
+      "line": 81
     },
     {
-      "fingerprint": "f72f3b9a953aa04996ab19a5014998cdc38c9c7d7081a9b21d9e86dba5cfc605",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2383
-    },
-    {
-      "fingerprint": "0ab28077aef34b412dcb509ef40e20b7ea785f434ccde8f29797e4671bba116a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2403
-    },
-    {
-      "fingerprint": "87277a8fde63b4effcf0ea3fd2f913b46e1c4abe091a4b40c88728d04c58883d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2425
-    },
-    {
-      "fingerprint": "7d068d594e569a47f8c678431da15ac31b7407ff585883d38adcf3a9d27ec29b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2452
-    },
-    {
-      "fingerprint": "41c0bdacb08d8eb876d93af3d5262dcf80c9f3003cffb60bf75a2096c7c703d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2457
-    },
-    {
-      "fingerprint": "62f3eda42653580be6022e5503ab847445e2003d81c7882375c2e4c65d3a8955",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2458
-    },
-    {
-      "fingerprint": "6bedeb57394dc969be0a4e5c4da50a8bf9fed50e9497b98296ae7250823a78e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2474
-    },
-    {
-      "fingerprint": "e6abfcd23ad2fe3733bb29853cc646e1e81c1a9e7ebff80b96bccee96c977e84",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2498
-    },
-    {
-      "fingerprint": "11090a23c006c6339dc42c9631b00979223ee7977a8f778f46c619d8792bc787",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2501
-    },
-    {
-      "fingerprint": "478ce3d69fa97afb81616ca4716b90e98834d706095e0f185ee4c0f40331970b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2504
-    },
-    {
-      "fingerprint": "074137fb27807428eee104d0b856e9a94ec1aa624571f564dc8cb70d92c0e03f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2506
-    },
-    {
-      "fingerprint": "64fdf9b4b8b82c6a902f56c8e39e84458197363ababbf523110886fe9a05a372",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2510
-    },
-    {
-      "fingerprint": "27989d38dc8208ae8cc2d0587ecf055333bd8a000af3c512f9c6bab4ec3a48cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2521
-    },
-    {
-      "fingerprint": "aefe8736ee5d8ddcde3d77f528cb5a8234b2a3900b81ae43f6772de894311c51",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2523
-    },
-    {
-      "fingerprint": "44536e316be1e8333a6b13fb14ac57b3dd82ef6e27c9924d04c37962439edb46",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2527
-    },
-    {
-      "fingerprint": "b88cd2565a6d12be857775543050e5e688a53d77817dee2d737616801aeec03e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2543
-    },
-    {
-      "fingerprint": "3052d7bf948584a7ef78705c64f3c18c16e13c907d7ea28d01920d79d762175f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2544
-    },
-    {
-      "fingerprint": "037a8d6ec603ede0853a82eb991dedc85a768bf1bc6475ad4e31eeef4ae2709a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2551
-    },
-    {
-      "fingerprint": "18dc1b64e62632e28aefe20315883a868054479f2db1c7337fc7641ff2e6f4c0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2551
-    },
-    {
-      "fingerprint": "b85a22cc3c3651b977e507ad750d75b0fb3b75bc93bbf377b3ba6743e6b89b91",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2554
-    },
-    {
-      "fingerprint": "5e1432d952b5ab63afd7958d01a069b1241440712036fa47dfda0c89d0c7ae12",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2561
-    },
-    {
-      "fingerprint": "860d1d603556bd1a810922860280fb748fcaa18b211a68195f2d778c2b323acb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2577
-    },
-    {
-      "fingerprint": "fb5363b4c0f299f678b4004a24a733bc30ee6824978850e21e1c756cf942ec5a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2598
-    },
-    {
-      "fingerprint": "f3b3ce818feb419694b37f9b6fb8bc601b683732d23453da8b119f03fcca89cd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2599
-    },
-    {
-      "fingerprint": "86dbf3fd2b0b9a3be145a0b6500c2da70b31517f08258ed8881d340f813dfe7d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2606
-    },
-    {
-      "fingerprint": "42daf2bccf0ee3e8473af6406ba50672d5cc4ed450e2d998e26bd7b1eb2425a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2607
-    },
-    {
-      "fingerprint": "e9b7453de440c0a3dc6af668a233eb1eec24aa4aabeeff83800d4de8b97a2a56",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2613
-    },
-    {
-      "fingerprint": "f0e7e5d4be384d1040a4b6c7b7265b5a7f7e6490e1985769bf432110780b2c3a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2620
-    },
-    {
-      "fingerprint": "101ed17f81c19eedea180696463955b9bc239a030d4f842a69582dc289cc7c92",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2636
-    },
-    {
-      "fingerprint": "58ec3e150404727a36cc801b7ea969af5ffe7eb48750420692f4377adc1afc6d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2654
-    },
-    {
-      "fingerprint": "82714c7293be7065692da84841e6646cbb300644ba9fac81c2443f84d97f7dba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2660
-    },
-    {
-      "fingerprint": "aacbe721c77b963156b26b12acecbcb749278683d06008e671b2e49960f41646",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2674
-    },
-    {
-      "fingerprint": "6d5c92880eb3d86dc006cafd8bcdaab67b73fc9245624e5d4283a85f043057a3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2674
-    },
-    {
-      "fingerprint": "7f7d5d8ffeea52b245a7e90fa982fb4a9dedf30ef0d3b695a809725bc17820eb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2675
-    },
-    {
-      "fingerprint": "78b024945156ec53074de5e5fbfe16d427c52af5482ee347ff5a64bb4a533c18",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2682
-    },
-    {
-      "fingerprint": "12b5fb9fcae32feb98b315e4208c1ce7dfd8baaa990df8302f1444a0c811b7cb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2682
-    },
-    {
-      "fingerprint": "2ad61b4b11f519cc0a858ac5d28f8e6b68c48f2dd980b6a0e622fc8d9ff48beb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2683
-    },
-    {
-      "fingerprint": "fadfc3b4a759e455bc8bc55ddaeb4743a74ee2efeb87c17f881c3d91b184f1b0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2702
-    },
-    {
-      "fingerprint": "ad75fd12c03fdc11580e77d6a1fb38eb152693c2f7246e783ab88c5ea5871f30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2703
-    },
-    {
-      "fingerprint": "4d2f667eebd16d34e251c460215062e5feab244b74c3a1128eb5cfebdd5aca2c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2704
-    },
-    {
-      "fingerprint": "0c4773575182b7a80bea08da6c80d283682898bc2454edce460bd5cee1709bbe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2713
-    },
-    {
-      "fingerprint": "7fef6af113426851982ad6746fba5d023088773218b52605abbbda7ff0e1e2d5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2720
-    },
-    {
-      "fingerprint": "8373af3a624c4f11c8d50d86c6611b9aea19f627b42b118ef62c1bd07b138665",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2736
-    },
-    {
-      "fingerprint": "1213a9782f1990c6e6c1c275a3210a1290b2401e2ba9cd5489974a9972fcd641",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2759
-    },
-    {
-      "fingerprint": "3a3e4cb5adbba15de18a8c3b11528384bc3edabf99034cb031ee1914adc495c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2768
-    },
-    {
-      "fingerprint": "41c5bd80098107ad2218f3cf9409d764d5a151133e0648c5672e5c80e2448dc0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2803
-    },
-    {
-      "fingerprint": "0a99883722fd3391c32f761f5442147dbdfea9010b1d728272dc70696f855f92",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2812
-    },
-    {
-      "fingerprint": "b89d9b75738b42b56ed96689d08374689438b3dd453660ceefd5c96602a84d04",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2826
-    },
-    {
-      "fingerprint": "36759faf8d6bc79c713e592d466d3de6e4ec207d1be57b2b5f7ed40c13813286",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2835
-    },
-    {
-      "fingerprint": "8e2595cc772c0910958dc93019487789974dc7ece5a219c288446f452bf8a0b2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2856
-    },
-    {
-      "fingerprint": "6a402975ee393dc2d2827f7fdac4dcc1e4927ed152b7998351ca3c55839e2273",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2864
-    },
-    {
-      "fingerprint": "1bb297eed53afe5dec4103f23e3124f1bc7fb20b3351866a3c80febb8526dc7f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2889
-    },
-    {
-      "fingerprint": "3d0729a16d54fd193d6f7b1ac6cbe58f596d91fa4e1cf6f97bcc3cfd0f0d38ee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2893
-    },
-    {
-      "fingerprint": "11bc8ec4cb446f1c6ec660876ae11a736a38cd4e1cc279010f2d49c87d54133c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2912
-    },
-    {
-      "fingerprint": "a97e369052f5a9f53b8f2939473d605b99d5c6fcc72dbeffaf117ec8618a347c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2933
-    },
-    {
-      "fingerprint": "afd6bb2d76307137cbc39552de287eaff4708908ace67c49d5fdb396bc210d29",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2943
-    },
-    {
-      "fingerprint": "688f3931cac3a546ad21578afa2a463d1b2c61dc806281b315da61dbc2010ba3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2972
-    },
-    {
-      "fingerprint": "85b5379039dab6e88ab7313c79cee532685523ea83a03c5be971469ab6d137d1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 2980
-    },
-    {
-      "fingerprint": "198ecfd2a7de326eb6df04abaff8d2a561fd8490eeedc7aa34f3bdfe0f8ab73a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3012
-    },
-    {
-      "fingerprint": "0342502d4c0ab0afaf326d6582dfb7ddfa3fe0302dd236b70f0a526ee44f923c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3013
-    },
-    {
-      "fingerprint": "44da7400f8da72c3ca57c203af24b65601d8f491791733ac5428feaacb5bccb3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3015
-    },
-    {
-      "fingerprint": "62211dd84b0de85e63f4b480b6765f1ad4a63f6bc07c06f33eb58628ef7b14be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3022
-    },
-    {
-      "fingerprint": "1f096abda56e82b6e5de533352a1ff9946348b9b259fc09e801647b679fce1ba",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3048
-    },
-    {
-      "fingerprint": "42dae8901dc0d1f853bdd6039acb459ba57092ed9dfeb505da5484fb7915b465",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3049
-    },
-    {
-      "fingerprint": "e38ad1a55ad702ffcd2eaf9b3a28fea240ce0935145fbc51e36a07f6b9925a13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3050
-    },
-    {
-      "fingerprint": "a7124d9098efb812451755e10a0753072fe252e6d7e2aefe90890ef3df93ba90",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3051
-    },
-    {
-      "fingerprint": "81fa500a7805f897d77c0ae2d22a32f2312fdc2da96215d590ebd978d561ae4a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3053
-    },
-    {
-      "fingerprint": "330f803093202a2bc33bb35db8a50ccbb0687487d2cd2622cf064da5c45a4211",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3059
-    },
-    {
-      "fingerprint": "b5d72438221535d97ec97b15af7b4f6f48ddb32a87341da4bb8e5aaee454fd37",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3086
-    },
-    {
-      "fingerprint": "01baea3a50bb2f79a5dc3d44853737457d094ced6af302c0d75fa406a2eac394",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3087
-    },
-    {
-      "fingerprint": "1052c906b4f635b77e744e78b83528002ae2a43694a1d187f6a4d8ab2c2dfb98",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3089
-    },
-    {
-      "fingerprint": "cd55649a3315f906890fffd34f8fbe0253db507c4a84da48face5df609afabf8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3091
-    },
-    {
-      "fingerprint": "68e5ada28cf1e64870c1d31237dd88f9ade37bb2fc157e65c6535aa715a06417",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3097
-    },
-    {
-      "fingerprint": "5fdee20b8a96df9af7c25ca45fcaa62463bd736675ffd5f39b5c7f2c50d9e4ea",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3103
-    },
-    {
-      "fingerprint": "2d26f96bd01ebd4969849d3cd54ace3d49300fa7fe824a03fe514dae854b88d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3136
-    },
-    {
-      "fingerprint": "3debdd44f94814aea78477ef7816e26bf1cb7550cc346205d4cc6a417b304ab5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3137
-    },
-    {
-      "fingerprint": "33ba0095ea24426ecc91bd7f8f8185a31a5f6e160ff075510d02fe002b93d003",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3138
-    },
-    {
-      "fingerprint": "ba7609981ad8efc7c467009de539d7d0d433c3269cc8a1cd74e18de1e9a3eecb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3146
-    },
-    {
-      "fingerprint": "9bd2441fa847ba949e5665fcc548ab9a2686d024aa57792b86bd70ec04e50722",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3166
-    },
-    {
-      "fingerprint": "3b461b21bb603a834860975feeed25defe7f35776e9decb0bc83998f7035bed4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3167
-    },
-    {
-      "fingerprint": "445d10c92f9ed80da6a5d04e5eb1516d6b5de9e8630f5128d06597ab67ab76d8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3169
-    },
-    {
-      "fingerprint": "a01a5c841ff4f0769cd755671fe12d89292bc574a78f2c4f860a7fa8e22f9cd4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3170
-    },
-    {
-      "fingerprint": "fa1f847b3fa7a22b962a13bbd51a175a51f14e963b58bb52b84ca9b4aad31824",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3178
-    },
-    {
-      "fingerprint": "cfd4ef79a6a8c78a41158efe3b914877a71fa38f2fbaeb6ae6c6ae9411c35913",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3204
-    },
-    {
-      "fingerprint": "f78587dbe129cc8169edb0bf6398321cd3ceff2481279d11ee865e1c4467369b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3206
-    },
-    {
-      "fingerprint": "81af80e2198b10a7314741808cc729e56af8f27fe1b0cc2ac6d73b17831fa225",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3212
-    },
-    {
-      "fingerprint": "b1ed8c7f0a261961e0daa181e6b4479e25ab2c469c050b9fc3e8fe179e9b574b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3213
-    },
-    {
-      "fingerprint": "e981cc98710c01831444962f1e625e80f9fe24006d8caf571057e326f9f2a19a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3231
-    },
-    {
-      "fingerprint": "92806e050013cff8d6f7cdb40d0069e24613977940b23517eac9f03ab9e2fac0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3233
-    },
-    {
-      "fingerprint": "4a232a6ba91fc0d0fbb750a4cc6dad89826d40fd49b6ab2c8bd6200bc83b816a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3236
-    },
-    {
-      "fingerprint": "3af34d9284bb1756dfa34c7a19442fa3c5357c10fc076db50399bb4f06b2acf5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3237
-    },
-    {
-      "fingerprint": "f253fb324aef91dbd375b62981d1ac14f215eda8f6aa6a19ccbe7b05232f930d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3255
-    },
-    {
-      "fingerprint": "67b9aac538f194611e08d598a4bb5394eaaef42287ebd336d71ebd7fd2f80718",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3257
-    },
-    {
-      "fingerprint": "df7ae2c8fcdbe6884be2f2c238c7d7c243df3969415cd9f5d3bd23c5fb7008b9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3263
-    },
-    {
-      "fingerprint": "363b080d14e32f4fc7aa8103dcfcc3bd65b64b6fafcc45f7afd4a3aa56ad1677",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3264
-    },
-    {
-      "fingerprint": "48f2e83a95e0eece561978b9ca3c3e615d6659a3e29d4af3839b84e991d07305",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3280
-    },
-    {
-      "fingerprint": "1611bc8aa14322dedb19b173c1c18f0c91a610fef2aac0db6ff7cce527a154c9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3282
-    },
-    {
-      "fingerprint": "a83f703ba2d78e91b8e2f5206ab1a775090a0bfe50a55d8f44cd13d66b4f1add",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3288
-    },
-    {
-      "fingerprint": "b4ff7e4e7e103929d415614c621bd833beac976eb5d4a45731416a3c374a0363",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3289
-    },
-    {
-      "fingerprint": "cdfba43214bd62e8ad099a9c2a2ae03f68a0a6da71397e66cc76ec8692321402",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3304
-    },
-    {
-      "fingerprint": "fcc438193ede10113c239f9262955bd111253ba23304d517c079a3bf09d8a989",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3306
-    },
-    {
-      "fingerprint": "f28b9341ede9308225a10e1b7f3fb64ff6bba66e64054f9bbc1003a696f622a0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3312
-    },
-    {
-      "fingerprint": "0f6fcbe5f0a0a3869bba235da6847022865330c6e9c7755377dfb654cbeb9958",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3313
-    },
-    {
-      "fingerprint": "c35f4e637d85c018d6f4b96a15289d694c302bc7e1c7927aa7439ddb0bee946e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3333
-    },
-    {
-      "fingerprint": "1a3fd5b19ee01bd4d49bd5dffe786c39d21269265af183d11f5ea1724c39e460",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3339
-    },
-    {
-      "fingerprint": "094601be6bb7ac8b0a4d1c1bd4360cf7d0b15ee4b03d198082ee3647bf862335",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3362
-    },
-    {
-      "fingerprint": "e68de81b6493b59e22ad4ac36f02ffddc3a3134cf9233d9d8ab11f60a56158f5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3381
-    },
-    {
-      "fingerprint": "710a04b08c2630bc096af3a92df80e1d2b9fa3d8531ec48c43306d1b5e67b8d9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3404
-    },
-    {
-      "fingerprint": "008bd07c3f4c13ceb7f181bc238b10ef0de3fdc8a04f6cebb23ab1a89ecaede8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3435
-    },
-    {
-      "fingerprint": "b326eae20922ffdef28101f84e1b49000e4f8a4e9cb585b1c9a0e022d49dddf6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3460
-    },
-    {
-      "fingerprint": "98231eb2a37ca4736942b04e002c50cb8eb879a6133490a8e87297cf4e15a4d8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3484
-    },
-    {
-      "fingerprint": "ac071f27a60db68c5eb30cf3efd756cf829cbfdf32d6f54664e16a9e6fdc7f7a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3495
-    },
-    {
-      "fingerprint": "df66580a5725a45aa2371e607211e51a57f09c20dbb66f65ba8b9102c1c6e955",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3516
-    },
-    {
-      "fingerprint": "4993b2920c75d1548a313b49b23dad7e87af2211ac33a7cba31e2a1a9a3ddea4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3524
-    },
-    {
-      "fingerprint": "f4623c0e9dee7ef9236b7f34ed031973847942d844dcc4ec4ec0646650e21b50",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3539
-    },
-    {
-      "fingerprint": "9a1b9a99833497aae5024a0db5b608c4f26d227b9165a0acb787a3f477ed1908",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3549
-    },
-    {
-      "fingerprint": "d91ed6d472c41292bfcb9b64f5c7d4c31612c5407e50de7647e61a5b8217ec6f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3568
-    },
-    {
-      "fingerprint": "e3934b4c62a5f2598ea1bf8f11075f57dad1f1c87a27a570807b72481651ab48",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3579
-    },
-    {
-      "fingerprint": "f2548b875e2ca16605ff6a752ce9a7970e06982ce661419583c02e14cc58d91e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3596
-    },
-    {
-      "fingerprint": "f78494b6f53172155c79c0aa2b03f6ea54255e22117e910820f5c18f0a0e9ccb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3603
-    },
-    {
-      "fingerprint": "31fe4c1bf0b7b2288ee123c710af45707bd0dfdfcd47c95ed8cf3dc5de768932",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3606
-    },
-    {
-      "fingerprint": "bbfa6349d3c3ba1ed6176af2f538aebb111acc6c2102d92aae4d7e6728898b6b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3609
-    },
-    {
-      "fingerprint": "298dd020f0c70c1dcdda39428f1994c1395844aa7a57079c12a1bf84259f3827",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3660
-    },
-    {
-      "fingerprint": "8f28731a1fb2fab175f22bec9360fce19c09ab638178336891082998e16b7d2e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3666
-    },
-    {
-      "fingerprint": "837b5f095851d37d4bf5d4c5374a886e6d4ac5202508e11e239c4b427e5afe21",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3689
-    },
-    {
-      "fingerprint": "2d5173095597dcfb915665b8393d45992805b29532db362eea391a58e3b15cee",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3692
-    },
-    {
-      "fingerprint": "20320a6d6bbe92ece399b9674063a7a9e8d55616e17f655c891153e40238963e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3695
-    },
-    {
-      "fingerprint": "a34dc8f088fdd46e46d95144d915273ad8f28938309289ba9915a41cd32e518b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3714
-    },
-    {
-      "fingerprint": "9d902a7dbe2685a77600954e2945f6f4620cf2ecd2caa1a3c348aaa53f967933",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3718
-    },
-    {
-      "fingerprint": "3c6913cfb96f652d82a7c3906cf87bcbaf227bea5adb2751219c4cb274c5c71e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3721
-    },
-    {
-      "fingerprint": "ac8c1fd464df0d380c9ca547eb25890db2c67c897da6f20e0f4d78fa2b4592c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3725
-    },
-    {
-      "fingerprint": "286cfc776bba364c80c456dd41060f24152988c02b7f1d920e66789b8372d97c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3736
-    },
-    {
-      "fingerprint": "9c39860a3b9da8b07f3b924278740f1434ae9ab2668fce7aeeb49bed1130cbe8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3739
-    },
-    {
-      "fingerprint": "1d026d2bed36cfc3d7671c6f8d41bbc959dce6f54724f56811d1364a8d5adb0b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3743
-    },
-    {
-      "fingerprint": "29b6713e5513139b5623ae7fc8c8e94a5fdec28680cea62c9e2c10cc52eef4d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3761
-    },
-    {
-      "fingerprint": "e964514afbc7b8b2984df78b8afcc64f07e557ed0bdf6ec73d6fcfaf4287a58f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3774
-    },
-    {
-      "fingerprint": "9a040e4cff1116d3e37cf9f79ef41fa63b5986bbae2c807550bfdf50064b820d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3777
-    },
-    {
-      "fingerprint": "bc3780d4b39a112ebfbf9ef22e58ce158fb0be9420abebd9d9e5f6d57ed4faf2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3780
-    },
-    {
-      "fingerprint": "656b10b1c83f4c3b3f5aa6881ba0fc887759677b38b15dd5a6db912e8b630e31",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3790
-    },
-    {
-      "fingerprint": "b9b450fb334c9b8c2f665ddf23cf766d5d222560bcac0618cc9fc75fdcc9ef22",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3805
-    },
-    {
-      "fingerprint": "40e9e483e50fcb86fc9ed716610cc3d16f00d4ca742a74e2b4779e2721300e6b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3809
-    },
-    {
-      "fingerprint": "2f1d6e185c7da713164511658d28531f429208c608d0a39b683e7bfee0cc72a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3814
-    },
-    {
-      "fingerprint": "af9dc2e2fab9f234935f5c1cbfabefcea481f012cda0e2b9c2098b509a395ff6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3839
-    },
-    {
-      "fingerprint": "99fea42e9681fa5b358697ddbdb44e26bff1001308e156c1342830d7e6029461",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3842
-    },
-    {
-      "fingerprint": "3f4153cf1f9a04ff0c22c27cce0a3e5fdc455e35b4256d7cd27bd09b5b27e176",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3842
-    },
-    {
-      "fingerprint": "b9b7cb3ccd326b64a810d941076d187e58801306c137e32e13a319b5f0484865",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3844
-    },
-    {
-      "fingerprint": "b84bed35202adbd9c62dbe155bbb152f5ddbb830c17ac51541d60fe876427e06",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3846
-    },
-    {
-      "fingerprint": "34a58f7a03dfa68a8832fe4a7674c7b5f48b733012bf66e73dabac47ee801329",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3850
-    },
-    {
-      "fingerprint": "c0510a19c52ec02038dd65c035f8cc8e60082a798661e4d8c6a90055c2d22f90",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3851
-    },
-    {
-      "fingerprint": "d860c29897617a7fc762534020ab31a756f03241e38f93d0efddcc2e3dc1f0db",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3869
-    },
-    {
-      "fingerprint": "17eb282fa5429c282dbbf3080c3e96f1ab3d58f2d181f568f071dea125bde25c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3872
-    },
-    {
-      "fingerprint": "775b95d938cc51c0d30053da392fa0a08cc54a27b5eae844e79aa4d17a774474",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3877
-    },
-    {
-      "fingerprint": "22dcd433e980364f0257eb917da581b184a3e3d949bc2334e755975e00875ca1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3906
-    },
-    {
-      "fingerprint": "191de52185ee7c3333dfc4b83acc2f16c5f035b84fb7e5adfde3d54f5471d9ae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3915
-    },
-    {
-      "fingerprint": "98a1b89e070c26a3c0af16ace43680b9815adf06e858c8dc68ff9ddcaf0b4fd6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3920
-    },
-    {
-      "fingerprint": "d35b693666adfecf6edcb7c281ba69a5153ab40b837b55312613027d2785f8a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3943
-    },
-    {
-      "fingerprint": "dfbcaa4e02fa89ec6147269e3ea51503911cde6650b83a2eec6ea04633bbbef0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3968
-    },
-    {
-      "fingerprint": "61ec5982d12257e029dcdc5c558ff1fd6bcfd8fefad5b2747b0be0ca47120b2f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 3988
-    },
-    {
-      "fingerprint": "646cf7b689f618084fb74a0083de88a40c77da426059b1ddf04f82d97ef9b393",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4052
-    },
-    {
-      "fingerprint": "25de96c46211660db213beae15d28d782cd8c7535b7bffe78b31b38ff887a0d9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4106
-    },
-    {
-      "fingerprint": "56ea26d058d93afd340d0213f9d0e845eb8045ac8e44773e264287ab640d2748",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4112
-    },
-    {
-      "fingerprint": "a860e85de28bf8a067baf1debbb11c1f87e1ba7b80a8ee40a19078c7117311e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4114
-    },
-    {
-      "fingerprint": "1e7adc338666d9fc141f7c410ea7819f32635bc8df395729106d0fa8ab392940",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4135
-    },
-    {
-      "fingerprint": "4d6d545dd1ef618bf07d5084c6962d04e7e61821137c753e3710c1bfaf86ab0a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4152
-    },
-    {
-      "fingerprint": "af86fd721f2dd255e6e158ba367fbecbfd9d0d60e1de94339895527c3fd28d38",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4170
-    },
-    {
-      "fingerprint": "7b0d4b5b17e2cc77c3c1651aacd89c23ff2ea73ac38c98929de1be35dff4173c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4173
-    },
-    {
-      "fingerprint": "7be60f901c8536fd1a77b1f3398b501e18284b67aed20f9290fea9739ee1fd4f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4191
-    },
-    {
-      "fingerprint": "bdb7f3c9dba637e64f9f66731bae309565ae9abcbd4949ead514eda0b2ee22bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4199
-    },
-    {
-      "fingerprint": "d35ebe146716c19080b5710a1c943ee0014cea61f51dfff08e5fc80ad70b97fa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4215
-    },
-    {
-      "fingerprint": "9018a43d93b0aaf21c467d81ad32aae188d05c6b83e123892959aeabf3c1ff46",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4223
-    },
-    {
-      "fingerprint": "81f8ad81756e99578ca8d8c25fe5f4b93ce07ef611cf2b49379a5b63fd0d31c9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4239
-    },
-    {
-      "fingerprint": "caaebc696a18d0cb041615745a15c12e18ac4b00fdfce4532c138de47357dd2e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4247
-    },
-    {
-      "fingerprint": "b6a2c1ffa082c9f9cac3b7f5e99d95f5c6800d0aeceab946c3dc88b39a74b5ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4270
-    },
-    {
-      "fingerprint": "59e6eeb6c9f52ef7b344011d65a9908e8877f9907564954ea9696ddbcb5d6bd7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4284
-    },
-    {
-      "fingerprint": "09e8125852b97539ac41cdf588af9daacf87cb7b552eb52a3141d37037a9892d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4287
-    },
-    {
-      "fingerprint": "d40564f300a1321f1767326546d4fb5115e12545fe1869aaf9454e4e5409e872",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4324
-    },
-    {
-      "fingerprint": "adf62deaa574cb3eb37f11739ce593a26b3fbd4e702105c4077219c9cb86ed19",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4325
-    },
-    {
-      "fingerprint": "7e0bd12f53953796a9aaf562f0c94cbca3fb89aaad87c569acacba3540a6ae86",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4364
-    },
-    {
-      "fingerprint": "60dc73da4875283e5a04af0c8f90f7e3cc79120a10d2fdb682b7243f5810ec06",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4376
-    },
-    {
-      "fingerprint": "be80ab6f44038d1f354a8362867382fae0970080cddfe437cb45c0937015d455",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4598
-    },
-    {
-      "fingerprint": "5216cc80aded366e30a0299bdc36f38e745c3a7746709004fd4f1dbb832dd145",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4610
-    },
-    {
-      "fingerprint": "798dee85dffeabe260f5d9f42081456457f1d46ff729bb01c959bd09c983c5d0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4620
-    },
-    {
-      "fingerprint": "e7849680ae504a123b3be1f1e001e07dd9daef6cd4b8ac3ac5e02516755333cc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4645
-    },
-    {
-      "fingerprint": "6805fbaa67f2cf1fb356ff106a75e3408ac2afc6133ffa5b4755663490061d7b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4671
-    },
-    {
-      "fingerprint": "5c99d74d86cb85e12e25b423611bdb01fbbcffbd44972ca896cf6c382b7d6f00",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/integration.rs",
-      "line": 4679
-    },
-    {
-      "fingerprint": "59d341ae47be68f25ae0d729b270ec9567a560c87e13b6f67657574ddcf726df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "535fdc154a09990c86761ab66804604926c6f5110ab8779692e6d8908e0d939b",
+      "fingerprint": "84653aa0252a77405aad04126f06f7905e8f28fcb8963105d9a08c6b3e330558",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 27
+      "file": "src/app.rs",
+      "line": 111
     },
     {
-      "fingerprint": "742614983ecd70b79f2d6b2c12b2d1fb727d5a711234c8c6e3fe3aa774fd6ca5",
+      "fingerprint": "684d78c07dea861e241f278f81e8c427ef3a8f1c0361bc097260d35803bfb147",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 27
+      "file": "src/app.rs",
+      "line": 114
     },
     {
-      "fingerprint": "645e0be563698af948085e112964dd875113f36436382a1424780ad1305ec6f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "cd070c1b8d685d13de1c84a91a3f038bfe39e49fd9a482c8f9c5d49dee0afbea",
+      "fingerprint": "0f2bdcbd437cc812046faf62670bf1fdbf2f0bf92feaf464f01ea37b60310265",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "34c7902b81112d09009a483e7e178773f8934b2b372e47da7e4b10b1932ed5a3",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 31
-    },
-    {
-      "fingerprint": "43f7fa98f4fb79badb2dfcaa1181d90ee7ef62886f7e4a985cb3bb0dc3f42ddc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "96ea0c916d5c04cbbf1d0dc25e95f9badb2a0b32e4663f0d7b4812a6ae2edc01",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "56870efd365e202b4df35beea439c2fd98fa1b35b88da6988fd13978bc93a376",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "ae50a10852ab28d10d119ae06f0004c0263ee24f4fd5262354b1d4137aee9339",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "f0fca478436c8ad22be18e546c28c82d1f2e58b3913b7a3d31acdd14c933d596",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 302
-    },
-    {
-      "fingerprint": "e2fbc35136c92914b708354380aa9a97d8bad2f760eeb42141e8edd8ea5905a6",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 309
-    },
-    {
-      "fingerprint": "ed84362810b15241412958330ec1b2640b54bb90c42dfe588edfa8ab7c64e2c7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 309
-    },
-    {
-      "fingerprint": "f0097937a0c1b452146d49edbd69ffd8de824c956319d157bd9f4d89c3565511",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 315
-    },
-    {
-      "fingerprint": "c6a9a6f157fc8c5fd37b53a51a51c824c47714048c50e1ae494377199064691f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/kernel_dirty_frag.rs",
-      "line": 323
-    },
-    {
-      "fingerprint": "e911a98373c91bac64557749ad6b20e83aea957846d7f98e93903ead6257ccc5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 6
-    },
-    {
-      "fingerprint": "0aaec3a1e8f7bdf9d988debd56eaf5d55ba15a3168c408f204448e8d1911a6a6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 7
-    },
-    {
-      "fingerprint": "552ed5e37c0c6b2c828e54fc0557de05bac5925df37e0c08279e45a8aa94d00d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 8
-    },
-    {
-      "fingerprint": "17e990a2cce34cccbc0c4c18185c4ec2de1247d53b771a618247ebaf7984f9dd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 11
-    },
-    {
-      "fingerprint": "c45fe349f388d2c573d02f5b91d642341fe54468261c6fcf7aaebc366c2dc618",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 12
-    },
-    {
-      "fingerprint": "e9210cfc3b2b215afd9bd86738c6a0751c461c7e331fdc2db4ded79ad9892f54",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 16
-    },
-    {
-      "fingerprint": "86de3783e6ae51bd5b3141c2c731ba58719fa1b570d53ed31a8abcf7cec33b98",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "7be52fc9175041aea127006d2f0e0ffd88edaf7b80fc848f9ff3fda10fb351e4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "40577488ec8557ef68b9b41cd5ef0d8da5b6cc414f72618a6425d3d88810272a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "bb18c813f4f6084b9d9e9900eb6e7979a08c07e65117e289ebd5ff2fbd2c8aa3",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/mcp_server.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "1ee5f80607a93456e7fe7b0b8d9558ca040173caffee449c9740b861cd5d1355",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "181d9acb16d6d79f0312548e3988ea941b1497085f655b008358f4b0d5d5dd96",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 37
-    },
-    {
-      "fingerprint": "7c69568c3a70fec7d0f46eaf4d3b3d5beef33ea48d4c71987f4fa29e30faf8f9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 38
-    },
-    {
-      "fingerprint": "a8ab1ec165de5b7d879dc4274549bacce37507e1c391d8e96ed7f467b74242e8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "ace9e0de409f2cec19834cc139fd1b9a2a7d432afbc8ac4ad33d41c692c3cdc1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "e382bab26719cb7abfc0dbed310a18ad4c7a5fa6b8f3c13f7d94635a665bb32e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "./tests/mcp_server.rs",
-      "line": 101
-    },
-    {
-      "fingerprint": "f1affc21b0a9bc0122ecc67380e932ca65d50b073726ee74b91df5862d6b36a1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 101
-    },
-    {
-      "fingerprint": "6e6f1d0f73ad1cce46c759bebd591b3f82543f218dda24fd293d9af3746e55d1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
+      "file": "src/app.rs",
       "line": 123
     },
     {
-      "fingerprint": "b9852e9f14262ca6732d53dd76e7b74f2a1e090ed95e4e177ff833f153b19463",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "306f441deaf6990385aed4976b2e0744ba56a17083f35411db37afc0d4e69f54",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "21d4b625db31f88605d480f0fcc0de1a518f2b348374d555518580f290466208",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 131
-    },
-    {
-      "fingerprint": "5e267a96c9932b0143a86490a0ecb9ea9761e842f9a05b574b14858158febe70",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/mcp_server.rs",
-      "line": 169
-    },
-    {
-      "fingerprint": "0a590bac30c65045e08e290568fb9294f6ad51f65b6d3fb753b4bd0354b58f27",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 169
-    },
-    {
-      "fingerprint": "f5e9e14ff12e50f044827d03eec0f7353474e1fb585da3e57575d21f69faf190",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "dcaefadd7bfdc8c465dd1f4354cc43253a98f8d4770e34a54b8fb71806df3c30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 177
-    },
-    {
-      "fingerprint": "1c2d888c87c6b585a46f55660f7cc152bff50bd253e082885087f75bab9a2099",
+      "fingerprint": "44dd312e5dd7edce894a22d56f8704ed8f7788f2695d32285a95a24482fe41bb",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/mcp_server.rs",
-      "line": 196
+      "file": "src/app.rs",
+      "line": 127
     },
     {
-      "fingerprint": "33057f76f04ad85dc02fd3edcab1affe37adb97d9b0fef68c20fd1d52d5e13ab",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 196
+      "fingerprint": "6d8c2db37617146d85042c2ecf129f77276c2b585764b75f542b12bbce9ef921",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 182
     },
     {
-      "fingerprint": "f120702f1bf70b2a45fada6f8d1a555dc0ca632de4646e37a2160827770302ae",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
+      "fingerprint": "ab006da558188cf1a9d8543b2b6f2e10805d944c47a48f840339d7f6621c1e98",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
       "line": 218
     },
     {
-      "fingerprint": "1d45ec9fe5d23a8d4f7f6c8bc753ef10c8cd2442f1b8477dc093e23f1a10f5d0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "c1baffdfe285212db641d876534a6489ab446f22e2f19382bed004d5fd242a82",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 219
-    },
-    {
-      "fingerprint": "b7f250156fbff74e361f9c584352b6dbae293864b997ce74d18f13f2a2c18252",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/mcp_server.rs",
-      "line": 229
-    },
-    {
-      "fingerprint": "c86a5b91506abddb44adcd2d5eb4346eee5883d8586d5c285bb427f0286515c8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 229
-    },
-    {
-      "fingerprint": "cd910faacb84b8f17fbea4739e4e3a46dfc8a55cc45e07f0cfc1d1a694673671",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 236
-    },
-    {
-      "fingerprint": "3a27bc880ace9b8b2c7f70df00c6532323fea47e991805f7cc0cbdff6061e227",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/mcp_server.rs",
-      "line": 237
-    },
-    {
-      "fingerprint": "da6167739ec31dd685732ea940d92dc068add08e26ae8b38f4175c7b6b245ffd",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/realistic_fixtures.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "ea1b8565d76f074c9bc7c5de1eb70988fa9bdff24fb00b4859b72d23d9152e1e",
+      "fingerprint": "c1887a9dbece5a94dfb3d274b27e939bc6848b868b8ca1a57a82c607c4c64a5f",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/realistic_fixtures.rs",
-      "line": 30
+      "file": "src/app.rs",
+      "line": 226
     },
     {
-      "fingerprint": "16118cfd00ebbabfa188e07db1edd4c34b88db12c3882d2ff5593cfdda05b073",
+      "fingerprint": "03b43728705f3614b1f3c6e231ce31a1aa0bcfb9722a52dd028bd52bd71628c0",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/realistic_fixtures.rs",
-      "line": 30
+      "file": "src/app.rs",
+      "line": 248
     },
     {
-      "fingerprint": "686bef2d69b093128594ecd6680b6874f6a843da7a918766e144032ceb5b9785",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/realistic_fixtures.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "9b0f4fd6a6ef1ad2c3c36ba2794677dd851d1a4e8db4f77004070b5954925f75",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/realistic_fixtures.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "6c09a468ee461508ad2e8550e259cfd5cc9d1322d42e130bcfdd4312126fe956",
+      "fingerprint": "1bcb211e9f8627cbc5aff8f58057783653a33a364f5b4c5a44f13beeed4b3efd",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/rule_inventory.rs",
-      "line": 14
+      "file": "src/app.rs",
+      "line": 295
     },
     {
-      "fingerprint": "d86b8eb73a80448edfbfef22b452a8528fe273a278981657bb02ded65aee175c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/rule_inventory.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "31980b1dd164b5f5406880018e506b0919818246e934654c3991b6ac683dab00",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/rule_inventory.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "65401b390401892e518d4a85119752dea453875fe7b6c460a3168f566ee2fd58",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/rule_inventory.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "523ef60f48fa5f279217dc42c93aea6bba8290f58f6f8d1488b49c7b1ff64350",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/rule_inventory.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "b1f86769e4dfe4f640a1220c27860f50901c31ddf8259f30e30505796f469a83",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_compat_bench.rs",
-      "line": 18
-    },
-    {
-      "fingerprint": "3fb278d510489b4f01f42ad47930e29074f262fe807e16e934cc51e1ea992404",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_compat_bench.rs",
-      "line": 19
-    },
-    {
-      "fingerprint": "d69f911c90acb3582f84850b4b14ba79d82b57e1dca981742b8cb4a52a1deb30",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_compat_bench.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "9da738ee524e70d7fba1d8b39f76b969faf13b1b8e8697fe9a2977990a191cb0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_compat_bench.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "c54622784b8207282f27211ddd927d34569cc2f121906ec11952c266ef1acb03",
+      "fingerprint": "826cacd22c6e8c3f6f18a53e45b9e1806a73a1ea3a84dec990ccd74652ff0d01",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 13
+      "file": "src/app.rs",
+      "line": 300
     },
     {
-      "fingerprint": "325a8bcda9d69f3b4d36f565873e0398b53e3d6a7a371bbf6528633621653a09",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "7a6ed60263c0b6f279ea510c54986014671b500f10673c3e55d99fbd6bb87bcb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 26
-    },
-    {
-      "fingerprint": "021e1b7e8d39027a7b84eee00bffb0226b450c9be0e2e73facb06a5cc4652bc4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 27
-    },
-    {
-      "fingerprint": "abcf29d53ea393a5bf0edd2d3e6146f46a72cc0dad61a50b58b50b698df3727b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "bc7b67ce9f85d63c5463e3a410a8b785a88de85c65b1e0245b29f68553f9c10c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "ae64d1b9e532208a9ec16aba81be5e551aec51c29bd2e017de5c3d4ceea7d9df",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "3ef755e3fba843ce3843e8a712e3fb7abc726d523842c662461e8079bad6356d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 56
-    },
-    {
-      "fingerprint": "122f26718d49dc5d320dc174dc708c0574f0e094a61fa42d20e92185093b382c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 60
-    },
-    {
-      "fingerprint": "2a5a1d44d219f6c7f84db2ab2dd8e3f4acbc5906dbf2fb84f237e59554565746",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "9384fdacbed6d09511f00c70bac768049cba3aa70c1ff8193f23007fa3e9fc0a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 76
-    },
-    {
-      "fingerprint": "3cd40dd99c7c09acea265572b6a843253f4914c6d2f4b8328cd2c775c2306a36",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "8a40f181d7b3d61ac1e32590cd90652221e73dc64f076e24a63019e688ab500b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "2dfc268d7d7b49469330b93e26c8d19939153e38c86634c3866fa49e5de63399",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 103
-    },
-    {
-      "fingerprint": "a8f18f921460120a2b673cbac0948575020a09699176a134db64999f988e40a3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 113
-    },
-    {
-      "fingerprint": "01c894ec817828aaabfe7c418f9b17e35d00e14c5619c2e47acdab3c3a21ff51",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "0c9105afae26d2bcd1d47179b331b6ee044c318ff907cc0efcb68293535103f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 126
-    },
-    {
-      "fingerprint": "779bf25e029c06953422ecb46ef45712bb5f330ba0d86b9aad9dbdfea0f7d79c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "6bc659818b159af7abbf4ec0f58525aa77fce4ce930bb3f3419182489915a053",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 128
-    },
-    {
-      "fingerprint": "8cba22217eef498ba9e88999566799a9a924e4ba171c1b4dfb524e58cae80cbd",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "971966926fcdffa0da9ebd699891bdd6597117966dd7154f8d6bf8cf853d5541",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 138
-    },
-    {
-      "fingerprint": "1299b6fbb6b81dd433edb4d1ada7d64189f74c9e68bafbc73aa97bad2d7a7101",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 152
-    },
-    {
-      "fingerprint": "729d225af5e454aa63d921b2ef8ee2d9653abbbb85640a13e2d31a72fcb92bfb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 153
-    },
-    {
-      "fingerprint": "677db1c684c7119d9d5c7bca071a9796d781971dc9801c16d1d70052ea38f1d8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 154
-    },
-    {
-      "fingerprint": "efefe909d683f7d6ffabfcfa31c43396f3bf44d5e88622b02efb71cfd895f30b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 163
-    },
-    {
-      "fingerprint": "2f1cbb0b2f4d1f1dfd6271199943d2227eab1813bc7d17455e75e337ef21d362",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 164
-    },
-    {
-      "fingerprint": "903152930d7d0f639806295da19e9fb36ec66ae5559af47ff7634c1fa7a3af0a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 181
-    },
-    {
-      "fingerprint": "dccf2c493cfdb894304baff834e1354d84e380d44b1b467cf4fd79121a560973",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 191
-    },
-    {
-      "fingerprint": "fa604130a27a1433a814d3ffecc0d12aa61d8e4f4d62a9ecf990e5c6fbce439a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 192
-    },
-    {
-      "fingerprint": "bee31e6fed34096f02d8ece509d7307e37b07903e6dc64e6b71297b2b3a1d3fe",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 208
-    },
-    {
-      "fingerprint": "82d0798e9bf1e0449e4e89f8ad87886b17957c219a21a92a49af572dc1d3dc1a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 210
-    },
-    {
-      "fingerprint": "8210d7fe285289f8a4ffb0ed7ddd022d855956d750a7c8da3546c9a802f60e9e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 223
-    },
-    {
-      "fingerprint": "8b3e8bced90c33693687c770f5aa7fb9d06cfd27786e195545256589228d2ee4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 224
-    },
-    {
-      "fingerprint": "27966e87cd9ce6b3b4f5e51b5d90e947e7cda3a0972f1d6930037e585c9ed01e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 241
-    },
-    {
-      "fingerprint": "895b5e3199a94adfee49e35e77d92c353accdff5194365be8513e7400972b3f1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_integration.rs",
-      "line": 242
-    },
-    {
-      "fingerprint": "93b397b6ba98daaaaf76e9348293ba0a97a9307155651aa10c28ae5f232d029a",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 15
-    },
-    {
-      "fingerprint": "3066caf3df6598bdcabde436caf345fa5147dd0a0c41a5a1f112cf5786b6dddf",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 23
-    },
-    {
-      "fingerprint": "f4fdeeec0b3a43449c6d38fd150d1358d04409a5e5e827f56e92c55ac771af16",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 33
-    },
-    {
-      "fingerprint": "2604aa9a1ba8f85012de990c7fb029b8cdfa5832722868af57bfebcfa59fd9b3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 35
-    },
-    {
-      "fingerprint": "487d800ac1268b7e79542c6336b1994fdaa2ae7827c8bc1eec46b878e5e9fce5",
+      "fingerprint": "d91a669c0868456b6adebd5c50a6af3350db5c04708c7439bf20548a31c86491",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 40
+      "file": "src/app.rs",
+      "line": 333
     },
     {
-      "fingerprint": "02c3727163ced0a426185062825a00bd893e461bf5e7b3219fa4fe3262837cf0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 54
-    },
-    {
-      "fingerprint": "2fc34a9063f3d72e420839989ba285f662138798285e7a5661a165e0162c3189",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 55
-    },
-    {
-      "fingerprint": "22a6880816845ad31267fb7e918d0cfb269ba54a59f3f83cf20c7b9d4c158bbc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 63
-    },
-    {
-      "fingerprint": "833b22af7775023dd3069317dc0e92744ed89ed435de54cf0f41a388b431e940",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 68
-    },
-    {
-      "fingerprint": "56e4014e523d852b192e7277cc378b5fa0c93387f7fd4e2d805a0c0bc5401012",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "94b499099be153de7d13423811a195945d3f123d90a1e90899259f4d3b771153",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 82
-    },
-    {
-      "fingerprint": "876d791af01a28c9ecaf36b1361803c1987b925db202ccea17909b29223bef5a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 83
-    },
-    {
-      "fingerprint": "afc24512dee0aafe7775cb0d7aa95065104e3e097a6fc462a7fb60cd619564e2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "60b5cc5532d1dae2bbf2ea7365fad08c8cf7cc206bb89557a0be47351f08bfd5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 96
-    },
-    {
-      "fingerprint": "1f10200583f8ebd68d490c1f87521246735b36ae305d0978ec4fb486108ebd44",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 99
-    },
-    {
-      "fingerprint": "e3d084d3c3faca29184ac6081c670a3d6d0037d43ef2a2eb03d548d66a145c18",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 110
-    },
-    {
-      "fingerprint": "cc630d42ae9343a4eb83fa517c78d24574c1bce266430235891c72e21e88d6a5",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 115
-    },
-    {
-      "fingerprint": "7a839fd33c7c2f600a9aac6854585d442b244bacbf529f20e670b5d625b99b54",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "847a62713d1b53886545057a173ba276ab983b147b0f59091b281c6ac940007f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 133
-    },
-    {
-      "fingerprint": "92fd5882cc4aaf6805badd6025cdd32349193c680323b88006f0234b064a4861",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "aac0cf3e8b3d3bb8dedec298f2384f1b132800c826be394a590fe19a8887ba91",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 176
-    },
-    {
-      "fingerprint": "7024c7fd69698221cfdabf23a71612b8781a29e0cded843e9498b17263203d13",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 206
-    },
-    {
-      "fingerprint": "c6fa816cff84e2e8e9baaa992324649a259b4fd8841bd6f6eca40ec1fe50ffa3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 238
-    },
-    {
-      "fingerprint": "e06928c33b756998fdf94b9351959b8c8e2dee325155f1fa52f9d78d136da330",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 270
-    },
-    {
-      "fingerprint": "346da5551947ad4a478b376ffbe297ffba512ac19c72ce013266f7228a45ef89",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 302
-    },
-    {
-      "fingerprint": "57ae59f98c0d4d730c58a42c03e48e184b75277d58914e511010f426712185c6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity.rs",
-      "line": 331
-    },
-    {
-      "fingerprint": "e6c4edbe46b45ec98c41c5454bf1f5cf54ff833a5289da9dfbaa877b489eb566",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "bcbba87f56300da7fd91cd15ad2b491c45cc14bae846bec37202bd82e0a1b887",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 40
-    },
-    {
-      "fingerprint": "b3042ff42959df092d79fee5bb9b4c75634383f44c69394ff6527ce8146ad53e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 50
-    },
-    {
-      "fingerprint": "8f018877587685d470a3d6a18e7780bbba1a91499b305612377b2241487926e9",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 52
-    },
-    {
-      "fingerprint": "420b5bc108afca25915d0258483182fda4f9dc2adc354bb8cec2bb104c17c9b6",
+      "fingerprint": "4e62817f3242080ad6c309a486a3ff2d73cf2b342d7f6c8441d2abb0fa401620",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 57
+      "file": "src/app.rs",
+      "line": 334
     },
     {
-      "fingerprint": "8d0caa32d20622ab5ef53f24aca331a754820f50e2d9edc1a8dff08394e92924",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 71
-    },
-    {
-      "fingerprint": "1b9ffaa3eca34f172eff75af842fc00d5e55846c4c059796d2a2ab4f41072b36",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "ad53b109e5acbc5bea3a1e9a31c66f6d16ed77e8cfe51ab103cf08031228475c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "a26e3e99abe4fa02f90accadaa09bc9200ef4c38b19e2aacffca683e3115bc63",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 85
-    },
-    {
-      "fingerprint": "61f59acd6adfb1c2b2c75628db878c58ff0ac79c565ee8495d552c8a74c45a52",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 88
-    },
-    {
-      "fingerprint": "7c38ab0c67e4d2afb16fb421ae5f85285fec058f12356b0aedeb65e093b87972",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 99
-    },
-    {
-      "fingerprint": "4e76e40ca0489b7108e79a938463832e9b7fca8250aedf1089f031c3c03d6c7e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "48f8b4b446f8a79b644a57c7bc9286eedd0ceb1b3109ac8fb38924c23f97c8eb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 108
-    },
-    {
-      "fingerprint": "794f1ed690f75907a0097bc4d59f4279b721ce5d15951e08a03bb3ca0615f4f7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 113
-    },
-    {
-      "fingerprint": "235cb9bf4b937d6c9925af4dd4c8da6ad97a5f6cb24c920407f1eba2348a672f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 116
-    },
-    {
-      "fingerprint": "6070e22f28dcf0af7826a8507e2a23eb0720b9afb90de10ec97fe12cd5e8df99",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 127
-    },
-    {
-      "fingerprint": "e728eba5a3e60f687adb8886d6fb55f0f94124e1741bb14245fba5ad1a9c606c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "2efa2f5625b137d3d0d078d7d5ddaccf2bc43552a079915de676f03353f0ec30",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "1d954120ab7e8f76db67653213b5519ce5345031d028be7389242d043d2dc47b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 150
-    },
-    {
-      "fingerprint": "124131026763035308f5958c825cdb67ca75c271cc761f9d7a5aeb8da2d86921",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 154
-    },
-    {
-      "fingerprint": "59b158550f2b3b4053c43ecbe63c045aea96cc46ee25ca064e45b315ead6bb2d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 195
-    },
-    {
-      "fingerprint": "af938ab20c18fbff763adcded5aa7e4dab44a65317d46e92ee31e8a7cdc137b3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 228
-    },
-    {
-      "fingerprint": "5cb1c964b321829aa4fb2a70feaf59a308ec3216fb22955343c3a1053ab2af3a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 263
-    },
-    {
-      "fingerprint": "f3069651c148b4fb017838c87aff92828d6f98f23bfa991f393ee96b2b54600d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 298
-    },
-    {
-      "fingerprint": "efa8d099bcb88c2cf02d0042a755482d0a2502f284dfadf5a72860361a49ff02",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 332
-    },
-    {
-      "fingerprint": "b88680a65bd975c28ede23786a7f581b01e89b1ac674a7c3491a8fa4afd88ba4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_go.rs",
-      "line": 365
-    },
-    {
-      "fingerprint": "62c0e46c6d15fad10df4adb8c6c6fc83e11be06237e5a72c4ccb71d5cfb80ef5",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 43
-    },
-    {
-      "fingerprint": "8c8f55f99526485815e662ebf764c6239e62b688e921193d969c4b0d86e8fb5f",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 57
-    },
-    {
-      "fingerprint": "b51f7b2b48b0cf3d66af21da2343c81636f7dc30466c03f9e4c5d626820fe67e",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 75
-    },
-    {
-      "fingerprint": "cce2def494e5b0971690690e9233a96f50813ec2597fa94a5d925159e5845776",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "0b3906b4e99d2d35394805f1c7451b1e22ff89b68416ad03ceef79745dde03f4",
+      "fingerprint": "3c6fde26b50a94bd23807c61d20e1a6e778bd3c91059d47cec40cef650e91f48",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 82
+      "file": "src/app.rs",
+      "line": 337
     },
     {
-      "fingerprint": "a472ad7ee543f085a6b31c076d3aac956449881796cd1af9450f8549bedb52ad",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 96
-    },
-    {
-      "fingerprint": "ff017700055ff18f7c09b0445db01080c193b3bd3387c00925935fe3b4c6b449",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 97
-    },
-    {
-      "fingerprint": "31a0bcdd53c65e42eac6296de9f04018471d6f463a1c411536ed0cf22fac4b7d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 104
-    },
-    {
-      "fingerprint": "ba08c7d6258b4d9d2574dc52f7c4d409278c3f42a2c0041d62705d9dff326c8b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 109
-    },
-    {
-      "fingerprint": "5a4d43788670595f70071bd8f74991b1b774ebbf639faa69db1197b3d03c748f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 114
-    },
-    {
-      "fingerprint": "d8dc388b0782b56cc3583b9dd985936c710803aa5469f17c6827263f38163085",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 124
-    },
-    {
-      "fingerprint": "d13c4e8f744b7e6415ab78f98499dc2988b65cf97e42d177388546c7bd752b85",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 125
-    },
-    {
-      "fingerprint": "e0dd1fc440b756156272f7d85ec8b946fd0545bd54bde35f3b11d79c24d483c6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 132
-    },
-    {
-      "fingerprint": "91ffeacefb5e400c8040ddd9b5769a5d990feaec57c0098a0419f36e7412d72c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 137
-    },
-    {
-      "fingerprint": "28b05ae50b9733c62ac6e9ac7f4d1a58dff69bbf433c33eee3a4c75af79fbb55",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "44bb3134d32c900170f4500c80d6dc77004e10e030d0c6885a1b87c7c1facce6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 155
-    },
-    {
-      "fingerprint": "ea141b3c1c60d0444ce5454ce1abf81d46dab0d6bf336a8c9b109e21d4dfd3c2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 157
-    },
-    {
-      "fingerprint": "312612d65a6f7824ac8f0662b4d912cec69b25596eaead47405c842e3556118d",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 184
-    },
-    {
-      "fingerprint": "b224a6d5ec1df785eb771e09a73dbffd7006612be4528f38040da849b1f3fca2",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 184
-    },
-    {
-      "fingerprint": "1291a1d6abeafeb50cadc4ac70d67fbc8037cf916373172f171f9b7c8be25713",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 187
-    },
-    {
-      "fingerprint": "6f200f66fb83193fbe3664375e755eda2ad9029b388823f1983d902a85cbb6ce",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 190
-    },
-    {
-      "fingerprint": "c6f730fe3ea4db4066d84110d81c2143569c8f13e16ac5ea48eef4774d2b1ec1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 225
-    },
-    {
-      "fingerprint": "44781015e15889d8077c6029bcccdd2f0dbc7273a6b74352ad65efcddce23e12",
+      "fingerprint": "93cc4bd12e64915eb4216761bfdfb7a53992fb75ba9280893bb5e001318390bc",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 318
+      "file": "src/app.rs",
+      "line": 368
     },
     {
-      "fingerprint": "e4f1091efd3019c1ef9418be51ef6d0bad631013c2a75765f9337531c9901653",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 324
-    },
-    {
-      "fingerprint": "f3c283e9bac8ade691c33e96efaed7fe04991ef92c170c7816a78d80f44d22f3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_inverse.rs",
-      "line": 392
-    },
-    {
-      "fingerprint": "7089e6886a1d26475514fbedab6a9ed1a7cc012eebb95c745bf314b7a2317b23",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "6750a6501f8720b63295574b8d83917c7747b4433cb3c8d9f82e61c167eb4138",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "4f200ba74980069092f76196578fb6f358b9dec58e44244bbd6f5d64125b7e3b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "6ef49f3de128e265f900440eb56feb5dcd7cd7d3ef27e338f524e662593d5df6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "d84611e7d6efdffe6897e424d312b8642bceba15d5f13340b7a8aa6845b6dd93",
+      "fingerprint": "326d3d2ffc0ff94b405373704246239a79cd267e4ed7679fac1e3e66fbb1301f",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 49
+      "file": "src/app.rs",
+      "line": 373
     },
     {
-      "fingerprint": "e9e39b31cbe03b90c7042f821350452424425331580258c7876135c9373ffab8",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 63
-    },
-    {
-      "fingerprint": "8b8b7c31b706aa4ab6cb5870c35c8914c28ed32a61a5173d34a260f97e446814",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 64
-    },
-    {
-      "fingerprint": "dd7268158e4dc56ea5809c81974c476a732ff5a18838f82c93b0f7b99e030ed7",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 72
-    },
-    {
-      "fingerprint": "9459207195a454eac2c9e466b8f047dcdde027669b2862bbc74b665cffb6f757",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "08d98fe70b48dc915ff4561cad764878f8816c96b1a9ee32571733f3f8c748bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "09bf79176bb27e4440a4673347264b705ba8e5eed115ffee55cbfb9bce0e8a95",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "d411da686282df5b843791ccdbb90df10ada875d1bb4bcae0fdc18e9f8088256",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 92
-    },
-    {
-      "fingerprint": "90c2266238b4b29d0a0f7d56176f5677929dbdcf597d577da20b7f8bd57e0583",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "ee8213e66265bdf26259f73f87b033a02193b5b4f452baa72c4cc250b3001475",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 105
-    },
-    {
-      "fingerprint": "3856aba1d154d16eaec48c6c75a0b44b1da4bc80fbb8aa93f2b7f623433ad931",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 108
-    },
-    {
-      "fingerprint": "4491f56b52df6a53f0a47f3b6932f6bcdb745efef121d8429a20a0fab68f79d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 119
-    },
-    {
-      "fingerprint": "3ec9bca8488f81afbf077a74a9dc5e1b97f72b4862b33360da1fd070ec22c7d6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 124
-    },
-    {
-      "fingerprint": "beb0d0ac8578717ad04bc9e78658eb0f316c3946ccb5d2b9c290a965a1a77ad3",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "a3f9476238e143d7a8bf82510d718e2efe55db683d5fa95d48b8efbdab5c1fe6",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "f56d2fb9b278568e18461125817838ba8dd56dfe1f071fa2e80ba6b27a22716b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 146
-    },
-    {
-      "fingerprint": "c63dd3d1e49cd2f09735445c955d54339bfdce323f09d10bdc6294e7f8df1df3",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 185
-    },
-    {
-      "fingerprint": "fb48781565ec73ad30a243fb9302786d2997db3b3de7780319536ad8ed47f5bf",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 215
-    },
-    {
-      "fingerprint": "0f4f21c6019b253059a60aa16169ea05bb040cf6ecd3b5e338429a026513e5b0",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 247
-    },
-    {
-      "fingerprint": "9c0f08c9558f18252171c95dc943bd9c759f662335c22f5e7a3e20afa7766f32",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 280
-    },
-    {
-      "fingerprint": "b987ef26952831eb35c2e6388cc1f2fc27879a07896a5c84c24a4dcc7d928971",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 313
-    },
-    {
-      "fingerprint": "8ca76bb8e22d41d79ab6dcd648b21c29676cde06a92d25bed4a62cec09f6d0a1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_java.rs",
-      "line": 342
-    },
-    {
-      "fingerprint": "42c0f33264cfcacd38cc7ba9b181e59f06c500c2ddd5f33e4763d0755eaa54a7",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 24
-    },
-    {
-      "fingerprint": "8565ed11fd25248c0af7068d989d6cfe59986eeff655d4c7861a825eadd072bc",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 32
-    },
-    {
-      "fingerprint": "982fab1c95ba81674328fb70b240fd2f8d9aa77d56f32ddcb2591e83899375be",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 42
-    },
-    {
-      "fingerprint": "941687e528b1222b4c0653cdbbd1e137544d5bfe717664cf851856afde47d35b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 44
-    },
-    {
-      "fingerprint": "5bb43dc2f3a5059e801335fc424e0992cb48526e8b61d3019bcdae4fb261dcef",
+      "fingerprint": "84682f2463f62374a525e0a241c704b83841295f35eb96e0b7059e34b0115b71",
       "rule_id": "rs/no-path-traversal",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 49
+      "file": "src/app.rs",
+      "line": 389
     },
     {
-      "fingerprint": "b00feb3760999f63dc2d95debf7df4b0dcfdce76302e9d09d2b98e61d226d1c7",
+      "fingerprint": "0865b2560a169b1d8109a294b6cf8ab2906d806a14e7a854ccc574c0807aeb57",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 390
+    },
+    {
+      "fingerprint": "bc5729f8d76734eb5093bd577979426fb57b38f6c5e736513921eefd61ba830d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 407
+    },
+    {
+      "fingerprint": "154c3fa3df5cb426ea371eae3e6733593abb7b3afe01332324e2a3167fd95d30",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 691
+    },
+    {
+      "fingerprint": "8178baf5d3bec2dc00475880cd568eb72f505c08857b94a65f591bef109acaec",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 701
+    },
+    {
+      "fingerprint": "a990b0b89b4b2dd072b881504971b2ad0ed1dc9a62f2c461acadbf6e11349685",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 709
+    },
+    {
+      "fingerprint": "1c8c4058b228248c5bd9c361e98e55ecb004beb6e3a4ad03c785b4c268ea8cf0",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/app.rs",
+      "line": 733
+    },
+    {
+      "fingerprint": "c33c57a6c6523f2d018640ce91f227a0f17a59eb58e1a21769c6ffc48dc647f3",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 63
+      "file": "src/baseline.rs",
+      "line": 283
     },
     {
-      "fingerprint": "fa08e006eaf1f4bc71cf5d293b5cad2cfc93351cfe2e8fde5007b4962b0ac6e9",
+      "fingerprint": "70b39e612ec7ae391d1f03108f5b53acfec8a6fed21d22bb312e5abcfa197acb",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 64
+      "file": "src/baseline.rs",
+      "line": 292
     },
     {
-      "fingerprint": "55dad4b63743fc67d1b365f6dd212bdb6c778a892c3c7f1729bd3ab646078f17",
+      "fingerprint": "d4b50c867863bda676fe489cc5ee6cce60866cfc2b1fc6917dd316bc4565a891",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 72
+      "file": "src/baseline.rs",
+      "line": 292
     },
     {
-      "fingerprint": "79b0f1c9f6ff553a05a195f0c209340864f4c69cfd8b82afc0844b5fd8223986",
+      "fingerprint": "085129a49c9aa8436ca19f2fa49673b441b2933dfcd3528d214b35d37bd0addc",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 77
-    },
-    {
-      "fingerprint": "aaee02caf022c17cc4fd833b517bbc573dea2e4453da945ee6ba4cb4fa7f1471",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 80
-    },
-    {
-      "fingerprint": "3524352b3c32b51456b8b37da212918231887c487bdce05195db0ec6e77c1ae1",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 91
-    },
-    {
-      "fingerprint": "899e2b028b4575a18b030f5c503aaf26ff71321892c9266b7fba938620e97974",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 92
-    },
-    {
-      "fingerprint": "f05175e3d558a692cbe09335cf243331217c992c1284cd027c5a65ae8ccff11b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 100
-    },
-    {
-      "fingerprint": "919297c05db8fae063630241aea0cf61f56860009c7df2bf99815be350a6ca3f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 105
-    },
-    {
-      "fingerprint": "1464de5430ae4277e9305459a844f5996c843cad62e05955f9069a804b29f86b",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 108
-    },
-    {
-      "fingerprint": "bc8b531ceb58e9e588359077c5b3d8598de734708a049a555460b041b2f47c49",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 119
-    },
-    {
-      "fingerprint": "a0e3d56d297e24dd293036e856b68e75581e9a98fa22f071939d9a8d5e9278c4",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 124
-    },
-    {
-      "fingerprint": "7428bd0c251d7046591ef4553ee86a9182bd2f22b3290607ff0571486e7a6da7",
-      "rule_id": "rs/no-command-injection",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "faad04395158115d57fae28e4ca564eec4c2671d51a76f9b0adf65a1b5e9f8bc",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 142
-    },
-    {
-      "fingerprint": "8169cb21f905a267f78d0181b318cf597d5437585b5ac401ac6c69fc0e783c2c",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 146
-    },
-    {
-      "fingerprint": "4504e6b5f97f5c8a431d9c2ab4561b18f2f5df2e4218391a91a0fdf1933b1e36",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 185
-    },
-    {
-      "fingerprint": "a297135682d35b31ae9ae49266a673bcf8a6737d477fafb920d08d2da5d6eaeb",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 215
-    },
-    {
-      "fingerprint": "88214048582aa14a1bae189c66ce8a9859d8db5641a0a19d2bc360eb58818068",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 251
-    },
-    {
-      "fingerprint": "eed55540e2bae623ee97cd39c3ba56b257d70708651b4158f984d5bb58536bfa",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 284
-    },
-    {
-      "fingerprint": "3468f58325b5fbd2ca46851e833ea61701d86954ee8479241726a0e3b1194a3a",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
+      "file": "src/baseline.rs",
       "line": 317
     },
     {
-      "fingerprint": "88cda4a340afcf657a59d54a9bd129272973ce7c576eed4783f1d9ecb06f67c6",
+      "fingerprint": "b7d1eae33aee81196828838c7d28075e26990fc7f2471d3158a0aa5589002182",
       "rule_id": "rs/no-unwrap-in-lib",
-      "file": "./tests/semgrep_parity_javascript.rs",
-      "line": 346
+      "file": "src/bin/foxguard_github_app.rs",
+      "line": 1037
     },
     {
-      "fingerprint": "56e07b4339a62164ecbff21e94eafbaf1ca97d6e99b56300e4b14acda6318444",
+      "fingerprint": "08524dc7a5a5fe77070d5b1dd20f465f60e1122396d285f32e7e6af8728cad30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/bin/foxguard_github_app.rs",
+      "line": 1081
+    },
+    {
+      "fingerprint": "6880e55fb893d06e5d8dbd1f8962d1bcca4705bd5289c2a276f9c73c94e703b8",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/bin/foxguard_mcp.rs",
+      "line": 157
+    },
+    {
+      "fingerprint": "8fe279ccfa5eafa41c2e0224e7d54361d5080f29e7568c1782bc15ce7e0b9a2d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/bin/foxguard_mcp.rs",
+      "line": 168
+    },
+    {
+      "fingerprint": "8ce7fa76bb415096bbfa250df9152ab53b73f8fb653935ec34f6f23f3e611c35",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/config.rs",
+      "line": 463
+    },
+    {
+      "fingerprint": "607437d2a6019c93199ff8be05ab4d798fd0fb690617f155d6c9ac810285744a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/config.rs",
+      "line": 911
+    },
+    {
+      "fingerprint": "63a1ce966db18def675e0e65ff62df7cba4429f74d2974f1c5d2e0d77468e317",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/config.rs",
+      "line": 948
+    },
+    {
+      "fingerprint": "b48878646916b0242ba69d8cbdf7f211433103b7e515bf1b03dc43867ee8b349",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/config.rs",
+      "line": 949
+    },
+    {
+      "fingerprint": "b93858d96b52df3dcafc3dfafcbb5e5f071a8a6eef904e4eea7e64d3de31715a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 990
+    },
+    {
+      "fingerprint": "fd47a56ee3466518b60b7b1b89d435dbc9a540f9426067c82b1f49f51ad9447d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 992
+    },
+    {
+      "fingerprint": "f49f6feb7cda4facc619e140443fc503856e15a332f21d8e0bc6fb9daf7a19e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1026
+    },
+    {
+      "fingerprint": "5055edc5b91bfc4f956548765be231eea4ebd2e5251739b2464fe578bd6b6ef4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1044
+    },
+    {
+      "fingerprint": "43b9ba07118a750d7d9af90beb9200430955c28d5843b565b080690669b0eae5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1045
+    },
+    {
+      "fingerprint": "dc91dbd64c9eb3d63f93df9fcf059705cc6c44de8c679b9cad25c8e1f2b67aaf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1047
+    },
+    {
+      "fingerprint": "a7bf73de58d3d0be79adbe536c0e5faac7fd9eebc2015822bb3e21a226de1229",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1063
+    },
+    {
+      "fingerprint": "307d36df056ff52e69995a6f183054d49a66a31ed450fdc723b364d97aa1eebb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1064
+    },
+    {
+      "fingerprint": "adf653afc8459726fe56c6b8f8541811513d2ba6530760cc009bcb675d299ede",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1066
+    },
+    {
+      "fingerprint": "bfbe30698194f129c5a4e9f52a516378e647bc4c539ccbe761cc4ff662d565cf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1067
+    },
+    {
+      "fingerprint": "ef35e6c35a595b4c7cdbd3d9729b1e3a08fa1a53ae85d5e24f6d3307b4b3f94d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1083
+    },
+    {
+      "fingerprint": "c95749c723f3592d25589fb27563a2bd68679e6351709463616cfcc84c7559c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1084
+    },
+    {
+      "fingerprint": "7c27affdfbe58e874d0bed7f649f29aacf21dc6666f5223280e3e3d6abf70f07",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1091
+    },
+    {
+      "fingerprint": "0cba121c8d607cab1794089596a9b3326bce0081a06a967d315f005ff9176a1c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1091
+    },
+    {
+      "fingerprint": "6877d25e2affae626ae1b2a0de6fa9f543b3c11298762e768f4a5bd1d1a372ea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1091
+    },
+    {
+      "fingerprint": "3ff5eee58a7aaa0a06703d8bdbf84a835e6194b97af1e55fa4b07115ab7331d3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1105
+    },
+    {
+      "fingerprint": "c67d8c05d943e1df1244473bede71aaf205054fefd7a204dbd644781640102be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1112
+    },
+    {
+      "fingerprint": "a01d83f4d4f62b4f64c3cfc51d753aa2d3d5b7d7907c527a66250eedb872ed7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1112
+    },
+    {
+      "fingerprint": "9d410e04a7f1f97e2fe793871f5886a52804a8925867f4d8f8bc89d1685b6d7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1125
+    },
+    {
+      "fingerprint": "d0fa53920ff9e083c9b32b5abe6624e4c75fb074a4dbb54a915be6e1bee6dfea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1128
+    },
+    {
+      "fingerprint": "8aeb208817ba40e7096d6b4978a8a8c939996fe72ef81a823e81177834bd94da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1128
+    },
+    {
+      "fingerprint": "1fefc0f486bd789e04093f5ba985d53928077ae9433c8b313a47d15a7abeef3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1141
+    },
+    {
+      "fingerprint": "daea31e9e36bbc2821ebc313511347cf6f6ed6e874d02102c45a6ed59939bd7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1148
+    },
+    {
+      "fingerprint": "791779a91f68540918d073d27f6ba346d9069bcb949dcace6f30a41bad7fcb24",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1148
+    },
+    {
+      "fingerprint": "97f67d43d00a493b2c618c10c2c77d2a5b914d85bdf64e8cf4899986ebbe5c78",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1157
+    },
+    {
+      "fingerprint": "0280c3f1be6164aa8643abef86cd5eb6c417520698c9765dbd04c600d65f94c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1160
+    },
+    {
+      "fingerprint": "a05adef76bda86cf9c6f92619298343bfa0f33faff921eee45a4d631e6a2cf7e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1160
+    },
+    {
+      "fingerprint": "5f5336172166cbd7d281d0aa16737eb835a9e0293ce8e29a9795dcf0f3c9f2aa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1169
+    },
+    {
+      "fingerprint": "5218756965717df52ec3f33d070611afd4b9cc306f8335641e47e3e92b49fba2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1176
+    },
+    {
+      "fingerprint": "3564f7fb1ff4f36872cc09703ede9ac3b63ecdd6d84351790af3671e7d091a45",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1176
+    },
+    {
+      "fingerprint": "0c192be785b5f2d90b7e6ddc89e6b3138fd157822de8031c93ef1d0e87d5f378",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1189
+    },
+    {
+      "fingerprint": "26bada325f3d091e1a0fc047029c0c0d8029f2e74f86824115ece4b483c477c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1193
+    },
+    {
+      "fingerprint": "07d8c055ab50e8d424f4e102a0ad97f55a2ae3904f427307f68b29806385b6b8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1197
+    },
+    {
+      "fingerprint": "5cbbf60fe17d020f8dcd93676842e74a0bace073f87ccafec6ac0270ee4059fb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1197
+    },
+    {
+      "fingerprint": "10f07c6557045bedb8db295945aceab872138c2e10ec6feac18ef579f16a8e13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1207
+    },
+    {
+      "fingerprint": "22adc5a762e53dae32a75c32b522a9ab6e5d33cf6b8b616bfa933405286f114b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1213
+    },
+    {
+      "fingerprint": "7a36a8dcc69c13c7c797366ad7b4a7a63e8a2f11a9ccc33a7e918857830c552a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1226
+    },
+    {
+      "fingerprint": "9f4f973f87e87e8d1bf81db788886019bd9927286d97cd61665859afed339382",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1230
+    },
+    {
+      "fingerprint": "ffe2cf39e14ae18d8933e4f356b1635d4b37fa434cfcf9861d47f4a6c03dede7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1231
+    },
+    {
+      "fingerprint": "8c4a6e5c22cc558430fe045a7540df922459bc2abe6167fe7a11c337593e0973",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1232
+    },
+    {
+      "fingerprint": "804b04a8b2b8f89c4b5fbd7925d4cd48cc82710360747033c0fd7fe33d47bc39",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1242
+    },
+    {
+      "fingerprint": "a6884cc9901a6992c08f1b23e5e63f12a58a6c14a658917676c30870b6499ee8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1256
+    },
+    {
+      "fingerprint": "1784243ef62e7ed39271c8d9fe7829297a48435191f370fd470c1c2ec2bc538d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1259
+    },
+    {
+      "fingerprint": "5a65a208948f57bc40635083cabb0bb59016c1eed2b1f272e172adce05edb3bb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1264
+    },
+    {
+      "fingerprint": "0a840e634668998e296112cc732a88851dff71daa2d53dcb2fe96064a72f9cee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1264
+    },
+    {
+      "fingerprint": "3d53e6c63210ae736e3b279fd66845e02e99b08f5dc2f7cb489b185acca6bfd2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1269
+    },
+    {
+      "fingerprint": "9f9d0601084633052af8b80132f6d83a7907ba72d4f88396f61db9d341ae019d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1304
+    },
+    {
+      "fingerprint": "cd57cb409cb5240afc2f5058c64b19d7c07855fb8d6c16f0433da289ef25e9cf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1310
+    },
+    {
+      "fingerprint": "e9e8f4a51e895a21f0103ecbe91f3d14473446eb7d6a8e3e798bf7444e848a71",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1310
+    },
+    {
+      "fingerprint": "610291531d0b33ccfc48f222587469ef56d607ce652090eaeaec980181985145",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1336
+    },
+    {
+      "fingerprint": "460f627ad6352d2b02a706c7efcac1b5d8c72ee74dc6c5d825bf513e875651c1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1342
+    },
+    {
+      "fingerprint": "a0a921f5016adc3ae7c6cb44fb0c32f16cb5c348f8fbb4564e74b4cca88dee83",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1342
+    },
+    {
+      "fingerprint": "c91f154395f4e671e26503013fe07c1aa96699da4e53da6e9b5684bbfe470219",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1365
+    },
+    {
+      "fingerprint": "eb7fcbc0dfc7a09942f4525f30ce4786f1641aa33647db203ab7fe05c62faf13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1371
+    },
+    {
+      "fingerprint": "6738aecfb9950f1d1fca85acd4421f7c231da333186a57073f893bbb6e363405",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1371
+    },
+    {
+      "fingerprint": "d68695a02db29ba19c16330ef9d25c2a14f60acb4467361e5440c25f2ed8c1f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1391
+    },
+    {
+      "fingerprint": "814e755b6589024e056b6de176c2d57d929cf13ab73ee828872c404c67f4b9e3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1397
+    },
+    {
+      "fingerprint": "2cb29a69ca070490670b7fb63ee514c22f423750abcd4c04802c3285653f90e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1397
+    },
+    {
+      "fingerprint": "97a10a7e11511e06ff4fd55c68016c6c5792b58b83883aa381d1d9916e8e8df2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1422
+    },
+    {
+      "fingerprint": "f49617f994553bb1619941ed57a6d3751514d181a5c5dc89352e8cb19226bcd4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1437
+    },
+    {
+      "fingerprint": "68c84ba3099a011aafbf8e1be2fd32a31150b9a92f17442acee58e84364e57b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1439
+    },
+    {
+      "fingerprint": "a4ca01bce4e66b5f35cd31a031bb97082f6f4dbbaa2347657ec400912a3fa19d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1439
+    },
+    {
+      "fingerprint": "9eea650276016273d8da3c39ea0fdfed9a0a1952a695efd89d2c5bf87e8bb93d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1449
+    },
+    {
+      "fingerprint": "123c9c2a94ebe35f67a2dcfb3e0113959f943e48b0918dba6ad6455dc8df91a6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1451
+    },
+    {
+      "fingerprint": "ec2064b311a3da76f9d9dffb90779bee8644858dfe789e3f0503f52af7d696e2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1451
+    },
+    {
+      "fingerprint": "f3ed625bb6872d86c36d9594c852acca46a636335f534a2bd0f3dbdd20486771",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1461
+    },
+    {
+      "fingerprint": "e2582d32d8bf5e2d74991c0c1ac9db1c59ffda7a6675e38e4113ff7e49895787",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1467
+    },
+    {
+      "fingerprint": "45f6fbec8445fec4a08a03bd4b3ea93cb7a06bb91d14cd60aae385ac3083c269",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1467
+    },
+    {
+      "fingerprint": "9ef4c103d7d5f86fe78e5374885b71a6f501f125c0b9cdbb94d204932a223a17",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1475
+    },
+    {
+      "fingerprint": "c9678fba3f0ceb15510382e7ae378611e12bf84d70799276b6a3e3f9a7ea9fed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1481
+    },
+    {
+      "fingerprint": "fb4610a1b85c9fc78746fdf379585ac3a6252cb1ef92f77fd17bc7b07767a708",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1481
+    },
+    {
+      "fingerprint": "a5899854c275fa3ef230e49af6bf6e7a7e74aded1ab59a61a9b0f5eac427ce3e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1489
+    },
+    {
+      "fingerprint": "82066d57f5a1d6eed23987d6e61341cff377954d6b342b506d8ba90c82d85a5c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1495
+    },
+    {
+      "fingerprint": "b027df40bdd6cf1b01321cc65cd6d96c20c8ac601778d6af7fe99af9ed4fe979",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1495
+    },
+    {
+      "fingerprint": "88afab9ee315b37fe6df3a7f3470931c1675250949b59c99fab900da0bf1174f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1503
+    },
+    {
+      "fingerprint": "dd51929249984f6465fb442e7e7a573e719295972487e974e89693dedb647a03",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1515
+    },
+    {
+      "fingerprint": "cfe45702900edf1e251fa85543c051711d99f639afe0488a8a8cb1cac2c82885",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1527
+    },
+    {
+      "fingerprint": "92b51b298c35864e281fc153b0a88bcb25c8961cbad06e006d0e07d3ff8942da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1541
+    },
+    {
+      "fingerprint": "e717f5431807172022d3af9170ad72edf536ad04394a84f71c4ba4f5b4a503cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1563
+    },
+    {
+      "fingerprint": "65d769b7d4f49696d26f5b66de2df3dfff51fc2cc9cabf3bb7a6aa0bdf56b484",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1569
+    },
+    {
+      "fingerprint": "849dc94350b6b6382e0a75e005b77ed335c4db75e261452f952e8716dbb10b59",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1569
+    },
+    {
+      "fingerprint": "752adb9bffb99afe056604c20f2e10b00e18d6b5065b6c2f41af65d1a2f598ea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1577
+    },
+    {
+      "fingerprint": "c733d6b1d409fdaa7b79ba79b20b8f457436b769a9a998fd0d832282ae73db73",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1583
+    },
+    {
+      "fingerprint": "89418d2b4df8c82d8675c21574df0a09e2111cea0bdc7aeed89050b794dbb3fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1583
+    },
+    {
+      "fingerprint": "c7effcac4ba6004a790560167ff7360dd5480484131653e9110641ce0173883b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1594
+    },
+    {
+      "fingerprint": "06f38ad5eb9b0f3f905d20995be3e663af5335f0018b8909c812358534840936",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1597
+    },
+    {
+      "fingerprint": "3966b56605c3c3e2840492ec9dfebb9ebf51771077eeb84ceb79cadde373e537",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1602
+    },
+    {
+      "fingerprint": "f855e452d285f98ae1122833678b5c6e23a009588b09a633f3f105165f960988",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1602
+    },
+    {
+      "fingerprint": "817075e39a724fed7147156bc33775e1320522b2ba3a7d53d64eb67d5f3fde37",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1612
+    },
+    {
+      "fingerprint": "2fc71f84b93efd7e7ffcdd938ac58b32344de53adffb3b72e75b6d6a34e03f64",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1616
+    },
+    {
+      "fingerprint": "d9c0562343e6e2a6679320d4e9eb61a070c77eb8027a8fe79f0fdeba9e8b4b7a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1616
+    },
+    {
+      "fingerprint": "64e5a03c6f35f1adeadd8a1b98842e977f1ca4cb506add36e79615b25280efc9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1627
+    },
+    {
+      "fingerprint": "c33a2033957e2f1eb20ac0640c61d128f4b3db4c8e9d6a7780d4f4967dfb7860",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1628
+    },
+    {
+      "fingerprint": "4d521d3111cf197d309c5d22621240d0dab43cbf4c28fd83ebd8b3a3a3167ae3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1632
+    },
+    {
+      "fingerprint": "96f3593f7c9407572cae81f22ac7e3b1703f46cbcb8c417507a95a0af454c7b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1642
+    },
+    {
+      "fingerprint": "a99f11a7610d68677aa855223b33e96b8a37cdd9b68a8f3473f8d552b717c3f3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1663
+    },
+    {
+      "fingerprint": "e4748b7a7415f485e207fe5384f7cf973b117bd3c1917fc327e7252b8b591494",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1666
+    },
+    {
+      "fingerprint": "4eebabacd5a9e64766eca2ccd7917680c166734721a6baa8575011cf4050d9b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1670
+    },
+    {
+      "fingerprint": "1a0587ba17ec5d80823f7c325b14cdff632b100bcae8bf9f116776b81e221c54",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1670
+    },
+    {
+      "fingerprint": "21bd10940761d7031778d95a5b718c39c29f94ceb97b930198bb75dae6b2538c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1677
+    },
+    {
+      "fingerprint": "73635d9ebb9dd71356e6ca3ce6763f256717aba598a9d90f3e0295174861b386",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1683
+    },
+    {
+      "fingerprint": "5cd412f914c6a6e1ada5f42625f4e3f37d235d0dfa0560574d7cfdae6649f2c0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1700
+    },
+    {
+      "fingerprint": "0d3130343372d771a142c7359d852146466d50eeecbeb4475d97380bd36955fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1709
+    },
+    {
+      "fingerprint": "73a0bcf8da3fc5505fcfcd30aaab10aca3cedaa87a2575e5a63a8bf32e0105fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1715
+    },
+    {
+      "fingerprint": "a80308c0960bc34273d487265ed64445ae635901d38772e7a837647dac3d6f79",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1715
+    },
+    {
+      "fingerprint": "a511d97d01d3a531690109e1c97e08064db11bd54a43356a9fca4ddccbf8802d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1729
+    },
+    {
+      "fingerprint": "cbaed1db2206322d4fe40fe3bcf1b17f9386be112428fcb544d6e2e72d2cd541",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1731
+    },
+    {
+      "fingerprint": "6dbc6330110bb3a2d88af2dfdbc422312331b63eb51643efd86f045057aa40b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/config.rs",
+      "line": 1731
+    },
+    {
+      "fingerprint": "439a189d212f74f369e20560a142c794a5045aa2e4ca0c6bcf3d05a6c5ec5e2a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/diff.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "687e0e9a55214e5c8de87dff496d9ed9525774ae44101ec05d9a8c2f292bb75a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/diff.rs",
+      "line": 217
+    },
+    {
+      "fingerprint": "2a91b86751a3cbbd328cc9e764e5fd46469860a1303ddcd4f4996876635e2c2c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 487
+    },
+    {
+      "fingerprint": "73601e0f47563aaea017821b247214c3069319366d03838e94f4fa5422bf4fb2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 492
+    },
+    {
+      "fingerprint": "3351fb446ec4a03f5f413a679d64f83d6233005ffe939aaf856a58987fad25dc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 511
+    },
+    {
+      "fingerprint": "c1b7e410e667e460dffe8ba2f0b589d5b45db6763c4a82520de7141481375975",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/coccinelle.rs",
+      "line": 682
+    },
+    {
+      "fingerprint": "a85ddce703f8ad10e125b2665e215f11b3e8acaa0653d3c72348ed8c0d8c1615",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/coccinelle.rs",
+      "line": 686
+    },
+    {
+      "fingerprint": "e5ba3cd47c5c4f0b3de3cac65efb3929bd3895301e42cc844778e049c1c999b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 719
+    },
+    {
+      "fingerprint": "dd5db6e7b5ffa060cfcc2d5513965a5355f7003d78075c9fbc10fd25cf601184",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 720
+    },
+    {
+      "fingerprint": "48c3ad7c01bf473077544cf2eeddc4de8c2357b4307a81be454880f93452a213",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 737
+    },
+    {
+      "fingerprint": "f814067e30414ffdcfca4f6c335280b6134516b67a4f19db8c224e2894dc3163",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 747
+    },
+    {
+      "fingerprint": "982974589b51c7678f9e923d8fa9c218ac8d55ac84c41b9a04a425c670e595e3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 748
+    },
+    {
+      "fingerprint": "bc15e234104b299d616a41d974e867368f59636f8f8579ca908b341ac6d86044",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 776
+    },
+    {
+      "fingerprint": "45b91fd4ef75a7d0cbc44d87f935bc818d059ac8cc84ab4c52a84595591fa71a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 787
+    },
+    {
+      "fingerprint": "96a1bee845447a1ed2a28c4121fde5beb66ed156b6319f1fb962801cf20fd35a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 789
+    },
+    {
+      "fingerprint": "d04f7b869e272c2c71e9aab4558cab82f72b00f0b28e5b16282ebda6e8585594",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 809
+    },
+    {
+      "fingerprint": "b4fc410d9bbe65df48a51a4498a562891bacdb1a62ff191ea6af7020d53df1a2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/coccinelle.rs",
+      "line": 811
+    },
+    {
+      "fingerprint": "378dc8791cee0be2d1779f1000bea2a790ebc02321318571f8303f387f171385",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 272
+    },
+    {
+      "fingerprint": "51317d0d50c19cc49bbdac8edc3b3eeeab8155e201eb54786b8c02db10f2783e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 304
+    },
+    {
+      "fingerprint": "c3f67942bbd9ebc6621735f62c50c1efa1fd319565f11f311c77892d49dd0730",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/codeql.rs",
+      "line": 677
+    },
+    {
+      "fingerprint": "5ec21114cd325eab18a48e5f67115795d9673e7a682839bd01ff4ff99b0aa0fb",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/codeql.rs",
+      "line": 681
+    },
+    {
+      "fingerprint": "b9f5a6d99333f3670862a7e9c3cce9a27a70a37f7a33ec33c43361b92216840a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 865
+    },
+    {
+      "fingerprint": "98ebfef392a7e04aaff3d529c2148119d79887419cc50c3e21b3174279ac374f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 866
+    },
+    {
+      "fingerprint": "307562b218d6d4f79b35a94985f4cb14975fc403e65de20eaf9600719cd18a58",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 903
+    },
+    {
+      "fingerprint": "aa22f237b3980c75d9f7bfa2f7f248c68076d77a4c106a62acdf832f65f07eb2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 904
+    },
+    {
+      "fingerprint": "737a34a0c13292b9b4734745a588dd2c5e5368f69c716ad0dcca2c5241150c90",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 921
+    },
+    {
+      "fingerprint": "235d389e4ebafe35bd5e9f649220eefc7cd1f0f286c2b89b71f00404dee08a6b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 922
+    },
+    {
+      "fingerprint": "c5aacf3d52588d890ecdab128dd4b6cd14f1f17a6dded6a54477dac6118755e2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 930
+    },
+    {
+      "fingerprint": "299eace7f5429144b3e083de38ff5651db5aa72ede93041b943c48176825beaa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 931
+    },
+    {
+      "fingerprint": "630098604fcf2a42ccfde0d3656df7ce8ee70feb5779316e5a9feb3888d69fce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 932
+    },
+    {
+      "fingerprint": "3f62d33763dfa269e63e79cddfee90ca87ebc8c74baa5e8af1dd71a2d3094b3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 933
+    },
+    {
+      "fingerprint": "95d4833074811c3ebb1395328c0a6bd720607f3ade6c75409833fa4ef49d8bcf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 949
+    },
+    {
+      "fingerprint": "b75cc161c1403aff716baf3af1f9732269dcaefea3ce4f9f3513369846733936",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 950
+    },
+    {
+      "fingerprint": "c3ae4ba389cde2a95f52dca2e3745ad5dbfa691d33ac09a084d180bbee271830",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 956
+    },
+    {
+      "fingerprint": "cc9daeb05dabda7d3e30f8e0ced0e247ea65135af5f26e3a50b3f9ba4ec6fff1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/codeql.rs",
+      "line": 958
+    },
+    {
+      "fingerprint": "200654956ff084669dda7819d962cd654b83dba3ee1fe99dd4708a1ed1398941",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/parser.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "08a30ab8ded1f8346a9c91e80cc4eca27762a2307e7da7b6cd6d0ca4278d9100",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/parser.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "bea6d0599d9226782a834015ea477c71bb41bf5635469e1ce7f9ac2581982eb2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/scanner.rs",
+      "line": 226
+    },
+    {
+      "fingerprint": "f8388a7d64821af43fa1572e5252f2b4038fba0ff4d448611644c0d23a66799b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/engine/scanner.rs",
+      "line": 371
+    },
+    {
+      "fingerprint": "ac51464c3d8dfe3a9274fa4451562cb7b11e5c520366942b090e4b24639210ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 553
+    },
+    {
+      "fingerprint": "1044c834caf0dc97127f074e41ca0dc41db9eb020ce2eff3ca6ca0817e8bb05d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 561
+    },
+    {
+      "fingerprint": "8fb6f2835efe4b219305d96d106d1fb7d2c144b98f89e33c9bd9cbdc84b9af23",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 568
+    },
+    {
+      "fingerprint": "c516475b7c1dc9b97e37b71d7c5a3bb93bfac0d31084eedfdc669381bb70e645",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1002
+    },
+    {
+      "fingerprint": "93d69f3b696ba369fca5e71e71a30b24407343a336b0cb29c2f3893da4ef195e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1010
+    },
+    {
+      "fingerprint": "4ab5cd969f549fd5c6797f2e96b23e3ead7bb472032ff422dea4c3234e08f815",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1027
+    },
+    {
+      "fingerprint": "326c87bd1d37b609fc3462554f0d1bcff256c429a88ca9b23ef9f7de2ff3433d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1034
+    },
+    {
+      "fingerprint": "0cebec77fc790b1a4e49f0e566a15974eec8615809b60889a6c6cb37cd1f8b1b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1056
+    },
+    {
+      "fingerprint": "3b411ade3a528a2779521079ffd51f513681161b5812cf043dc732a9f9d5152b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1065
+    },
+    {
+      "fingerprint": "f67bef3cca688be1c96ebd4843a39d0e4027a7105295ae2a09751365110ae2c0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1074
+    },
+    {
+      "fingerprint": "1d1b2aaded8333b54889dc615ff543baaf2921b64717a0ad0311783a4119affb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1430
+    },
+    {
+      "fingerprint": "4dc5177107758305e32f7ccdbf1e0c385044a676e0c68a182b6b2199dfff429d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1464
+    },
+    {
+      "fingerprint": "f65c3d7efbad3deed48216d48d688f597fe91c1460c426e42b3682c53600117b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1472
+    },
+    {
+      "fingerprint": "05da5e8f591af3b227536f1686bbbc75fa31ed68a54372922c3796050ab9b8be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1481
+    },
+    {
+      "fingerprint": "85c7dc3244e0c16e8f29969251c1ff7264ff282314c3cf8cd469622e16cc31a3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1507
+    },
+    {
+      "fingerprint": "bea5136930bb8baf406172bc9149a8dbda6e965669b4573cf2370445ec1e38cb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1518
+    },
+    {
+      "fingerprint": "d7e210d6305e7538cd223acfd64b01694e957a742c99f9c3727231d007ae4a54",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1519
+    },
+    {
+      "fingerprint": "fba0bfd9053ef6830c3d153e6605f3f8761fc80e61fcc1a598739779cea0120e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1521
+    },
+    {
+      "fingerprint": "9a225aec42d7b4d76c2042b92bb2c0e814e604b684241e86ad4eda92c43ac84a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1523
+    },
+    {
+      "fingerprint": "3a21f4f8c562d5ef47bc87f078d11c4f38eed391b7614ddfcd193bcdccc7520d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1527
+    },
+    {
+      "fingerprint": "60805282de4b46ab473ba39053ae98f4e63a6faa20aeac8d83baf530ae9c66fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1529
+    },
+    {
+      "fingerprint": "cb04d88686523fe18a5e43821c06d208b04659956c37cc7cc71189880f7fbe10",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1546
+    },
+    {
+      "fingerprint": "a503761d227877bb310ebca6144568c35df341275e5fc7c93639127b04bbfc17",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1547
+    },
+    {
+      "fingerprint": "10c9fa23436f81616cd514e2abc70f2f5095f845e69cbd6f5f9cfd3a5483b7c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1549
+    },
+    {
+      "fingerprint": "c52c0c339131a3155db83a1042cd027c68040fa0a004112263576ca29287ea4b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/engine/scanner.rs",
+      "line": 1553
+    },
+    {
+      "fingerprint": "a9ede1a3dac849591e057cb9955767b4fd71374a938b8be55ef4ccda707d458e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/command_injection.rs",
+      "line": 311
+    },
+    {
+      "fingerprint": "3fd1ffcd04412e93b976def63d09295a5b99d9ef25fa2324bb56fd7c9739d387",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/command_injection.rs",
+      "line": 312
+    },
+    {
+      "fingerprint": "25e1a75edc1a4186b021bc10e33a98cf75fe9a29c7cef888b49115a7bcefc542",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/command_injection.rs",
+      "line": 323
+    },
+    {
+      "fingerprint": "efcb5434c97ad5dc107f5e1498d8da160bd8223e81b68fe8e9971fc12f905824",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/command_injection.rs",
+      "line": 324
+    },
+    {
+      "fingerprint": "464c8ccaaf6ec054b86a455e65b4052da35e8731775a26b908395e6708384671",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/fix/mod.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "ed0838f8f0d98685f358c42439a15528d9e7fe17eccc8b2192158a7fcc459888",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 445
+    },
+    {
+      "fingerprint": "bb7dfef6a3a67c1f12ffc8f3ee8784b85fa9310a7ef67d8bbe94b1b2f960a5d7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 447
+    },
+    {
+      "fingerprint": "64dae8437180d825d20796c3f38074d0a776dba9ca722ba1219af27f401b2b7c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 458
+    },
+    {
+      "fingerprint": "2421b173a30e0e92fcb47882a21957ea9c0f4c19f7a3264b35b684a117e65550",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 459
+    },
+    {
+      "fingerprint": "bf90d5995554683b2f10635600af35f6026b20ccdb14f357007cd264e3fbc468",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 470
+    },
+    {
+      "fingerprint": "a012ed326e99cc9fe2afadb0dfc67e74dfdd68f29e1d1118a80a9e782d532910",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 471
+    },
+    {
+      "fingerprint": "23d13172fca81f4fe52750efb4caf74039bb0abc609b28e2074041451e9443c3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 482
+    },
+    {
+      "fingerprint": "1dc10b1cf7385697f62c66570209182bb8a246c7eb49e0064a3b5da0f4da266c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 483
+    },
+    {
+      "fingerprint": "c3858f6bf5575eeb98702d470d560813063b7f976c481c5f63191f4cdaa10812",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/sql_injection.rs",
+      "line": 494
+    },
+    {
+      "fingerprint": "3e87d23a692b2b157f85dfac0bbf5f1fceeb27ca05ebea080db6101a9489f365",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/xss.rs",
+      "line": 121
+    },
+    {
+      "fingerprint": "abeb80af6ea624e36d5b01de216c679d6615682cb855f251d5dd65b7c1451abe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/xss.rs",
+      "line": 123
+    },
+    {
+      "fingerprint": "e78865857c320e9dc7ad033eb1ed1fea6a0e51dc335f9cf821d3fdd7abc67c23",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/xss.rs",
+      "line": 131
+    },
+    {
+      "fingerprint": "4d3a8d9176cee403b8ccbdb4597e8409b71eeee01fbcd24d491a663b68e2956c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/xss.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "8dd74fbc5b40378a7c75e89abb7b40bb1ad7aa25a62db741a2b450480c7b4236",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/fix/xss.rs",
+      "line": 140
+    },
+    {
+      "fingerprint": "0fb7af0d28786b9b48fea422733d7388ff8a7f7abe362fc06091f3e76266b3a9",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/git.rs",
+      "line": 35
+    },
+    {
+      "fingerprint": "1771f06dccf7397d4276534cae956ae92672e2f1d934f8924f23f5d28551d0a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/github_app/review.rs",
+      "line": 823
+    },
+    {
+      "fingerprint": "562ad31268b5ba3baa9425195993c949e428faff545359b6fe92591f0b74973d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/github_app/review.rs",
+      "line": 850
+    },
+    {
+      "fingerprint": "afcfc9524dc4e7fb94241bc5470e6e8fc46a2f2643def2f67c2dd8647f55066d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/github_app/review.rs",
+      "line": 879
+    },
+    {
+      "fingerprint": "a94a0fac87c21efbf2f7cabe80823f4988f97380d05856c518b8821555145f32",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/main.rs",
+      "line": 133
+    },
+    {
+      "fingerprint": "e34d88f407f6fadd74ca0c7f5f4c8bbbb4115aaa331115b939b64c15abcba374",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/main.rs",
+      "line": 141
+    },
+    {
+      "fingerprint": "cb3c84ec1d77277c7a562a19890ba03c14ad7e04453555df08a5c31b19d84401",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/main.rs",
+      "line": 146
+    },
+    {
+      "fingerprint": "38c69955cd649ef83dda58d8bf5ee68e618a95aa9747e408d51deeb799b8b03a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/main.rs",
+      "line": 274
+    },
+    {
+      "fingerprint": "99ff4be68d25ef2154c8c358c64f0cb715fcc4132adf3a3bb75d9f94fb06a282",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/output/mod.rs",
+      "line": 140
+    },
+    {
+      "fingerprint": "e12ffb1f2614f7dfab2270bf583a5ea2e81fda8bb80f56712a45f6cae8d620aa",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/output/mod.rs",
+      "line": 181
+    },
+    {
+      "fingerprint": "46ad53c2b7c95005be6dfe970683b23cfbe95e31e6e7bf7bf81cbdbd8cda269c",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/output/mod.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "418832b6782e3b54db430e30724ae6bb45db30ae806714907a21fafccda54a16",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/output/mod.rs",
+      "line": 230
+    },
+    {
+      "fingerprint": "dc364934659dee287c6ca3b292b5fee761104705b9b78aa2e6a6bfa1318288c4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/path_identity.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "b5fbafa79237f0222f7a47b2594168c1bb48f8dcb58a4b25e5cad28f11b0dbc6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/path_identity.rs",
+      "line": 75
+    },
+    {
+      "fingerprint": "cb9ae0b7bc17e496be2db505e41894211fdf604fc3395527cbc1583b0341a531",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/path_identity.rs",
+      "line": 112
+    },
+    {
+      "fingerprint": "a2bafb7a3c3c1cd104e82ab1726eeb3f58dc15234fcd64d6d878fe48c340805c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/path_identity.rs",
+      "line": 176
+    },
+    {
+      "fingerprint": "27d8f4df67af848fe9a073c670fab131803f15090c223fa7559a1160093f0b9d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/path_identity.rs",
+      "line": 186
+    },
+    {
+      "fingerprint": "e27e1dc22cb91fd742d651fe4107b9be4bfb4b49f7f619e79f759cf19b310cd8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 271
+    },
+    {
+      "fingerprint": "d542b4bbad9d872c3bec302fd8b4d2ecd1de1f3b1a5e8b2cad8dbac0f4ee0825",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 471
+    },
+    {
+      "fingerprint": "4fe32d264c30c3d0ab7af8be321a299f7c19683b356964385e7557a30b9ecde2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 614
+    },
+    {
+      "fingerprint": "cd33a52e8e91d5dc3acf0b42ede3131a5b4b6dd231e775c55fe12df211a64346",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 639
+    },
+    {
+      "fingerprint": "d5836794e553d5441a6b3c672562919007d3d71fa8e9c8949741e13a3119cdfa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 647
+    },
+    {
+      "fingerprint": "8a950c5b02d75743e42c4c79606227fadb8065686d4ede5f34a21751cf3e6bab",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 650
+    },
+    {
+      "fingerprint": "11e997204df9e46e03b550ef950d9cbd6c9e2be2df26ec314ed7b83a4be14322",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 653
+    },
+    {
+      "fingerprint": "c90d702a98bba16d6c76ddca500ef4a3e3e1a4849c1bdf42a0290355c9ef4de7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 665
+    },
+    {
+      "fingerprint": "214f55557737692cf784337c3b808d8b990e942dab7bd4727ea4bb048fd54b1e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 669
+    },
+    {
+      "fingerprint": "6f81ba27ebec1d05b3429971e2cc285865af344c43ab98a7ad49dd88b4fc1c99",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 684
+    },
+    {
+      "fingerprint": "e60530e15b42bbffe10eb521326bd527104c837f1dce0640e3f7960d05b95344",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 694
+    },
+    {
+      "fingerprint": "1e3fdcca9fe8cfd7d5c07a03a8ce850c8fb55d1667b869f836cb81241e2bc1df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 707
+    },
+    {
+      "fingerprint": "edda87ca3dd658a2f55e41a9818cadcdfbdc8b22e8a0f13a7273b447e8d20ebb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 714
+    },
+    {
+      "fingerprint": "de0035eac01e4001608341a625bb74fd08d83521c259be17d2423121232fb3f3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 739
+    },
+    {
+      "fingerprint": "55757d883354d3eada53240a2737315e38e849d82da862d8e0500f9c161a2640",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 758
+    },
+    {
+      "fingerprint": "623c8085c04f653152d89f219feeb7ce708ec7a0cf03103be73911204674a183",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/cbom.rs",
+      "line": 765
+    },
+    {
+      "fingerprint": "8e881c253420d34d7b84174d7ee8280ce1cdb4891fee27f08ff88a7834021821",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/json.rs",
+      "line": 114
+    },
+    {
+      "fingerprint": "7a0058aed994c642dbb5205e8fdd81977afbbb23c774def12f9d98b131839f30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/sarif.rs",
+      "line": 341
+    },
+    {
+      "fingerprint": "ce5e48ae309c832b72686a06f3e2b18d3a326556cfa4f114b481cd8dc2c7eb05",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/report/terminal.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "f97cfa6114e9eee582f4e982720fc3bc770cf210b7c909bca859f7a4d25a61c4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/report/terminal.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "f7e3cca3c557aa9e1ae1880b610d4a6453845fbd6fb0c55b58e7f090b5f93632",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/report/terminal.rs",
+      "line": 126
+    },
+    {
+      "fingerprint": "132a9248b391ad4e2e3a1dac6a5c4b1cdf08de834fdb018074e700eedc3c9187",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/common.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "541c4abef44b5dae89680adfdc5397047f3249d6f47c00e8129c6faf9ee6f2dc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/common.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "667ea92e202fabefabb1741116f57dcf027152e79957b947870999b1957a35fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/common.rs",
+      "line": 407
+    },
+    {
+      "fingerprint": "f5019ce3ad62dc3a852c435364ccfc792e2c876844254010c072acc6f8d5f431",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/common.rs",
+      "line": 408
+    },
+    {
+      "fingerprint": "c29709aafc4d8a41cf6941ab08b64974bbbef928a329348ea960d9907e94628d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "7e03f786e15ab3e4ee75e3d11d1c68299fcdb22108aebac11e8baaba08ec33de",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "6b89bb439134293a7d43d9bfffc1d9f903d5d0005952b9661cb7ec231c3afa11",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "4b7348d9c44449878fa261747258fa8b7409473d53b1af1b704cbe70ee8a0397",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 47
+    },
+    {
+      "fingerprint": "39f2a9fd9ffbce6cfecacd3058e173402aae35189a28e4f8f7a42d3fc4267a18",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 54
+    },
+    {
+      "fingerprint": "dcb50cbd62abb5f6f1c7f30ee4accf4fd1510c25f69b56faf0167ba346ac0a0f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "415b9d839b1fda603819cc35ec82f2ce475a15902292ce3dfb31ae978b82fd69",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 69
+    },
+    {
+      "fingerprint": "a8b166dca8ceb89221d77c042fd1a0074a14766cfff8cffae7a30bcff1902a98",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "018b9844033be4aca9ef1812c36933954bbda67756a379dd55b0d206c4c6321f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "6f26b599fc6b344d589ab6409d7e0ef39c9794bbff45f05f53269e4d6faa2be3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/config.rs",
+      "line": 94
+    },
+    {
+      "fingerprint": "51646a5804f21d44db4332489c19d956be0d0b44781c7b527f28feb53e5cd37a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/csharp.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "b59bf1bfb2de19e64894d7b555feafa059073e3bee1b9568416941b6a7070fdd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "f83c221eecde60ef82ee193155d4b0d5529c7f742ea4b017f79058c55a6bc865",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "8ca694d8d32485480ddaeed527e3bb9f8cde5525b8b0198eb87790fa41f8b81c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 38
+    },
+    {
+      "fingerprint": "727cbde16d8ab12ce4b399b3dda66054d5f797349613f4145dfda5e7cdc88b8f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 45
+    },
+    {
+      "fingerprint": "11387bf12f2d701272695deb1250134801a31b7cc3c5e117e070a256b029c1e1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 52
+    },
+    {
+      "fingerprint": "bb943085dc13fa5d66b4448b5b52617720d0923e76f9fa343dfb03dacd8c0dee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 60
+    },
+    {
+      "fingerprint": "1c6e4fc7b26001aa0f45e8cf84ba5c16a37a0a4fd1b0b98ce647b7c1522f2da5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 67
+    },
+    {
+      "fingerprint": "83e0b04b218ea951e289985e4e2ccbc37dd31d19527fc1f5273444468625d553",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go.rs",
+      "line": 75
+    },
+    {
+      "fingerprint": "adf01283677825ccca62de0c326345d641733cc7a72cb7d60ee255026dda8475",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go_taint.rs",
+      "line": 1324
+    },
+    {
+      "fingerprint": "b5b4fa603d603ca81719a7d07a4e61ffd03756cbce6c6d924c985b71cea1c1c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/go_taint.rs",
+      "line": 1702
+    },
+    {
+      "fingerprint": "ee702d574c2ec170394362ce53850a51cad7090f629adbec059227393c859bea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "90c637f2c782afce381ffc3a726e73abc33a2217baf6bf9986ee242099870b4c",
+      "rule_id": "rs/no-weak-hash",
+      "file": "src/rules/java.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "3370bb38960d840552b925343e8f9cd4a72c62c666d5831efe2d54e68dc7d540",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "b3968d2da3535d0faaa3c62fe2add56fdd246a11b3af9015f2eeb4ca507595d2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "32924b8dc48bdfe57f0b73712d78e4909ce9d7765098617f9cc92839e3ddf3c0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 41
+    },
+    {
+      "fingerprint": "d6c708eb7a35a86c01241c559610f1c0903525ed3e08e6e389ab3794dd062ce3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "2c7c47495e576c6cee03d7259bc63b42363429faee4604523b8d9f9b895c198b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/java.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "9bd355445f4f61d716456c2abd29753412de7c6b8d9dfbcba6eca4c113aff20b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "c4a167a6da8e6f61f41d12c91c2846377e5349735eb2048b038d5ff83fdaa610",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript.rs",
+      "line": 28
+    },
+    {
+      "fingerprint": "9ee6ea663b55aab7c3fca5724f7c4049aa3c930e5d1b852ea22ca2c1bc1b180e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript.rs",
+      "line": 36
+    },
+    {
+      "fingerprint": "60b6705fdc91dbabeaa940d26386516281c8949391978c03938375cd0bb5135c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "1bf61e474fae3b589b3a1a8adea2eb5e64186a5990b9e1bcfc10d4baafdc8dd2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2121
+    },
+    {
+      "fingerprint": "cbbc0d0d25c5890c8b79ce25cca1b893ffe65191e4d5689a7ed486191669bb2b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2278
+    },
+    {
+      "fingerprint": "fbf80ab1edefa8f07d769d067a83e0c766793ffdf6a09705e796dc7219c3aab8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2300
+    },
+    {
+      "fingerprint": "388d4a80550015bc009dd6f5ee0fe37a32132f90928d10ba630ba31bb9b8db9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2309
+    },
+    {
+      "fingerprint": "ba56537d3721391b7b00983663942e737b637388da9c17183767137356788d6e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2318
+    },
+    {
+      "fingerprint": "383ddc031c09dcf5347d810967d73c92137ef3f6bce3329b1004ce4e53bd93c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2514
+    },
+    {
+      "fingerprint": "d63d1a79ce1cde075e5123010e56f26feaffa7ca637a500c40fc2dbc7015568b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2534
+    },
+    {
+      "fingerprint": "cb358b49b2a9b567918f46b9bf861de6dbb67cfbada9399cc11c9944750844ff",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2550
+    },
+    {
+      "fingerprint": "1a8c3ffd9182547ade25f69248e9227d3fcc979d7695d89ee7ace75e05f90109",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2568
+    },
+    {
+      "fingerprint": "c5b02733711d6bafcc705bc8af79ef3dd1f11a1ae5935b5e41892104c99cbfed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2584
+    },
+    {
+      "fingerprint": "5491016fada3f63b02dc6246d9f3735f63d00cff8c626e08a470e71e4c77a0eb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2601
+    },
+    {
+      "fingerprint": "dd6d48917c773089431e5b8066f433434af09db68b3760486ce2f79a8dc7480f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2621
+    },
+    {
+      "fingerprint": "720d33a911135ece1247d2bc13161fa45bb527b162572a6a61747de0877b7d82",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2637
+    },
+    {
+      "fingerprint": "9a22dadeb61633348f13d853a295c79d1b77e6acd3e86062c33863e5309c184e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2656
+    },
+    {
+      "fingerprint": "4b7df8c00d5da91eb39ea86c837f309833ac2d250a20fee86160b455687a6783",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2681
+    },
+    {
+      "fingerprint": "788899b102fa609a3c27e887bc0cfda1327a3ae43ea8348cb37a2c44fcb484d5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2700
+    },
+    {
+      "fingerprint": "587a9345ced278bc63ded567dd5ea4001f92836aa3b3fb833faa2ffefd7b8c34",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2709
+    },
+    {
+      "fingerprint": "c3e46ab3db13536585dbdf4be818e3845cf4db0a38888f1d6e84f63f3c1aca7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2729
+    },
+    {
+      "fingerprint": "7ac4871ad4dbfe116faae2b5197a910382d9d1a7488c1b8fbbac2a142f9f142c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2749
+    },
+    {
+      "fingerprint": "2625582f4072070a60ef723cc19dc7a72e012f7e7e434c5ee0a826dd9da54ae4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2766
+    },
+    {
+      "fingerprint": "64ca95ac30c43cb8a8520ea15cc142aad51c7175ecd573fb0675d45a72e32338",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2787
+    },
+    {
+      "fingerprint": "6984f661784668d3c11d2e10ef11be89cecc9d8d4647cceaafb060c3934ccf63",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2811
+    },
+    {
+      "fingerprint": "73eb5d28f558af0bdd37b40c36263d5b8bb420cbff3dece1dd10ef071bce226b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2837
+    },
+    {
+      "fingerprint": "d42e311b43ee2ae57101972254110ca9b5b2171e508ab1c37c05ff2d4e85e144",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/javascript_taint.rs",
+      "line": 2856
+    },
+    {
+      "fingerprint": "a4bca856cc76a588767ea90129b34cfcdbb4023486b26ddd23901ecd10721273",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "f97b78fe1547fc50b566791dffb8060a7a9ecbe8acdeeaac609f0818a2e5530d",
+      "rule_id": "rs/no-weak-hash",
+      "file": "src/rules/kotlin.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "654b1e18e48caf6f01ec082945325a659adfd22d92bedc4a5f5d824c8f9d906c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "477f37f2d17cded8a2230756c4b386ee6174f295f540cef713ce46da0718293c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "670e44e2ec6c2f9d31f4aa269904600c78add7abbaa627bae9727872258de4bf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 41
+    },
+    {
+      "fingerprint": "a7e7a0637836c83c3cc54588a038a9caa8042eb2c5b93b62b2168255542418b8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "94bf254b494e7a42ef8e5814c5bc04fbe357a0067be117f226c967c4a95b17cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin.rs",
+      "line": 1031
+    },
+    {
+      "fingerprint": "dafac73300294807dd8a29d1ab06128601f57e417fdd1f4c4a57b2c5663c0a21",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/kotlin_taint.rs",
+      "line": 766
+    },
+    {
+      "fingerprint": "6340137fe978156cfde44d9522eb196b7a097fae2ede158488a96fd3e0012083",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/manifest.rs",
+      "line": 489
+    },
+    {
+      "fingerprint": "b000e3b2a486603c1e3d9ce3c43063adbccbbf36ba10114269ca6606b0a445bd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/manifest.rs",
+      "line": 533
+    },
+    {
+      "fingerprint": "c7258887451f20b6ad406335dd94e4dda6c6da90023268a3fa854441d48feb6b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/manifest.rs",
+      "line": 755
+    },
+    {
+      "fingerprint": "abe1cf13fda36a89a400485e484d235c02ccb3e128bf37b04721bba9a1f97786",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/mod.rs",
+      "line": 976
+    },
+    {
+      "fingerprint": "f6e8ef0d3a7b96e20e4a77928a146820798c89b818a9c35828f905713be9ca5e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/mod.rs",
+      "line": 986
+    },
+    {
+      "fingerprint": "e3b7d0b3a0becdfd9d5c664c9d1f235a0133b2c46ddc2041b380509f6cf40bf6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/mod.rs",
+      "line": 994
+    },
+    {
+      "fingerprint": "d3f202c67f11aaf37795ef054e74f88ca51aace629d09f1c1f098a3c071ec1df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/php.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "d713b0625cc1279c1d0e6f8193d63837efd877a6d739cdeceae2ba78c1caf936",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/python.rs",
+      "line": 19
+    },
+    {
+      "fingerprint": "f29816de2e4818d08906b6d75d31baea66983d763218c5c28b08e6b706c72def",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/python_aliases.rs",
+      "line": 316
+    },
+    {
+      "fingerprint": "385271f7b8f8e7028a62f55895ddf8dc2b7e351d324032051cff85eb5829fc5a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/python_taint.rs",
+      "line": 1495
+    },
+    {
+      "fingerprint": "32670b615b429611e964755b6208e06d15fa14dfca6223ee48b65c4dfb3e8219",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/python_taint.rs",
+      "line": 1685
+    },
+    {
+      "fingerprint": "5144585ab0f5d37444198c3b2687f23523533732dc422d337d411f54dae5d2b9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/ruby.rs",
+      "line": 836
+    },
+    {
+      "fingerprint": "ba95fdbae9bf77a2271f838aabb6f11a4228263f28bf160bc42c7743342944a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/ruby.rs",
+      "line": 839
+    },
+    {
+      "fingerprint": "af9409323fb8725b36eb884a43a3db4109a44cc2ce4ace7efc4962e0548ad2c5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/rust_lang.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "19e18f199ae89abc2affff103f91156f184d3270d4f7a208cd2cf5479db47d9f",
+      "rule_id": "rs/no-weak-hash",
+      "file": "src/rules/rust_lang.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "645126a5bad82bda2eee5024956c7bde404c9f67e00fba00af02ee2a39e4cd65",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/rust_lang.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "05c2524d07da952ee1e9ec00bb2eb034e2c70ee430bf174d6e8e86ef4fc02cea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 350
+    },
+    {
+      "fingerprint": "dc68f471abfb732056c9004f38062e4cbe08c1b858a4ba343e132d7a40f1a045",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 358
+    },
+    {
+      "fingerprint": "08779c8ee735c7784440218ab990f0b4b62f3b28f3e1d940350ec4c4f73ae1c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1066
+    },
+    {
+      "fingerprint": "bfa4a48299378da919962752d5819f969731ff362b60f43aa4598cb58609549d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1354
+    },
+    {
+      "fingerprint": "68ad49be087f312a6d323cfd7998ea78b9e2ad65265aac772d6a8199bb05c709",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1355
+    },
+    {
+      "fingerprint": "f7a856fa0b11f4912c62e4d3038dc266cc1317e9dcb5cbd8d7259653e146a065",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1370
+    },
+    {
+      "fingerprint": "7baa6360d74c18f723ed7fbde48e42e90b60f98d31e3057d47eebba9da880e55",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1414
+    },
+    {
+      "fingerprint": "52229b57ef1c7a3fa461da7679f9d03fc59f93b8c7b0f8390fb3bd786cd2e140",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1415
+    },
+    {
+      "fingerprint": "94eb9d3781663e776bcc9a4f82072814fb8af759c54265746dd154a7027b72fc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1439
+    },
+    {
+      "fingerprint": "2311dbb2a7cc36534d0ed5efa9695941ecaec6caab8dc0995e80dcb312b3903e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1454
+    },
+    {
+      "fingerprint": "69071ed5ca521b51f771e0c0b31f1356cebe29ac48533787ea69ab90e16296e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1480
+    },
+    {
+      "fingerprint": "eba657cb0f5c3dd501aed39efaad3909076eb5ef4e5e54dc6909e4a34070ad85",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1483
+    },
+    {
+      "fingerprint": "fca6b545711ef74466c8b553d38cb63d6785e799abb9c30d8fdcb73de604ee92",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1503
+    },
+    {
+      "fingerprint": "a3b9aa5f45a486786e1af7a6cfb88a32b1e9c76548055c75c0f8d2e6d00cf697",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1506
+    },
+    {
+      "fingerprint": "50aa31b9550887bc61fac49aac2b6fa669c9b2b779d5f6492c621099e0a5dd16",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1523
+    },
+    {
+      "fingerprint": "4ee5dbf12af3175ea5e54d18cbc45bded6aac38450fddc612b8d2ed4c9560fcc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1526
+    },
+    {
+      "fingerprint": "d97b68050385e1ee32b04428088a42ea87d98f6520010c214cc799be4c5e51df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1543
+    },
+    {
+      "fingerprint": "f3383ef99c7a2a2f1397d729452eca4e7d51646206e15bce4a4e58849b672db0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1546
+    },
+    {
+      "fingerprint": "b6385b40fd9e4102fc211e09244cb4fb0d32a8ebe20d4fb346d55aa57d2412da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1563
+    },
+    {
+      "fingerprint": "30e80a47981961599039c71ea2a04ed1b4a99d70dd494557383bf3ba9d9c88a7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1566
+    },
+    {
+      "fingerprint": "a0e7cb6c4ce0a17d37131a1f9777faff02cd562d37d4c60d1324234df39d8c87",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1585
+    },
+    {
+      "fingerprint": "16ce40fbf16f4441db6b285cabba08957d1c3216cfc5b502d07abf97e9674eae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1588
+    },
+    {
+      "fingerprint": "36f416fdef5642a0a0c885ec63f15edbf41b050e67e64ad4dae5b412fc0970b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1609
+    },
+    {
+      "fingerprint": "9a3eda78bd3215a65553ca7ac02ebd7b3ae5594ad3dfaf1e3e5744ba10ed7926",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1612
+    },
+    {
+      "fingerprint": "cc0b3bde9ad90879520ff5316aab841da96ec2631c0224047c6e4ca565af0baf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1633
+    },
+    {
+      "fingerprint": "fd1c332119a5332b5bf284b8d6ca95833a8999cf7ba4ca8206d7037eda7a1864",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_compat.rs",
+      "line": 1636
+    },
+    {
+      "fingerprint": "d00b5fb54c083e505c3891bbaffd26f193a2f20ae51a9ebc3aadaf97fe593112",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 548
+    },
+    {
+      "fingerprint": "dc7a95c7335e7f6866e3737448806aab48f967a156bf397dabaf49f2e237cf83",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 648
+    },
+    {
+      "fingerprint": "b9b4965ac6d86c5a21f6a9a9a681f3e2cd35afcf2bc477992d9e33c3e4238bde",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 731
+    },
+    {
+      "fingerprint": "89de24e9c4a82cff867b3fd439145da198e5ff99b6d461b7b877a55ff0cad83b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 743
+    },
+    {
+      "fingerprint": "b5d975a0d694d12105912d5885414c0ec0b675f8d44c645385fbb7885b742802",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 755
+    },
+    {
+      "fingerprint": "e755d7626e24236e3c90cb27492f379571e268df35396a3b1febb2ec4e1842c1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 764
+    },
+    {
+      "fingerprint": "a290358b740ea016b11b2e297e155d3bf065e40e6f328cae6d4a8fba50d1a0ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 773
+    },
+    {
+      "fingerprint": "cfe0e25710a111023303967b439fd621e8715c7d6dc95e4f5fcf26b5cc040762",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 782
+    },
+    {
+      "fingerprint": "a765aa76460a1085e4b3905b55d54607f2929974c9a49992a5a1a0b28a716f2b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 819
+    },
+    {
+      "fingerprint": "e6243844f065c81d1e0d6929d5abd8d206b45eddbca7e9ff11aafbfd4ae37815",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 842
+    },
+    {
+      "fingerprint": "383b4b6550e80934d2a72cc278cab932bfb4cd709c0f91c5fdf304b3f12fd034",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 857
+    },
+    {
+      "fingerprint": "13d4c6eb4d47a5ee05dcda81eeaeb1d9e79d35634dcf167da4915994ad142d7c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 872
+    },
+    {
+      "fingerprint": "8022fcb8f30f8e8564de0d508874061cf5cde5c189bc0a3682554117cb767960",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 895
+    },
+    {
+      "fingerprint": "87129c93a27990a6ef513d1839889044ca324e3998bd302aa0985015322d1df9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 914
+    },
+    {
+      "fingerprint": "f7715a399e60d5c297765ec65fa81a1127aa871ee768628755e185dc62988516",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 927
+    },
+    {
+      "fingerprint": "e210195447b8a639f6650de31496b858f27bcae9469a98149d7d1de337115e9a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 1060
+    },
+    {
+      "fingerprint": "fc8df3fecc25c6658de871fd17c0846738d6a856c00f63f5f65a7cbb13d9e482",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 1109
+    },
+    {
+      "fingerprint": "7c4c495bbd5683edb91f8dad461f273dd55bfc368d42c666361d4499a3f81015",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/semgrep_taint.rs",
+      "line": 1126
+    },
+    {
+      "fingerprint": "de05ca117a64342b617dacb46b039e283229fdc9e8a4faf2d50cef54494834c7",
+      "rule_id": "rs/no-weak-hash",
+      "file": "src/rules/swift.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "424f64ea7f4a86b3ab44825776456181b4afef3cf46e9275e382d746bc58799f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "5ba4b40171cb10331564abcd8a610248cda21a71649cc4db475fe51855f128f2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "c75bea11a81a0b03894809543d8f67efa50f3603139b898bdec154d0828b12ff",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "8ee3bc50cab3129ab5ed047e104be06cae0d7b258a99e2ae521260e3aedd2ec7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 41
+    },
+    {
+      "fingerprint": "d7b5b89b7e498c607fcdd56c1988bb2663073552855d59cc3206501d1d861205",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 51
+    },
+    {
+      "fingerprint": "88ad5081528df8fca27fa3d3ccb2d0e740a5dec8ce57066d8c9290a1acec6b4e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 59
+    },
+    {
+      "fingerprint": "da5dbb8bd9745d058224dddbd01556680f2104c794d49ebd2c1af7fa3484503e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 67
+    },
+    {
+      "fingerprint": "12b2eb4dec9f40ef883dc4a6d2ceb2220b12067eef3c54fe9e57256bf1df9819",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/swift.rs",
+      "line": 74
+    },
+    {
+      "fingerprint": "e607c1db0c1f3e822407c289165a688b9dcd814af1f54a37cdcd2281e21b2d8e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/taint_engine.rs",
+      "line": 814
+    },
+    {
+      "fingerprint": "af023f5e53b261acf50c40c3b1cc3d84658ff2c93dbbd502ca55950fd05e438a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/rules/taint_engine.rs",
+      "line": 839
+    },
+    {
+      "fingerprint": "11755c78a9019b2384073451fe4103835374a4302e90f906965f3de07dc7f27d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/secrets.rs",
+      "line": 189
+    },
+    {
+      "fingerprint": "87aaa88b46756d7df2449ff7f633af96ef2cce9da1b2d927f92215f512d626fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/input.rs",
+      "line": 354
+    },
+    {
+      "fingerprint": "7f4f0cca69c67a6182fb4d7322f2eab49e3eb526a4c062b66ad470074b38f760",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/input.rs",
+      "line": 357
+    },
+    {
+      "fingerprint": "a7c91b3ba7f4e7fcd7f5735e66a3a11466826eb8760425dea73a45711f520135",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/input.rs",
+      "line": 361
+    },
+    {
+      "fingerprint": "b4d0007020671beff8a163598ed61a00c5f206f0840bf98c79a05b45fb6d657b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 434
+    },
+    {
+      "fingerprint": "6ced696090546e95e7e56ef20b39039cd57c4806f87520fd65521f2333b94180",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 461
+    },
+    {
+      "fingerprint": "a8b9acc7cd05cb074936a3884a342c523621606480638d7af6790262d033dbfa",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 642
+    },
+    {
+      "fingerprint": "d36755630817b1528de70677379fe5f090960e82a0db9b9c3cbe2fbae979a47d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 646
+    },
+    {
+      "fingerprint": "80d040df5940f60161b2c3f5327b912715e6ace72dc5eb2c9e79953bfd67d183",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 666
+    },
+    {
+      "fingerprint": "78e2957014dda9f7db46134cfd3977cd5e53bdb6045f3a9883964c528e7a7f75",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 687
+    },
+    {
+      "fingerprint": "57c84ee65eea06122d4895900832429676bf293cce4b77fc1efbe29a4877df13",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 716
+    },
+    {
+      "fingerprint": "f7623592b5cd58fdd43ac073f7d91edcc9ee02ad95de0cdd8a3e977ef6cffe12",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 752
+    },
+    {
+      "fingerprint": "d7e9c01a592bb73fe9adec73e71b8a22a3180acc56bfb17143e8779c0733016f",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/input.rs",
+      "line": 828
+    },
+    {
+      "fingerprint": "f883f552282a1117eb3a4aa5d601bcbe476504618a8de3d04aa1a5ee97db9a81",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "614a02e5c0af12f274f4c332a6ad4d0d1f358e8a7b75804a7e3eb5150c66ba39",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "1b05e36783cef19087ce2d56b0006c25510f83a3f03a9831c67c0962e89dec30",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "50fdf6988664bc928b187a9ee8d0d9bc0e76a6b6253ce4900d5da08d7dd98057",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "7d1066ca48fdf7709e137eee55a00750ef8f5a202f3e86feaceaa99546d1f428",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 319
+    },
+    {
+      "fingerprint": "103713866df419db8c00e3ec1ed827f895f3a70e2573636f8e026b4551b141bf",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 338
+    },
+    {
+      "fingerprint": "c2f9b6f9c32b10c5cbf57916f8dc756c1a5595fb14e633d034e52e2374cf09ff",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/mod.rs",
+      "line": 350
+    },
+    {
+      "fingerprint": "02c6f06955b5dd3c96eb101bfb4ce6879ffdb7a64f28a2460cec653bf7b0b62d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 391
+    },
+    {
+      "fingerprint": "25a2b7d60006e4073828e2651ccb66b68d18de6827750caf830378e77606d7ad",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 395
+    },
+    {
+      "fingerprint": "acb20240443c2f78c82d49c4c73ad22cea0c032710368f43a5c683634da516b2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 401
+    },
+    {
+      "fingerprint": "91918c3d775a40343e94f032a46d2dcf6d789d5f1e1d3fb39adf4909cca44fc1",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 406
+    },
+    {
+      "fingerprint": "57bb8e16ae775836eeead3eb2e020fec237769671b7c92ee3837724055dad67f",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 414
+    },
+    {
+      "fingerprint": "d09d4cfdd3a79df3c9a15e450180cc7820edd6e88770ce1394a8cac359640eb9",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 416
+    },
+    {
+      "fingerprint": "02d3aa6b622733cb5ac42697d6c41aa6217f08e50f11e50bd007aab84d2a6056",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 427
+    },
+    {
+      "fingerprint": "a7f8ba72364ffd2b16bfe6fe0ec2fb65b1745573317f840a9956411caac70a1c",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 427
+    },
+    {
+      "fingerprint": "de2a05fd4cdfd2fc8e6ea8b8f33de4da1ff297bd1c73c94ca35dda0bdaa2f39a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/state.rs",
+      "line": 428
+    },
+    {
+      "fingerprint": "6a7150a8ece6d348b04109e814190aa37b45751990e26d03aac1f470337552cd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 135
+    },
+    {
+      "fingerprint": "a21862aa287109e7634fb8a284fae919ed3e4680a8fef8e49936b0bd9e60658b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "5559964797ce1d13c063bc31c1eed259f838232331b4051e9cb4ef65e195f56e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 168
+    },
+    {
+      "fingerprint": "04da7d1096f89730d47eb3e2be47d66a56976528a6cc4bd9494552246de34dae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 189
+    },
+    {
+      "fingerprint": "906f5e84875b9895136f9b106ddc988500422bc23b61979c948866499757a36c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 201
+    },
+    {
+      "fingerprint": "8b57c2fce02c6253e186c6ceba9f64b357bcc56983635ca649b1f975b255cce9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 217
+    },
+    {
+      "fingerprint": "f74052c3aa7b41bb88f3e2e0b7eef0da6f1466000665d1309f396d8e03f6ef41",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 243
+    },
+    {
+      "fingerprint": "aa6798866f8838590a328f61c5a7960cc0007fea5118180a64fea474a28b4d26",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 704
+    },
+    {
+      "fingerprint": "2a69be4766f5a7a5871fe1955f4b67572c040c3cf70234c409227b084094677e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 744
+    },
+    {
+      "fingerprint": "63c18173e00084d6ba08ec17d235c72cfb799f3ddb2cdb7a501434d9eb7d3015",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 784
+    },
+    {
+      "fingerprint": "2a07c9e116faeddbe136ac244dc5b0c135a1d4c3c9feab8c988a43c58991e9e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 824
+    },
+    {
+      "fingerprint": "bd568616c08b861547e343ccaebf5e874cddffcf47e57544192dda724f4e2509",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 838
+    },
+    {
+      "fingerprint": "a895ecfd9f83df89ff10b06c92060828216abb4cfed766c5c3c31a1dc0af9dad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 840
+    },
+    {
+      "fingerprint": "8896ac697084f45fe2671f3fc1fa2eab595add27850adc3da02c9da6fab5fcb3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 841
+    },
+    {
+      "fingerprint": "43fbe93ce99e9e2bdd9499f9a89ee5842293603181aee9bd1124f90eddbf40b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 866
+    },
+    {
+      "fingerprint": "6fd7c1decc86e53cf674261644d3a3fb7b5bc7823e65d47b2feffa919ae0916b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 868
+    },
+    {
+      "fingerprint": "57254b06bfaefcdf223054aaef32566f105093b81a80836e5308cf6806fe7774",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 869
+    },
+    {
+      "fingerprint": "12a037f3a35672eef6cc0befbd54872ef85db828951374c3f7b8f83c73f3f10e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 881
+    },
+    {
+      "fingerprint": "c5355a927316e097ca7cd242a1c9cd298b8f56c387746401366e8561f3ade5b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 898
+    },
+    {
+      "fingerprint": "e749232d695bdeba1761b8f28b333a699fa5801c33321f19a8bc8ce7b279e374",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 916
+    },
+    {
+      "fingerprint": "bd6a7c467096956ac4cc0765c49cbef7fe530165f309825ddaaefaa1fb92564b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 920
+    },
+    {
+      "fingerprint": "1632f66b4cee94d2cb9808e4ec7d66ffebad0177c5bec21a1e0f59d6679a7f70",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 934
+    },
+    {
+      "fingerprint": "4123a4791f6ce96e73057a421d6d92b9d2cc6c673c582d00460f10bfdc3c3e8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1365
+    },
+    {
+      "fingerprint": "9f319a18265b637225bd34efe6bd977b30a27276e43b0c19babe4cb158d0a6cb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1479
+    },
+    {
+      "fingerprint": "5f55285e26ac419b78ea8423b60b1ea1c3cf7267eb70026b984a0c336b9e7a45",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1742
+    },
+    {
+      "fingerprint": "c1f9107e89d94f9fdcace7247d2dc55bb69e6a5d7d7bc463c072cb826ed4d65d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1749
+    },
+    {
+      "fingerprint": "9abdfeac7786d250bcf5b60c6db66ceb7ab3e9c15210472a01ca06499aebcbb2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1801
+    },
+    {
+      "fingerprint": "ef8bbc4c0fa75deba9d5676a165592e662de060c54e60ef2d0443834b1881781",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1813
+    },
+    {
+      "fingerprint": "d135e4ac20a81ca28e1fb13b3f1c95231ce4d8b572723382d0837eb0406fb7e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1865
+    },
+    {
+      "fingerprint": "493773b35113c3636e10da3b42efe5d35c4ce4f3e5ab92bc718d4091e3559086",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 1873
+    },
+    {
+      "fingerprint": "6ae422676bb2abad052e6db1dad71d250288bcd147bd20a45f9aef5e9f413bec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2111
+    },
+    {
+      "fingerprint": "ecb58cfaf22a2032de484f3f06092afdd91aaec411673ffcb519b085a497cb76",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2112
+    },
+    {
+      "fingerprint": "171afee94c7b5556089aa562970ffac26e5f200695b4892c6a90fa3291fa56f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2195
+    },
+    {
+      "fingerprint": "3164162747b188b9c0d3f7d088a94f0081bf1f0a9b927c533dc0e55f68e22f9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2224
+    },
+    {
+      "fingerprint": "45210621a1d3d458cd20c71233992d2a3ebc8a79769c3c09aa25073254247e51",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2230
+    },
+    {
+      "fingerprint": "b605132130c211394c1cf731c639318d7f75db727128a4624110e5add3b7d633",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "src/tui/tests.rs",
+      "line": 2246
+    },
+    {
+      "fingerprint": "2dafdf212dfe08480a62ae5edda7241ec832f43836ec3cdd323f536579039a2b",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/widgets.rs",
+      "line": 1108
+    },
+    {
+      "fingerprint": "45ddacc677c33795697c69a5d26eb32f32d9280c2636cecbaea7c72e2df221ce",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/widgets.rs",
+      "line": 1108
+    },
+    {
+      "fingerprint": "c8cd61d7c981287b4b6e2bf058f6c509d168ba4717ce4ac69a3014cd60c7ea2a",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/widgets.rs",
+      "line": 1123
+    },
+    {
+      "fingerprint": "6f6b9ed08a2c411e9493bb2297a2f8241947b1bdc658d8d4077e4cb257421b15",
+      "rule_id": "rs/no-path-traversal",
+      "file": "src/tui/widgets.rs",
+      "line": 1123
+    },
+    {
+      "fingerprint": "a2620902862597457c466e9172eb3dba9ef308d7b8bf99dbd301c9795c254b85",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/ast_rule_batch_bench.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "beada04d745fd3f38e115b0ea946c6d7cec2a077b519e141feb73c1163c0cae3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/ast_rule_batch_bench.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "f4514c9eaa6024b256f62ead0bcd066a59b008a7af2cc3c9ecb390216765a732",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/ast_rule_batch_bench.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "575ffaf4fcf786413ea90c3c00d4ac18da66a765fdb055b4ced290472561482e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/ast_rule_batch_bench.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "0a42b62356bcfda1e3101c7a3984d2142b3c47ae38e6d4833d424f9aa9c69e45",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "65d13a0f10ee8816cb77a05dead5b3a17f47f84248740d9574bc06669a91ac9e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "433cd3f0889bffe7b0592e65d9298cea78c5848114aae9056795cf2315131222",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "1ec6ba7f3356078b65dec9cdba0551d57bba879602eef81a966ab1dc194e3854",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "835e315c53de1f3f03873ab092be6e1e41976c6ab2b42a97eb79d35205d1f82f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 106
+    },
+    {
+      "fingerprint": "7465caf895f2654f1c71af53511394515712c5027f02d4ca0286582c8f5fed8d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 168
+    },
+    {
+      "fingerprint": "2eb8cb29cf86689a3a3adc2cc78b9296f2df4ba132650cb523e5790421888554",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 195
+    },
+    {
+      "fingerprint": "a8c019ee62c699770dc3ca5d4ae948ee0c480ed869ea3e4b7698eecc52af2f4d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 226
+    },
+    {
+      "fingerprint": "0fbfee7b7fb457db978e237d5badd726e1b371486c62933e6c1ad003d6c12d95",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 244
+    },
+    {
+      "fingerprint": "e4c1e998ff0addd04964f8ef0ff3415760c5e38077fa5e83dfdeb1797be61b55",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 10
+    },
+    {
+      "fingerprint": "2381de6d4719e806185346c3b851822fd35c91294d72be78406a3db4fe233c81",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "70146b54a95e08cc0cb141f3971827f3f21360df2d5d1a3c5eba06f05bec40b4",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "8151c43f9600bd8397f34b02b579b0361ac3d40641d7a2da0605b706432c8ea5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "22ee50e53d948a6591e5cd0d8bc02a389c163cae181f34c1e287b4f11fc56d92",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "484be581378fa54e10f4f6525fbe325f7b8d9a7498ad3f3eb1dcc9e955aa4920",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 46
+    },
+    {
+      "fingerprint": "ff992325b96ed461e78d3ee363a88e9fd26b9941f5c0f779cea1f70c5168fca8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 51
+    },
+    {
+      "fingerprint": "ed50c9667d0c555c4863cb79224b169893ef625ccd4cdbaddd4c0e27322d7126",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 52
+    },
+    {
+      "fingerprint": "866a8dd1b1e021c3ee0bb86464a38b01c89401171dc79ee8be9bede2bc3c9bb8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 61
+    },
+    {
+      "fingerprint": "aea1a1d8e92b571cb7b7441e16a08d959e05606555e46d2b1818b1de05f0318d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "84849ef16cc4ba2b74c05c11b3f4aa7238b01aab498306380bf6b4332635b031",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 74
+    },
+    {
+      "fingerprint": "99222843b20a82990d43133acee7b37ef5aa66594e6191c859803a20c2f93666",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 78
+    },
+    {
+      "fingerprint": "ec0a3e52c2b8b9d862daa10e281da819388783267d4b4135db0d6617250f8a37",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "c758b4e69aa12bdebee86de3365b0d85b15bf60e218f17918c43cc42111f577b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 129
+    },
+    {
+      "fingerprint": "c7238cd2047f1cdf3b3b0ed06c236928d819fe3b3ec8ef730ee7a50ba16e54f2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/coccinelle_integration.rs",
+      "line": 138
+    },
+    {
+      "fingerprint": "23ac45656b99b597ef3dd1e92e203a232bcfe7a4850aeb2c163277bbb004248d",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "d2a720785f7fd546be41022d69984d3b2b2c7d4fd288abaa8cf4628304123b76",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 235
+    },
+    {
+      "fingerprint": "3d3a9548abd30cb4a16de323a5c1f3cd3e1f5b82d694c6fea788880c042ae7dc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 235
+    },
+    {
+      "fingerprint": "f44e1ec87c820650182f409ec6ee4f2f1106aa41d4aa166889b188dd809a8c79",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 295
+    },
+    {
+      "fingerprint": "e3b02b235e35af0b3fbfeca3e58f4a687be78a78b642fd563ff07ba4d27b3932",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 301
+    },
+    {
+      "fingerprint": "23c23660db60119820308c7c7d1be38d73e4e5f701bd74f063ae620359ed7cdb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 310
+    },
+    {
+      "fingerprint": "071ac062053902f330ce5b96ece104474196e30aba739fc1944e1c39bdcca8d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 317
+    },
+    {
+      "fingerprint": "4f4dfceaa54ced2eae92eb546400e72977ae1bd5c7a446243b295e0dc4fd7131",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 348
+    },
+    {
+      "fingerprint": "1209e93dace0e874a4cff128dac57b0920b185e034404ae7010db2aad27d2fa8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 440
+    },
+    {
+      "fingerprint": "7eccd0c248f891a359f078f0110a8992969f7896e64f5ff8f2a176b3a1085c41",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 442
+    },
+    {
+      "fingerprint": "ed25afc47fbc6c53f4a06e1d345db63c52e2a8086aee373a9f132185c295cf13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 505
+    },
+    {
+      "fingerprint": "2f2a5fc4f1b31deacef754a52b08687a7ea8cbb7f308c7f7471329b1c376d6cd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 508
+    },
+    {
+      "fingerprint": "fea4487f3f4b8e9e2499c4c3a0618a8cacf0bb31efbb9d00de42ec467c7c1cf7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 511
+    },
+    {
+      "fingerprint": "a9275eaa092dfce6165d08877b76db8384630f2e546cf3cb89d9f1f1cb62b260",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 514
+    },
+    {
+      "fingerprint": "f808f5909f2dd0acafc85b5a57ad9cbe6caf00f3d2827efbac17ed00812426a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 516
+    },
+    {
+      "fingerprint": "16b7efa586f3b794b2a991be82a3806bc185f7771c109ffd85586da7be0238f1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 547
+    },
+    {
+      "fingerprint": "ef9c4b336aff384d52f35b431a2f535818eba5b34770e0aba4185f6dc4b8f3ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 550
+    },
+    {
+      "fingerprint": "79800a0b9f0ff16f91d9ac9b916ff76b9911c562dfe0d04ed9764fad26772f35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 571
+    },
+    {
+      "fingerprint": "8edd0ed99f8599c7b050fcfd0bec2ba80aba29b7f0cdd81d6fb2e19e7d60f900",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 575
+    },
+    {
+      "fingerprint": "cb16dc6d6571fc5e31fc8596b13a56e4f61c36a37fa76ffceb887a2798090b19",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cross_language_matrix.rs",
+      "line": 617
+    },
+    {
+      "fingerprint": "cca76b4eaa1a94e2e7ed7fadc692558c7e9494e7d50a385aa97c215178657aa4",
+      "rule_id": "config/apache-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/apache_vulnerable/httpd.conf",
+      "line": 12
+    },
+    {
+      "fingerprint": "7388772c5a17d001e2e5cdaa6ec016b488f9e348380f2e820a068b3fcaf09c60",
+      "rule_id": "config/apache-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/apache_vulnerable/httpd.conf",
+      "line": 13
+    },
+    {
+      "fingerprint": "182aa2a3c84d26312d10f87aa53c887c49c95e22ce5c1a908bb16009b9c36246",
+      "rule_id": "config/dockerfile-insecure-tls-env",
+      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
+      "line": 6
+    },
+    {
+      "fingerprint": "74cc1c5dce221c350bee70cba446220ec98e9f5a0a1a0c684d3acb10b5f395f6",
+      "rule_id": "config/dockerfile-insecure-tls-env",
+      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
+      "line": 7
+    },
+    {
+      "fingerprint": "9fbec51bb5e3947eb2a350dc9070cff9e39706d6b82dfd884a61594f755fa558",
+      "rule_id": "config/dockerfile-insecure-tls-env",
+      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
+      "line": 8
+    },
+    {
+      "fingerprint": "122be477525966bc2b84e0eb949607bc20b285206a897dc7e5b166ee1d3a5611",
+      "rule_id": "config/dockerfile-insecure-tls-env",
+      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
+      "line": 9
+    },
+    {
+      "fingerprint": "d61169e19132005dfc65c02d1e9630e0a8fddee2f40e53949a381e013f022ab3",
+      "rule_id": "config/dockerfile-insecure-tls-env",
+      "file": "tests/fixtures/config/dockerfile_insecure/Dockerfile",
+      "line": 13
+    },
+    {
+      "fingerprint": "01eff1369b351751de61a81b44daf97a1bae693487dee7bff915c79207b61a74",
+      "rule_id": "config/haproxy-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/haproxy_vulnerable/haproxy.cfg",
+      "line": 4
+    },
+    {
+      "fingerprint": "07f744316b556274ca8f1bd652650c0ba7b137747b07fce3d224dc66f75594f5",
+      "rule_id": "config/haproxy-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/haproxy_vulnerable/haproxy.cfg",
+      "line": 5
+    },
+    {
+      "fingerprint": "ffa43ddfd340072bc1a9be2e5932ad560fd698121407afa9b64edef377ecf14d",
+      "rule_id": "config/nginx-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/nginx_vulnerable/nginx.conf",
+      "line": 9
+    },
+    {
+      "fingerprint": "7bc9a246aae4e807f7d99c596cc91592399dfc87b6003c74aa57b6c157898885",
+      "rule_id": "config/nginx-pq-vulnerable-tls",
+      "file": "tests/fixtures/config/nginx_vulnerable/nginx.conf",
+      "line": 10
+    },
+    {
+      "fingerprint": "0fca57684a0f495e2ef699557e3e45855b09c1db512e7c281adb12af9eb36dd4",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/Cargo.lock",
+      "line": 6
+    },
+    {
+      "fingerprint": "b8078cfde095c35f86be7219f7787f65710427d92804bc0eeeb0cb4a12cc3d82",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/Cargo.lock",
+      "line": 15
+    },
+    {
+      "fingerprint": "7d6e77a0cea6bbad3a9b4a915488bcf8ab699aa1d3e9b1e307be01a8ae83ec1a",
+      "rule_id": "manifest/cargo-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/Cargo.lock",
+      "line": 32
+    },
+    {
+      "fingerprint": "d5caef4ee4e083d7f52fecbfc420a0c8a6630aa8fcb6689ff8c453207cf1ad36",
+      "rule_id": "manifest/pip-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/requirements.txt",
+      "line": 3
+    },
+    {
+      "fingerprint": "5207d81992b3638f99be9c0111f24b965b6d8096ed63319149fe840dfe3ebf64",
+      "rule_id": "manifest/pip-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/requirements.txt",
+      "line": 5
+    },
+    {
+      "fingerprint": "0dfceded66d414886fb17cde6f6e170d298be39fb51719cc51d38d57af199455",
+      "rule_id": "manifest/pip-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/requirements.txt",
+      "line": 8
+    },
+    {
+      "fingerprint": "c11f6a7579133d4a296baba27aed3c177ea51e0c29e38d756a1290c14c1faba2",
+      "rule_id": "manifest/pip-pq-vulnerable-dep",
+      "file": "tests/fixtures/deps/requirements.txt",
+      "line": 10
+    },
+    {
+      "fingerprint": "9d2cd4cccc5afbcd837086797b314f35e8d89719e88737aba0a9337360570c94",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/aead_no_cow_vulnerable.c",
+      "line": 27
+    },
+    {
+      "fingerprint": "231e12870ad9b08e43e9e60ae9249a113b53ebd87b7ea3903cefc8518442d745",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/ah_aead_no_cow_vulnerable.c",
+      "line": 35
+    },
+    {
+      "fingerprint": "4e36ad6e8e33fb15938886b6d38683789bd52369d8d8f4055a5bcffda9eec950",
+      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
+      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
+      "line": 29
+    },
+    {
+      "fingerprint": "debbf895535d931119a758457c054dccd260549f15339e98c36a562bbcc09234",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-aead-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
+      "line": 29
+    },
+    {
+      "fingerprint": "cafb81e153f2df6bc7dca8a08a7c763996c3b7178024bd56bb9173cb143f01cb",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/crypto_template_wrapper_no_skb.c",
+      "line": 31
+    },
+    {
+      "fingerprint": "53cee790d48f9f1afc452a0cf1a53e83c56a798632b95479773132ac8bef2aac",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/ipcomp_skcipher_no_cow_vulnerable.c",
+      "line": 33
+    },
+    {
+      "fingerprint": "1aa31d81625e2a99fa10acb41086b0d4c0093ec762f6d8df410be54ce2a782aa",
+      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
+      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_authenc_store_vulnerable.c",
+      "line": 30
+    },
+    {
+      "fingerprint": "f38449484cb169bcba0dbe31fe5efba662be71bfcd755c397aca34cd7a4146c5",
+      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
+      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_memcpy_to_sglist_vulnerable.c",
+      "line": 33
+    },
+    {
+      "fingerprint": "a2c79310b13739aa45471c7c7ca9184451705934a84ae4e11e9d455b1249b055",
+      "rule_id": "semgrep/kernel/dirty-frag/scatterwalk-store-on-shared-sgl",
+      "file": "tests/fixtures/kernel/dirty-frag/scatterwalk_store_vulnerable.c",
+      "line": 28
+    },
+    {
+      "fingerprint": "5fc8f219a20a8ccbcb8bca9b02574aa04369f477657ee6b0964f15555ac4882b",
+      "rule_id": "semgrep/kernel/dirty-frag/skb-inplace-skcipher-no-cow",
+      "file": "tests/fixtures/kernel/dirty-frag/skcipher_no_cow_vulnerable.c",
+      "line": 28
+    },
+    {
+      "fingerprint": "7ddceaf20d067b4b92c792c10c0c7b9860bf71be137e5fd08cb2f67e3fb7f128",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "0c30808c31dbf7439b3193f01f778316f9a33c7aaae33f34f87923770b2a46d5",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "7262f444a10b51e63275caf72825889a3eda621fb38233ae4503b740aa06f951",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "1aba013367850a1dd1fc57d7a9e72bb07059a6c49b2922e509e2eb4dcc3ad5ee",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "5c8771dec816762d2c98fca808ac51a870d0b42dd57a31def265e883791dc8e9",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "35e61ed1c0752084ca7f5a53292aaf138a48461006a2e8ddf6b7d13385e17d01",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "eac944d5e1a2c6feae3119467353d701e2bf32b153dc6dd6a0ff6174a70a37d6",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "ac00919b5c73df1c91d28ebfa747b87d38fb29fb7e5de5cd4ede671ce100024a",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "7d4d717e0f02ec0e1607d49b166152684a2e5be01b24e13ce22e6283b52ab091",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/cli_tool.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "e66e224ac2516a402b6f23e88ca2d5f53a92ebec5b92528a3b6fcc6253d52aa7",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/realistic/django_chain/queries.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "cec595bfe3398f97c7bc1bd4fb562483e5c8aff4943821027a25c7b6012be8b8",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/realistic/django_chain/views.py",
+      "line": 22
+    },
+    {
+      "fingerprint": "ed0c9f03cc78fed5e5c5679086bf44301f1d2564c417c057385356ad67ba5a9c",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/realistic/django_shop/queries.py",
+      "line": 20
+    },
+    {
+      "fingerprint": "1d6e6b2b963ff237e60470c0ba14ba57c74cdd13cb9db91737bf74b460e2b577",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/realistic/django_shop/queries.py",
+      "line": 27
+    },
+    {
+      "fingerprint": "7e111a1e431d0f78049212f7d44e2143ac3b56baaf90fa4c4fc55abd033ae95c",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "786a8f2c41098168a9ce47eae91647822269dcaaea40bf4bb829ba4b0560ffd0",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "ee43af471b9dac64e98487377251f6c26c8e785274bf751591a749e26b57a428",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "085fad2fa794ccb554208a69f357e009b07ffff1115df2e3e6a8722d41113b92",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "ca50be76e3952345123bdf855835e3cfb3ee9218a3e5579d6fe219aaad289c81",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "4284c578d24b83efc9de9b3b9432e2936c0355ea63415abe73d3efec0eee8c26",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/realistic/django_shop/views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "1e911c8f8f8aa7b758b9e7c721c7854b49fd9bc9380282ac6780f8488204f092",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "a78d242fc9ce19866f176e90d6c1cbc242d87b069aa9e5d226c576d196f66b4a",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "9683b28aac71c1d0c22175220ca0de607b700056ad3eb76fa11a92a17d6c8249",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "9863dc791617c123b5c8339a31b965b4472d33f9aed2cb3ad22c780b222efb0a",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 40
+    },
+    {
+      "fingerprint": "d35dae3ba60694871013203dae991411763c6af432a96bc91a417ef8f331583a",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "2f62653634deb1b6a591c29e30ccee6e55063b0cc9884419a230546ea1c9f912",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "847b2ed23d547f3d8caf7a9311fb9917708eba5d0b81fad84d05455e681bfecb",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "154c018904a61ea19a699f97893357c3673f17a82d8e01268f06d3d44dbad67c",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "8ebe39199b3caffd158a1b1bced520d19377fe701548e972359cfbdebfd40825",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/realistic/django_views.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "4d2e022792b56040561d4c5f12225077f02917e9c146adbdd7aab11c809bed03",
+      "rule_id": "js/taint-sql-injection",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "edab1ccecd7ac0a8721597985df4512d98f9ba91edbab2820dc37a038836e2d5",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "4526476a652a71ab3648c159161b9c01c455b99ed888419bb45b10efd13b09e1",
+      "rule_id": "js/taint-command-injection",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "fdc3a5bb5275865fd2306cfb7091838a454ed58609379bbf75f2d93e856339aa",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "29901713f644260a131b135e0399533555e38bec1f37f366d7dedea7eaa7fb4a",
+      "rule_id": "js/taint-eval",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 40
+    },
+    {
+      "fingerprint": "8aa89227b7f1ce67998361ae8c055b123d6e51a08db3bd1afffb10e2817210f7",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 40
+    },
+    {
+      "fingerprint": "6eb3b1cbb46ec742cae9dfb4c8862e61616b6f98e86038ed195ccf2c8c110565",
+      "rule_id": "js/taint-sql-injection",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 48
+    },
+    {
+      "fingerprint": "afa2ac4ee64d6282733737ed4edf20ebd3843b95799fbfcf23200134cd7372a4",
+      "rule_id": "js/taint-eval",
+      "file": "tests/fixtures/realistic/express_api/routes.js",
+      "line": 55
+    },
+    {
+      "fingerprint": "22773c1b28d4cee3876d220a52b7a123e8271b24c1cd9aabb51ffa6300d854ff",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/realistic/express_api/services.js",
+      "line": 17
+    },
+    {
+      "fingerprint": "e2ffe6d984d17dc362166572b5a659942506bddb1ebdbb5973fcba8dc5b98114",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/realistic/express_api/services.js",
+      "line": 24
+    },
+    {
+      "fingerprint": "d47115213478d3de4af6e6ad429ab48d6ee4866de4ae0aa37185252901d5906a",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 25
+    },
+    {
+      "fingerprint": "bae2a47fd5c5d9a0c35014b49d2233939dd210950312cd55dffc4737c56324ba",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 25
+    },
+    {
+      "fingerprint": "10e344e160a9726f0ab27c74c0d3d8188564f136fc0e12feaeec2779c6391d59",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "6b3ed194a03d4a877b6290810ca92280df7826714ec28e3f33a3a6153059fd2c",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "e069247a9438625130fab05a1f0d22488a4a308147251e4ecc02136cc4d78234",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "7db74d28cfc2c8c35f6fdcd530650a5ecc422ec76a6671da4ef2185ad3566724",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "6fd8ad8288e5de040cd2fd127b36804889f56321bda76834c1aa68eab8a4ea67",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 46
+    },
+    {
+      "fingerprint": "30321be41f33c22c7c142421c30a0616746a6c3217200f80d24179b415aa795e",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 46
+    },
+    {
+      "fingerprint": "f8fd12d7e5ae24d61a9f97e794dfbea8c75c61a0f224b4564ee98ce988389901",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 54
+    },
+    {
+      "fingerprint": "05697b4b88669ca8c95b1b40404a814eb0ef951ceecf31ba316ebd9590d11158",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 54
+    },
+    {
+      "fingerprint": "6d8ff49ce699d9edfd04a6325b14d80fa9783f8a900e94fc930731d3bf164fc2",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "48550223f22ea4bd56cead743e8db79ef987fa46dd75c0d13564b2f0d7f5a840",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/express_app.js",
+      "line": 76
+    },
+    {
+      "fingerprint": "172dcb8ca889f89f9c2a19a5257f15f1c908f8914bf8e9b63b588aa372e873b3",
+      "rule_id": "js/taint-sql-injection",
+      "file": "tests/fixtures/realistic/express_chain/routes.js",
+      "line": 22
+    },
+    {
+      "fingerprint": "3d9c17406e0ae505331ff7cf3b287ed3dcecfefa30c4b99b9d0464d8e4280bb2",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/realistic/express_chain/services.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "03b4bc3d5f64e9e9bec104382472559caaf36add5024d7ea2ff091dcbcb4da08",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "4b32e124e2d8bc9b2b30ec0c336c0ae5bc198276a68981e8a050918c60a2b407",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 34
+    },
+    {
+      "fingerprint": "479e099b3a2a17cf3c19ed48babaa7074d188b14c4f5e717cb6404a2a7a6eb98",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "7fc5717ce549eaf27143130a4c85045c250ea755e81e2dc92f65a2ad605f4e1d",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "5cb16dfe6d8caffdc45baa354a863b34f79fe9c886f0636e38d20409273af11f",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "e6e5fb920c6ab791912e8a078411667f81c75ba3343ce278221ed3c3dcbb3d68",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "2fb4071c25d26b28e9adf929212bd72fa80f2167eb6fe2066a38ada99931e8ec",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "4f2b0f42728457462cb278e3bfa7ec5eaa0b454eca06205ab704b94d97c6ee2d",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/fastapi_app.py",
+      "line": 62
+    },
+    {
+      "fingerprint": "8a2be401fcb946c52a0812397e02657a857d516aed042e80728a4b1c9629cd0a",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "d12c68de3731863c068ff7f21d7cf8943a876cd5e0b651166de168ea6b51ca17",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "6d08f3590f6c1b21824ebe4b42566b72107c7153af757528e522ad2fc78ed284",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "7b5bc58109dec5c2991b29dd35afa2ed806ae1954c9d3f7e373fb4cc3b2d7321",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 48
+    },
+    {
+      "fingerprint": "0bdbaae3b2934d15c7888910796481706605bae1f1ec000ca2c40b0cd87bbb49",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "613a5593f54778ec47718ef0557842b3716e829409888a2ca57d03ecdfd711ca",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "afdda845fbb547bf6defe18187fba7d328ecc2d60252963eeb946b08458851fa",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 64
+    },
+    {
+      "fingerprint": "8c2055c6cd0419d139711d0374c58afc5dc8a2ea8f92486325082af57a6c7be0",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 64
+    },
+    {
+      "fingerprint": "cc8f7861a76a26d46a6882ee36e0d914fd5b65c40b3b3c10b7e7de7193fb0382",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 72
+    },
+    {
+      "fingerprint": "922d7722ebcbca1c8f737dff7d7bf216304dccafbed8cf8eceeb447835e30af8",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 72
+    },
+    {
+      "fingerprint": "296f48bd961c97171c7f30726ad65f81b7341a4dab2666b8e8284f29146647ca",
+      "rule_id": "py/taint-yaml-load",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "7460915b0eaa793fa88eb5d90098a51544d632a45afaf01a7ef2b39b8fb5b840",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "cff75567667d883480abf2a2a271120ba315bf8b8e2054cc8d7e780ec3e20f93",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "4acee6452ea9f412951bfe766a8e7c883b88a38dad7dbb7c48f812e7adb05c55",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/realistic/flask_app.py",
+      "line": 104
+    },
+    {
+      "fingerprint": "ede89ba35b864e9a384ab8215dc1b32c347b83d8f395f6fe8913566f245ea5e8",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 36
+    },
+    {
+      "fingerprint": "769b568e3fbb2c4600f1497ea08b611acf7b3f903506ce83461305ed50216bfb",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 36
+    },
+    {
+      "fingerprint": "72c3dd6c1946a052670a609dd8325de676c47f2fd9a2d933f85e775a93cd9947",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 47
+    },
+    {
+      "fingerprint": "ef53339944a2b806079808b96ec4eab5395987242a2bcfd56c09af474a6d3ccf",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 48
+    },
+    {
+      "fingerprint": "0e27313660face6e449cd277b95278c8957b35953797813ad0014f8186d6224c",
+      "rule_id": "go/taint-ssrf",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "971e4d892fe08d61b03c9275f19c3711c3727fb9e5da3e53063d96038dfc7f02",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "257e96fad56d279e0547820f1f16d410ba28f02364e90af606036702fe980294",
+      "rule_id": "go/gin-no-trusted-proxies",
+      "file": "tests/fixtures/realistic/gin_app.go",
+      "line": 73
+    },
+    {
+      "fingerprint": "228748ab5ca40216ef6b28980dbc83beae98d1f835c1659b9a3e600e46aab1f9",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/realistic/gin_chain/handlers.go",
+      "line": 24
+    },
+    {
+      "fingerprint": "9ec139f5d82e62336dc572b2868de02d05ac9c843e28f15b1e1818a5f4bf7992",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/realistic/gin_chain/store.go",
+      "line": 14
+    },
+    {
+      "fingerprint": "a87fc6ef824d8fe8dbfdab496275523f491d34585055fa84bb9ee568b278a84e",
+      "rule_id": "go/taint-ssrf",
+      "file": "tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 25
+    },
+    {
+      "fingerprint": "b228cd3d15778f22335b32a113daca00e1411f91263b76c9bcbf1c635a56571e",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 25
+    },
+    {
+      "fingerprint": "9628fe4bf7373704088f162ee469fcafe2e28d5b01cf3c7f442d7a1b88f51414",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 32
+    },
+    {
+      "fingerprint": "ff26c9d0b5fe73d1d254e1f7bb3550c1fa3f9af5b9e79f54356521b78e66067c",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "0c5deddfe278a0df50ac5f8f93c89aac1774feedb2163e3f4334a34684d583f3",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/realistic/gin_service/handlers.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "8b75c43f4ea8a0306ee82e11378b941bea207c70648b7c50616c79464ba63556",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/realistic/gin_service/store.go",
+      "line": 15
+    },
+    {
+      "fingerprint": "e5d16ca2dd911e64f6452d37ce9ec71f4ffe3fec181fb9697733bdd3f2b84188",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "2e777b7768266f787d2ba89419af1ed85cf7faa588df3e3895bd18ca8865113f",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "8ea3cbd26a419eb7767fba6f18a05c8467f4509293ef287057a0b84dee1bfbc0",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 28
+    },
+    {
+      "fingerprint": "d8b703e1edcda7d7ad207517a53e70ef0c35f6713d2699902239d38343e61853",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 28
+    },
+    {
+      "fingerprint": "9d35f702fa063d370291a9849784867f4e089302fab625b290aad9ee1e5d7c9e",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 37
+    },
+    {
+      "fingerprint": "6a124eecf6a21ff9d3b3e729aacfaf3cacdfcb3d9e72ad1976328f665d6be7b8",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 37
+    },
+    {
+      "fingerprint": "de9a1c056d3238fb46ca0bea3e856252c560e39513a36bee78e5a631c008baf4",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/hono_app.ts",
+      "line": 52
+    },
+    {
+      "fingerprint": "5c1650de0e78ed87d863ff06921f9957ac7b116e6b35b39b080fe1613de5c9ea",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/realistic/next_app/actions.ts",
+      "line": 15
+    },
+    {
+      "fingerprint": "637d7e1d8fdbb4995dbc564655f8b68504b4b2fbf5fe4b7d809a57dfe533cf60",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/realistic/next_app/actions.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "680c0dc5824725600b4d73cd4bcaead1fbe2bfcffb7fa2f2002a3c65ed4d4115",
+      "rule_id": "js/taint-sql-injection",
+      "file": "tests/fixtures/realistic/next_app/route.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "e0b7f01ee441f17459304f1876e4d53a556efca51cf947b480df8b2da2941969",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/realistic/next_app/route.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "a98581f4cedf5abb72731ee30f5a8cd4b7b4eb7281490ae68d715fcf2b89160d",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 20
+    },
+    {
+      "fingerprint": "de24c3d13ccdaef2f693c8fb98468a6529013e542b2849d9b8be4ceaed9c1d44",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 20
+    },
+    {
+      "fingerprint": "93c2a8e9f308a7abab56dc3e14c836370056592e790c9d73b0f3492505258af4",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 27
+    },
+    {
+      "fingerprint": "e7691394a54042552f03bc99120fe3fbdf9823702a0fe5305a9cc8fb65ef103d",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 27
+    },
+    {
+      "fingerprint": "3f739c89bea90e6e10cf9b6efb8a19bf8398bcda96ef16267342d6c2137f19bc",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 36
+    },
+    {
+      "fingerprint": "fb0eecea560c3cbb1e4b8402b7bd8f2dca388d9e11f9f93ec465c8d84a6cf3a5",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 36
+    },
+    {
+      "fingerprint": "39ce4132611577697d5e20d7b5e4cf880c9335a1e42e6a691cbeea51696ce81e",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/realistic/nextjs_handlers.ts",
+      "line": 51
+    },
+    {
+      "fingerprint": "b866cc29768c3ae885d040c7f729f7034ab26c308fd185f81659e488cb2d10a6",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/safe_cli_taint.py",
+      "line": 16
+    },
+    {
+      "fingerprint": "dd317e26c39458c4b0d9aee7365cacce90e67864c250a2de30d22a72ee9ba252",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/safe_cli_taint.py",
+      "line": 20
+    },
+    {
+      "fingerprint": "7663daed7116be574ab87734251b96b3e3310d9fe7fd83a377452f2728d023a0",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.java",
+      "line": 13
+    },
+    {
+      "fingerprint": "f7f90c964b1334869dbe7f70cf7dd13216ecbb25b841113e172e0f118f5ee44f",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.java",
+      "line": 14
+    },
+    {
+      "fingerprint": "08ac93463e48644502c5e87a5c068eb6318b2ba0c27d6bf9bfd4f7278506b306",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.java",
+      "line": 15
+    },
+    {
+      "fingerprint": "ce452f6c3734a72d1860c91abc9504a554689f81591239b7020b5012c4c83077",
+      "rule_id": "js/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "571180ed7c3607d0f5c530cee1ae4e6dbf1bde9b9d3c6cc1885107ba0fa88b9c",
+      "rule_id": "js/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.js",
+      "line": 13
+    },
+    {
+      "fingerprint": "beb2d63311bf9f7674824f020a33fd44fd497ef8bdbc6b9fde2f92c4a178e114",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.py",
+      "line": 12
+    },
+    {
+      "fingerprint": "937c24740f78c304a19aa190259546dacb4ad4bf1f3ce1a871cbd22321272f4e",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/safe_crypto_agility.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "20c2a6f43b7e717fac0cde8f3d713b66779c887ea1b59624653d852c14f3e972",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_deno_taint.ts",
+      "line": 14
+    },
+    {
+      "fingerprint": "2216608a3f185d9726fc118496fb6927e57e885343812ee6d8a64baeef542a04",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_deno_taint.ts",
+      "line": 21
+    },
+    {
+      "fingerprint": "0856f21da66557ace48d61ba81094d57ad1004da8055ebafb9c8dca75684f09d",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_django_taint.py",
+      "line": 12
+    },
+    {
+      "fingerprint": "930de877e513c600bbfaeef7870c27c22623f17fe10f56283d8b63f0ad6a53f1",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "282be6ef062d1de96c66d1229a42a8898c04876a1bb9c8b75af50cbb8d41e4a3",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/safe_django_taint.py",
+      "line": 26
+    },
+    {
+      "fingerprint": "a6d7197db5a7cc17df918274f7be27647e7976ce232e4101de65165673be6222",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/safe_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "868e78f26e695287f6d4cbf0271629e7109ca33e6ada0f7b2e08931417ef4283",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_fastapi_taint.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "9d7413d057ebb43cb55fa1ec335b67e13050008516c99f3c67a42ce3e05acbe7",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/safe_fastapi_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "456fccdb3503cf100b292e113169e08852030e6f3a35baa3b2306a1f5a941e59",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/safe_go_taint.go",
+      "line": 27
+    },
+    {
+      "fingerprint": "b42fdfaa5c420f4a3fe62b0e09c542766707032ef41252762e8f662090386de9",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/safe_go_taint.go",
+      "line": 41
+    },
+    {
+      "fingerprint": "fdb9bc819838ab95bef5143b2f0976314d910f9948541e2fc4ed5f79f73414d8",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/safe_go_taint.go",
+      "line": 73
+    },
+    {
+      "fingerprint": "805a4cb3ce1dc7151addec5daa77751e0de567637643d30f030feebcd11ea5b3",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_hono_taint.ts",
+      "line": 8
+    },
+    {
+      "fingerprint": "5671ade78883ddc129e99fd4646ab30dfda6fbe76bf9610b02f940f0547ea4f3",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_hono_taint.ts",
+      "line": 17
+    },
+    {
+      "fingerprint": "5ecad7ab194c0e192c42ffefae62c691616294f8ba75325d987a8d67f9a16add",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_hono_taint.ts",
+      "line": 25
+    },
+    {
+      "fingerprint": "cffcdf8cfc2c0810abbbd2ac46da2c6e40d70016c5029035cddd4f1851a8a080",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "517b0ea422fd88eb2638d94ae89d66422820f181780e2a96d04aa42d579308ba",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 22
+    },
+    {
+      "fingerprint": "3777ff04d307e3e2ed78f6f2dd3d641f476a12a8a32bf690e2deabb0f39c6356",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "c6d7d487ef7a11e40799175e23616e637909da70aabd1f5c50b961c7eaa18efa",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 42
+    },
+    {
+      "fingerprint": "dd9f8ceb3dbfc15437e647845582f30fb153c549893981f312a8ed04d43716f4",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 47
+    },
+    {
+      "fingerprint": "8072494dafa78f8c229e97587dba4882cb84e6fbbeaff4ca24668bcee88d4ec3",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 78
+    },
+    {
+      "fingerprint": "12e9e8c847cef734a9552d1c6b4bcbdcf7d364a461f34664b3fbaccfbdd65ea8",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 84
+    },
+    {
+      "fingerprint": "6b8209bbd50e35d10edfb72cc5aa47ade0d6f139ecdd92ccfa8873886bd4bfb5",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 90
+    },
+    {
+      "fingerprint": "065d9c3ad1215349b569ea0768a2542e4837173670b9e17406f035f08a1d95bf",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 96
+    },
+    {
+      "fingerprint": "3e2ec861014d632d7b7e24beecc7be23580888b0db42b2af16aeacfee2655114",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 103
+    },
+    {
+      "fingerprint": "25950985f4f4384558cfb657c78eacc6130718460f8184ac18d763cfa3a55072",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 109
+    },
+    {
+      "fingerprint": "6b309caa78175a399349ad65e38fa56039bc7fd3911e8cffe3b5120296a4a1b6",
+      "rule_id": "js/no-command-injection",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 116
+    },
+    {
+      "fingerprint": "f5dc6df08855bb1db85bc7a9553d71b02a2ae2f4c70a4d2c880c71fcff0fdd6d",
+      "rule_id": "js/no-command-injection",
+      "file": "tests/fixtures/safe_js_taint.js",
+      "line": 122
+    },
+    {
+      "fingerprint": "8e6c16f2f64ef1c2b38a11c923f90624edf44d4e33ef05e4fcdd965ffdc2e8dc",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/safe_nextjs_taint.ts",
+      "line": 15
+    },
+    {
+      "fingerprint": "32e699354a927c472b54c3ee69683a01a62af461bc71a795abf0d9060f3b37a0",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/safe_nextjs_taint.ts",
+      "line": 22
+    },
+    {
+      "fingerprint": "bbff26802e3d60dc88c31b39af8e3c70549fa07aae05bcd32373b4ae5eb6c1d4",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 16
+    },
+    {
+      "fingerprint": "7e80ac6e2b938e847736711887d802be0198bea0261b84a7f32154dfb5201001",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 23
+    },
+    {
+      "fingerprint": "557946d976613570c40e7d82df6763ebfe8a7755942339b5a9cdbe0e518f41c7",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "e33970a5087f3c062678040a4b8eaed41a27ebd260e1e71d52f692d9204f4029",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 42
+    },
+    {
+      "fingerprint": "f2a982ea13122373fe5499a9fa358da6595bb41f87fee569161f0bd157549eae",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "9d450122dd404bae78280afa7ee40618b6119b0f846b092b6bfa366d83cd10e6",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "1fe0b991b73a63dc0152210313de31ae32a68902267170736e04f3176b7df130",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "68d60aefc6ea725020fd6125021c371566de5362946558c05be44946182aa87a",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 91
+    },
+    {
+      "fingerprint": "69500074e951bc735b33c625543e8ac80db6e4395833f3493c3bc07c1e1ae85d",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 104
+    },
+    {
+      "fingerprint": "0372f821f387253a907c85635bf38d6445a7d008624209af8d85a17db0e7074c",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "788343a5558176c8cdb62456a9262ff11958b3313b5b7651612ff28f2f791d22",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 165
+    },
+    {
+      "fingerprint": "7468a336f0ba59cfd80495243c1c3d118971ebaa86962831fa2e6a40fcabd74c",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "eaada929b895d2f468ab4a7f108f804851872d1ace8286fcebd077aa857e4c01",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 177
+    },
+    {
+      "fingerprint": "6e951c0841e39c33c046c76fc6a8825eafcc87e709392910f7327c7be844abf7",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/safe_py_taint.py",
+      "line": 184
+    },
+    {
+      "fingerprint": "991c5d4d95aa796175cf96ac1e3a8b0f899c776f5b0a12b99c268a12d02974d6",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/semgrep_taint/safe_js_eval.js",
+      "line": 5
+    },
+    {
+      "fingerprint": "8d8a32678bfbfa359d7afe15ecbdca042c33abacfdfad967a9c652c62de34d7a",
+      "rule_id": "js/taint-log-injection",
+      "file": "tests/fixtures/semgrep_taint/safe_js_eval.js",
+      "line": 9
+    },
+    {
+      "fingerprint": "77e919d55917f59b9ebfe86e768e600aedc934529a46049a3f931b3919f9edd3",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 13
+    },
+    {
+      "fingerprint": "3978727f2460250a87f2cdef7bf6b9d00215e726cabd70cf2f74c4ef923dcbd1",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 13
+    },
+    {
+      "fingerprint": "cf7676e33a69ec333dac4c4f435e1102b90611aa64c59be67efb0e611ad6bd58",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 19
+    },
+    {
+      "fingerprint": "3e2c4d94d77152b4ad20e1373fa9013289cddeef002d7eb4e8e4a70eff88ae56",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 19
+    },
+    {
+      "fingerprint": "87665b4cc9c0dfca5dcecf6dcd44201ae66e99f2b51d96063b435354daa6bafd",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 26
+    },
+    {
+      "fingerprint": "7be5bfa17fdab2911fb58e822a0f3a52336bab638fdd21f123d5da258ffc1436",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_go_exec.go",
+      "line": 26
+    },
+    {
+      "fingerprint": "afd859c2f10294e58fefd1c5b8f0eb4e82bd73206b9cfa3028f02db0b1186ee7",
+      "rule_id": "js/taint-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 6
+    },
+    {
+      "fingerprint": "eee25efc2b1e2d21e98d0cb59407dcd4f88b58c79c07b0fa7f50b4d9adbc2297",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 6
+    },
+    {
+      "fingerprint": "ff6ac41d5ff58d19b95f608873bc6021e308fee1799bfae2097bcd9f04750552",
+      "rule_id": "js/taint-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "91d8069b2c49e6c80996797d3f99807c0f2c78db15e0250f4c926fa70d0c1b80",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "ab9099ed14e07beeee359ff2a396bb55097c30fd6d45682729fb51c7b57d7135",
+      "rule_id": "js/taint-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "564acab7a2a5b740f6354f017de98b7ae4cf2829b03b2c52938e39d99e30cda2",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/semgrep_taint/vulnerable_js_eval.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "62b41bb7820d394f16507bc9a97611f76c303640c8669f52165232ac5b691123",
+      "rule_id": "cs/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 21
+    },
+    {
+      "fingerprint": "9dbbb25983acd7706a3a69b520323257d906e7328880932690c96a4f90b7d03c",
+      "rule_id": "cs/no-command-injection",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 27
+    },
+    {
+      "fingerprint": "bd8bb15d38e01fc101b9edd23f29f59de035aa427f524567f93579c4e2f24599",
+      "rule_id": "cs/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 33
+    },
+    {
+      "fingerprint": "781331b16b4fca0724ac7ee561e408441ff43be5139f86e852d82e01f7407a20",
+      "rule_id": "cs/no-ssrf",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 41
+    },
+    {
+      "fingerprint": "fb99c69774e147d5051e844f4495d9efc9eb838904367a1df227b4fa131da17b",
+      "rule_id": "cs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 47
+    },
+    {
+      "fingerprint": "7d91ba4b1c08481da5fe4b4f245fb5e70d94221ff237d6b659167dcd2ff3a16e",
+      "rule_id": "cs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 48
+    },
+    {
+      "fingerprint": "d1470c9eebf69df59d6c7c861d213e533415d2b80dd680572e5d30c724e91497",
+      "rule_id": "cs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 49
+    },
+    {
+      "fingerprint": "bd36af830f81c52ff5ea38c620d60cd03186e10c93ba4aee5693100bc6bc5ad4",
+      "rule_id": "cs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 50
+    },
+    {
+      "fingerprint": "916e1a1592e73684d7709e81ab765b8b666348a0179adb79adef61a1c58e8a41",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 56
+    },
+    {
+      "fingerprint": "add3e274d1d5ab6e1308044f1293dabad7ce5b898232bd721499330a39abe981",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 57
+    },
+    {
+      "fingerprint": "513022d0c9c7d948c4ebe924c733ff505a05422270055b9567597a12482bdbed",
+      "rule_id": "cs/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 58
+    },
+    {
+      "fingerprint": "ab0c86ca9848bce79bd63a820e5268c754af4b45b79660f9ddeb32da5205ca79",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 64
+    },
+    {
+      "fingerprint": "77432bfb5107b96c750d89f9cf945e9eb712227e64239f0c320146bfafe6d0ee",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 65
+    },
+    {
+      "fingerprint": "6070362001a4d4dcadc8f561c75285edb893b74d97025ea34f45b326c06f2216",
+      "rule_id": "cs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 66
+    },
+    {
+      "fingerprint": "1bd4b77411a12b861cb17200460952a62e126a2d6ce906a21569be901038511a",
+      "rule_id": "cs/no-xxe",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 72
+    },
+    {
+      "fingerprint": "0ad5a7fdfdfcf91aec0b60b31257981e0ed8e77f6cc5c79527e8915c62bbbdc4",
+      "rule_id": "cs/no-ldap-injection",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 80
+    },
+    {
+      "fingerprint": "da3cbdf4d4172c023f7bc7a70100ab891796d573d632932d0adda2169922c9cd",
+      "rule_id": "cs/no-cors-star",
+      "file": "tests/fixtures/vulnerable.cs",
+      "line": 90
+    },
+    {
+      "fingerprint": "80bb89b4d4b6a49ea2c45c37f11441d748fe0c7c46361be766b1711cc834dc65",
+      "rule_id": "go/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 8
+    },
+    {
+      "fingerprint": "92ec46a28fb21cd67cd3b0c4b854079bb74b7fca956f566e5c15bd2dceb24602",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 22
+    },
+    {
+      "fingerprint": "2aeafd91c60ad3e8d17dddb864e5b88d34405ab36ec831cad4695905c967de2b",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 25
+    },
+    {
+      "fingerprint": "2544f42c75d8db9e048dac34973134c51cfd0032231d902d47a1717c0e6bc283",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 28
+    },
+    {
+      "fingerprint": "4d361f24d83e404eb03e931e739d0810f9e7bb1ff59ef535b324d728ef0b8645",
+      "rule_id": "go/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 31
+    },
+    {
+      "fingerprint": "bb0844b2915872f8d0a29ede56096b47be87444d95b6b7f414f082dd7905851d",
+      "rule_id": "go/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 34
+    },
+    {
+      "fingerprint": "f3bf785bee57e5965395b66eac112567f1eadb32523bf3ea69b90b4144b30557",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 37
+    },
+    {
+      "fingerprint": "e9749d6e242fe71069cbbaea1b929a7d497d14c801a3f89f195b7cfeb9956e0a",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 40
+    },
+    {
+      "fingerprint": "265b00410655df91d038647f514d78280c354b2a58bc68d18a7224ffeb46f35d",
+      "rule_id": "go/net-http-no-timeout",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 43
+    },
+    {
+      "fingerprint": "fb9df63854ea70bd63a8d3224a3f327c56077573946fbf7499629fddac315ccf",
+      "rule_id": "go/missing-ssl-minversion",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 47
+    },
+    {
+      "fingerprint": "af2ff5aaef41a629ecd8ed2ac96524ae9b0db2966c5aebb22bf3f285d422c2dd",
+      "rule_id": "go/insecure-tls-skip-verify",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 47
+    },
+    {
+      "fingerprint": "b5fb51f69e16d5e0483772c8f2c243977e766b68dbd93967b72792cc98ff3ce3",
+      "rule_id": "go/cookie-missing-secure",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 51
+    },
+    {
+      "fingerprint": "d8e1d0396b40597a275ecaf1d9e48d43a8650dbfa2c10632d2662c2522ebd96b",
+      "rule_id": "go/cookie-missing-httponly",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 54
+    },
+    {
+      "fingerprint": "f7eb53f118105ecf1338564f4705cf8e4517db2c1c83c0be7a0bd07f9a43e580",
+      "rule_id": "go/math-random-used",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "014c82dae93b1b14c55da8a13e2a9ac397e1b84f4c7cf269ef431e0fc8fe690f",
+      "rule_id": "go/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 60
+    },
+    {
+      "fingerprint": "beb8cb3506a9dcb8182d76a2436e74dd73537b1e7f3ae325e421b4399989b01e",
+      "rule_id": "go/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 64
+    },
+    {
+      "fingerprint": "e2dee9928305eae185be09c53903a2596713634900d41b70fb48d5a634043982",
+      "rule_id": "go/jwt-no-verify",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 67
+    },
+    {
+      "fingerprint": "f7a5f479c70065ee4f28809d358cfabed0d2c4bd48dbfeec3d6534219ca4551d",
+      "rule_id": "go/jwt-no-verify",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 70
+    },
+    {
+      "fingerprint": "9a764021db70aa4d3944869c3934fe3a9abc8c796de45e5bed044a68b226fb24",
+      "rule_id": "go/jwt-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 73
+    },
+    {
+      "fingerprint": "50eddcf314d8a5a3fd0d07f8ad2332a0f469be55839405c77823074ae2a6b3ff",
+      "rule_id": "go/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 89
+    },
+    {
+      "fingerprint": "a5c11aec7e197211b1e084f3148c890efda35756cffbb3bcb7d78e589f1fa6a7",
+      "rule_id": "go/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 91
+    },
+    {
+      "fingerprint": "e0e4b95e68eb3d07f7f054e24657f7beed6bd21f6394c6658bb3d0d854a07499",
+      "rule_id": "go/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 93
+    },
+    {
+      "fingerprint": "e9e7820bdb2a99d2be34d6a71aab1ca4f114d64e9dd4b3158857bc8b602376f9",
+      "rule_id": "go/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 94
+    },
+    {
+      "fingerprint": "5daddf624f76bbb202bb438b47edac4810dbe319de33647e1908458a57429469",
+      "rule_id": "go/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.go",
+      "line": 94
+    },
+    {
+      "fingerprint": "7858ecdbd8c0023409b5c802ba0e702f3c1867b5b229f8a6ad018d7185f1732a",
+      "rule_id": "java/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 13
+    },
+    {
+      "fingerprint": "4ecaeca12c1ff5b6cd13e9c9176745f92e882e26e58067d2c6abe8dbb641a26c",
+      "rule_id": "java/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 14
+    },
+    {
+      "fingerprint": "19f3cf7e24fb73f599d6354dbe4676be9855615af82274c3ecd3ecf99e6220d4",
+      "rule_id": "java/no-command-injection",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 19
+    },
+    {
+      "fingerprint": "b822fa3c271899babf70aabd6b743841808e263c91483dfd5cba65323b552c23",
+      "rule_id": "java/no-command-injection",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 20
+    },
+    {
+      "fingerprint": "bd7cad7fd2bdb8e096dc51e448f2341a7feadef7c1a3cfc7694dd16f461a487b",
+      "rule_id": "java/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 26
+    },
+    {
+      "fingerprint": "a673beb8a6ec255456dd484a10258d44abf43c6b27722cc07b55dd1c6ee926b3",
+      "rule_id": "java/no-ssrf",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 31
+    },
+    {
+      "fingerprint": "6b25be7b253bcbc7d844008a385190df0f470179015c4a78b75c633c2a9aad2b",
+      "rule_id": "java/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 36
+    },
+    {
+      "fingerprint": "9a1b311858af238470418cfa7a6a4a6f8538f5b1093a8e9fbd3b82d6e196b840",
+      "rule_id": "java/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 37
+    },
+    {
+      "fingerprint": "224d0239f52177f6f3b7ccbb12a88c3ca63aac9b48597865e419d456ce38b17f",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 42
+    },
+    {
+      "fingerprint": "cedbb18d88c77244412e5e7fca4d4344961e2265f880835ffe594d88febed844",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 43
+    },
+    {
+      "fingerprint": "69b5161cb9706a7b34f6514cd72f1f0b7076995c4c4fc298a49bfdaa34bd108e",
+      "rule_id": "java/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 44
+    },
+    {
+      "fingerprint": "482ad5e0d1a2479251c0ee2f5b7c98b64e37858a9c4280f69e0f7e8b90ec12ee",
+      "rule_id": "java/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 53
+    },
+    {
+      "fingerprint": "605f15346c6c4a1ed04a3aa81570f026c9760ecd53ba2b6f12276c29d1c194da",
+      "rule_id": "java/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 54
+    },
+    {
+      "fingerprint": "f3545312dc23f8b412bdc3a99c46620ff080c1c1cdccd8e2e328e390a6830c2e",
+      "rule_id": "java/no-xxe",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 58
+    },
+    {
+      "fingerprint": "b3f98f402e4b8d2bda0a474c8e66d4207fbfc0d8881bc0a31fa67788a46b8465",
+      "rule_id": "java/spring-csrf-disabled",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 63
+    },
+    {
+      "fingerprint": "0b1c9c19f72890d7f2d3a3e4af465958e84661f6e7c227e4c034afe40af5e34d",
+      "rule_id": "java/spring-cors-permissive",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 68
+    },
+    {
+      "fingerprint": "089ee8a769be2b839dc87c2b823d3db47c6737d22e923ba72064d7911671572f",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 73
+    },
+    {
+      "fingerprint": "3a93d0bdd0a6086bfa0e21b0e6fa39e53779b7a063237f504164583563a4b94d",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 74
+    },
+    {
+      "fingerprint": "c21c53af39c9886396de47c6916b798ee0a96b8652f9278b4ae0534808bc831a",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 75
+    },
+    {
+      "fingerprint": "449dd77e296a262c75aa565050d0706eccb1a82c4febbe32a35a18cfb49236b3",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 76
+    },
+    {
+      "fingerprint": "5d591fe7d66e9d785d95eb99a09b38cb7abaaaab0a6a02f8bec90fcc920b84a5",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 78
+    },
+    {
+      "fingerprint": "021b43260b332e8e80bed679c3575980b18c93979f7c60bb8fd77daf2cb422ae",
+      "rule_id": "java/no-xss",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 79
+    },
+    {
+      "fingerprint": "0a7bfae2cab34c7bb6d7730e6b26201fb16cfe244e692387e95796ae831f8ce7",
+      "rule_id": "java/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 82
+    },
+    {
+      "fingerprint": "9a1a84a235b6e3238a24dda43e06c23aff5043b96d6d758734e7fc737f693646",
+      "rule_id": "java/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 83
+    },
+    {
+      "fingerprint": "b4fd9b32149f4afa70438de69e204d1294b96fa6b4be29f22fcbc7af76f40c5d",
+      "rule_id": "java/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 84
+    },
+    {
+      "fingerprint": "26e797effb120f8ceb546ef9b93a6b5b4ae6dbed7ed5e2aeb7e6e3eaa0f5c574",
+      "rule_id": "java/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.java",
+      "line": 85
+    },
+    {
+      "fingerprint": "365dd09432060e168ff33564ec524211436e313fac1fd09c496bb7cb7a732998",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 9
+    },
+    {
+      "fingerprint": "039ebc065984c4790103dc355bb15d608bd5f069d167e889b33d12a5371df164",
+      "rule_id": "js/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 12
+    },
+    {
+      "fingerprint": "dfa00e0e5db86546622bca67cefa3fdd349ca7990006b8c2c12fcb0ec7b30701",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "c664d15fd7e181af287cd408c89d3ab368a84c122444a9689ffb8e712d8072a3",
+      "rule_id": "js/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 19
+    },
+    {
+      "fingerprint": "c5733794707665e91e4ef231dc7340b7779026bbb8b956066fa2fd95965a79e0",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 23
+    },
+    {
+      "fingerprint": "141714e8e71171508e5726303e06ab0e990e5f3c37a6e5cf16f2dfd1f271d017",
+      "rule_id": "js/no-command-injection",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 26
+    },
+    {
+      "fingerprint": "0ed5064d8fd951750517e5a101474a4c9572b387a0fdaa2954487b0bb9c2ba6a",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 29
+    },
+    {
+      "fingerprint": "a2404e50192c3c3cac0e7a65cc38d173fdf64c4529c8325f9f79d57620cdf909",
+      "rule_id": "js/no-open-redirect",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 32
+    },
+    {
+      "fingerprint": "759ecd5c6d9fa5d1c9757247a416cc5cb945148c1deed04933c8f2106a3b977f",
+      "rule_id": "js/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 35
+    },
+    {
+      "fingerprint": "178f74840647211575e378453ec91ddca6a9a07f6fa788760add7c89518f570e",
+      "rule_id": "js/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 41
+    },
+    {
+      "fingerprint": "a2d13b71b5e1bd3535349d34af97fc067905772bf517cb06464be6f2c9661593",
+      "rule_id": "js/no-ssrf",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 44
+    },
+    {
+      "fingerprint": "f2a38e8c8b72ac2b605531ba25c1f852e01be08ebf923fbef39d61eb6fcf05fc",
+      "rule_id": "js/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 47
+    },
+    {
+      "fingerprint": "efa07d0cc08479a2ad7a3eba4f518f8e80d92f4af453cb97d0600f223c65ce46",
+      "rule_id": "js/no-prototype-pollution",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 53
+    },
+    {
+      "fingerprint": "65d3b6219cc82505572167f80f5a29841f9c916a0041d52c83aa375e20ea2837",
+      "rule_id": "js/no-unsafe-regex",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 56
+    },
+    {
+      "fingerprint": "b1623004d47035a76c03620ec7283c07bcd6339a8c7c2d8fe7bcefd99242d4df",
+      "rule_id": "js/no-cors-star",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 59
+    },
+    {
+      "fingerprint": "86d2aa628026d51fbb6a04aa5a1e654ce11de2fdda2b1bb8e14ba9750222721e",
+      "rule_id": "js/express-no-hardcoded-session-secret",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 62
+    },
+    {
+      "fingerprint": "9813bc4c62b9ce15cf3e65982547d7bf3842d9c02a4e45b967c3bd58f433e29c",
+      "rule_id": "js/express-cookie-no-secure",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "5fca449d494d61415bb0b5050151b70070f7b0a318f794d710b3bb5cdc837e52",
+      "rule_id": "js/express-cookie-no-httponly",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "d7a384260cf9b187d1597459590ff08a828845dd475080625a97346f5ececf68",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "e463cda0530917026b5fdcc98f2c9b5c50ff2b91dd86cc11fc7c0c7bae958841",
+      "rule_id": "js/express-cookie-no-httponly",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "f4059c4542eb2d5f2f4806f2be50845c8cdd823e4b6991358893206cd8a2ff65",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 68
+    },
+    {
+      "fingerprint": "be59ef289fd4e5ee7993896bf2616541f2fd14e1a27fc436e9294b010b63a7dc",
+      "rule_id": "js/express-cookie-no-samesite",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "45c0af8633a1205cc367c2b41748abc1bc8545ee1b395a0f82d4d33d62ac9977",
+      "rule_id": "js/express-session-saveuninitialized-true",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 74
+    },
+    {
+      "fingerprint": "cc2fd05e4ba5516d05f92914b0b6910249b88c97f0d72864447ba90e2fd7a60f",
+      "rule_id": "js/jwt-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 77
+    },
+    {
+      "fingerprint": "1bcdf545654fd29567a94ba6bb29961916e6a55515768827cb859342024ce36c",
+      "rule_id": "js/jwt-none-algorithm",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 80
+    },
+    {
+      "fingerprint": "9343330782ed8e41bcdc8a8f935b2d16064f4b4fb946a5b2405df4f7c481d3e3",
+      "rule_id": "js/jwt-ignore-expiration",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 83
+    },
+    {
+      "fingerprint": "40c10ff42a0d9653db1071143a1b20e09101fbcb629d4cdcdbeeb3355d65f258",
+      "rule_id": "js/jwt-verify-missing-algorithms",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 83
+    },
+    {
+      "fingerprint": "2e25bce24cc5718b2bb336dde3df2e5bb9ebff601a887cd411002529cd06fcb0",
+      "rule_id": "js/jwt-decode-without-verify",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 86
+    },
+    {
+      "fingerprint": "0ecd669561bc9caa07097d121fec78fdd3a231918f9eb16d31367a4f5597343c",
+      "rule_id": "js/jwt-verify-missing-algorithms",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 89
+    },
+    {
+      "fingerprint": "7557db38000476bb799521dede921ba323e8c3a0e6844521e12a328a3d5f7c97",
+      "rule_id": "js/express-direct-response-write",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 93
+    },
+    {
+      "fingerprint": "d2e31d96115174091e9edd8ffaaea323bd231a94b4abdc401afad1133f44031a",
+      "rule_id": "js/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 97
+    },
+    {
+      "fingerprint": "a116304af66988cb6a5d6e4b8d4c259d11e6031f29c8724c0b2d9d9273581368",
+      "rule_id": "js/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 100
+    },
+    {
+      "fingerprint": "14158b72b616249cfdd829a17ec245467a74e357d64299d852f587b6364cb573",
+      "rule_id": "js/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 103
+    },
+    {
+      "fingerprint": "fd67427867bb9575d40f6bf4fe260113528e8e352b82782379f804f97850252c",
+      "rule_id": "js/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 104
+    },
+    {
+      "fingerprint": "cb04b044791be80a3d4f685cb135058f637f66177191fd838c2432707488f5d0",
+      "rule_id": "js/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.js",
+      "line": 105
+    },
+    {
+      "fingerprint": "62e9d3df44f81e283d2386807ef123a6b0aea20138ef749c074abfc2b666c446",
+      "rule_id": "kt/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 7
+    },
+    {
+      "fingerprint": "732924110c49c679ca65c768e57629bb036e335e411793ae56e98a36d47da6e1",
+      "rule_id": "kt/no-command-injection",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 11
+    },
+    {
+      "fingerprint": "ad99a59fd7726e3de058ede89cbb4c34cef1c00121a54dbe74ae5b2d57b8e88b",
+      "rule_id": "kt/no-command-injection",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 12
+    },
+    {
+      "fingerprint": "ecbb1380821d73efbac0c1e3a2f82f6f2d36befbade3182034bb8527747012c4",
+      "rule_id": "kt/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 17
+    },
+    {
+      "fingerprint": "aa47e33844eb61ef39c146b8203abe685bd38aba55e3ea5194a1d911c3860956",
+      "rule_id": "kt/no-ssrf",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 21
+    },
+    {
+      "fingerprint": "8752688b85dbb3dca19b4022145eff0ba599a8e75de692038e489541a8c04391",
+      "rule_id": "kt/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 25
+    },
+    {
+      "fingerprint": "b69dbb7cf5555ebe50e61c3d54cf0b44cf8dc4b92e404abc1e63709626b94c11",
+      "rule_id": "kt/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 33
+    },
+    {
+      "fingerprint": "eba42d6a43bbe68471bc2511309d8272fde3216243806c227162c780a98b00e1",
+      "rule_id": "kt/no-xxe",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 38
+    },
+    {
+      "fingerprint": "9ecde7a3dc2c16478036e972d64f8ebeb98ab0c57cb9e6bb57d9a4732041f059",
+      "rule_id": "kt/no-cors-star",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 44
+    },
+    {
+      "fingerprint": "2bf902f4860a94b5411f53551bb4e15c9555e0ab062cfcef0e7eac42dbf520fa",
+      "rule_id": "kt/no-eval",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 48
+    },
+    {
+      "fingerprint": "16045c3fe690084df1d0e1ac82ef4492f3437cb174acc93593445b5e503e8ecc",
+      "rule_id": "kt/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 53
+    },
+    {
+      "fingerprint": "4b41deefaf554a3b64fcae10e42475952dc5ece6e3ec8d0711c45afcb4443c9d",
+      "rule_id": "kt/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.kt",
+      "line": 53
+    },
+    {
+      "fingerprint": "daaee9e693f26e4fc2048ee775881d7b8fdca9977a0db0611916cecea1782c37",
+      "rule_id": "php/no-eval",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 5
+    },
+    {
+      "fingerprint": "d2c86d7f1c27f1687318aa23d632721879c07ff8cd0133ef42202a42f586b9c8",
+      "rule_id": "php/no-command-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 8
+    },
+    {
+      "fingerprint": "971935e5f96c435ada32d891004896edc7f39506011f9762e2404ace5998ca46",
+      "rule_id": "php/no-command-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 9
+    },
+    {
+      "fingerprint": "341ec40a97f8e635e6884a0ee6ea957045551ff1571e73ad0d3dc9e1cf36a0ae",
+      "rule_id": "php/no-command-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 10
+    },
+    {
+      "fingerprint": "00dcc59aa7ba69c174841222263cbb7227715ac19e8d90b264bd3c20c65a03e6",
+      "rule_id": "php/no-command-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 11
+    },
+    {
+      "fingerprint": "ae71584ac4edc20d2c386588f9ffb061baf5d0537a72b140b6e50c7dfce8de9d",
+      "rule_id": "php/no-command-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 12
+    },
+    {
+      "fingerprint": "315d93e1de2d4757a6f0ca83fcbf468da869ecee7ded1b1da3e2d2f36fb0697a",
+      "rule_id": "php/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 15
+    },
+    {
+      "fingerprint": "d25a1b2f51c4e780391d55f5dc0e2cc4e0b25cc078ad7b49672529742aa9a6f7",
+      "rule_id": "php/no-unserialize",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 18
+    },
+    {
+      "fingerprint": "7b11ccec78ab78ed0931c69c2baa9ed1f81a32080cc964e3abd7dc4000e689fd",
+      "rule_id": "php/no-file-inclusion",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 21
+    },
+    {
+      "fingerprint": "ec17b0b74544a0a1c419ea6e829d06c1e9d9b5a4724dd46ee0396cc520186295",
+      "rule_id": "php/no-file-inclusion",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 22
+    },
+    {
+      "fingerprint": "d629db58c283143926fa182b25dfa701dc01ad813bd7ab251ae6072a2487fdfc",
+      "rule_id": "php/no-file-inclusion",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 23
+    },
+    {
+      "fingerprint": "a08b2d9fcbb6c1fe04176f468fc480372e7db7c5863bffe9fdf504f7c5839183",
+      "rule_id": "php/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 26
+    },
+    {
+      "fingerprint": "57b00ae457b7f5596d4890eca153497206f78f3b82ab85dec7c568bc2f4ba936",
+      "rule_id": "php/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 27
+    },
+    {
+      "fingerprint": "0f4f68576c862d2ff79cc957e8a28c7d9d06c70c4a6211ff1e9f221dcbe4d286",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 30
+    },
+    {
+      "fingerprint": "40207b7d1faca890d3a8a35b0995bb14b7893ec306308374b9c39ade59f784ee",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 31
+    },
+    {
+      "fingerprint": "077582dcb6557aad0376ab94b04b6291f266e41b83942aa18f894f60cfb84318",
+      "rule_id": "php/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 32
+    },
+    {
+      "fingerprint": "bdd01fc355d02e988dae0c7ac7cc1f482464d57d04d09dc7cba6ad96620baf90",
+      "rule_id": "php/no-ssrf",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 35
+    },
+    {
+      "fingerprint": "3ec872f5e7d1d0f3163094977fdf1b3949ef28107ea5cac954ec2dbef122028b",
+      "rule_id": "php/no-ssrf",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 36
+    },
+    {
+      "fingerprint": "88e2d6bedd3c59a597691183025a032129c8381a82f0d6a1297b4edcb9dedeb9",
+      "rule_id": "php/no-extract",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 39
+    },
+    {
+      "fingerprint": "51c2f0174f01516379866275cbdf2129ae5139831004e8443fd1f1d85e7f7db6",
+      "rule_id": "php/no-preg-eval",
+      "file": "tests/fixtures/vulnerable.php",
+      "line": 42
+    },
+    {
+      "fingerprint": "44d64bba6b6c2730991a45ecf862da6ce148ab5f5439f48ba86a7e8a5daf8344",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 11
+    },
+    {
+      "fingerprint": "72d9816b690d316e941d480692772715fa299fd5441245f8f244f295b83efede",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "6714ee91aba031e2f38d01317706fdc2412c8158715080d61dceda8477a805db",
+      "rule_id": "py/django-secret-key-hardcoded",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 14
+    },
+    {
+      "fingerprint": "38b8af3e68bb35a0aa583e664ba987e6c0d21a0a75ccdf779e3e15032ee78217",
+      "rule_id": "py/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "d6d7cc2daf6964793a57595782fc87f5652d27b27c9a998e88270c0a255fd203",
+      "rule_id": "py/flask-secret-key-hardcoded",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "f85c07441e91b827d7153a6d935fbaa2c02cd29007ae005b3420f97e44a0701c",
+      "rule_id": "py/session-cookie-secure-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "fc4b8475aaac5bacf16502946b244c53d721774b47aa32ea7904f4418cf141af",
+      "rule_id": "py/session-cookie-httponly-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "91c5ffb630abce824fde45e4f2665298977d01f8848ccc7d3d684644a8cc7a8d",
+      "rule_id": "py/session-cookie-samesite-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 27
+    },
+    {
+      "fingerprint": "d04f7173ecf7602b5d3f36fa5c86d564ad92f6af42c37b1f6a4a862e726ae915",
+      "rule_id": "py/csrf-cookie-secure-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "be0554c97f525e3150841415a6823b22a912bcbb47303310e49480efb4c0cc5b",
+      "rule_id": "py/csrf-cookie-httponly-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "03d62cb73d7c22c2242b76fb27817b3cb5bc22dd83f57a1964c11c95d9aa7afe",
+      "rule_id": "py/csrf-cookie-samesite-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "ab9bdcd91bfcec0fda0a0de2a8da3f982d76612f553d3c81515300bafec8ad03",
+      "rule_id": "py/csrf-exempt",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 39
+    },
+    {
+      "fingerprint": "1214843797d0e93da6f69adc03a09eb4dfcf32985582566fb2e42b9367e630c9",
+      "rule_id": "py/wtf-csrf-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 44
+    },
+    {
+      "fingerprint": "265d5fe8d5a7a787f58677595f3681e04dadf35f313d383b7e7955f6faaa843e",
+      "rule_id": "py/wtf-csrf-check-default-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 47
+    },
+    {
+      "fingerprint": "15c4410221b39dd6e8f4fd7f18113dcf83ea810592d036e56ad708e3a8560461",
+      "rule_id": "py/django-allowed-hosts-wildcard",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 50
+    },
+    {
+      "fingerprint": "388a8e2a1f63f3b3d3580ab21bd64175d2edabadf1319e25e454a3c4c02d8044",
+      "rule_id": "py/secure-ssl-redirect-disabled",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 53
+    },
+    {
+      "fingerprint": "8180da97b36f936d4a400ba633a28118cf8f77c9b1ff50a56ba4121bc822a765",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 56
+    },
+    {
+      "fingerprint": "7046dd4b0950d9a57d43cbb5cb5293854ed977289869d226eec435de3c6df760",
+      "rule_id": "py/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 59
+    },
+    {
+      "fingerprint": "8a9dd0088207e67639bb8fac42bc631cbc711e68640d7c97992d340761f39d74",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "4a0ee15cf6b1b4291e21c5fdcfcec2a0ae8a3103a5382ded00578ec96cbbe23b",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "a26a00bfcbadcc4f320483fda6e9ba4edc6b6c062872dd36798c8b8ffabbb15c",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 70
+    },
+    {
+      "fingerprint": "c4b0e2670a328d0b35826c227573f4900cd84a0a3206cca89fff6edae5867bbe",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "e6ac0586526eba8dfb4a4fbc06fbe6dc4660f99289d0b75203f26294c2d91199",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 75
+    },
+    {
+      "fingerprint": "2462bc2514d2da52ef4ebcb4d77aa86b50c2ed5211bcc4a680e4590bc7ccc982",
+      "rule_id": "py/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 79
+    },
+    {
+      "fingerprint": "cbda0bb402dfd6bd588d1bd17b1cfdf49bc45f7569b6636bbbb298718b39b9ca",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 84
+    },
+    {
+      "fingerprint": "910711be56db68bddd4f46c81cfba03af9301ca787937501a990e00e2f3af908",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 92
+    },
+    {
+      "fingerprint": "5b113e6b6dab55b76656fbb0676f9d89acbe3d8cd1664fbcdc1630f9ef61c21a",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 96
+    },
+    {
+      "fingerprint": "9220a4cf355b235a0dfde74f9c7026efd5abd8a063c02ed791a4f27467346b77",
+      "rule_id": "py/no-debug-true",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 99
+    },
+    {
+      "fingerprint": "9e62396216f88293cc3198c4fe373d0e8dc675af945db72af28ca40c09f00217",
+      "rule_id": "py/no-open-redirect",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 103
+    },
+    {
+      "fingerprint": "a910ad4cb4182e108554aa68aa3590ea1a70dba4df26fef8b81aad11c4ad40f6",
+      "rule_id": "py/no-cors-star",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 106
+    },
+    {
+      "fingerprint": "7ca6533ea21b2d91a444ebef5c651b26293c02373b90b41dea6778d1608455bd",
+      "rule_id": "py/flask-debug-mode",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 109
+    },
+    {
+      "fingerprint": "82165a8c7f544de546faf8d532d57cec98525e62e3aab5758406ea32734df85c",
+      "rule_id": "py/jwt-no-verify",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 113
+    },
+    {
+      "fingerprint": "57d313727ab7520ca0c21cc312afb5c04899f02d0609ad8d9b58402166a56316",
+      "rule_id": "py/jwt-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 113
+    },
+    {
+      "fingerprint": "81a8e3dd73dfb77a245026aa726b87856b7c5d228ebc83c1263296530877f4b2",
+      "rule_id": "py/jwt-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "f05e65ba0085f5ea69de3999277caef6baddf17f9e6c63d1ee3ca10ca475a885",
+      "rule_id": "py/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 123
+    },
+    {
+      "fingerprint": "aa691f5f1e55df30f770ed5cfef4ff9279176eba18955acda7d564471af5ce72",
+      "rule_id": "py/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 124
+    },
+    {
+      "fingerprint": "31b62633bf46c0eda73396f1d019623052f3e99969a0535575d4269e8949fc77",
+      "rule_id": "py/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.py",
+      "line": 125
+    },
+    {
+      "fingerprint": "5131f6f591acaf9b02587227af453125835dbde54436ec90114634f076d92bde",
+      "rule_id": "rb/no-eval",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 4
+    },
+    {
+      "fingerprint": "ca9c4dc177f6cf4a0c262224fddfb89b565e80f8a5ecdfc0f1f4f8765e0cc45d",
+      "rule_id": "rb/no-eval",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 5
+    },
+    {
+      "fingerprint": "059abb68648a91b8f700c56e28d291c451c2fc7ab22f7c1fb3e0803bb148200f",
+      "rule_id": "rb/no-command-injection",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 8
+    },
+    {
+      "fingerprint": "d7443d63b814af067cd26ac23af77a527acbee3123db35e636b17db3b9761b62",
+      "rule_id": "rb/no-command-injection",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 9
+    },
+    {
+      "fingerprint": "14295d8ed1412ac2b939313ea2d11614b05ae24574fd6df4f0159bf270d3a87b",
+      "rule_id": "rb/no-command-injection",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 10
+    },
+    {
+      "fingerprint": "e1bd02d31ef06c8c61943b389cdbc186c2a3b55333eed50ee45a0d3147632a14",
+      "rule_id": "rb/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 13
+    },
+    {
+      "fingerprint": "bb860ad690113cf9600da253a282a670ac53bee0b4fd62f6ae483d191aa78ee4",
+      "rule_id": "rb/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 14
+    },
+    {
+      "fingerprint": "44b0caac1ffba4b62c3386e1684a60129f310ec65fed279be71c2f0d8454e629",
+      "rule_id": "rb/no-mass-assignment",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 17
+    },
+    {
+      "fingerprint": "d1f3aa87e44514135153271cfb47c3caf1405ef2e4d2b1442bb8b94dee580729",
+      "rule_id": "rb/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 20
+    },
+    {
+      "fingerprint": "c84bd2e22ea67de225d5ec4340ed33d965bf093ecccb4fa8816d1831735a8861",
+      "rule_id": "rb/no-unsafe-deserialization",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 21
+    },
+    {
+      "fingerprint": "f44b2cd8e1976f3f50e8573475b1f465242644c03780169b46a5ec52f9e8359f",
+      "rule_id": "rb/no-open-redirect",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 24
+    },
+    {
+      "fingerprint": "f71930c219cc4318578bf45d74b6a854f0a14ba7cffb38703b5e58c99bdf42b7",
+      "rule_id": "rb/no-csrf-skip",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 27
+    },
+    {
+      "fingerprint": "877e99c2c81961da47b2378ae14e2ed49e2a63b36136fe54954e075b40987876",
+      "rule_id": "rb/no-html-safe",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 30
+    },
+    {
+      "fingerprint": "f9901b3aa3fe0179e275c9189680eea2eaf945fee8719d82f8af775af540a256",
+      "rule_id": "rb/no-html-safe",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 31
+    },
+    {
+      "fingerprint": "9987f155bb467eb39b0fbe58d150d66b79e5c6ca6e2dd3be74b5c2b49a680c51",
+      "rule_id": "rb/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 34
+    },
+    {
+      "fingerprint": "f0c71e6212950e63a33bd5f92bd4f09aa32447d3b83e4500f8a6d59380ca13d0",
+      "rule_id": "rb/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 35
+    },
+    {
+      "fingerprint": "38623fc67fe028198c8af3b53ec0463f9b6c346a209c609cb869e242b3596af5",
+      "rule_id": "rb/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 38
+    },
+    {
+      "fingerprint": "2ba3785cd40ff643a5988081bb439ff243657254350fe059d1adfad0862d104d",
+      "rule_id": "rb/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 39
+    },
+    {
+      "fingerprint": "45877691efe76fe6c9f6ababd0153570ccdfb7a43345141a456d0444352f6058",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 42
+    },
+    {
+      "fingerprint": "2cbbc090549686aec4ffbd374888408ec9ae7bf2e9155f89d2a0ac05d93ef543",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 43
+    },
+    {
+      "fingerprint": "a339ce7fe02e76b90c34e2d7b02b658c7fc9e8f7d307e0902df7694efd225169",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 44
+    },
+    {
+      "fingerprint": "9262f2435636964628c829d4f71cc37968577e7d0b3a27ea9263fc70d9c806be",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 45
+    },
+    {
+      "fingerprint": "e2d7260b7ba96dc98071e601cc5efdda755384d403583f5c7117906b37c06cb6",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 46
+    },
+    {
+      "fingerprint": "f871dd30239aaea0ec748a4e20279c6792c2b5d3e381c2846932c40d1755532d",
+      "rule_id": "rb/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 47
+    },
+    {
+      "fingerprint": "94e081911bb1fe495fa7b916d49a0e10b895670a13b5e23ee0b1d4717913112b",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 50
+    },
+    {
+      "fingerprint": "f11901b310a96f6e5ee1d92afe602823660117f1233b7b1a91b36c0e9c137bc1",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 51
+    },
+    {
+      "fingerprint": "b33b9786955619c1425c267cb17be6e240a883d56d7d67d7b380bd8d3921ae59",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 52
+    },
+    {
+      "fingerprint": "30f6b8d3e126ca801fa50bb9e3a14ffcf9bed4bfbe2d10a19539244e6303ac5c",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 53
+    },
+    {
+      "fingerprint": "7382ef4d1616234e6ad5c57a6837c25941256f96946f51dba10d2f971472ad6e",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 54
+    },
+    {
+      "fingerprint": "9a19e2d2007774b913882dd0573869e0b2ea9dfc7d9afeb33f64eaa99265f7ab",
+      "rule_id": "rb/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rb",
+      "line": 55
+    },
+    {
+      "fingerprint": "55f64c9f2d59ab5bb32b0a644a9c6e27ba53aacd10059b038a57793faaa0db08",
+      "rule_id": "rs/unsafe-block",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 7
+    },
+    {
+      "fingerprint": "61314f459a03fa9ca9314c98a44aff11234e9c64847b225d583d53e243b0c9cf",
+      "rule_id": "rs/unsafe-block",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 15
+    },
+    {
+      "fingerprint": "bb99ac80edb346700139ef477de5e2f25ac81d55b7c9f824339fb7bbb8acbe76",
+      "rule_id": "rs/transmute-usage",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 15
+    },
+    {
+      "fingerprint": "66b7289e96d4f02134c4cf765a349baa1f871f7bf9176d757fd67ebfad13f26b",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 20
+    },
+    {
+      "fingerprint": "4033f12ffa98e34650d8e96cab02340eae45781725ccf787fc24e783e94cfe49",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 20
+    },
+    {
+      "fingerprint": "a625dc6243ef2242505a497096d73acbefd94085d318c46a69bcfd2e66115f81",
+      "rule_id": "rs/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 25
+    },
+    {
+      "fingerprint": "416f2acbf877f2be72385a2021f7058f67128e187b95721cd4643311c03f133d",
+      "rule_id": "rs/no-weak-hash",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "4b6d54da527f058afbd8532f0ffe1718bdccdce6fdddf038fa550b0dda8de48c",
+      "rule_id": "rs/no-weak-hash",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "2e26e3e1401de2918d35b223bfd0e78b40e4ef805a556da289c7bcf600701901",
+      "rule_id": "rs/no-weak-hash",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "43a67108988bbaac6fdf99377a9dafbd4bdc21ba1385a6855cd7fc44bb8abd32",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 36
+    },
+    {
+      "fingerprint": "55678e142d9d7419a0ce7ef17df469aa902190f0b308841d700cbe7dd7e8edc1",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 37
+    },
+    {
+      "fingerprint": "9f83904557b47c87405e73580fc6ce5ae53884ab573667e4c8215f3d779f8277",
+      "rule_id": "rs/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 38
+    },
+    {
+      "fingerprint": "fdfde1104a06945292342499f74d2b9ce29470206e8b1138365e0f89bb8e858a",
+      "rule_id": "rs/tls-verify-disabled",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "d4e95b977255f9c265ff711af2d974b17a411d60839b31dcd46e5ff3a9fbdc5f",
+      "rule_id": "rs/no-ssrf",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 50
+    },
+    {
+      "fingerprint": "3f378aa3a0a2d2c9705a63124b7ce1d06805951caee7fcac89d4c8600d8e2c84",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 55
+    },
+    {
+      "fingerprint": "7c73ae5da15b3ba71e11679bfca5d9dc664d4cd39788955718983970f9482d21",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 56
+    },
+    {
+      "fingerprint": "f1f21afa584b02a1006125a71c8936135c3d533ddf8cfd5ef752101de922b05b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "00a2fb3374291a99f397e11ec8892698007bc3949e1656a79dd38f4f12017a5e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "924e84b505bdaa2a119eb309c30f70c78203ad4aaa82083da2f99922a79eee9d",
+      "rule_id": "rs/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "c7ed7f80d499e2170a501d45b23d945ee31a157cecf7872b4b66af4350956dfc",
+      "rule_id": "rs/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 73
+    },
+    {
+      "fingerprint": "e51f1497de93b15e1162c5a658f9d53341d8d391a3d1dffddb743387fc16e5f9",
+      "rule_id": "rs/pq-vulnerable-crypto",
+      "file": "tests/fixtures/vulnerable.rs",
+      "line": 74
+    },
+    {
+      "fingerprint": "cffff214acd2940ef44ee7e60cd0eb52f1d7393030de3d062907b0f0ac4c51d1",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 7
+    },
+    {
+      "fingerprint": "ddd2585bb291418669eb1798c08d60eb9d970f03eac7abdfb4d381a7dea12d75",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 8
+    },
+    {
+      "fingerprint": "80c598c4d25497ade73316ccc730895540ada900c5c85df8af24f38eb57e7ee1",
+      "rule_id": "swift/no-hardcoded-secret",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 9
+    },
+    {
+      "fingerprint": "7f9786a4fa7b53c3c28818a23b41405f9ffbe37457108a5e6cc705a912d94d4d",
+      "rule_id": "swift/no-command-injection",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 13
+    },
+    {
+      "fingerprint": "f149185498f5698da1a18893ac367a0f07433d56d1a1a5aa5d2f1268dadf41ec",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 22
+    },
+    {
+      "fingerprint": "6bedfb98b6d930258662c60a2b59b9d05f6ca917a18d00017cca9019f7e2c758",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 23
+    },
+    {
+      "fingerprint": "e09751061c8ba00d9b2c7fe01f696bdc6b58a1ec398fc333596c1ed3d84270b0",
+      "rule_id": "swift/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 24
+    },
+    {
+      "fingerprint": "964404d6c41f437e93a0489d0574828368a420bb4ff161ad0523e8aa77546214",
+      "rule_id": "swift/no-insecure-transport",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 28
+    },
+    {
+      "fingerprint": "989ccf4c0de3b6028d767e78d4c3abb0f9df1e8de4b140b1b82fc475241a55a5",
+      "rule_id": "swift/no-insecure-transport",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 29
+    },
+    {
+      "fingerprint": "a64140375b5fa07ce5d595cc1896e4757466beed7f46b0228e74a987f40c9efa",
+      "rule_id": "swift/no-eval-js",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 33
+    },
+    {
+      "fingerprint": "82050c81790486bb9fa06fe06e7ad4ecf5feebe920717f5557e05345d87cc6a3",
+      "rule_id": "swift/no-sql-injection",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 40
+    },
+    {
+      "fingerprint": "fb227873f950500821e7fe7409aa1aad992db289a8dd7d4593003bc2ad38db42",
+      "rule_id": "swift/no-insecure-keychain",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 48
+    },
+    {
+      "fingerprint": "31adf694d36068dadc10499f9f1768648da69384612dc42199041c9b77d82e0f",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 56
+    },
+    {
+      "fingerprint": "2d938431985642f023f27660f9afed961080aa56b9e09458f1388f6955d790d3",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 59
+    },
+    {
+      "fingerprint": "a07778f9c9c9b0a0e4997a4b82777d56171a79388fa4be094cdb8e0a6c4f7c59",
+      "rule_id": "swift/no-tls-disabled",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 60
+    },
+    {
+      "fingerprint": "1177be0108cebbac22dce80b2d7f90d39e3de4bbdd3eb998afd4b155a812de9c",
+      "rule_id": "swift/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 66
+    },
+    {
+      "fingerprint": "31ec83f12dd92eddb604ab798da30c80602e978ab82f4061f19fe2e9a9a09b38",
+      "rule_id": "swift/no-path-traversal",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 67
+    },
+    {
+      "fingerprint": "5734476abf368572189acc03d20309f879da475f6868d18fec7e017384a96ab3",
+      "rule_id": "swift/no-ssrf",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 72
+    },
+    {
+      "fingerprint": "6bac66cdbebfa91f875ecc25b05a1228b265f35fee4a91ca135a48cefc1ba4c5",
+      "rule_id": "swift/no-ssrf",
+      "file": "tests/fixtures/vulnerable.swift",
+      "line": 73
+    },
+    {
+      "fingerprint": "e57f0f135ecac1022a71be38c16fb75658d7e0a4e623afef6768935dca6a5aa2",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 13
+    },
+    {
+      "fingerprint": "bbffad23e6c0952438444256d2c9085d86345d5f472436f6071476d2530bd332",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "de1214bd254616b7aa62ec17a8e3c30550f1ee8c845af299398fc438086b3883",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "92922dbd47dd57cd2ac903c2bd39a655a6bf2c2d58961c0119b07527de8da91a",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 25
+    },
+    {
+      "fingerprint": "0d26255e81ab19fa0d8f55cddaa3a433af3ccf710b3b16efae9637f7890dd41e",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 25
+    },
+    {
+      "fingerprint": "2d275ce553ca527e5ad80cdca151d52b5323a20a2cc4b1a7b3259e33dd24908c",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "a207b1c48d16f7f1da88a5d9d0b0f31a0172dbf77c9a7d5e6bdf16cf430398f3",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 31
+    },
+    {
+      "fingerprint": "e77f9f856cdbb8c386d0cb7ef575d4b811605b9997d18d8406739530a7614dc0",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 37
+    },
+    {
+      "fingerprint": "2f43b6c5dd056d61352e6324fad701e2a9cb3263c36ed7a50a273a9b75ccd911",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_cli_taint.py",
+      "line": 37
+    },
+    {
+      "fingerprint": "379b4b3006d8c8936a5f6f3aae7bebf316aea9ed2022ad0d3205d1f5c21bb4c6",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 10
+    },
+    {
+      "fingerprint": "5e0c5316af04aacd6a0c2c454e8b3f82669ace3429ae4880756fc61280a7f370",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 10
+    },
+    {
+      "fingerprint": "eae633ddca13c6fff86298b1f03cb6628ee05bf0388535498164fb80e88246e1",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 16
+    },
+    {
+      "fingerprint": "819444cc390a3434e0677e742580dd9969611f46178b839974c506ecb0ee30bf",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_deno_taint.ts",
+      "line": 16
+    },
+    {
+      "fingerprint": "197f882857a622033f865864e06227b87d4729f6fdf55f89dc52b6648d628bf4",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "f875f5fea68b9f455b34d1f23e5588c302fad8cee4c1b78dee85ac32dc6476d4",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 18
+    },
+    {
+      "fingerprint": "0daa17708903696f48aab41f97b51a132fa33ede48930acfbf977b41e6c80ae1",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "c0282b5060ccb304125c65982f3780d1b7d49cbcbe3e69cb4693983938e4ff68",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 24
+    },
+    {
+      "fingerprint": "cdfb55d824bef54533d77eddb87ba3c39cb1b89f5a2a9757812b2e7b5b384528",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "6a5dc6f32630e2c96409a92a02af83ef101c9b032f7e678837948e310fc7859e",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "f912c5dd28576acada845c5be70744785d088e6d2b353d5c7dfe7532b95ffda5",
+      "rule_id": "py/taint-yaml-load",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "067b4c7519accd96c232efe23da8bbd93a9bcd1962e1ab3e1cbffa4607b75b90",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "94a4ceb55a3c245efda83924f0f532e5fb51b0a52846657213e2fd3f7f923720",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "254d1c60dd352015cbd8af4de112d5e6a55e68d202c06590c3f6f6d82365f5aa",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/vulnerable_django_taint.py",
+      "line": 43
+    },
+    {
+      "fingerprint": "673a00889e6b5a3583756f13e033132e41bf364f85eb2d8788015e0f2cc4680e",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "f5ab1d5b9678e5cccf0ebbfc37b61c0ccda8d54639502182c47ab32a6a0e556c",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 19
+    },
+    {
+      "fingerprint": "6eb92a46a0ec331f4713f60a1874986bffac4eacb353eb029859f92ffd81c3fa",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 28
+    },
+    {
+      "fingerprint": "badd09873698d71a5113ea241d4aa3038ce73244fae6faa4935ac26c739b560d",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 28
+    },
+    {
+      "fingerprint": "bfb961c2665d50928ca7ff6a2d817d7e1807fd2bc358bb53a6776123d1d46f46",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "291af20d310288ce8217d5fcaa66d2dcfd02ef41f62adb2fe87cb3ada1a81b09",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_fastapi_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "1316efff994048b0af4ba8781956dd3d722ea84d92832db90dcd6275f8fe5470",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 23
+    },
+    {
+      "fingerprint": "a97a2fab86afb8b5f0e273e3e093cdfdf0f20d8bf6086b5072f4c444564f715f",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 23
+    },
+    {
+      "fingerprint": "b1462aefcf462154757aaada2a217e5c0a9ae3e909fdd2b98e5bb08be30143c8",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 29
+    },
+    {
+      "fingerprint": "74ff9fedf5489216d9c72f6ef3df5c970fe57ed05cf4b39e55dcb11e94f101b2",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 29
+    },
+    {
+      "fingerprint": "a64272869ca9a63c131d8c7be16c3d19ebb137d4a06d2b6fda19b370412618c4",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 35
+    },
+    {
+      "fingerprint": "8a8a4feb3ffab5369fbef3d2e073d5104cbe32213b54fc32ff65e8eb77aa82d7",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 35
+    },
+    {
+      "fingerprint": "39edb2b9d0f6298c7b18dd674c61bbf0c4fe151bb4224c6934c4cb6b72a49b99",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 42
+    },
+    {
+      "fingerprint": "62ab1910bba8734b4beb1a3096ee2dc9d0ae8e3c1feea5a686c4fbab4ad49eb5",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 42
+    },
+    {
+      "fingerprint": "89c3698b9d6ed8fb7ecb9f574cf2d33c5480dd18613fdb3468c3fba3624e5852",
+      "rule_id": "go/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 49
+    },
+    {
+      "fingerprint": "a124e4c5f8fbd88ca4a1f669a2560f67f9fd1904e3bd796b71a080c9a93d5731",
+      "rule_id": "go/no-command-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 49
+    },
+    {
+      "fingerprint": "50e417e67dd896c61a2864f9e6466810c9c3c96a72bb25916d3f68e2e5c88d2b",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "e1d6f66d5741c4796911310a3b768d7cc9b78804b1f07d4001687475505aab71",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 57
+    },
+    {
+      "fingerprint": "55d5d3712ed153005e5cdf76a55bdd88441738f181d8c606e3745ea29708f22e",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 63
+    },
+    {
+      "fingerprint": "fd5e9093fc5d2fb6df2f57e4e599102b97877f06b33a2d3923e0a709757a5f1a",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 63
+    },
+    {
+      "fingerprint": "a8f3f99a7237f5cb9f7217dacd47b96dce2332fde02487788f445e2f7f083365",
+      "rule_id": "go/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 69
+    },
+    {
+      "fingerprint": "b7ce08f5009015815625c1f38310e6325e45bbd05e549bbb11caf16bfdf043ac",
+      "rule_id": "go/no-sql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 69
+    },
+    {
+      "fingerprint": "271e4781ba671e675d5ddf87ebc0c7b9a1ef6e42edc1e3abce7221f92168f9a9",
+      "rule_id": "go/taint-ssti",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 78
+    },
+    {
+      "fingerprint": "345bcb464c8b60eda1a7fc313bbda7a758671d6e66ac9d84db5c9a3715561192",
+      "rule_id": "go/taint-xpath-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 86
+    },
+    {
+      "fingerprint": "d7db7b756702e8c8037b78c3f38a29bea165ec7abe4d8efbad852c462ce97d34",
+      "rule_id": "go/taint-ldap-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 94
+    },
+    {
+      "fingerprint": "277fe0fa798de8e5143dd1b19674f9b83d6152f9ad70ff810b5834b045c66063",
+      "rule_id": "go/taint-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 102
+    },
+    {
+      "fingerprint": "5b325c2e03dffd12cffc5434509aa3b2652eb3a1f47a718c2ed35bd0065a82d6",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 102
+    },
+    {
+      "fingerprint": "aeed00abda4122f087525ac98f502e6eab75b7c45663b4727d800adba589ce6c",
+      "rule_id": "go/taint-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 108
+    },
+    {
+      "fingerprint": "2ff4900fa0d116f743fcedaca5311a0ec162aee7eda532f67cd33d72352fd478",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 108
+    },
+    {
+      "fingerprint": "1af8bd0b48af939ff81bffc13323420d2963b1458c995f3b209417446f9bef9c",
+      "rule_id": "go/taint-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 114
+    },
+    {
+      "fingerprint": "2bb2ea008c40eabf12181d9d9fa42c32212cb0286031dd0ed5c2fbd1691dc168",
+      "rule_id": "go/no-ssrf",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 114
+    },
+    {
+      "fingerprint": "4271c3425ec30cc64c02d0137b594bf7a718db8b29f8b83d50abbf268034b7af",
+      "rule_id": "go/taint-log-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 122
+    },
+    {
+      "fingerprint": "28b3a5bb692d1c6f67c0951f6a17ae4e70a4fa5e79304c99e76e428eddf20e2b",
+      "rule_id": "go/taint-nosql-injection",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 130
+    },
+    {
+      "fingerprint": "a54bd3069ab4c5660cb1d5e6c6e873f5eb6507d9d07837a7a95bbfcc6c0a3e3d",
+      "rule_id": "go/taint-path-traversal",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 138
+    },
+    {
+      "fingerprint": "413330410715a36edf2f1da3af93613816ba70be8938275de01570f2ee5ba024",
+      "rule_id": "go/taint-path-traversal",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 144
+    },
+    {
+      "fingerprint": "1630dba88460698f5384b03efb449eb5e09be5bb76f48dfdf1c2bb4a6e915b95",
+      "rule_id": "go/taint-path-traversal",
+      "file": "tests/fixtures/vulnerable_go_taint.go",
+      "line": 150
+    },
+    {
+      "fingerprint": "912097ddbcad5a903b9078eaadc9c0714ad722e33b184d45e52ae0420700dd5b",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 11
+    },
+    {
+      "fingerprint": "2f0649c6bf8e6242ebaac0dc2058cd82ea0d90ef737f40d7c2a8d487fcaa25f6",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 11
+    },
+    {
+      "fingerprint": "88cc453d6cbd24dd19b7c8568cbe248baafe65e547ce72bfc235e085f79cfec6",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 18
+    },
+    {
+      "fingerprint": "1afb5736ab9f5291e2dcd7308e4befc299b6743bf4c8d9e72d671fcdfea149c8",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_hono_taint.ts",
+      "line": 18
+    },
+    {
+      "fingerprint": "b153de9953136cf01c61dfbd862caa0526df1e682a0ab5dedbb8bbdf3ff4a18e",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "ce470983319b7c5df1283daa8ec39fbe25a2e466dad9ffbdea7e1d22a1c8c095",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 10
+    },
+    {
+      "fingerprint": "ffd3e907359f6fa07dae4e3bdbb8c16868c048f85cf912c6799a5a5c9475408d",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "3cd8c9f6a0c0a7af5c9b6ffaeef85929d70a60bcf240bb12060790865353f3f7",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 16
+    },
+    {
+      "fingerprint": "ef8104104f3251b5fbc3a126115cf9a36c82420689ef7c5b25463b52f8cdee23",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 21
+    },
+    {
+      "fingerprint": "17e4cb571a036bbc71900f6eec320376008c0f073b4c7f1c232301baa3c0063e",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 21
+    },
+    {
+      "fingerprint": "2d6ccef3db1909e54deb9bc2eae0ba9a3f19481a349b4757ff4e03243ecd44b8",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 27
+    },
+    {
+      "fingerprint": "ce63aeca2e326bee2bd436dce6a97e43ab4aa0aa9cd3c04f0917a383741c10c4",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 27
+    },
+    {
+      "fingerprint": "175ad5da4070d002bc5a5083be9fc3ba227ff89c2a2f82b2371a8cc9e35d5cc1",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 34
+    },
+    {
+      "fingerprint": "c85f65bbf3abb09d5397f3c845dfe319c3890a824fed0de88189a9fe0bd89a67",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 34
+    },
+    {
+      "fingerprint": "d6b6e584036058f4ec5a5c42aac5c41f0a568f06d81f2f7e2ccecf407df41627",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "2fe3b782cf612739df1c78db2cf13a6502e9206aa4e35171b3e65b768eecfaa0",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 39
+    },
+    {
+      "fingerprint": "d3a0fa666732d6cb1ffa02d5a2322db018ff4028842a8538bd234a5b33ca842c",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 51
+    },
+    {
+      "fingerprint": "67193ef5a07794d55765958bbd7d96a6e14f075c41854fb15e5029fd2d632ace",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 51
+    },
+    {
+      "fingerprint": "344909a6ebf05348c7096f2d7e753dc0ca531949b51df6d6cc8739e41ac532e6",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 58
+    },
+    {
+      "fingerprint": "1f4527f2b3ae49fb9d91f5dc70c76de3275c7c74a15c82531957e2ca0fbda10c",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 58
+    },
+    {
+      "fingerprint": "c4307c2e10149b1a9305a62ed1a2612aeb64ad17d0e42419c5c3434ac73bff74",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "b073c94698fdbf266ddc0b4af7d4fb6bf180d5b6416d0d5722deccd0ce009953",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 65
+    },
+    {
+      "fingerprint": "769546a438cc5a1661f58385f3c324a20ba0216b727e6210fd19ffdec4495457",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "5824256ba9d58bd4d2d53e9a5054ec71ff92604ebcb1259c8f7bdd588bd4579e",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 71
+    },
+    {
+      "fingerprint": "ba6c83704b1885beb1d162276da346b8dd2fa2a480d73b52722b28787df538d1",
+      "rule_id": "js/taint-log-injection",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 77
+    },
+    {
+      "fingerprint": "a6fe6bb201dd743901c721535473117d1452289fa9e10b6dadba898f39a63e94",
+      "rule_id": "js/taint-xxe",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 84
+    },
+    {
+      "fingerprint": "70c9af6c0e8a6e5c0e8d1fd1224f5c94f9d14df97949c270f3d33d339452a98b",
+      "rule_id": "js/taint-nosql-injection",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 91
+    },
+    {
+      "fingerprint": "2d5b4c0e0bff8c31d5a170ecc31eabae4c4e3febf301d40c5b371d6b709b307e",
+      "rule_id": "js/taint-ldap-injection",
+      "file": "tests/fixtures/vulnerable_js_taint.js",
+      "line": 97
+    },
+    {
+      "fingerprint": "12cd9d85748bf95097532c3ecfe11fe61fdc580bc6f946ac33adb5f9d063cae2",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 13
+    },
+    {
+      "fingerprint": "5ff80f5701c59b42fdf1909a06f4bb10c9fe1578f92a0742ca9e6e336a13765f",
+      "rule_id": "js/no-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 13
+    },
+    {
+      "fingerprint": "9237ee72aeaaced38d884cad1492b27956183daa75ddfe0ada6f0d496a8934a9",
+      "rule_id": "js/taint-xss-innerhtml",
+      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 19
+    },
+    {
+      "fingerprint": "3672563f5bd8b9d3c919a5c60148983d0ff7327c052a6d022a62de0dbafbe7fa",
+      "rule_id": "js/no-document-write",
+      "file": "tests/fixtures/vulnerable_nextjs_taint.ts",
+      "line": 19
+    },
+    {
+      "fingerprint": "91ae20fa132bac2d728a99c352ff61ca8854bd4a597b4cc1479191ab09a11c36",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 30
+    },
+    {
+      "fingerprint": "ce915ca1f7d802ad7843b1647478e71d157048f724da9a898883733a4ec35109",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 33
+    },
+    {
+      "fingerprint": "4d8ab4b1e1251e752bfbc5e67cd7ead35e1babf144aee81424585c5c27fe6515",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 36
+    },
+    {
+      "fingerprint": "267cab98c7af3ca4af31143375ac2f81a0eb8d51318b95abbc01574bcb532163",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 39
+    },
+    {
+      "fingerprint": "d9a98e32f8d5cdb6137d96870b5ae1373d59f89041c32a81a2a3b178efce6139",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 44
+    },
+    {
+      "fingerprint": "5c0368528b9b8571031d6a21a8dc5f172ac9f4edf2e04600ba5da07d965c5f83",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 47
+    },
+    {
+      "fingerprint": "6b9db1ba74e9f5981999d0ce272f4c5e6b449b63aff6d199c9a7e1e4f30aa56c",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 52
+    },
+    {
+      "fingerprint": "3b0c6cac5b1fdb55368d180d806bf9b542de2e16cc41cba3aabb06dc373d9e2b",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 55
+    },
+    {
+      "fingerprint": "79c23c5f0b1616a68c166e9db6f83963f21468adf2250f54333f185c412e2768",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 58
+    },
+    {
+      "fingerprint": "7454ac5da6acd03769bd39a508c5e602660c1bd2465ef27c592acba85c24a981",
+      "rule_id": "py/no-weak-crypto",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 61
+    },
+    {
+      "fingerprint": "d724042b2b25471d5edf176f3606903c3eaef6dbf7475ac0e0d07c2623d83309",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 66
+    },
+    {
+      "fingerprint": "40872065716b4fac47a8d83e494d18ba0c2b60bf70e25f1e80c46c8dcfbf3c33",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 69
+    },
+    {
+      "fingerprint": "3c2e03133ba2fbc2968e9a266826c6d724c515466bad39aabc1d14d9691051eb",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 74
+    },
+    {
+      "fingerprint": "7b4f3f41f628993745d475d9071ee1286de194bd094884104d375bc3014ff113",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 77
+    },
+    {
+      "fingerprint": "2f098702d3d2b6f7b80ff66bf20343f8e6d3401fa9d79cc82c570ee1222b8b8f",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 80
+    },
+    {
+      "fingerprint": "89b3c30a22b0ce8ef4441de328a215dae3c13ae67db9806b70c770650033b989",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 83
+    },
+    {
+      "fingerprint": "d54ddf48c96631fbbf0371899f84b91b8f6e6b94f3f0c65f68dc2f62bd1efebe",
+      "rule_id": "py/no-path-traversal",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "895724f2e8c6cbc1144cf17dd1e7ecafc8e93c851a230efdbbf57e324dd10802",
+      "rule_id": "py/no-path-traversal",
+      "file": "tests/fixtures/vulnerable_py_aliases.py",
+      "line": 93
+    },
+    {
+      "fingerprint": "a9ba13625f04823b386424134085e8eb5e69dbe625d73d57f58eaafe88b81b84",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 15
+    },
+    {
+      "fingerprint": "decd219767874cd986ee5fa67a74239a55396ce3035030f6aa87138a1da40e2d",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 15
+    },
+    {
+      "fingerprint": "350e04ac5c83f9c459ac5e172a26bba5739340b5faa8ce54bfa1ecbcee3cf275",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "d0207727c4fdd13333c240637abc3d565167b6ebc173dc1d664c9bb466b787e9",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 21
+    },
+    {
+      "fingerprint": "e00041e7da36c426920fa7b453344dd4fa883ce3759c210512c64787a391bcca",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 29
+    },
+    {
+      "fingerprint": "c892e614ccde5585ab3c4563e0450dd30e954db4fe8dbc846262e42832cbd310",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 29
+    },
+    {
+      "fingerprint": "ffe01d7b2629bce227adf79ef23708a0d17a3cbae50f2e78437306c8b84cea71",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "453233eff5419c41e3b70652b32bf59878561a10d1f19e477e52a5af8090d357",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 35
+    },
+    {
+      "fingerprint": "cc35705cd80666115b0497c4d5ab46af8639dd22c00b90a5a2dc32b731610d6e",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "5c43912dba5622d1bda77a35200e7ba3d11badc5f3a4b2592e99d6910a9fa8dc",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 41
+    },
+    {
+      "fingerprint": "4c5222d9662e36b060019169a7572812d58cd354f336d3bc8fb2b75864797b99",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "a7fca691dc1d54f00f16a134265de0f5bbf3ba862b131cc5d6bafcc7a690e086",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 46
+    },
+    {
+      "fingerprint": "1c1182cc66f319a522f208620f207206f5671b889692e8d7693139b6a1c0ed53",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 54
+    },
+    {
+      "fingerprint": "0da756b833368861c8ff1fcc5d9fc350c42acb6cc894470f41f468bcd4950806",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 54
+    },
+    {
+      "fingerprint": "fc60725e6f0c44a07447b2828ba8351b7a3e226a70ae402f80b6e7ae7f33d47c",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 60
+    },
+    {
+      "fingerprint": "356a5f485060e934956dee85f4e3f3502f8cf0fdf76a2b07d7760bde082ee53f",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 60
+    },
+    {
+      "fingerprint": "310d2a360cd1a6191fbf820c589cb27fb742513251520cb0791556100dbef947",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "461f15b7da5b8c55719f94326971c9406aa676654f037c0868c78e93312c8b53",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 65
+    },
+    {
+      "fingerprint": "7872424fd4a4594563e96ac91364c25f8567d6a00d1b91f7846eae9deed8e8d0",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "a1eaa18d64573fb8cd2781c0c1839901764271370625e82eaf4cf33279fa3dc6",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 71
+    },
+    {
+      "fingerprint": "9b36276d999736d8ff9a2ff2d6e5296c60e6d4c65af8fb4c510e05577a0ec145",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 76
+    },
+    {
+      "fingerprint": "a51526481269f763d51b233363c43bf7c7fbd547b9105801d45ebedd473fee6f",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 76
+    },
+    {
+      "fingerprint": "e60afb6ac7854e3f5407f28c3097b51a677be3c7668cf9b81a7322b5389830b4",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 82
+    },
+    {
+      "fingerprint": "316bbc63df2c04dd85604d3e7f25b6f905e4fa8afbd49f87f80fd55a320c1e40",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 82
+    },
+    {
+      "fingerprint": "27f18b073f9042a4b824222493d07940a6f5b6abc1cec3461236f10700359dd7",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "c6bdaa437eea617fef9ea75de6894857fc82749f18eaf6f35ed2512f5932aebe",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 88
+    },
+    {
+      "fingerprint": "77645ac0b3eaa3a35053527fad3b46106ccfbf2f12f63551c7e08d70ae6545fc",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 94
+    },
+    {
+      "fingerprint": "4d1ac224eef76a19dec5abe4e4853bd18d2e6ab7a7a0cc00f38fab1362ac65a5",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 94
+    },
+    {
+      "fingerprint": "5422345f34fc1db28db9c998403457a33dc93c179ec4d4906b95b2bd7c2faf39",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 108
+    },
+    {
+      "fingerprint": "4fb1a559e68e8ea9465f4d98be7305552f5bbf846ec43fd2f32ec4447f1dfb89",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 108
+    },
+    {
+      "fingerprint": "93ab4ef2102c8a8e8836f4dd0abcf70ebd572e0a2714004ec1b54613b975dc1c",
+      "rule_id": "py/taint-pickle-deserialization",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "336618fdcce534672982ade23fa10e7fcfaa54631d50085dca7826648e140649",
+      "rule_id": "py/no-pickle",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 116
+    },
+    {
+      "fingerprint": "e198f668910f82331193520353db71ff02e70ce0bd82ba0c3e106c686fa8394f",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 131
+    },
+    {
+      "fingerprint": "18e85aefe5f7e47dab1fc2078e4570e472c61633574c3c3a4d385f05c2c7a0e2",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 131
+    },
+    {
+      "fingerprint": "6ea634b0a7b42e41c5e757d581a1980fb20a51e4d7c0455cb214cb5fa3df3067",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 137
+    },
+    {
+      "fingerprint": "d9dfed23d169ea9ad41f18e40c579818647096277db92141416072a99af1fe8d",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 137
+    },
+    {
+      "fingerprint": "e31b934ce8ca23e2316dd07322d1209681e0485793068d509f02130908eb7be5",
+      "rule_id": "py/taint-ssrf",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 143
+    },
+    {
+      "fingerprint": "88b1cae800c5b97593fee96294ca54a6d280476f8b0ef27c58d5ef659c8e63d0",
+      "rule_id": "py/no-ssrf",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 143
+    },
+    {
+      "fingerprint": "a6f6549704dbffa9d9e265e7d6b0cbd457f3e87c4f4c3bdcf9a0838683c0ad3f",
+      "rule_id": "py/taint-yaml-load",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 149
+    },
+    {
+      "fingerprint": "92d21c14be3a73232d3eb38fcfccd3125525635fdb24c156900087c768ae0e04",
+      "rule_id": "py/no-yaml-load",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 149
+    },
+    {
+      "fingerprint": "147d06f38179f5e76258704241fc9a1d5cbc632568517fa50e12bb7f060cbbca",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 159
+    },
+    {
+      "fingerprint": "103a462e2d273b058b4123f4af8cd2c8a62952e9251038f35870633d91abec08",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 162
+    },
+    {
+      "fingerprint": "b2a5bd47f7d8f3eb6c13a648ecb83c33d9db28adb1a02efb179685b04d88b77e",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "351688691bd061bfaaa723d3e98e54ac1a59a39426e34ddc54d744afdfedef28",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 171
+    },
+    {
+      "fingerprint": "f77a0177d99c138b545bf1a2283f303e6827f3c9c3b615e9add784072a385b65",
+      "rule_id": "py/taint-eval",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 176
+    },
+    {
+      "fingerprint": "caccb41be8f20963f785241a9f6f8c76771e1e077e4d9f9915356e96d151d350",
+      "rule_id": "py/no-eval",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 176
+    },
+    {
+      "fingerprint": "8a32055951dc833b68408c23beb5002d3089b07e8fb0a86c9125a437a41c0a39",
+      "rule_id": "py/taint-sql-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 185
+    },
+    {
+      "fingerprint": "ac24a483e81a9e1943179e9914859fb3ca215c84108b966ef8e3a0d9f81f464e",
+      "rule_id": "py/no-sql-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 185
+    },
+    {
+      "fingerprint": "58457cc7fabd0ea901f8ec7bb209583653f953d45b18f2f19122a2a492f058d6",
+      "rule_id": "py/taint-ssti",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 195
+    },
+    {
+      "fingerprint": "aeebf902b3afcc49ad1637f1826a5d3b8bb0ea01fba9b24e75d19abbdc146fec",
+      "rule_id": "py/taint-xpath-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 205
+    },
+    {
+      "fingerprint": "ae4eff687020c523b8223510746dfa7677579a7f15a22fa02e6bbc9de527084c",
+      "rule_id": "py/taint-ldap-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 215
+    },
+    {
+      "fingerprint": "c2d72b3deffc0b821d83a0992109df8b619927697962c83b0a2810ca5464f193",
+      "rule_id": "py/taint-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 221
+    },
+    {
+      "fingerprint": "d7a7764c41f5f431fcf8219d4c8c79c9fe9c093276fcbfe5ad63403330fd2cf3",
+      "rule_id": "py/no-command-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 221
+    },
+    {
+      "fingerprint": "dbf4fd2ecc9cf90a801af36f48432a61f2a4cf219af49b8c4eb779859f4f5479",
+      "rule_id": "py/taint-log-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 229
+    },
+    {
+      "fingerprint": "cab337fb08775ad7564ce151177a51888e740602da040b2199c04606e6b8c69a",
+      "rule_id": "py/taint-xxe",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 237
+    },
+    {
+      "fingerprint": "b7b66f1e1167a212c6deb6d2de48e177639974921b8af3d64733c78183c31638",
+      "rule_id": "py/taint-nosql-injection",
+      "file": "tests/fixtures/vulnerable_py_taint.py",
+      "line": 247
+    },
+    {
+      "fingerprint": "2c62e40f4e1d63c4cf3d57e1fe93c1197840b7fb73bc5d367953e9c0149a3326",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/vulnerable_tsx.tsx",
+      "line": 6
+    },
+    {
+      "fingerprint": "89fa04df927b713fd9b90b9dbba4b5259a2aa5535d0de6438da6c493f6636d75",
+      "rule_id": "js/no-eval",
+      "file": "tests/fixtures/vulnerable_typescript.ts",
+      "line": 6
+    },
+    {
+      "fingerprint": "0ac21ba14f6dd2fd4da127365a5b3aed2b516812bec64131ac57d50f7c152b3a",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/integration.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "e90eca37356da4dec12f9ba19778711f9e1dd35abbbfa732a6e3c6f9acab7bbc",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/integration.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "e20d4c0d4b1302729db753fb352b6396efce66d2ea98116ab39bfbfd067a8020",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/integration.rs",
+      "line": 62
+    },
+    {
+      "fingerprint": "4b25d128113f93ffd554ba69f3ed2dc512d735ccc6612d928fbf943860e91174",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 83
+    },
+    {
+      "fingerprint": "01099ccbdc104fd744d1fd247756438c547df75fee9965835cae895777606b5d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 92
+    },
+    {
+      "fingerprint": "accbfee7f4159296057031d09787d5bd4cd74516dafa4b2d6925291155216667",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "de05ebe8eb8ef53187a92180f08a80ff82ab00cdbf178c9b5836d680e3e622fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 102
+    },
+    {
+      "fingerprint": "10b5baae63e12c73849c9be4cb5cbfd642197f9f72f9cd4a46eb1c01649917df",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 107
+    },
+    {
+      "fingerprint": "313bb578d2462ffd1d86a3b376e73040b869affcde1695e5b8d7915412fb88c2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 109
+    },
+    {
+      "fingerprint": "3aac268e021401685272caf141366dfd20d43a1cb863cc0ecaf557b8f737099a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 118
+    },
+    {
+      "fingerprint": "09ddb58b7c80f38304f8947ac854b814cbcff460f38a9f71116e3128c69c66f6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "40a588b3af2fef3ec6fcdd8cd8b84b71d2f225ba5b01676494396ed2d904556f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 129
+    },
+    {
+      "fingerprint": "e7ffd780f5f5b62c341ca6c0a50575ccefdcd3ce484867d26bc52900a512c008",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "e547fb3a66edf8914a46ca2c5604c1ebd9e718a5cb380814dbf933c30c86d51e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 139
+    },
+    {
+      "fingerprint": "f54625a8554ea3d31c99469973499ab895f1a10ff93c89948deb3dd82df8232a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "c49365a69f5a7e0f74143712854d49fe6884bf7b9207740e26acb7e3e37a921a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "ee817f31f5ef067a0b7643b487cd77a534cde4b6687a504a1e97ed0fc5490cac",
+      "rule_id": "rs/no-ssrf",
+      "file": "tests/integration.rs",
+      "line": 254
+    },
+    {
+      "fingerprint": "9b177309b974a83b8433c6bf2071d1279e3e3bcf94650aba48f33cea9dd74a5c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 270
+    },
+    {
+      "fingerprint": "d5b1db252d5c4482c3eed1a889436a124673f60af9f7d248f65ea4d8ff3dee40",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 364
+    },
+    {
+      "fingerprint": "b386e531c77c91b3d1cfa4d6bd84afa1f1fb19a06f7aa075b81acf0cd1ce6677",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 402
+    },
+    {
+      "fingerprint": "2f2f2e63f5bc6755d4e9de50ed904338f2e7840681e1641856295e6ddb1d1370",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 439
+    },
+    {
+      "fingerprint": "40a1bd4ed5bfe1ad74370190712eb76b83412660a6f8f168ecdf0972ee8f1aa7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 471
+    },
+    {
+      "fingerprint": "36d89e675fb69bfba83d8019df471fcdd999cbc2fae128a4594b528385317a59",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 505
+    },
+    {
+      "fingerprint": "d3d131403938cae1c25911c43f9ade9e7064d3d7d2e536465abdc59b1188d70d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 539
+    },
+    {
+      "fingerprint": "1de51f9d582634d7c08242791a820b6dbf3eafad0a1066db335b84549b310325",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 572
+    },
+    {
+      "fingerprint": "6df08417b3a7b2724e4d6b7bfb47fec72a67cb3f4a8bda81f25b7e380903d9ef",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 605
+    },
+    {
+      "fingerprint": "4036ba53daa3b2d910de33f4c58e2f469e075fd30c1f06a9af8d1fbbe857bc17",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 627
+    },
+    {
+      "fingerprint": "f0111525a0cbcf3c61fa90670ec570689a4df5d5da753fb3608bb68970487d9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 647
+    },
+    {
+      "fingerprint": "e842ef94b12fb65d06c7872a772b7988d1ed39aaeebaeb965269fa4e7354a708",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 714
+    },
+    {
+      "fingerprint": "31915a0440de73dd2cf7b7f21df76ee229dbe5bb69fd078bf52bbda4e0f38d05",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 769
+    },
+    {
+      "fingerprint": "d829066c757e8a815813b340bf8726d672c669a2ce3e1d9b32ff1c0a9015575e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 800
+    },
+    {
+      "fingerprint": "6cfe05734a6d8399becc4e1d10e527d5b7b195d43ae32bf66757483542041039",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 822
+    },
+    {
+      "fingerprint": "c5c6e367840eeb832294f035cc8fe0367df7bbff3ce69c209cb891ce876cfc8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 848
+    },
+    {
+      "fingerprint": "88c6e1e346010e003ac02404763aa923c2bebde7ccca24071235610f8960c14b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 871
+    },
+    {
+      "fingerprint": "4a051e11f8646b6f4a4013fe9fc2c56181a4dde7e8b53267a2f734e044ec7fe7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 894
+    },
+    {
+      "fingerprint": "86d134731111e2e43d27340d31c5d8d03a247145b898668ac6d0a3d35f11dce1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 916
+    },
+    {
+      "fingerprint": "0a3020f77a1e48df2edb607a3354247d180d1870a28929df62c02a5e589612b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 939
+    },
+    {
+      "fingerprint": "fd3090e61aeed4aa071a3718a836015761a128ee5e180a72b6a8f8f5817dfefa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 961
+    },
+    {
+      "fingerprint": "1de06dadacfdd3436f7f1c860aa3b4099dfcf14417531895e48edba17052636e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 981
+    },
+    {
+      "fingerprint": "fe3793daa15a061dd99327a90bdbd069c4610cdb5fa588fbb8c76988e5c7cd3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1001
+    },
+    {
+      "fingerprint": "4c8ba6f2379ad5513b47a4690f6e8aaa1d8a8de3d1f9b1ded75c3aa9393eecc3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1052
+    },
+    {
+      "fingerprint": "78b66df6239934f6a700ef8387757f7e8cefb81ff5fee29bb5bb55f6ded75cf8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1122
+    },
+    {
+      "fingerprint": "8463c25d30c0663b770348880a44da989b3b982fc47d9d0578d7d5611682f7c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1154
+    },
+    {
+      "fingerprint": "8bb710cae0ad24d0f0d5cf32d1f22c1788b3d6309f2f92e77c85c6d7d685dfd5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1174
+    },
+    {
+      "fingerprint": "a41463432e159f83493cddf32e041bd83f1a6387b90c6f2ee6680c613af466e7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1217
+    },
+    {
+      "fingerprint": "73cefba65f7dbe06bae8714f1e6b8b51bf6889cc047ee1ec7f727b72efb4ac1d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1239
+    },
+    {
+      "fingerprint": "2e1bab2a97d9619c10ce3abafe4b77f48b0ed503d447229d48533bdadcdbc25d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1241
+    },
+    {
+      "fingerprint": "57632105c23d6c44141c305e6d5e362c206a23b5f261e56c688ab247b669b6c5",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/integration.rs",
+      "line": 1247
+    },
+    {
+      "fingerprint": "9ac3242580627c2600c8e21bd88bfda9f008093a4618d6103a7b1411f52e702b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1248
+    },
+    {
+      "fingerprint": "ed6e8c70b395edbba41b01e7f21c720b0aacdfc2d37a6e564a2118e938f5ee11",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1249
+    },
+    {
+      "fingerprint": "64406d04968f10e01e07b77881ae13dba003e5d7bd2d94490d088048b936eb9c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1251
+    },
+    {
+      "fingerprint": "b2f90bcf8c9b11fdfb277be539cf7113276fe0b692dc34e58a63bf58e3ace02a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1252
+    },
+    {
+      "fingerprint": "d538e03102a180d0137e9fcf8190033fe517eccbc3104cb6ec62ded0f3a08dc5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1317
+    },
+    {
+      "fingerprint": "85dd4ed44078b7e42df4c2e22cee84446b9df957d6e2b7fc3dfaf71b670010ef",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1364
+    },
+    {
+      "fingerprint": "8c9c29b4c0535a3d5c54a4bf3d4eb82dcbee53441924a665c99ff6438399d312",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1407
+    },
+    {
+      "fingerprint": "8c5dc5fd6dfc266e2b6c913265dbbbeef1d7359d85f833e283c976b3d02d847e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1435
+    },
+    {
+      "fingerprint": "45faa4058999899fa5d25f3da8beaaefc0a1b68bd180894f2f3d28d2a763edd3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1482
+    },
+    {
+      "fingerprint": "04308a850030f568770611c9c64b6afdbd1002440cb2828752e7717618b96337",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1529
+    },
+    {
+      "fingerprint": "cd5f091fb8cdc8b993a277a00289f22fcd3decf06dd0e5c1ebff9ee58c0a4270",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1580
+    },
+    {
+      "fingerprint": "de1da56c4929d448e8e4656adefac6c0d5d55e22709bda14e17fc7154b4d1834",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1616
+    },
+    {
+      "fingerprint": "8ce9f0d5ced39621fecab9d4c6c1764f3ef40e88dc6d638de7465ea57c6ad803",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1657
+    },
+    {
+      "fingerprint": "14bc436c22f06b92099e76d45345e8f64e5a98dcd91b6c1c088423e4995731c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1690
+    },
+    {
+      "fingerprint": "4c1edca6465895c76a175e1356afaa44b8039aa4b6c87c8b2f3138c0b9da20e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1721
+    },
+    {
+      "fingerprint": "149b435018228a944a5232692ed107ee399f7783558c7400e806bad46b34e6eb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1752
+    },
+    {
+      "fingerprint": "b0720a4e45b7ef1a490b00e1655099f0f17cad205da030e04625fd00a6362907",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1783
+    },
+    {
+      "fingerprint": "dcff05c436ea014f3efaf2ff33a99517e6455a8284ae9b6236184c6e1896a267",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1814
+    },
+    {
+      "fingerprint": "f8fb666f0d7d38e66ca3f5793780c61795acf85f3d2b619c986106a52272ba4b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1845
+    },
+    {
+      "fingerprint": "46a39ef15f0d66c433b063362894a0912abe50dac08622202976bf65e4c0ca17",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1879
+    },
+    {
+      "fingerprint": "fa8df1192501aa0d21c7f0c841c8aa4271b6345db66e1b5cd1395bfb47e2fb1b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1885
+    },
+    {
+      "fingerprint": "c1b82a5596fd29b60063319296edad413156870fb281be7d7cdbf29d50e67948",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1925
+    },
+    {
+      "fingerprint": "26982982ee48d241a6f3660cb052c747576a9fb6d21fc3f85565ef6cd24e324b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1928
+    },
+    {
+      "fingerprint": "ecb231945ab4c85c9c30c128dff95f2dd671af204ba9d1abc91c98cc52a271fb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1934
+    },
+    {
+      "fingerprint": "27d206d80cb72501ba956acc3d58e6b097e35edb898037e64a7829270fbb3f41",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1949
+    },
+    {
+      "fingerprint": "545ee747a958ee77efd154b25cf1e87555ca04a54d8e22515192ca03b5811864",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1962
+    },
+    {
+      "fingerprint": "7174acd821b557963130abfef95a08c9ed233c9f8180d559a916e166c5a1656b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1965
+    },
+    {
+      "fingerprint": "96957bf0b6172d888e4e2c0e74e48f7f52b3e5c1e42ecb54edfa77f462585041",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1971
+    },
+    {
+      "fingerprint": "c3ee59ab571353a5577c8e48f1342c931df81dbff7dfa699d1eb9246c26b7ea0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1985
+    },
+    {
+      "fingerprint": "2babf85793c2d453bec255e883cf94542bc8361d583f0c4bd86354a0e590c67b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 1986
+    },
+    {
+      "fingerprint": "88e6547b66b9bcf16182f92a2aaea932919795b76208b63962f7962d8fd04b03",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2000
+    },
+    {
+      "fingerprint": "d8c39421e9c76b672dafd0b1da012f6b8c9647a8cc69ad0d9c9e262c561da72f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2003
+    },
+    {
+      "fingerprint": "f2066905e5bd72b87f41cd356f9fbb5049359211fd82dd6c59abfc6e005f6a35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2009
+    },
+    {
+      "fingerprint": "163703d5da213602049644924fc66df25faf062d9d2ae7494272b3510883daa4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2023
+    },
+    {
+      "fingerprint": "63e760ec6bf7262b2645a85cf5830f65b8d40f3c0550c7e3a3e047ecb69e4585",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2024
+    },
+    {
+      "fingerprint": "290f6318f5cd0e202b4314f4cb95a5dcb36f00ff679e97bde8fcff57dc730ce0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2038
+    },
+    {
+      "fingerprint": "00936dfaf449fdf5d61f51ea1bc5a47c3a638945d558719c17c323a0da39f3bd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2042
+    },
+    {
+      "fingerprint": "51d46ec32da0a0904dd06f2afb2c9af8f27027600858cdfea7cab78232d9929f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2045
+    },
+    {
+      "fingerprint": "e585238b9f9dd31bbe10b1acd5d66d658b11a65d19f9d2ed53e7a74efdf8e09d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2049
+    },
+    {
+      "fingerprint": "ea1dc6ae4cc61d3446c09e0b3dd878ac1e601c5ea435ee026eb21794e3cf6b7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2064
+    },
+    {
+      "fingerprint": "0b609d43ee3f58927dddef091f7392c00c2cb6a4dd69bbbdfae2a1f4beef947e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2077
+    },
+    {
+      "fingerprint": "f02fe33c516d1b48c0fa22feecdedfc1ac8d4a8b3bca09089ef4a9d504db2caa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2078
+    },
+    {
+      "fingerprint": "214bafde3c71a38cd0a2835ea2382a22159fb818abff013b91e23520e566d61e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2083
+    },
+    {
+      "fingerprint": "248669218c8074882cd5bebafdd1a0dc434a6fd135361cc1bbd0788b1f6c37c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2085
+    },
+    {
+      "fingerprint": "9ec15d20a14e4b7ed06f51621cedd295f2be0da5452ae3cb2072c5011a015666",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2090
+    },
+    {
+      "fingerprint": "20fa2b4fd05d2fc5b3e11cb6570431ff5c673f5f37c89edd312662f1b804d4dd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2103
+    },
+    {
+      "fingerprint": "d8dff4d07c7c1db886b5c5e5e6a401b2dfc3f3f7fdbfa658cb96ed1530a0681a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2110
+    },
+    {
+      "fingerprint": "576fcac56bae5af0d57ffe86ffda51e8ea7d63745ea8263b7bb27b3016af7b08",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2119
+    },
+    {
+      "fingerprint": "a281bd97a94225ef688aca5b99fc0e7aa60e92486281aa0193e67b1d0e0e8da4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2134
+    },
+    {
+      "fingerprint": "b1459329dce437243b635dd36bf9a7667d8f4db23f2aab05337ac476d8f6270e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2148
+    },
+    {
+      "fingerprint": "e9118b3af945fc0eb7943a43034a2d07611fe7acb6c795aca7548445ad8d4836",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2153
+    },
+    {
+      "fingerprint": "ea3ef593bc858fa9d6bdca89d14b1cd318ff98b4ec87f898f0c77cf9f775ac3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2157
+    },
+    {
+      "fingerprint": "a1a663b4b6be949478cef4a2f6704f278ff2a2a37e92eb28b2c2485d0ae1e43b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2166
+    },
+    {
+      "fingerprint": "cb80e2723121dee3a256e8be593aa46ceae6a6b0a5275659e52f7bcad8706d65",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2169
+    },
+    {
+      "fingerprint": "c04ee26e01495c2bab4f765976714d8ecc53c33863bd104be1f73dc6b5fbd4a9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2171
+    },
+    {
+      "fingerprint": "3a7309329798951820a0dfa0ed00a29e0d3de4eff159d3c956d8af7936da3b3e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2182
+    },
+    {
+      "fingerprint": "b5f890632324118d289f3e1e12a22e3475f5e26bae06145f46a5aea34ea08e64",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2183
+    },
+    {
+      "fingerprint": "78e1e0a72633e2a3abedc768068596843939bf4cb8501e06cb3f0061c0835fad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2188
+    },
+    {
+      "fingerprint": "e04f42d3796be4b5d66f0aef97d890386182d12f3d0f766735afbfc71dafd944",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2190
+    },
+    {
+      "fingerprint": "15ccd0d82c3cdebe8c2f4dbc3d0757b451783da472bfd05d57ee7f2bb7cbcec1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2195
+    },
+    {
+      "fingerprint": "b217ce7ba18828047c6c8598f88db60c1384a127a43526972bc247edac37f44b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2208
+    },
+    {
+      "fingerprint": "a43f937d2a758d2127abc4ab2c953baf4085325b9c2773eb314e43e0e3766ea9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2215
+    },
+    {
+      "fingerprint": "3da881fa1656681caf06a9c8fe5e265610aa821f4512462c9f947c900a60095c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2222
+    },
+    {
+      "fingerprint": "3ba4e8811f405f55a30f95269e8849af48109553c784a9f82ce7c54da32ea700",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2234
+    },
+    {
+      "fingerprint": "4b6f6b90353216444f48675ef6be2f25c229c7032c4b31e7b098cd7cedeb8c2a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2240
+    },
+    {
+      "fingerprint": "2fdaadcf2a51426fe01313fced56487fb335efc4fcb9905139e86b15d519d6b3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2246
+    },
+    {
+      "fingerprint": "2fb6ee731d7661ffa893ab6b48eac7632751d244e3c67a42290cc0569f198a8d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2251
+    },
+    {
+      "fingerprint": "5f5884617ad341a5ac4251c82c3f16813cb5e5c0a53ab9fa0dcae1f84d3051be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2257
+    },
+    {
+      "fingerprint": "e69846861989bcd5ba4bf74afcb04c31d0a4cfa4e4a7ff5a88de70eeffffa116",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2265
+    },
+    {
+      "fingerprint": "547e9ba3f8db49b04efafbdc927f6366db7bd938592ec02aed698fa0d4f1d522",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2293
+    },
+    {
+      "fingerprint": "596b027b9f56dcedfba1d119e65ccfee5c8d8e478e81dde04f7408a2c8c0c382",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2294
+    },
+    {
+      "fingerprint": "a91a256fac11bd26a188e95b79dd79c3cd082712bae47f28396da414420db438",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2299
+    },
+    {
+      "fingerprint": "b36104b17a4850679f885f7e0550ea423561893f15ef5d893f8001f94b1ac57c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2301
+    },
+    {
+      "fingerprint": "7d637783bb02290c900e4c8b981d23a4a5f8ddf2aae5f791cc820c1728c1dc24",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2306
+    },
+    {
+      "fingerprint": "fb067ca0506267f0ed8c510775695cb68a7a2fbbba3d4ad2f4d45f6e06835037",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2319
+    },
+    {
+      "fingerprint": "ff76224c6f7c074e7685ba6344f5319a88bea468f6c790508b06aaf0d40d6f82",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2328
+    },
+    {
+      "fingerprint": "2794e89e44830f2c56794eb4a0570f407671622be442cd228c18e3601e2fb4a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2329
+    },
+    {
+      "fingerprint": "1afd99b696a22b2ae281d2fdb95f9cfda4e8b150d9937faeb441d29ebf0258d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2335
+    },
+    {
+      "fingerprint": "9e72f8a13858d33fdf353dcd4f8ffc053da7b6ae6a28d519a251448fed6e2489",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2337
+    },
+    {
+      "fingerprint": "a0444d94d5628f0106a658929a47144990b9bc0530b2a4fa8aecd33bd36345b1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2342
+    },
+    {
+      "fingerprint": "a60f11923e650a29ad68635f771e1660a2715f3405157e6c56a264bb22377bd8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2356
+    },
+    {
+      "fingerprint": "f94687235d81dcbcbbe1de10fe2c691ae774b836004d3cda231254c55a834b3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2358
+    },
+    {
+      "fingerprint": "0a6b236e09723229abd9d178050cdfd8eabfbdf5ef1f1746762174e4692a752e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2364
+    },
+    {
+      "fingerprint": "0fd9ecd3b364a4405fad63cb41d1ee21be9f014028c3102fbd547d4c543d224e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2366
+    },
+    {
+      "fingerprint": "dbe7cd6c1bae0c05b8c6cd807674963ee91e4a7960ddc6aad0e573d917e3f47e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/integration.rs",
+      "line": 2373
+    },
+    {
+      "fingerprint": "42d8488228c8c5283005b3da070c07a308874c236ff5d9c45ed83e1873685f85",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/integration.rs",
+      "line": 2376
+    },
+    {
+      "fingerprint": "e80b55334c9f4ccb63eb3a196e817b2cd9762da94c80dbe1df28465fdb610089",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2383
+    },
+    {
+      "fingerprint": "c7a9bc46c24779edbf1684ab9b03af80c7d2f200e536b9a840d519592478da9e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2403
+    },
+    {
+      "fingerprint": "cab104ba8434cc4a5d172f9f1c5661fd2a3d9fa09f20d5bf849a4a4fbdd4082c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2425
+    },
+    {
+      "fingerprint": "b9bcd371269bd023c85a220705ec680646c87463d10e25816ce1a29524a100a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2452
+    },
+    {
+      "fingerprint": "f65ea6c2b9add5691f340c832b1e331941e03b1a37ce0acabe7b0bc767f54884",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2457
+    },
+    {
+      "fingerprint": "7f441ee5912bf87e7e544d589bf4078005747f50840518898afcc8f2d9001921",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2458
+    },
+    {
+      "fingerprint": "836c14ab7c90b0292706a9919506e93b0d5607c0ad652e257b1e47373066b100",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2474
+    },
+    {
+      "fingerprint": "cbbc0736afe065eab35ea2a0b039edc7ac1bc0412dd6a62404529f42e4880e9f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2498
+    },
+    {
+      "fingerprint": "751bedc137fa8348ed42be94deba531c23cf52bc01c502c201c497044631b124",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2501
+    },
+    {
+      "fingerprint": "4335bb3f5f7b0a7d69b00703dc0c81234384309d03d7067584297eba7902231f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2504
+    },
+    {
+      "fingerprint": "b466da86b2216747d684801edc0e523487862a677d6de6a8f883b801dd5372b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2506
+    },
+    {
+      "fingerprint": "70783fc0e2e9181cc1dd5da70137f6709cd4e417abf61d365f7ee8a717b8d8d6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2510
+    },
+    {
+      "fingerprint": "3e98b0be9c0763d307ebeed68cbd1d85547947992ed70dda0920202248704317",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2521
+    },
+    {
+      "fingerprint": "80526d6559d8dc99b19858b74a398527f651f9e35eda1eafb95bbcddc550a33a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2523
+    },
+    {
+      "fingerprint": "23c3f5ff5071803d7c532f33c0a006c906c4c2b5e479b09c3be415a81b937df1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2527
+    },
+    {
+      "fingerprint": "ccb953072c3cef27ccd84ab7dace3b37e8ea8434b2b146ccc9401668d27ebd23",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2543
+    },
+    {
+      "fingerprint": "0ee5d3ade0a91c075fd50122e6919a6f4e46f42b2e126dc62d49887651c9aaab",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2544
+    },
+    {
+      "fingerprint": "5540a5e25c7b9eeb867eef601b383a95f7b758adfca3e6958141c3e7aa6c862e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2551
+    },
+    {
+      "fingerprint": "f9bc51c804740467e95614abf4cfb59d0dc63cd17d5694c4eef5f57406233ae8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2551
+    },
+    {
+      "fingerprint": "efa931f0b019669d554f0836bac758516c2aee1a877b811f5a5c9f8ae92eeb46",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2554
+    },
+    {
+      "fingerprint": "c58f211baecc8c8695f48e7e56be45d2a23e53f5d10121fad0c83508b9dd7849",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2561
+    },
+    {
+      "fingerprint": "a89ce854d985845f79a0441c8dbb44084fe18f72a50869073c2f9a28ae26df2a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2577
+    },
+    {
+      "fingerprint": "d7a8c720fe1e6d02671e59da2acac1babd4b060f39fe2fbb4b0691f45f652bae",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2598
+    },
+    {
+      "fingerprint": "d6f76c2270772991d44f76063857a0946ead88d07ebc1f3381163e194458054e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2599
+    },
+    {
+      "fingerprint": "d1039140030335815efd252b51f0697af2aaf6f8f7bc2f694feff8ec29748868",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2606
+    },
+    {
+      "fingerprint": "f9c8a3d09e7f17314847e856a0a32006e35f746f03b5b2dcc056a368f13499ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2607
+    },
+    {
+      "fingerprint": "72b6d02be9e6823c1c09b458fae73dbbb8686564b8c056930412498430f0f295",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2613
+    },
+    {
+      "fingerprint": "86363a427e624554ca3875ceabf845d01e5ff2558fa78f99af1e3a78541277fa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2620
+    },
+    {
+      "fingerprint": "c8c63a35050fe7d28650c1b4210d30784819666d104b463cebb19509e47a0bea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2636
+    },
+    {
+      "fingerprint": "a7ae9fefb319134bd51a3070b89c71062cdb17813c4e4ce56b401168274ac2d3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2654
+    },
+    {
+      "fingerprint": "be1f8da593a91b71d37a4b45e7fa3a83df241148991e5fbc3e421c3ce61d10b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2660
+    },
+    {
+      "fingerprint": "208291809db0ce2fb903af2144b206e0d9b2aa7cd80dbb62b2a40167877efe3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2674
+    },
+    {
+      "fingerprint": "df3c5f8457be058bf41726e34c0938b75aa62f2cdb3d66dc660f16ffa3460256",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2674
+    },
+    {
+      "fingerprint": "2cb1de535ca9b0eefdc87eb554e32cf6a7a613de2572711cbacc72ca25500233",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2675
+    },
+    {
+      "fingerprint": "06bd2f822efd47db040fb0a59081caeabdb8be36501731e6b3194fb7f261977b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2682
+    },
+    {
+      "fingerprint": "46089de48168f93e0dc9b0c1e7f75bf1577e1f461730af7d0afe18eaa929dcf6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2682
+    },
+    {
+      "fingerprint": "b436f515dde3313794280bdac6dd942b92e06f96dfe3975cc41eef387a0c3c11",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2683
+    },
+    {
+      "fingerprint": "81569593e11654546f53be24d3b1c28785dce98d7af386cb8f48c81b1cebaeb2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2702
+    },
+    {
+      "fingerprint": "17300ef76eb12a70d6eb49e57901158a6c080a5f4854b9dc150b902d23c3c963",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2703
+    },
+    {
+      "fingerprint": "077378458f41c84f2b27071fac8b31b72ac0ffb4b3a7c61aa0da389b87d83dcd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2704
+    },
+    {
+      "fingerprint": "333506c1229361cbae196637298dd477ababc2b0d53a8dbb5fbbe7ff253a071a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2713
+    },
+    {
+      "fingerprint": "e52b89adff54bb83d6fb3e493a32849dc38ac9332ae550c8993a829494ed0a1f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2720
+    },
+    {
+      "fingerprint": "03d60c94164376ca2f1919cfd49a19b72ecc93b943bb491f296e61025ced83dc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2736
+    },
+    {
+      "fingerprint": "3a212b47af24559abe66ca1772060fe6f6f4ba78752edde1b19f906ce37caf2d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2759
+    },
+    {
+      "fingerprint": "f3573684f2ff18aab03cf9248f101e305906a5ec5c64d3b0268a02d41363c6ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2768
+    },
+    {
+      "fingerprint": "b9795453c9b18f5d154dc817a9d28cc9a51aafcef2c4c4fc1dfcc60e971c0171",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2803
+    },
+    {
+      "fingerprint": "f46729158541aef6c85c4689536c0ca49343a1afb09ef590f7bcf665bb9be065",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2812
+    },
+    {
+      "fingerprint": "a268664b252913b7726030424abb8e191122536842a2d16e2ca15e8c6ecfd262",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2826
+    },
+    {
+      "fingerprint": "26b922b418b96c327f9b063036e7268f3716430aec8c6ac0afe2e9f10e65e379",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2835
+    },
+    {
+      "fingerprint": "37f3a30d375f4203f2cd64054b2221e6b0b95637b62b0d7c076b29fe5627a425",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2856
+    },
+    {
+      "fingerprint": "5e57384c6dd54713aa60223bdef439bd5369190f86c5845f2d2c83394af383ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2864
+    },
+    {
+      "fingerprint": "0b1d97e4bb6d86744be0a4b175ccee198958101b582cb9c5797541bfecf64d2f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2889
+    },
+    {
+      "fingerprint": "6e198fedd1ba59b878642a5081645b3fdebe47b49d05080b5b75200f5feb1aee",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2893
+    },
+    {
+      "fingerprint": "55afeda150777dc6571ca9ba866dafbf6c4b4e3c85a5971ec108aad282f67e62",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2912
+    },
+    {
+      "fingerprint": "ed6e652ce7688d80999c38dd688195ed89a0eed5e4596b657c1821873d78d45d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2933
+    },
+    {
+      "fingerprint": "4f64ceb6311fbac6e9bdb36f82450552ccaae2cfaaa6c15fdef4f0a0b326fccd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2943
+    },
+    {
+      "fingerprint": "3e4e1d44f42620912ef2b34f66d0275fb82a44a0f578128a1405d9f615ddd7fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2972
+    },
+    {
+      "fingerprint": "5fbe943002e30bc4e4cc65e792d8bbafd4d995560ee8e91bd903f801daae2603",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 2980
+    },
+    {
+      "fingerprint": "f8a0291c775806c5174dd0d5b698a2119863724b53527b55df2a8cc614ee3d06",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3012
+    },
+    {
+      "fingerprint": "7ac4b7aa59ca49eb21963925c9033f68b32103f5b31ed2e8e49c5c0aa070d6c3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3013
+    },
+    {
+      "fingerprint": "f401571c3e89b3bfaaac9d5a29973a93ca41e0535bad4af984987575ace81d28",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3015
+    },
+    {
+      "fingerprint": "b032f032b61b6716d6dda6dbfe28c288e18e44e720349f73de9c51251646e137",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3022
+    },
+    {
+      "fingerprint": "8f9a8e9c00058faa310a3b485fd488c62d50272705e015c693b1abf3ed25cefd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3048
+    },
+    {
+      "fingerprint": "97fa42060258759a8898402dcde3cb59cf9019f74409d50ff0420123903064c9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3049
+    },
+    {
+      "fingerprint": "18f9f9b4c1ef36ba025658419a628bf709886051dc99f9811fbfbc5b119231a3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3050
+    },
+    {
+      "fingerprint": "74e08526111e587967c92de03bfc7971c98f5ccd6e02a5094e7b735db24779bb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3051
+    },
+    {
+      "fingerprint": "d9c5e7aa61fe03cadf8105995b3978aae7c99acaec964cd0192d86471746fb6e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3053
+    },
+    {
+      "fingerprint": "dc8bcd032ea13ef105ab8348344489f43eb274eebabbfc13d13fe84b1e3defc9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3059
+    },
+    {
+      "fingerprint": "96359456beee424befca4cfea614e6b9225b27456fc9c99ffb1496b2c2ba745f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3086
+    },
+    {
+      "fingerprint": "a9c4870e0bf4ddc4f82f8388081cbdd601b53e49b099e79fd2d042ea807f7a03",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3087
+    },
+    {
+      "fingerprint": "2885dc4c832f8177a664a34869d71b1ebddd6ac1f45512ea70b8be027e6e60e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3089
+    },
+    {
+      "fingerprint": "6380dca363a5a24a052fff614746cd7861c000f15534fb973ebac24c719f2b76",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3091
+    },
+    {
+      "fingerprint": "fa820e508cf7d407c892b2f8dd6429da26502483f657de5d898fc101ad92714a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3097
+    },
+    {
+      "fingerprint": "885cb6d8f2e9003f03da616db2acc72e0ab1097d187ee664d8b17255385fee33",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3103
+    },
+    {
+      "fingerprint": "3439230f65a2f41d779dcfd0a531e1c4acbf433048cf9cfb474e4885f3354647",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3136
+    },
+    {
+      "fingerprint": "5e2205fa7cadcd5da01e1dc52b63289a828e7650acc0faf1b7dbabd28d38d5f5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3137
+    },
+    {
+      "fingerprint": "aa721265ff5afd640238c2d098f2b8b5868f5257f60ed25686d6fee4a1882c91",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3138
+    },
+    {
+      "fingerprint": "0c870a4dfe43a82e2efb0cbdba6656ef75be271fb0a9cef5c92f76f284f30e11",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3146
+    },
+    {
+      "fingerprint": "6d5d2cd162d7854a4f8c18b54a45e93689211d5c8305a68a927d3662bd0d0a2e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3166
+    },
+    {
+      "fingerprint": "447fe7bf6edc642a58b163420fc5f7b30cdef3d6569de6c14ab03e6eecb6d462",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3167
+    },
+    {
+      "fingerprint": "fe5ba2661e769f9fb8f4a553e3a04977d38d8d484a3ac10a86be6fbe635b4251",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3169
+    },
+    {
+      "fingerprint": "ae00d465eea89493b88188c2ce69db8bca9bc530ca7162369ceaf7d645d7f39f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3170
+    },
+    {
+      "fingerprint": "6f79efba72ba55ec21c2dee6eeeac32234a45c9326da42b697f4c7d63704e1d8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3178
+    },
+    {
+      "fingerprint": "2bcf9a1f220583d7ad8b458724826d9f66a99ccdf0edd6d3049e6dfbcec61df0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3204
+    },
+    {
+      "fingerprint": "87f52a380303ba9304bd246fa71fd201e12a4ae300db64f53e51737012ef235b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3206
+    },
+    {
+      "fingerprint": "03e88b2f92ec8564bc5687e21ab94d32398012db4ec8e974daf8bddeda6ff91f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3212
+    },
+    {
+      "fingerprint": "85bae88e83c25b86d740daefa88ac255f291bcdb97487af02ffd89ed4b1a7aea",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3213
+    },
+    {
+      "fingerprint": "e1e6cbc4460d1b29257c52f7e7323630b3dc7d6f5803a7591957eb32a65d7c66",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3231
+    },
+    {
+      "fingerprint": "eb96ada1654cd95457672cab976d99a117e80592d02f3b7dac14c78e5fc5b1f5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3233
+    },
+    {
+      "fingerprint": "ed7821da4ad862c7c5d4744ed746fbc764ca23a1f06d01815b6df78cfb2573e5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3236
+    },
+    {
+      "fingerprint": "1ca4188331adff668ec340bdacb20366a1f8fb5545b3098d342fd64fa81f360f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3237
+    },
+    {
+      "fingerprint": "53016ad406f11df4d9556503d7594927868c3682350905c6ebb56862ee3e108c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3255
+    },
+    {
+      "fingerprint": "e19d98996f4ce5de8e09614453b4434ff36afc2e34ea74cc62e23eaecf3098c7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3257
+    },
+    {
+      "fingerprint": "4f3798dc9cea1a05920f29838373eed0cbc3d9e99bcc227da3136f598511fc70",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3263
+    },
+    {
+      "fingerprint": "a69d1aaa1762de5f848b5aadafbf67125d5aa409edd15b52c78c325ddf8b0925",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3264
+    },
+    {
+      "fingerprint": "707b37caea9dbdf9662492578862cae2603ccc20f075a317d11d35d777c83fdf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3280
+    },
+    {
+      "fingerprint": "d2d795fc2ebc5d2f9171baa79926c36498efb0eb736a9e2a874feed044ce427d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3282
+    },
+    {
+      "fingerprint": "8ac762c2176fd8cc1a78a732d10060af2503909785ed9e293b2620a9f4418551",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3288
+    },
+    {
+      "fingerprint": "71706bc53a004539b53622e2801e20253fdf64ae8bfab1ba892fe5954cd89c4e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3289
+    },
+    {
+      "fingerprint": "1049ec7638898c66bd2629541bcb07e97e05a2f14fd427ff444bfa0eab10fc42",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3304
+    },
+    {
+      "fingerprint": "bc8cb977db68df88eaa15317030d9dbe61fda7969200d0da0448ac9edfb032e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3306
+    },
+    {
+      "fingerprint": "18770a87b59c4f0bb1092918ac8ea7867fc0fea6961b1c5228aa6a44fe72e2be",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3312
+    },
+    {
+      "fingerprint": "0a459b62a90f9f1404bd66d6c4ed36bfb413e825d3649783199b11e9918096ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3313
+    },
+    {
+      "fingerprint": "f57933c46700472e0606983bf82b8244a81f0f6142d236241660be37c3852b4c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3333
+    },
+    {
+      "fingerprint": "0ac6d1e1570ef04df2e97c27413596c9fc45b478f6bee8258ea88a694a048056",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3339
+    },
+    {
+      "fingerprint": "5de91cbb22ac36c9b642ea5b2b163b4e0498551bca12490cd8c20b34d70239d2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3362
+    },
+    {
+      "fingerprint": "56f09fd947961358417c81398d230bbde26115843057d118d44a7f3806c91258",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3381
+    },
+    {
+      "fingerprint": "b03d4227798862c52fb71ebe767673b8f471d2484f093d90b68739ff7e70b43d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3404
+    },
+    {
+      "fingerprint": "57c22b42251ccaa647e94eb093a9fd8ee9b2e7cdf23218fdc2a951b999b1c1e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3435
+    },
+    {
+      "fingerprint": "300b5e3bc0ad7768ddc5b79318507fbcf5895989f66cd346400680b9306605af",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3460
+    },
+    {
+      "fingerprint": "09e20bfdeada4d2aa702ce213bc7013b7d8fde02c499b95e56951626a2940f88",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3484
+    },
+    {
+      "fingerprint": "4b19c00750aeed95206e89108b19193a4e6cec7d63e0a6d1360e1d38a35af564",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3495
+    },
+    {
+      "fingerprint": "9489d3ad439e646a6c467b6bc5c771d3211c03038563d4c5445a447c4d01bf59",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3516
+    },
+    {
+      "fingerprint": "ba1e7c65200784beb97633fef37b03c78e5124cb22f134604b7e12c22e9c2824",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3524
+    },
+    {
+      "fingerprint": "8741056e32491cd183e4da8274c25527176a6fa524b2da30653723b0a764dd30",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3539
+    },
+    {
+      "fingerprint": "8051b8051e421384f2ac763f12c2cc3e2e2cc895e954a3f9e54db4b62128de6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3549
+    },
+    {
+      "fingerprint": "67797c656443e23e974deee5ff42a8c6aae6dbfe7164ab775c11ee2949609e40",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3568
+    },
+    {
+      "fingerprint": "554f7f5dcc6e5641f17751424260e6ebf60d2731a2a8bbee931dec477d6f5c76",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3579
+    },
+    {
+      "fingerprint": "5805496bf713253516b124a65bc5a57651e97e1ecc940547909c33723c42bfe4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3596
+    },
+    {
+      "fingerprint": "c000a2610c71db289dc9497f56a31034435d84774a731acca1760a7ae2e9e798",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3603
+    },
+    {
+      "fingerprint": "287557f958ad0e872421ad83aa4fc6433a8ab2921531f998b3a74b1c3a5f6e6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3606
+    },
+    {
+      "fingerprint": "44926bafd33b2320a10c787c22276abda7efc92717a710b8158aa6a22034ce5a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3609
+    },
+    {
+      "fingerprint": "bb9b45c3580202fa6ac92f3665162e33ccd206a4e25848981a88abba304a3fbc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3660
+    },
+    {
+      "fingerprint": "399345f6d1d2fc28c640ac612757e93ea1bc37c695322fafbc780297bf0c372e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3666
+    },
+    {
+      "fingerprint": "e6dcfff01b9869e26ee61cbf2073eadc7bcd7232925b8d13d07af2b2bc09cc8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3689
+    },
+    {
+      "fingerprint": "0fa576e4630263f692c12812becd5f279c00e3c02957d3c271b8da6c0d9394b1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3692
+    },
+    {
+      "fingerprint": "21f694fb24089e5f333f36c32e106bf9a4db7bfed9e66859841cbb1f2182f39a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3695
+    },
+    {
+      "fingerprint": "3aa725111d4f0adce56ce5eb99c38c7ec722df1844ca27c5e38418d6d930fe0d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3714
+    },
+    {
+      "fingerprint": "1087a921f7d46cedbe1121f5237f0a43e71bac9656d308cc19c8932826b01fd6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3718
+    },
+    {
+      "fingerprint": "e6c86b9e3c2b06fcc387e536517cc73d9da5b1ed69d618e225594fe2dda3066b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3721
+    },
+    {
+      "fingerprint": "4b78d2301f7f52c24af4e44f2c57551c99adb6ee7f56a17cfba7ac711892199e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3725
+    },
+    {
+      "fingerprint": "72cfff3e1caece64d48d4029705dc951fd686853f14d6ffd18575699565e88d0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3736
+    },
+    {
+      "fingerprint": "e1dc4821ded9b8448526188a8b45835bf9d4649955f24a0713bd09d4316514db",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3739
+    },
+    {
+      "fingerprint": "5daf9434e57d78c67fc741d0a63ccb8f155790aa1b6fe3c68d37f94980bb2d71",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3743
+    },
+    {
+      "fingerprint": "cc247b842fb942f28d1ada83ed39d986c1cf446a41496e05aec99451362bdd38",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3761
+    },
+    {
+      "fingerprint": "192fd132d7ac2b1a9c1314e8790aaed6c1a55e33f6fc868b125ba87f2ff5eca8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3774
+    },
+    {
+      "fingerprint": "3d03a22350afb723afb5a71e4eaff08f065a4130ecea48b43e9c14bb3aeaa145",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3777
+    },
+    {
+      "fingerprint": "950792a83e10e224f9e403ac73ba50f4bbbdb4822ec423d375aa3cc28c000096",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3780
+    },
+    {
+      "fingerprint": "08945e7fca4c7b845b0710618405fc149b84775b85bcfcb722dab46035bc5a9a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3790
+    },
+    {
+      "fingerprint": "8f44298be6cec4d48facdac0080052617b2696df064fe51ab4d74a4124a9833b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3805
+    },
+    {
+      "fingerprint": "605f76ffecb99dc74c2cde0c2ff6d9b4c5038505dbaf3e497ac3ec74874be538",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3809
+    },
+    {
+      "fingerprint": "8db676854878fbf5046ac4a6cac9a63b1931a4b05a41486794317892cb07e47a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3814
+    },
+    {
+      "fingerprint": "f6d2323eeff700d8e40b15268e80c757b7741d07b9605f366d8b8ba34ee7ba8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3839
+    },
+    {
+      "fingerprint": "3fabb9cd51d7d557602b132a057fb71486eee3afa7451e7ea75f13d01b9eb02d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3842
+    },
+    {
+      "fingerprint": "f67c684f98d0ea9ff59670167bad6e0ab78165e52d18f0e8b151b379e6fdc1f5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3842
+    },
+    {
+      "fingerprint": "9440014a5699c2f448569b7c0184dbb8e9de3f85d5b95f2ebe185c5cc0c0c6d5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3844
+    },
+    {
+      "fingerprint": "96a7ac0f11f04d2feb3bc10fb2d8131b8253b7da7086b3bd24e4f599f125f7b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3846
+    },
+    {
+      "fingerprint": "05857dcf916d598e37e803ac71354598cf51cb499c65d7ad06f67c7bfa9a2279",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3850
+    },
+    {
+      "fingerprint": "5007264235d0dade1567ed5a4e8f2df58ebaf29fd7a5c03ce69c6367e2d29022",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3851
+    },
+    {
+      "fingerprint": "b8db99215911a3d494c19639f4a8da77731b5cc5278c74652b58c4ec5211326a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3869
+    },
+    {
+      "fingerprint": "cd46e8e53359779187401f975056d3122c597f1528d99acfcf2c390ed8cbb3ad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3872
+    },
+    {
+      "fingerprint": "6480ce32e4f730729777ef9c0205842f9fdcbe23fcd1cf236f9f8982ae8ed31e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3877
+    },
+    {
+      "fingerprint": "b286a3c98638ab1e2e323d79c869a63bc746dcf4c8f1ce12707c7571284d79fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3906
+    },
+    {
+      "fingerprint": "565cce2183ad2fd40f1c5ae1548b1b5b4a0a47c0248e000e37f54a6450a540dd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3915
+    },
+    {
+      "fingerprint": "a56c273171c1eb5b175156502b28578ad0c101cdb33ede4013b513be517f35c0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3920
+    },
+    {
+      "fingerprint": "241e79ad3de5a0912859ec8458b1ad3847e2ed2305fe195886251b56c05925f2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3943
+    },
+    {
+      "fingerprint": "752113008aae38e1ff8bfa4406fdfb76d1abe80640016be064724b6b86593c35",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3968
+    },
+    {
+      "fingerprint": "6078afd406381314795d5be4470ff9bac47bc3eb695a92aeb0b143909ef14019",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 3988
+    },
+    {
+      "fingerprint": "e262fd9bbc00ac69c2bf949fd89ea9dfcbab00ffcca4b36a64145f8e734d3c07",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4052
+    },
+    {
+      "fingerprint": "c503eaaade718206dc486c585e4c5a9bbc568a0bda7493083364d0ff573a9b7a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4106
+    },
+    {
+      "fingerprint": "7f0f6bb72f1e85014f145e7802a04f4833d349956a7b2f01316803f7e6c2e4bc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4112
+    },
+    {
+      "fingerprint": "21c991f247e093dacbafd4d1ac00a398597bbb006c7df37ccc95b271f5f8347f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4114
+    },
+    {
+      "fingerprint": "e85a97a74e4da8a9dd45ac1ebe14ec04f73dea0ab34c5e92d5590c27564890e4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4135
+    },
+    {
+      "fingerprint": "b3ae2de7b3b08a1a5456e648d0cd1e7a7968830aa6d4eae176d5b4e7a12f02a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4152
+    },
+    {
+      "fingerprint": "a34304e926c7b20a73005e1bf08c76f49eb1cf28e4b13348b05bda73d09f6ba1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4170
+    },
+    {
+      "fingerprint": "5ee79b6af0e71e9c1b3afbe92f814a1fcd3aa3fe5d1e2a2920a83621f6ff416b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4173
+    },
+    {
+      "fingerprint": "9cc7ac7e5434ba60e456a326b1efc64fabf8a996d3bb6f1e66621e7602702797",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4191
+    },
+    {
+      "fingerprint": "3dfe4d9fe09828dfc94d1f22a4a0cc230412f08e2097abb79c29621893937ee5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4199
+    },
+    {
+      "fingerprint": "b24e96ad75684b548e8b77494dd62674ab4432c85547506795df8212fa80fdb4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4215
+    },
+    {
+      "fingerprint": "04f83a3bc2332e2155f59d25cc33ee969c7a2a8bb75acc6c9d29af0bd42c7609",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4223
+    },
+    {
+      "fingerprint": "f8b26c56f534aed38cb67258871104ee89163ddd6de6a560d8c804f2d85dd4b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4239
+    },
+    {
+      "fingerprint": "59e80aa0e8f872d5a5f4604999cca8e76e98edc43b3fbcb3b7695ea936983cc4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4247
+    },
+    {
+      "fingerprint": "af60986c98790f5ea3cf7d878645739c43e601ab0f02d886fac27d10273ed835",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4270
+    },
+    {
+      "fingerprint": "eb94a008e85d05e06967b513bc81064bcd642bd4f30ef0759968f58f09fd3e9c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4284
+    },
+    {
+      "fingerprint": "41243a2ddb83aa8c2f78b2aafb6109969eda3e0f0c1ee37e6bd7abfb8786fc3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4287
+    },
+    {
+      "fingerprint": "543fedc3c7f3af9027561f38a49dabc1568bc41d5f2629dd149831dcfd59be8d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4324
+    },
+    {
+      "fingerprint": "fecb1ae6359d9bedb32a631b7c334e936c037af58935345cf125200487793820",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4325
+    },
+    {
+      "fingerprint": "a55736bfe23f80bb51f35137b240b7b912b3a1b4ac707fb4a9e088a05688a096",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4364
+    },
+    {
+      "fingerprint": "9313f506786da9e1451cf7974a0a5c4f373524b5d8efd24fc7140971e50d5fc3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4376
+    },
+    {
+      "fingerprint": "fb46a1520a10a19a869546e29adbd801c61e2921376afcfeadef6926f4937c2b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4598
+    },
+    {
+      "fingerprint": "529f4b8f3edd97abd4816dfe26e5007e6401ba73be4bab05cd1f451138623cd9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4610
+    },
+    {
+      "fingerprint": "a9336c512144c828edcf35fc104f1c8c9a0b55ae069db6b0c53615f508daed73",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4620
+    },
+    {
+      "fingerprint": "1ee5ffb4cc249a5166e59f076cd823b6c1e40d67d98514230fb4dc5070beafaa",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4645
+    },
+    {
+      "fingerprint": "7d79c953d1c7fd7ea2135e401e41c24fca0bfda891eed7197165af7bc6d72669",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4671
+    },
+    {
+      "fingerprint": "f68209bac1aa3a64889710f7660461b07aa3b665cfd7eba86a38a58879dcf4a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/integration.rs",
+      "line": 4679
+    },
+    {
+      "fingerprint": "5b676a923612a17253cb4241ecfe1149d305cd1f3a17b037d532754e079ed18d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "d8de9860cce1f029445d41e5ac78042695657cea1c29f836c36dbf3c06f3cf8e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "d5b309c69371a75b1c10b0cfc7ef2917ddc4beb45ae7b03e84ed5ece2d6d1088",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "692ba80c3d0728606ae57fab7d132c1a963c81322a88136c29cde06386056b60",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "da284e4240b4e9a6839bcbe1f818e42179fe370737cee444e876c6e3dab51cf6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "44802833b7c83ce91b817285f9b6c281462a821138d9c40292f5399f9a813c61",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 31
+    },
+    {
+      "fingerprint": "57c9595a878fc649d941f9d030b25a42eb21408e93108b39c69bc017bd276f6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "9117a4b6813d43e352bbeba89c57d41ddd65427c55167738d626587d237b296d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "554fa6ef69849cd965f126a560ddf9533eb75499a396af844bd3c69f5e8ce3b0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "0fa842f18a766c19f6c762ed86d21b01117765175c1edbe7b4e313dbf904b6e6",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "813304b455e9dec6e248b3de2c7ea8c9c23efa5fdd7bd42ff14e7a56dcca9624",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 302
+    },
+    {
+      "fingerprint": "99e2510f3f768bce6cb4dd930e5b1c7b3aefcdb146e4d64b132233d7e74dc6b4",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 309
+    },
+    {
+      "fingerprint": "09cd31badf15add9b71d42950ed19f0de255b9d9fb50ac82973dc38d41699ad8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 309
+    },
+    {
+      "fingerprint": "70247f8dbe0ca49d7fdb3ffbbf76b971581bc88b7d2bd6c03198c0029bb764c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 315
+    },
+    {
+      "fingerprint": "8ff30d0e9a833d9fec7e919d83d7d9aa3ded50299df6cfc10ca42b0f05862864",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/kernel_dirty_frag.rs",
+      "line": 323
+    },
+    {
+      "fingerprint": "dc18b3811a71980f4bc74e9dc2fe44206a0bad562cb259681efc2d340f946219",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 6
+    },
+    {
+      "fingerprint": "44e2510952f59f7aaba733df279b6862c157813d72c8e36d0ff7ec3ccbbe26ce",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 7
+    },
+    {
+      "fingerprint": "1117050f4d7c985fefc16faba94e26fae8d31a41c5bb24b667288a2c67f2b7d5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 8
+    },
+    {
+      "fingerprint": "934a08a87fdb317ad96e5ca90902a28f9cf5ed75917d24aa7dde4894f898ef1a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 11
+    },
+    {
+      "fingerprint": "eaa7fb35f9a6150923f102020e012efe6e0d6736f3aa9d912f726a527e81f691",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 12
+    },
+    {
+      "fingerprint": "fdcb10c0aaf863dd53364fad417eb5adc55bebcbcc90340f75425e14d18023a8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 16
+    },
+    {
+      "fingerprint": "8d49a6a35cc9dbefa62f73c5f1000ae87732cdaae58dbe77e1a5792762e267b5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "03c49776d30d96d7d3a082d3649afcd035bbfa3c199b4e87dd522efab5831eb0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "619f644c972a758e318adb84988c4781bfd9d03bb7547690245e3e4c06f0c03c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "4cc12810301d0a5537b4335ac331ec38af1bd847c5eeb7ab190ac94af3736126",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/mcp_server.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "e53ef71394f965994bf154ed3065da42fd5c1d26102990f28b1662155976c216",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "6a82e3dbb2270a84e458ec4145fd4a9167b60021eb342bb7bf268d8f11799281",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 37
+    },
+    {
+      "fingerprint": "d7cfd0d150db26e42e339a832e8e7f8bda725d7971ecdb567a71d6c56d2c1553",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 38
+    },
+    {
+      "fingerprint": "5d2e1819f5ac84190e1902f6291a76c94d132065f1e497939bdf9c73c3074191",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "a55772a45470425dcdfe359e2c4f3453c501c3df783d234f6e8d7c1a2d2403b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "16485cbfca1a0974cb6bf6240741f5f8bcda3be5305424de6c8cadea0f9d9c29",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/mcp_server.rs",
+      "line": 101
+    },
+    {
+      "fingerprint": "d4caffc61609c1f8230bbd3bb687ce5282d8b51ca2c9a2e6a67df4d1f4b52ed0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 101
+    },
+    {
+      "fingerprint": "a4e75e281a4ce7395f714f372d8b9bcc5b3754842c611e7a4b1de669b3b81cbf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 123
+    },
+    {
+      "fingerprint": "49f1644eb63e49445864d6471bea86493d4701169ea4276f7ed228e6bd04a907",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "2253ba753bf81c1abaca598ed37d64516e0e4398e77a05468f79545dfc795e1c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "43a4752e3d4ab35fae3773a43e5113e3eb008330bf303b9d95fc7133c7fac7fd",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 131
+    },
+    {
+      "fingerprint": "73e3c78cac8292d227254c3517d604c7d12251ccf5dd47953db8ee093c236ddb",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/mcp_server.rs",
+      "line": 169
+    },
+    {
+      "fingerprint": "802d07ee054bc35f62e71937db7fb87a06e38e7ab0317dec24cf12d1311e2170",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 169
+    },
+    {
+      "fingerprint": "87ae70bcd85a9e6cb8abbce0f312eb397aa3df3945cd2909e13e06809601d09e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 176
+    },
+    {
+      "fingerprint": "67e04bf0213aa9602334a6850343ceba3f1d26eec408252101af50275577e07d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 177
+    },
+    {
+      "fingerprint": "4a42f0184c1b237af25cfc0660a31ae6326981d3087d594325979090e905b613",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/mcp_server.rs",
+      "line": 196
+    },
+    {
+      "fingerprint": "4332da8f561f2cac0aaf5ec4bddfcc4c5e4538b50ac4291b4160e93314226501",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 196
+    },
+    {
+      "fingerprint": "05a40327a2d375aeddc3e1dd4ed465e511725862a93e11d2fa8f4d9f60be9575",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 218
+    },
+    {
+      "fingerprint": "ae94927e06980f0f0ff3893c10cd544b924792cefaf65d5ec9a8bc5501e71cb4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "7c11326459ff0289990e63a5c406697896f0badd99f8d671d81ae616c3c7f932",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 219
+    },
+    {
+      "fingerprint": "c5014ae863b0f4b37472fbb1ab40ec19a4b6283d260f73f1334530c134b703d1",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/mcp_server.rs",
+      "line": 229
+    },
+    {
+      "fingerprint": "7d74f3dd6fa03f6a8d86377d2ffbb3673b083b5e9b39dfdb16464f76783f158b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 229
+    },
+    {
+      "fingerprint": "fd758dc5fabce949aee88506f9db07bb901f10c0942e138ddcf4e8d6c01c9ed0",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 236
+    },
+    {
+      "fingerprint": "57f614af85b624cef768da96ae8ff56480e21521a54f37806ed3196c95f9beba",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/mcp_server.rs",
+      "line": 237
+    },
+    {
+      "fingerprint": "4bafebd7d3eb5f7fc47754e7f68339b578680114204d9ccd59d2e94683415764",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/realistic_fixtures.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "30e52bb2c4338c5817a122277ab3ba1e983201105df8d7944bfb39fb45bad6f8",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/realistic_fixtures.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "e56ccd6a010411541ef69ecce7ffc5f5cd3cf8105dbe11c01b0008843068c6b2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/realistic_fixtures.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "e412384a0016814f1153762b774e262676fcef318f1d3cea76266fc140f24e8b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/realistic_fixtures.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "368aef39fb027e812f843c537945ba5078c8d02272dc0c6c6806197e5cc5f8ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/realistic_fixtures.rs",
+      "line": 55
+    },
+    {
+      "fingerprint": "7cef49e361e76d83ebbcabae09d7d75df13b85823dad9cd6bed24a5357c4c0bf",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/rule_inventory.rs",
+      "line": 14
+    },
+    {
+      "fingerprint": "b5364fe21fb3466d3193e837d5d950e8f19a75fe8cba3694f014990eb61e43b1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/rule_inventory.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "36add59ba2eaa7106ae806fc7d5f6bae59f1024f732ed5480105aeb3585f5616",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/rule_inventory.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "c087a473d41e6b2c141e1460eb57c949a91c0e2371340efaf91873527cfff5e8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/rule_inventory.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "bb76786fe231d34afa055af18ce1261cdd3902dff87551cdb7519bc161e9381a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/rule_inventory.rs",
+      "line": 35
+    },
+    {
+      "fingerprint": "e8af280826775db7c5803843b2bf50903418c16fbdc78fcad84f167a307e67cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_compat_bench.rs",
+      "line": 18
+    },
+    {
+      "fingerprint": "82fcbd3d7f88913e43fcf60b983fb4dc136b7ae91937b3a57c0710d347fd4536",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_compat_bench.rs",
+      "line": 19
+    },
+    {
+      "fingerprint": "05f6833bae093a53ea69bb5b8175a44c6cb1aeac07db8c15c7a620b29dccca13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_compat_bench.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "2f9780411e6222e8cfeba741b4026fc63847dad0b01dde6c52c93e0914df2742",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_compat_bench.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "e8ca6229fde41d7400464cc84eeea64622598fb82a32689213cdc56ab0a7aead",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_integration.rs",
+      "line": 13
+    },
+    {
+      "fingerprint": "55ecfbcd9904148ed802a36d56fca1652ed2132e87aaba8530020088b8348c6f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "82d24c5d604685d4ca76a63be8ea327601591d5499b9fcfa54c6cc9e4b6aad3c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 26
+    },
+    {
+      "fingerprint": "ece14bcde58b2e6a6b82d3fb5dca2fd03ec74c1509189acb0fa7cb8e7920ae91",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 27
+    },
+    {
+      "fingerprint": "ca31bdb418f4d2cb168303bc9d5256665b4b8fd84c621ce6384ff27b869f6e57",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "ecb79ec6ce9d432742d1a4a54de59ecefe6343dce1f97d24287af95f8bb57617",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "379949bf011a82eab1e52af698f8d272bd67e83f52fcf33229c9bbd3a5e27416",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "261d92897d4eeed56ccf4991932808e715b1b601b47bccf66d62a0c14ed1f73b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 56
+    },
+    {
+      "fingerprint": "a10be81a75a055f8a99f2bfbb34bb77b22ddbe196c22740d8471aeab1f8adf3f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 60
+    },
+    {
+      "fingerprint": "5403cbcbc5e09e61a8a13cec9184d29a07f8e31b7e82626dc25e7ae4d4830b73",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "92208d7ef2d66f9929cb55cb7bce8463c38343a3929d2b3780ceabbf7dc52b61",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 76
+    },
+    {
+      "fingerprint": "b94815bd5cb171e60c3f418b850a6f39c90c5dc65983f34cfd90161f55df62b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "0e8d7a96a235f7318a1f9a8852662cf0a9fae50263f393c4940e7e3a807a74b7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "01c46e92159f0496491850d724d798e356693b8c637a79e661ee2309f41fa106",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 103
+    },
+    {
+      "fingerprint": "949496f0e32b9ce843676d7fe36a4c1ac1d7c59d0b1464733c666c7d33607fcf",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 113
+    },
+    {
+      "fingerprint": "53b17a5f2ac6eccdd6140ee1611af4a1ef6a8df7842784925f572e78fabcc521",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 114
+    },
+    {
+      "fingerprint": "7e6c1dbdf7d959150ba8f9e7c6441b6bf56bde18babb94101d741a66c2b782f2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 126
+    },
+    {
+      "fingerprint": "f147ae61d612b2c6a505084abb7187b28bf98d89ac4c013e9b168e284f42a497",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "f1f21c853763b3f85876492a4520e4fd6217f888edf1612d9b48a3b03f81cf2a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 128
+    },
+    {
+      "fingerprint": "29de3047ce8e794d375f895366b144c6fdc1955c9f3e78318c04566d8aecb4c6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "5c29aed385e9a6ccb20df293cb9e7acd374539f0eaeafa5ff2ed67a5375c9b1d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 138
+    },
+    {
+      "fingerprint": "37efa047d4178f353968e939b200f4b46c3616ffb0cbc68630b3121e06513dc1",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 152
+    },
+    {
+      "fingerprint": "f30f34380601834b23a2960c844f9058a494af70ac0fcd8ae8f2705acde0b707",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 153
+    },
+    {
+      "fingerprint": "79b399bbe118dfa79913540fc1ddd59be27d399f30f2f80e66750a8400f3d53b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 154
+    },
+    {
+      "fingerprint": "64e9e22cd1079083379782fb784e901ba63b23b2ec14f8ee3b028c895347388c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 163
+    },
+    {
+      "fingerprint": "8bfcbff65558dbd4c4165b2a2da2471f14e0f4066f79f6c88d7ad15da93eaf7b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 164
+    },
+    {
+      "fingerprint": "1d09409988993529c52bdd7b2e929945832f05a2d8a7cc096b4454bbc0127d09",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 181
+    },
+    {
+      "fingerprint": "f900e5e9c31738c18ad035b66f6b2bd45ea64ceae59a300eb26927b581f95c02",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 191
+    },
+    {
+      "fingerprint": "cfdc289968b112b89ec68fe70326ab68d535dd110cf55b843da0f3b008bfe575",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 192
+    },
+    {
+      "fingerprint": "3e5583a0ad0b515c9654f409a485055dcc382a72506abd4a2d2321ee80ce5cec",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 208
+    },
+    {
+      "fingerprint": "f5077bf9a349517e6a3e747e3d3596cbf979177840234afd258dd3881ff3f29b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 210
+    },
+    {
+      "fingerprint": "b8bdec6458308d9e9f8fb6976b6cc767450aca143d5725e20468b30d15f24b4f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 223
+    },
+    {
+      "fingerprint": "711335af0ebed91c5160ce441d8735c7f4cdd53842001be6e2a6d13b2bb31315",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 224
+    },
+    {
+      "fingerprint": "41e0a340294153f119f5418b13564a7f9a17fc248ed46d96c6430fb3262589ef",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 241
+    },
+    {
+      "fingerprint": "dc863f9def16842279cc6b761549a7d0c4ed200c6c501a72be379016f78e71fe",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_integration.rs",
+      "line": 242
+    },
+    {
+      "fingerprint": "eac902f450f0fb90d5cc3c1df23790dc60c4b1e4ebf2aba8cfdb5811535c76b9",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity.rs",
+      "line": 15
+    },
+    {
+      "fingerprint": "34a66dc04512bd11636bf38c044dec457a416d97169d5e763a57ae5be0a56b27",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity.rs",
+      "line": 23
+    },
+    {
+      "fingerprint": "83e549a4b128f9a4688b9c9b9c5a341e1fcd459ab1003f87967ced51e93e9264",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 33
+    },
+    {
+      "fingerprint": "ffc140bc8d5a1363ad5a804d3683493848bce522d9706008bd63bf3c1afcb857",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 35
+    },
+    {
+      "fingerprint": "7d0c191a6cf5c84840ee321c27db63b5ddb09f60826669a35169dfbdc4d15b8d",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "a2beafc9390db3cfc89f09058dafcb3a64a6b60eff43cc9707a4e1d85fb1ee4d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 54
+    },
+    {
+      "fingerprint": "f40e3535b9594cfa33b3ec307fcf4422d1cd006f65c8fbe2ffb881da24c74e1b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 55
+    },
+    {
+      "fingerprint": "e1f9fa7723a1ae788aecb2e7aa044f061053b0bfd47517bd249fa4e753e23c00",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "8dde96376ef87474763628945878c844d7444865d988d4626006869cf4209a74",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 68
+    },
+    {
+      "fingerprint": "0206fc8f40f66871a10990226f5d7d75a0b84d3cd8eeba9c322a7e4e9c7536c8",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "e1d22f37a1031ef0554dd06ff97d142928bdcb3e34cc1f93960ff3ea2a3637a4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 82
+    },
+    {
+      "fingerprint": "5539b431c0176d413d8bcd6b6b12e8b017811c77ad3e8ea4ffd825be15c28ec4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 83
+    },
+    {
+      "fingerprint": "7693e951a50fadf76edae36b996d349bb70412554abfaf39a53e2c3ff4d2df88",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "d0d23cabf16a744221b157468693592132c50ce7999103008d18977362c7c15b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 96
+    },
+    {
+      "fingerprint": "abccdbfa93babca0c61f2fd2723db5729f5ca74779f7fbc5f5fbceb958ff8580",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 99
+    },
+    {
+      "fingerprint": "fe7feaf0cff960df9ed08ca12805e52a812eda45144d0716556eca16e32a24ff",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 110
+    },
+    {
+      "fingerprint": "8aa9fe694eee3df9f2b7889480089bed4c7f59efbfb5f9b7ce2d695b0896d8b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 115
+    },
+    {
+      "fingerprint": "36f017f590cd8275202ff7b6459607ae2c29433dda8cd090440c2e695b016f13",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity.rs",
+      "line": 133
+    },
+    {
+      "fingerprint": "736d1843426ac24651b62b58784b50967e6ba084e051b8332aef23d492d0bea3",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 133
+    },
+    {
+      "fingerprint": "fa7efe4985a1824499beb665ca07ebc2a89cdb732d24a2db094eea3cc08f1a2f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "a7637797d37d7a9ebe8c310099d91fe980346092e12e286983da8f6c182ae69d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 176
+    },
+    {
+      "fingerprint": "4b3c8a6abe4eabca91765b9a2fa3ca0a2c2062bd37f880345677b549d550cc97",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 206
+    },
+    {
+      "fingerprint": "1ccabe6818a30795e427c3366ea6254dc07596bb2ce03bb0d42c594292c07e04",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 238
+    },
+    {
+      "fingerprint": "857a67b989cf2798eb13bad529941e47f409bc282b90a0e482c19fafc2da8530",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 270
+    },
+    {
+      "fingerprint": "6b5f9b22c3faefada3054f15b3c3eeca036a645eedba5a7b4e641f84eb38b347",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 302
+    },
+    {
+      "fingerprint": "bf086cc72c82987e6de1185dc36411b856076ae166bd19925970828acbbf7b27",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity.rs",
+      "line": 331
+    },
+    {
+      "fingerprint": "9867020ff29324e2cc391bce161c1bbf0145b052e0cfd2ebcb8cc458a7e689e0",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "eb65b9f8b85491f533b3901f1acc8ea6810e238d277454dbd23673835f176334",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 40
+    },
+    {
+      "fingerprint": "960d15c1c57d5e1072a46c7bfed6f632a94e5e80da359eed731c46bb2219ff16",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 50
+    },
+    {
+      "fingerprint": "84b03431b020f6f65c3d412f2800b274483ca9114912096c0837b9e69ce5230d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 52
+    },
+    {
+      "fingerprint": "2cf50c314c62e66349ea7a614c42a1e3a859dadcbc6c86ecc1ec70952826550e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "c88b04a0514753edcde7b895e31f3e0b2efe463e9599fdf03f3be50a0848ba1f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 71
+    },
+    {
+      "fingerprint": "8f5df9785349b3c3e33f649d95d624fde05e275c5d4959a5d526f7a1f487fe47",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "30d9efd1d30d6ed5141f87e90a4cd9b8268eb9099c6a10a3a7b6f42d4f91b6bb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "0265382cab14855c708d840953393b1a746db096e21bc9bfaeeef34bcabc2057",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 85
+    },
+    {
+      "fingerprint": "008c2594ae4cccd2246683eafc22bd55acdaef29af0b794f35d4ad0d3819f8b2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 88
+    },
+    {
+      "fingerprint": "d43762b2ba9c6fd32f2956852d465302fc2d2a89e4f729d06b628a2dc30cdf5c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 99
+    },
+    {
+      "fingerprint": "c08efa0866b9a135efd03e8b9075c1af8f1b548ea2ae09631fda2dd0ac1d49b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "78e9b930f3f8f207147319ca9add46ee3185d7a1027c999482a329bd9d4e09a7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "4a2e1d6f8e0d824ece7403d1258cc03c68d76897304842d49ef191f61dbd4d05",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 113
+    },
+    {
+      "fingerprint": "b323dab13517179b0f85a08d6e1af19f64d3d22a0149d874afcc72c72b7bb39f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 116
+    },
+    {
+      "fingerprint": "ae690d304111b4655fa799a9fcf5c38c8776f365dce02da5449a676d57178e13",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 127
+    },
+    {
+      "fingerprint": "4c9dd90648458a0a7b263bb02b5ba6864618a9d8e28d99641d9a1ceda35f8917",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "71a0bbfdcfa1c0bdd37b88756110cfcdaef368c5ff90b74018fe558ef5435a65",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "131204f10711b6a51701109dcc2686c3743fd3c67ace4ec201b42ce5b19638a5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 150
+    },
+    {
+      "fingerprint": "367c3fbfaa9481d189107132b7d60bc67482d08584bf1e46bb6245e81d407d7f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 154
+    },
+    {
+      "fingerprint": "95f257fd21e548ab7eb979e34ecc44e13dec236ec1f2215e69007c6a2e8cd033",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 195
+    },
+    {
+      "fingerprint": "3f0bf9aee0b437a63241a4a1fec8c31bb1e1bbef5679108a2df75bbb0acb899a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 228
+    },
+    {
+      "fingerprint": "4af032b51e7b2e742b2d3e3398b150d952c63f931a1af28bda3016aeae62a424",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
       "line": 263
     },
     {
-      "fingerprint": "4cf1c478a2c49176af7c1f72f0f07ee70372ce79a946079bdb42dbf5b83d28b1",
+      "fingerprint": "38ec7574a5d1fa30b24e4be229c65f4b2fb609994d8451c77c77469b0d2d9cf9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 298
+    },
+    {
+      "fingerprint": "e2e093c2c89495bdcb4f736b191fd68e39f318c4f9287574e8632e8da82c4527",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 332
+    },
+    {
+      "fingerprint": "ca1ec4b033d2aad90c74d56a894457902f58b0a6783b7e0af271d59e51de864c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_go.rs",
+      "line": 365
+    },
+    {
+      "fingerprint": "f160efcbc0e23cdce9a8026626c4e1d26bc2e23b62cc90b4bd8f8fc2c20be1ad",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 43
+    },
+    {
+      "fingerprint": "5758c45e9d2ef39851914b968197adf2b6709437a8d84749c48cd3290ef5a9e3",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 57
+    },
+    {
+      "fingerprint": "c752658a5193cd7dd0b42ff2eb66984accfa98f9233d1a979c8e98f4f7723486",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 75
+    },
+    {
+      "fingerprint": "e84ec2128b658c1d681bdf1de1cc6a917a0827b6bc204ea10690da5ac83c3262",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "ff121f6fe52ec934fd37478e93cf6dbd7e4205e002787bfcf936ca0cc010d03c",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 82
+    },
+    {
+      "fingerprint": "48788b76fd676ce468c679cfd0f64ea684f8f1322807bf456d3870018199c2ac",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 96
+    },
+    {
+      "fingerprint": "821b4f5047302df750b85a7db2374d1644b7961c07bd69742b097abed3b5aeb2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 97
+    },
+    {
+      "fingerprint": "89f6714f3059c044fbe2c0c15fb9bcb7f797a074d1b1f06d8282a888e2bc1946",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 104
+    },
+    {
+      "fingerprint": "5871139745836a362b60da0b635664fb9df66082083ee1ae59ce90525e98ec84",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 109
+    },
+    {
+      "fingerprint": "a069e940efa9cdf6e104e9bc1a4f62e1477d2c4bd39100063dad6f60b6efcbcc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 114
+    },
+    {
+      "fingerprint": "c4a043714fa7a5c56936f0377b7ed350ddf688ef7745dfb8a44236ac8a6e6193",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "571c15a7965ec06a44686decd2976dc42bd5ee3beab3ab6042ac20d3d0616ecc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 125
+    },
+    {
+      "fingerprint": "6eb7c9edb097e1166edcb900c1f233afd800fca088fa2bc75e8fea64143967b6",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 132
+    },
+    {
+      "fingerprint": "f733704fae72a145e6429755fb98dcc06c19e8ff905ac7721a8fe20d8c7daee7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 137
+    },
+    {
+      "fingerprint": "e9cdf02e4677d28bb3f19f9d0b7d5043ca0b975b32b5eca76b2a24f729a211cc",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "c11fd7ffb7779edaa1fd7b44625881e5678578f1bf9b9eace5dbfb8bfb14ea38",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 155
+    },
+    {
+      "fingerprint": "94eb9bffb212c623b797c5e7d271e76db8686b430ae73cc044cbe7e202e24667",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 157
+    },
+    {
+      "fingerprint": "b48fc329a53706f9066403be9f6bbf6472410cddea0828d7b141b35f9b3842c9",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 184
+    },
+    {
+      "fingerprint": "e22d5cc92c9e21be669eaa55e51186b434076bcf2941e67eb5f3b0acc4dfbb2b",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 184
+    },
+    {
+      "fingerprint": "d6610807a8b38e7ee93b2ea5da9858064fc38d1a4297e757ceb3d29068d4da93",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 187
+    },
+    {
+      "fingerprint": "bf3f8fb2240c9bb796914352f6a70b94f9b33511e863092ba30c458e3d18df0e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 190
+    },
+    {
+      "fingerprint": "6e0faedb2551e29009b5ff2c390741037a7d7217f5ec023c28f0765719447652",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 225
+    },
+    {
+      "fingerprint": "e03b35e93a415a3ab0db5e0ae76011f1e09ac451c5d1b016caf204cb77c34896",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 318
+    },
+    {
+      "fingerprint": "fbfde0ef4da8ea3ccfe1651b2fe0ca72b53e60a17aa393968c7c9ac56e26a8ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 324
+    },
+    {
+      "fingerprint": "e58e2c28b8c151cb6948f984c96677f7b1d94a4474688da6608e8edfb620ee67",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_inverse.rs",
+      "line": 392
+    },
+    {
+      "fingerprint": "62b1ee570260953c4ae1fd89e2bd64a0fc1852940483596afe24e25a139cf1ae",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "b5cad3a6bfd8877f07086c6b44ffb4954bd0d3b7401bda803631b7dba47ec47f",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "67e000921f72543b012b1a87d9ef4fc2280e4020e4f1a1ebc0817c340697b691",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "ffdd3368e276cbbe9243c53f2d8b0c0b26df69329e507f0e803d931dfa50d8ff",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "24156268caea76c0aa8f0451388d12d448e7a90c70bd9073fecc453c0b332999",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "52cb58a76c2ee47139b93e0c576f0813d907fcd8b8a489c4181a7191ec3b292e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "56c9d25a20912902ecd564f1579951d41163173c65296f9bfd64f64ca54605d9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 64
+    },
+    {
+      "fingerprint": "a470fe97ba06c47896fbc32f623c53ebad868a18e5a3a3344f4a44886602b2ed",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "9348a1c9646a391afffbb243c4ec9cc9d8f805f4d3c77e9427079ee0569ce5b4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "97c625befe913d2896cdeeca770b8a1121e4af82998ac5c76cd6b110fc4ff662",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "d5e9c0ad6ba0e57a63d532ca605ee8a80973c718b015cbdfd917959e5a494c5a",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "d5cb7568c92502494c41033de7bd8a986a8c352df5ccc47809ab5c138ef31071",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 92
+    },
+    {
+      "fingerprint": "809ac1811c00682212afae6efed3630cae91768be0070f5ace8ed74bc5038e61",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "09f3a7debcb8f2f7521be821253db053d0ec9a22c5e41baa1c876ef20861df21",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 105
+    },
+    {
+      "fingerprint": "735f4b1451afeb419c67b824e65063fbe6f696bdd8287bf7ec3bc8330ebf96a2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "aa21018360675d18dee10dfbfa27bf087e549586a8f185f05ef51704c544f8da",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 119
+    },
+    {
+      "fingerprint": "d8864ab36563667d6b8d959b74967e742f58619bc25688d2e67e229726a2c4f9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "5d3be4e45bc29bbce68e261274b448442b47bb3c302c42820dd2f65be263d1e1",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "bc01f2e8cb3cfe730243d3fa8588fe351abf674e72966be4280347caf83693e9",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "f3b8ce1b7c76c453cf9a2cfe60bdbac5640b1165213be5d3bc3a96af64ba4435",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 146
+    },
+    {
+      "fingerprint": "4f541787e1ab73d07b60dd5d358d99d553bafe2a07ba9f03df3d1fcc815ea416",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "622697b648053162a483841286b7406ebc612753dc6d14f6c4524c3ff7b52973",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 215
+    },
+    {
+      "fingerprint": "fca29ade62c33ec75b9954c18f19101d9ffc381d00a82bfd5f48181de316047e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 247
+    },
+    {
+      "fingerprint": "6a64a01b9c17a15e79ef084048d4e84749b9439f940bf50e06f1d96d91556cad",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 280
+    },
+    {
+      "fingerprint": "e3af6665b3a6e37e8b1bd8337b592a90dbc6bb3c091a72a3eb53bfb135d17a0f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 313
+    },
+    {
+      "fingerprint": "522d0f591b997b51c28d57cf071fcfea161bef6ad62cd78e3a141c5ca5ce247f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_java.rs",
+      "line": 342
+    },
+    {
+      "fingerprint": "0e93783bb0b2b7f2d956679423ee00362ec1b2075ca463032b12e2a8fc31fed5",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 24
+    },
+    {
+      "fingerprint": "8b0b056bb273c030aa72b53f92b3b6cc659f7fcea4c42f941b81d423d0194faf",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 32
+    },
+    {
+      "fingerprint": "1d09ac42b0eeb78ff0d1d03cdc98644bbc2da214a2c8574d8767ba614d9d9dbb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 42
+    },
+    {
+      "fingerprint": "a9729b44da3a30b3b3e02d9a2b329790d7635cbd3c69acb0c457a498b26a880c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 44
+    },
+    {
+      "fingerprint": "a0926c8f8384ae2d450c50aaa84fa9fe0358eccef7c19c27a383a115c6ce31f2",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 49
+    },
+    {
+      "fingerprint": "9f92d3ddecbdb551a9143f1e5d3e5e59faf0ac0364adf5bc2c999e9727736171",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 63
+    },
+    {
+      "fingerprint": "d7e01b1ddccd4e13ea71584788b3c686335c1085aa957c43aded9af1792d5428",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 64
+    },
+    {
+      "fingerprint": "3f0ebe0df07b51cee1a74fe6f1d5530928756db331337bffd5d13db63015debb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 72
+    },
+    {
+      "fingerprint": "15bd1c2c446ca6ae78b8658dfc9c4cd8777fc54b95d870e28c4699c661ee5005",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 77
+    },
+    {
+      "fingerprint": "0adb3d23104e261e70fce919a050238cab5c4bfa6749f81948abcfb2e0d4b82c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 80
+    },
+    {
+      "fingerprint": "be49ea88fd7c2d268dba787222a3ce3bc35a92ad6bf9d73cb4c5002318a71fb5",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 91
+    },
+    {
+      "fingerprint": "d2e2cbcc06d78dddd007195c4779e5e025deaabd67ae03e9914e17e7dcf288a2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 92
+    },
+    {
+      "fingerprint": "b7ccd4e60adf7a68d638e6e098f94633585217776858c7e14e52d14b6e3c3d3d",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 100
+    },
+    {
+      "fingerprint": "2b58439f25aa49688d77865ce623adb64a9d6f16b5d39e746e7bfbfd68b42ad7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 105
+    },
+    {
+      "fingerprint": "f4aef8f5572a542619e6dd7b1ad95ea69163c404bc230a694ae2ccd32f5c9314",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 108
+    },
+    {
+      "fingerprint": "a1383f2c75599dd39ac8300ff8460a0481ac57e5822f3794d7c50974fe04ef88",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 119
+    },
+    {
+      "fingerprint": "e7a1d869608261febc9c649deff8608db04b8ab9a6eb85a5a0647b431563c93c",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 124
+    },
+    {
+      "fingerprint": "1098715b5c6efe79ad4eb4f49c7d964b88d08f220184e61c0da5f05b885f737e",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "0e1952598db1489b9f7acb465583517825348da6bd5f291f8b0906dbd9657e44",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 142
+    },
+    {
+      "fingerprint": "d28b32f3624bf19078bef446b0fa9aa078f4bf8ecd505268a1c3e9c345e243c4",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 146
+    },
+    {
+      "fingerprint": "b22b61f1f2cbe56b286c945b6fd869e4ddcc01ec755cdd716fc55abf4f32fc51",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 185
+    },
+    {
+      "fingerprint": "fb7629a12bd0a19f74b744d1a5a0e94b001b44c4fd09b8118dd392255f0946af",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 215
+    },
+    {
+      "fingerprint": "ac1a282547130c3b4512560669bd7eba5ed50e5bbca8b376b4da565980dd28fb",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 251
+    },
+    {
+      "fingerprint": "cf914fc332093c4de1558f53988c125188650df5ad7e43a0f07afa0f994dca62",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 284
+    },
+    {
+      "fingerprint": "cde7bbc86478dca9e0f1880457dbec0cc9c86f9d64be6cf5870b1e5823311d87",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 317
+    },
+    {
+      "fingerprint": "291a93a59f25fdc97ff00b074489e44d27630ac0b257fb470adb4c610298a7a2",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/semgrep_parity_javascript.rs",
+      "line": 346
+    },
+    {
+      "fingerprint": "224d0c1c89c1a1a564ff5499a97f91ad4a5a1b8fd1dafc7ff304faaf91d9d505",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
+      "file": "vscode-extension/src/extension.ts",
+      "line": 263
+    },
+    {
+      "fingerprint": "a18b59c82157ee6d3a33694ece494dee42849140a323024433bd56cf5b1c0dda",
+      "rule_id": "js/no-command-injection",
+      "file": "vscode-extension/src/extension.ts",
       "line": 368
     }
   ]

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -1,6 +1,9 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
+
+use regex::Regex;
 
 use crate::{Finding, Severity};
 
@@ -61,6 +64,23 @@ pub const HARDCODED_SECRET_PATTERN: &str =
 /// Extended variant for C# that adds `connection_?string` /
 /// `connectionstring` to the base keyword set.
 pub const CSHARP_HARDCODED_SECRET_PATTERN: &str = r"(?i)(password|secret|api_?key|token|auth|credential|private_?key|connection_?string|connectionstring)";
+
+/// Pre-compiled [`HARDCODED_SECRET_PATTERN`] regex (compiled once).
+pub fn hardcoded_secret_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(HARDCODED_SECRET_PATTERN).expect("static hardcoded secret regex should compile")
+    })
+}
+
+/// Pre-compiled [`CSHARP_HARDCODED_SECRET_PATTERN`] regex (compiled once).
+pub fn csharp_hardcoded_secret_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(CSHARP_HARDCODED_SECRET_PATTERN)
+            .expect("static C# hardcoded secret regex should compile")
+    })
+}
 
 /// Default minimum length for strings flagged as a hardcoded secret.
 ///

--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -1,9 +1,21 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, walk_tree, CSHARP_HARDCODED_SECRET_PATTERN,
+    csharp_hardcoded_secret_re, is_secret_value_long_enough, make_finding, walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn cs_cors_star_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"WithOrigins\s*\(\s*"\*"\s*\)"#).expect("static C# CORS regex should compile")
+    })
+}
 
 /// Check whether a subtree contains a `binary_expression` with `+` operator.
 fn contains_string_concat(node: tree_sitter::Node, source: &str) -> bool {
@@ -445,8 +457,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern = Regex::new(CSHARP_HARDCODED_SECRET_PATTERN)
-            .expect("static C# hardcoded secret regex should compile");
+        let secret_pattern = csharp_hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: string password = "hardcoded"
@@ -657,8 +668,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let cors_star = Regex::new(r#"WithOrigins\s*\(\s*"\*"\s*\)"#)
-            .expect("static C# CORS regex should compile");
+        let cors_star = cs_cors_star_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "invocation_expression" {

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -1,8 +1,12 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::AliasTable;
 use crate::rules::common::{
-    get_source_line, is_secret_value_long_enough, make_finding, make_finding_from_offsets,
-    walk_tree, HARDCODED_SECRET_PATTERN,
+    get_source_line, hardcoded_secret_re, is_secret_value_long_enough, make_finding,
+    make_finding_from_offsets, walk_tree,
 };
 use crate::rules::go_taint::{
     self, go_aliases_from_tree, go_taint_sources, NodeMatcher as GoNodeMatcher,
@@ -10,7 +14,68 @@ use crate::rules::go_taint::{
 };
 use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn go_sql_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)")
+            .expect("static Go SQL regex should compile")
+    })
+}
+
+fn go_insecure_skip_verify_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"InsecureSkipVerify\s*:\s*true").expect("static Go TLS regex should compile")
+    })
+}
+
+fn go_min_version_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\bMinVersion\s*:").expect("static Go TLS MinVersion regex should compile")
+    })
+}
+
+fn go_cookie_secure_field_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\bSecure\s*:").expect("static Go cookie Secure field regex should compile")
+    })
+}
+
+fn go_cookie_secure_false_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\bSecure\s*:\s*false\b")
+            .expect("static Go cookie Secure false regex should compile")
+    })
+}
+
+fn go_cookie_http_only_field_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\bHttpOnly\s*:").expect("static Go cookie HttpOnly field regex should compile")
+    })
+}
+
+fn go_cookie_http_only_false_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\bHttpOnly\s*:\s*false\b")
+            .expect("static Go cookie HttpOnly false regex should compile")
+    })
+}
+
+fn go_hardcoded_byte_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"\[\]byte\(\s*"[^"]{4,}"\s*\)"#)
+            .expect("static Go JWT secret regex should compile")
+    })
+}
 
 fn go_composite_literal_type_text<'a>(
     node: tree_sitter::Node<'_>,
@@ -84,8 +149,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_pattern =
-            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").expect("static Go SQL regex should compile");
+        let sql_pattern = go_sql_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: "SELECT ... WHERE id = " + userId (binary_expression with +)
@@ -206,9 +270,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Short variable declaration: password := "hardcoded"
@@ -649,8 +711,7 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let pattern = Regex::new(r"InsecureSkipVerify\s*:\s*true")
-            .expect("static Go TLS regex should compile");
+        let pattern = go_insecure_skip_verify_re();
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -688,8 +749,7 @@ impl_rule! {
             None
         };
         let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
-        let min_version_re = Regex::new(r"\bMinVersion\s*:")
-            .expect("static Go TLS MinVersion regex should compile");
+        let min_version_re = go_min_version_re();
 
         let mut findings = Vec::new();
 
@@ -744,10 +804,9 @@ impl_rule! {
             None
         };
         let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
-        let secure_field_re = Regex::new(r"\bSecure\s*:")
-            .expect("static Go cookie Secure field regex should compile");
-        let secure_false_re = Regex::new(r"\bSecure\s*:\s*false\b")
-            .expect("static Go cookie Secure false regex should compile");
+        let secure_field_re = go_cookie_secure_field_re();
+
+        let secure_false_re = go_cookie_secure_false_re();
 
         let mut findings = Vec::new();
 
@@ -802,10 +861,9 @@ impl_rule! {
             None
         };
         let aliases: Option<&AliasTable> = ctx.go_aliases.or(local_aliases.as_ref());
-        let http_only_field_re = Regex::new(r"\bHttpOnly\s*:")
-            .expect("static Go cookie HttpOnly field regex should compile");
-        let http_only_false_re = Regex::new(r"\bHttpOnly\s*:\s*false\b")
-            .expect("static Go cookie HttpOnly false regex should compile");
+        let http_only_field_re = go_cookie_http_only_field_re();
+
+        let http_only_false_re = go_cookie_http_only_false_re();
 
         let mut findings = Vec::new();
 
@@ -1041,8 +1099,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let hardcoded_byte_re = Regex::new(r#"\[\]byte\(\s*"[^"]{4,}"\s*\)"#)
-            .expect("static Go JWT secret regex should compile");
+        let hardcoded_byte_re = go_hardcoded_byte_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() != "call_expression" {

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -1,10 +1,63 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
-    HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, make_finding_from_offsets,
+    walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn java_sql_methods_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery)$")
+            .expect("static Java SQL method regex should compile")
+    })
+}
+
+fn java_weak_algo_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
+            .expect("static Java weak crypto regex should compile")
+    })
+}
+
+fn java_xxe_factory_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)")
+            .expect("static Java XXE factory regex should compile")
+    })
+}
+
+fn java_xxe_secure_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
+            .expect("static Java XXE hardening regex should compile")
+    })
+}
+
+fn java_csrf_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\.csrf\(\s*\)\s*\.\s*disable\(\s*\)|csrf\s*\([^)]*\.\s*disable\(\s*\)\s*\)")
+            .expect("static Java CSRF regex should compile")
+    })
+}
+
+fn java_cors_wildcard_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"allowedOrigins\s*\(\s*"\*"\s*\)"#)
+            .expect("static Java CORS regex should compile")
+    })
+}
 
 /// Check whether any descendant of `node` is a `binary_expression` with a `+`
 /// operator that involves a `string_literal`.
@@ -79,9 +132,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_methods =
-            Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery)$")
-                .expect("static Java SQL method regex should compile");
+        let sql_methods = java_sql_methods_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "method_invocation" {
@@ -415,9 +466,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let weak_algo =
-            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
-                .expect("static Java weak crypto regex should compile");
+        let weak_algo = java_weak_algo_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "method_invocation" {
@@ -606,9 +655,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: String password = "hardcoded";
@@ -686,13 +733,8 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let factory_pattern = Regex::new(
-            r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
-        )
-        .expect("static Java XXE factory regex should compile");
-        let secure_pattern =
-            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
-                .expect("static Java XXE hardening regex should compile");
+        let factory_pattern = java_xxe_factory_re();
+        let secure_pattern = java_xxe_secure_re();
 
         // Simple heuristic: if a factory is created but no setFeature is called
         // in the same file, flag it.
@@ -729,10 +771,7 @@ impl_rule! {
 
         let mut findings = Vec::new();
         // .csrf().disable() or csrf(csrf -> csrf.disable()) or csrf(c -> c.disable())
-        let csrf_pattern = Regex::new(
-            r"\.csrf\(\s*\)\s*\.\s*disable\(\s*\)|csrf\s*\([^)]*\.\s*disable\(\s*\)\s*\)",
-        )
-        .expect("static Java CSRF regex should compile");
+        let csrf_pattern = java_csrf_re();
 
         for matched in csrf_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -908,8 +947,7 @@ impl_rule! {
         let mut findings = Vec::new();
 
         // allowedOrigins("*")
-        let wildcard_pattern = Regex::new(r#"allowedOrigins\s*\(\s*"\*"\s*\)"#)
-            .expect("static Java CORS regex should compile");
+        let wildcard_pattern = java_cors_wildcard_re();
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -1,11 +1,52 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    get_source_line, is_high_signal_secret_name, is_secret_value_long_enough,
-    looks_like_secret_value, make_finding, walk_tree, HARDCODED_SECRET_PATTERN,
+    get_source_line, hardcoded_secret_re, is_high_signal_secret_name, is_secret_value_long_enough,
+    looks_like_secret_value, make_finding, walk_tree,
 };
 use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn js_sql_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)",
+        )
+        .expect("static JavaScript SQL regex should compile")
+    })
+}
+
+fn js_redos_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(\([^)]*[+*][^)]*\)[+*]|\([^)]*\|[^)]*\)[+*])")
+            .expect("static ReDoS regex should compile")
+    })
+}
+
+fn js_user_input_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^req\.(params|query|body|headers)(\b|\[|\.)")
+            .expect("static Express user-input regex should compile")
+    })
+}
+
+fn js_sanitize_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)(escapeHtml|escape|sanitize|encode|encodeURIComponent|encodeURI|htmlEncode|xss|purify|DOMPurify|validator|parseInt|parseFloat|Number|String)\s*\(",
+        )
+        .expect("static JavaScript sanitizer regex should compile")
+    })
+}
 
 // ─── Rule 1: no-eval ─────────────────────────────────────────────────────────
 
@@ -58,9 +99,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // variable_declarator: const password = "hardcoded"
@@ -151,9 +190,7 @@ impl_rule! {
         let mut findings = Vec::new();
         // Require SQL keyword followed by SQL structure (FROM, INTO, SET, WHERE, TABLE, VALUES)
         // This avoids matching plain English like res.send('delete ' + name)
-        let sql_pattern = Regex::new(
-            r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)"
-        ).expect("static JavaScript SQL pattern should compile");
+        let sql_pattern = js_sql_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: query("SELECT * FROM users WHERE id = " + userId)
@@ -896,9 +933,7 @@ impl_rule! {
 
         let mut findings = Vec::new();
         // Patterns known to cause catastrophic backtracking: nested quantifiers
-        let dangerous_pattern =
-            Regex::new(r"(\([^)]*[+*][^)]*\)[+*]|\([^)]*\|[^)]*\)[+*])")
-                .expect("static ReDoS regex should compile");
+        let dangerous_pattern = js_redos_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect regex literals: /pattern/
@@ -1244,12 +1279,9 @@ impl_rule! {
 
         let mut findings = Vec::new();
         // Match user-controlled input objects
-        let user_input_re = Regex::new(r"^req\.(params|query|body|headers)(\b|\[|\.)")
-            .expect("static Express user-input regex should compile");
+        let user_input_re = js_user_input_re();
         // Sanitization wrappers that neutralise XSS risk
-        let sanitize_re = Regex::new(
-            r"(?i)(escapeHtml|escape|sanitize|encode|encodeURIComponent|encodeURI|htmlEncode|xss|purify|DOMPurify|validator|parseInt|parseFloat|Number|String)\s*\("
-        ).expect("static JavaScript sanitizer regex should compile");
+        let sanitize_re = js_sanitize_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: res.send(req.query.foo), res.write(req.body.bar)

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -1,10 +1,55 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
-    HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, make_finding_from_offsets,
+    walk_tree,
 };
 use crate::{Finding, Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn kt_sql_methods_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery|rawQuery|execSQL)$")
+            .expect("static Kotlin SQL method regex should compile")
+    })
+}
+
+fn kt_weak_algo_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
+            .expect("static Kotlin weak crypto regex should compile")
+    })
+}
+
+fn kt_xxe_factory_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)")
+            .expect("static Kotlin XXE factory regex should compile")
+    })
+}
+
+fn kt_xxe_secure_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
+            .expect("static Kotlin XXE hardening regex should compile")
+    })
+}
+
+fn kt_cors_wildcard_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(allowedOrigins|addAllowedOrigin)\s*\(\s*"\*"\s*\)"#)
+            .expect("static Kotlin CORS regex should compile")
+    })
+}
 
 /// Extract the method name from a `call_expression` node.
 /// In Kotlin, method calls are: `navigation_expression` + `call_suffix`.
@@ -150,9 +195,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_methods =
-            Regex::new(r"^(executeQuery|execute|createQuery|createNativeQuery|rawQuery|execSQL)$")
-                .expect("static Kotlin SQL method regex should compile");
+        let sql_methods = kt_sql_methods_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -465,9 +508,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let weak_algo =
-            Regex::new(r#"(?i)"(DES|DESede|RC2|RC4|Blowfish|MD5|SHA-?1|.*ECB.*)"#)
-                .expect("static Kotlin weak crypto regex should compile");
+        let weak_algo = kt_weak_algo_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -522,9 +563,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // property_declaration: val password = "hardcoded"
@@ -622,13 +661,8 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let factory_pattern = Regex::new(
-            r"(DocumentBuilderFactory|SAXParserFactory|XMLInputFactory)\.newInstance\(\)",
-        )
-        .expect("static Kotlin XXE factory regex should compile");
-        let secure_pattern =
-            Regex::new(r"setFeature\s*\(|setProperty\s*\(|setAttribute\s*\(")
-                .expect("static Kotlin XXE hardening regex should compile");
+        let factory_pattern = kt_xxe_factory_re();
+        let secure_pattern = kt_xxe_secure_re();
 
         if factory_pattern.is_match(source) && !secure_pattern.is_match(source) {
             for matched in factory_pattern.find_iter(source) {
@@ -664,9 +698,7 @@ impl_rule! {
         let mut findings = Vec::new();
 
         // allowedOrigins("*") / addAllowedOrigin("*")
-        let wildcard_pattern =
-            Regex::new(r#"(allowedOrigins|addAllowedOrigin)\s*\(\s*"\*"\s*\)"#)
-                .expect("static Kotlin CORS regex should compile");
+        let wildcard_pattern = kt_cors_wildcard_re();
         for matched in wildcard_pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),

--- a/src/rules/php.rs
+++ b/src/rules/php.rs
@@ -1,9 +1,22 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, walk_tree, HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn php_preg_e_modifier_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"['"][^'"]*/.*/[a-z]*e[a-z]*['"]"#)
+            .expect("static PHP preg_replace regex should compile")
+    })
+}
 
 // ─── Rule 1: no-eval ──────────────────────────────────────────────────────────
 
@@ -361,8 +374,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern = Regex::new(HARDCODED_SECRET_PATTERN)
-            .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect: $password = "hardcoded";
@@ -499,8 +511,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let e_modifier = Regex::new(r#"['"][^'"]*/.*/[a-z]*e[a-z]*['"]"#)
-            .expect("static PHP preg_replace regex should compile");
+        let e_modifier = php_preg_e_modifier_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "function_call_expression" {

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -1,12 +1,25 @@
+use std::borrow::Cow;
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    get_source_line, is_high_signal_secret_name, is_secret_value_long_enough,
-    looks_like_secret_value, make_finding, walk_tree, HARDCODED_SECRET_PATTERN,
+    get_source_line, hardcoded_secret_re, is_high_signal_secret_name, is_secret_value_long_enough,
+    looks_like_secret_value, make_finding, walk_tree,
 };
 use crate::rules::FileContext;
 use crate::{Finding, Language, Severity};
-use regex::Regex;
-use std::borrow::Cow;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn py_sql_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)")
+            .expect("static Python SQL regex should compile")
+    })
+}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -77,9 +90,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment: password = "hardcoded"
@@ -135,8 +146,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_pattern =
-            Regex::new(r"(?i)(SELECT\s+.{0,40}\s+FROM|INSERT\s+INTO|UPDATE\s+.{0,40}\s+SET|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE|EXEC\s+)").expect("static Python SQL regex should compile");
+        let sql_pattern = py_sql_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect f-strings with SQL: f"SELECT * FROM users WHERE id = {user_id}"

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -1,9 +1,8 @@
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, walk_tree, HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
 
 /// Returns `true` if a tree-sitter `string` node contains interpolation
 /// children (i.e., `#{}` segments). Plain string literals like `"ls -la"`
@@ -485,9 +484,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // assignment: variable = "hardcoded"

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -1,9 +1,30 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, walk_tree, HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn rust_sql_methods_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(query|sql_query|execute|raw_sql)\b")
+            .expect("static Rust SQL method regex should compile")
+    })
+}
+
+fn rust_weak_hash_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\b(md5|sha1|Md5|Sha1|MD5|SHA1)\b")
+            .expect("static Rust weak hash regex should compile")
+    })
+}
 
 // ─── Rule 1: unsafe-block ─────────────────────────────────────────────────────
 
@@ -137,8 +158,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let sql_methods = Regex::new(r"(?i)\b(query|sql_query|execute|raw_sql)\b")
-            .expect("static Rust SQL method regex should compile");
+        let sql_methods = rust_sql_methods_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             if node.kind() == "call_expression" {
@@ -187,8 +207,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let weak_hash = Regex::new(r"\b(md5|sha1|Md5|Sha1|MD5|SHA1)\b")
-            .expect("static Rust weak hash regex should compile");
+        let weak_hash = rust_weak_hash_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Detect use declarations: use md5::..., use sha1::...
@@ -338,9 +357,7 @@ impl_rule! {
     fn check(_self, source, tree) {
 
         let mut findings = Vec::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // let password = "hardcoded";

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
+use std::sync::OnceLock;
 
 const RESERVED_RULE_ID_NAMESPACES: &[&str] = &[
     "py", "js", "go", "java", "php", "ruby", "cs", "csharp", "swift", "kotlin", "rs", "rust",
@@ -344,17 +345,22 @@ fn prepare_pattern_for_grammar(source: String, lang: Language) -> String {
 }
 
 fn rewrite_go_semgrep_micro_syntax(source: &str) -> String {
-    let metavars = Regex::new(r"\$([A-Za-z0-9_]+)").expect("valid metavariable regex");
+    static METAVARS_RE: OnceLock<Regex> = OnceLock::new();
+    let metavars = METAVARS_RE
+        .get_or_init(|| Regex::new(r"\$([A-Za-z0-9_]+)").expect("valid metavariable regex"));
     let rewritten = metavars
         .replace_all(source, format!("{GO_METAVAR_PREFIX}$1"))
         .to_string()
         .replace("...", GO_ELLIPSIS_PLACEHOLDER);
 
-    let func_ellipsis_params = Regex::new(&format!(
-        r"(func\s+[A-Za-z_][A-Za-z0-9_]*\s*)\(\s*{}\s*\)",
-        regex::escape(GO_ELLIPSIS_PLACEHOLDER)
-    ))
-    .expect("valid Go func ellipsis regex");
+    static FUNC_ELLIPSIS_RE: OnceLock<Regex> = OnceLock::new();
+    let func_ellipsis_params = FUNC_ELLIPSIS_RE.get_or_init(|| {
+        Regex::new(&format!(
+            r"(func\s+[A-Za-z_][A-Za-z0-9_]*\s*)\(\s*{}\s*\)",
+            regex::escape(GO_ELLIPSIS_PLACEHOLDER)
+        ))
+        .expect("valid Go func ellipsis regex")
+    });
 
     func_ellipsis_params
         .replace_all(&rewritten, "$1()")

--- a/src/rules/swift.rs
+++ b/src/rules/swift.rs
@@ -1,10 +1,79 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+
 use crate::impl_rule;
 use crate::rules::common::{
-    is_secret_value_long_enough, make_finding, make_finding_from_offsets, walk_tree,
-    HARDCODED_SECRET_PATTERN,
+    hardcoded_secret_re, is_secret_value_long_enough, make_finding, make_finding_from_offsets,
+    walk_tree,
 };
 use crate::{Language, Severity};
-use regex::Regex;
+
+// ─── Static regex helpers (compiled once) ────────────────────────────────────
+
+fn swift_weak_crypto_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\b(CC_MD5|CC_SHA1|\.md5|\.sha1|Insecure\.MD5|Insecure\.SHA1)\b")
+            .expect("static Swift weak crypto regex should compile")
+    })
+}
+
+fn swift_sql_keywords_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\s")
+            .expect("static Swift SQL keyword regex should compile")
+    })
+}
+
+fn swift_interp_string_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#""[^"]*\\\([^)]+\)[^"]*""#)
+            .expect("static Swift interpolation regex should compile")
+    })
+}
+
+fn swift_sql_concat_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?i)(execute|prepare|sqlite3_exec)\s*\([^)]*(?:SELECT|INSERT|UPDATE|DELETE|DROP)[^)]*\+\s*"#,
+        )
+        .expect("static Swift SQL concat regex should compile")
+    })
+}
+
+fn swift_keychain_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\b(kSecAttrAccessibleAlways|kSecAttrAccessibleAlwaysThisDeviceOnly)\b")
+            .expect("static Swift keychain regex should compile")
+    })
+}
+
+fn swift_tls_expired_certs_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"allowsExpiredCertificates\s*=\s*true")
+            .expect("static Swift TLS regex should compile")
+    })
+}
+
+fn swift_tls_expired_roots_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"allowsExpiredRoots\s*=\s*true").expect("static Swift TLS regex should compile")
+    })
+}
+
+fn swift_tls_disable_eval_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"\.disableEvaluation").expect("static Swift TLS regex should compile")
+    })
+}
 
 // ─── Rule 1: no-hardcoded-secret ────────────────────────────────────────────
 
@@ -21,9 +90,7 @@ impl_rule! {
 
         let mut findings = Vec::new();
         let mut reported_lines = std::collections::HashSet::new();
-        let secret_pattern =
-            Regex::new(HARDCODED_SECRET_PATTERN)
-                .expect("static hardcoded secret regex should compile");
+        let secret_pattern = hardcoded_secret_re();
 
         walk_tree(tree.root_node(), source, &mut |node, src| {
             // Match property declarations: let password = "hardcoded"
@@ -174,9 +241,7 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let pattern =
-            Regex::new(r"\b(CC_MD5|CC_SHA1|\.md5|\.sha1|Insecure\.MD5|Insecure\.SHA1)\b")
-                .expect("static Swift weak crypto regex should compile");
+        let pattern = swift_weak_crypto_re();
 
         for matched in pattern.find_iter(source) {
             let algo = if matched.as_str().contains("MD5") || matched.as_str().contains("md5") {
@@ -295,12 +360,10 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let sql_keywords = Regex::new(r"(?i)(SELECT|INSERT|UPDATE|DELETE|DROP|ALTER|CREATE)\s")
-            .expect("static Swift SQL keyword regex should compile");
+        let sql_keywords = swift_sql_keywords_re();
 
         // Detect SQL strings with interpolation: "SELECT ... \(variable) ..."
-        let interp_string = Regex::new(r#""[^"]*\\\([^)]+\)[^"]*""#)
-            .expect("static Swift interpolation regex should compile");
+        let interp_string = swift_interp_string_re();
         for matched in interp_string.find_iter(source) {
             let text = matched.as_str();
             if sql_keywords.is_match(text) {
@@ -317,10 +380,7 @@ impl_rule! {
         }
 
         // Detect execute/prepare calls with string concatenation
-        let sql_concat = Regex::new(
-            r#"(?i)(execute|prepare|sqlite3_exec)\s*\([^)]*(?:SELECT|INSERT|UPDATE|DELETE|DROP)[^)]*\+\s*"#,
-        )
-        .expect("static Swift SQL concat regex should compile");
+        let sql_concat = swift_sql_concat_re();
         for matched in sql_concat.find_iter(source) {
             findings.push(make_finding_from_offsets(
                 _self.id(),
@@ -352,9 +412,7 @@ impl_rule! {
     fn check(_self, source, _tree) {
 
         let mut findings = Vec::new();
-        let pattern =
-            Regex::new(r"\b(kSecAttrAccessibleAlways|kSecAttrAccessibleAlwaysThisDeviceOnly)\b")
-                .expect("static Swift keychain regex should compile");
+        let pattern = swift_keychain_re();
 
         for matched in pattern.find_iter(source) {
             findings.push(make_finding_from_offsets(
@@ -390,19 +448,17 @@ impl_rule! {
 
         let mut findings = Vec::new();
 
-        let patterns = [
+        let patterns: [(&Regex, &str); 3] = [
             (
-                Regex::new(r"allowsExpiredCertificates\s*=\s*true")
-                    .expect("static Swift TLS regex should compile"),
+                swift_tls_expired_certs_re(),
                 "allowsExpiredCertificates = true disables certificate expiry validation",
             ),
             (
-                Regex::new(r"allowsExpiredRoots\s*=\s*true")
-                    .expect("static Swift TLS regex should compile"),
+                swift_tls_expired_roots_re(),
                 "allowsExpiredRoots = true disables root certificate expiry validation",
             ),
             (
-                Regex::new(r"\.disableEvaluation").expect("static Swift TLS regex should compile"),
+                swift_tls_disable_eval_re(),
                 ".disableEvaluation disables TLS server trust evaluation entirely",
             ),
         ];


### PR DESCRIPTION
## Summary

- Move all static `Regex::new` calls from inside rule `check` methods to module-level `OnceLock<Regex>` helpers that compile once on first use, eliminating repeated regex compilation overhead on large scans
- Add `hardcoded_secret_re()` and `csharp_hardcoded_secret_re()` to `common.rs` as shared pre-compiled accessors used across 9 language rule files
- Add language-specific `OnceLock` helpers following the existing `config.rs`/`go.rs` convention for JavaScript, Swift, Java, Kotlin, PHP, Rust, C#, and Python rules

Closes #411

## Test plan

- [x] `cargo test --all-features` passes (all 513+ tests green)
- [x] `cargo clippy --all-features -- -D warnings` passes clean
- [x] Baseline regenerated for shifted finding fingerprints
- [x] Verified no behavioral changes — all hoisted patterns are identical string literals

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized security rule execution by caching compiled detection patterns, reducing redundant processing and improving overall scanning speed for hardcoded-secret, SQL-injection, weak-crypto, XXE, CSRF, CORS, and code-analysis checks across C#, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, and Swift.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->