### PR TITLE
fix(vscode): handle versioned JSON envelope from CLI output

### DIFF
--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -7802,16 +7802,28 @@
       "line": 328
     },
     {
-      "fingerprint": "56e07b4339a62164ecbff21e94eafbaf1ca97d6e99b56300e4b14acda6318444",
+      "fingerprint": "90c2586207192e627dae5b27ce0b5a63bf7e5b1148c3da39e88c802795165d67",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
-      "line": 263
+      "file": "vscode-extension/src/extension.ts",
+      "line": 282
     },
     {
-      "fingerprint": "4cf1c478a2c49176af7c1f72f0f07ee70372ce79a946079bdb42dbf5b83d28b1",
+      "fingerprint": "e261b1a819e84534c7c8477d984bc76e5e3aa073d61543915435dd44d1ee7cea",
       "rule_id": "js/no-command-injection",
-      "file": "./vscode-extension/src/extension.ts",
-      "line": 368
+      "file": "vscode-extension/src/extension.ts",
+      "line": 387
+    },
+    {
+      "fingerprint": "3b7fb57b9ceaf603867cce53273548719a76e887714d3e6a2da8521412042fbd",
+      "rule_id": "js/no-command-injection",
+      "file": "/Users/peak/coding/0sec/foxguard/vscode-extension/src/extension.ts",
+      "line": 282
+    },
+    {
+      "fingerprint": "6a4111c89e606885191c4b728afe2dde4cf22f79f6affab3c9197607b22e4b4c",
+      "rule_id": "js/no-command-injection",
+      "file": "/Users/peak/coding/0sec/foxguard/vscode-extension/src/extension.ts",
+      "line": 387
     }
   ]
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -98,7 +98,8 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "test": "tsc -p ./ && node out/extractFindings.test.js"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -17,6 +17,25 @@ interface Finding {
   fix_suggestion?: string;
 }
 
+/** Versioned envelope emitted by the CLI JSON reporter (v1.0.0+). */
+interface ReportEnvelope {
+  schema_version: string;
+  findings: Finding[];
+}
+
+/**
+ * Extract the findings array from CLI stdout.  Current foxguard wraps
+ * findings in a {@link ReportEnvelope}; older versions emitted a bare
+ * `Finding[]`.  This helper handles both shapes so the extension stays
+ * backward-compatible.
+ */
+function extractFindings(parsed: ReportEnvelope | Finding[]): Finding[] {
+  if (Array.isArray(parsed)) {
+    return parsed;                   // legacy bare array
+  }
+  return parsed.findings ?? [];      // versioned envelope
+}
+
 /** File extensions foxguard supports. */
 const SUPPORTED_EXTENSIONS = new Set([
   ".js", ".jsx", ".mjs", ".cjs",
@@ -277,7 +296,7 @@ function scanDocument(document: vscode.TextDocument): void {
 
         let findings: Finding[];
         try {
-          findings = JSON.parse(stdout);
+          findings = extractFindings(JSON.parse(stdout));
         } catch (e) {
           outputChannel.appendLine(`Parse error: ${e}`);
           setStatusDone(0);
@@ -378,7 +397,7 @@ async function scanWorkspace(): Promise<void> {
 
             let findings: Finding[];
             try {
-              findings = JSON.parse(stdout);
+              findings = extractFindings(JSON.parse(stdout));
             } catch {
               resolve();
               return;

--- a/vscode-extension/src/extractFindings.test.ts
+++ b/vscode-extension/src/extractFindings.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Lightweight tests for `extractFindings` — the envelope/legacy parser.
+ *
+ * Run with: npx tsx src/extractFindings.test.ts
+ * (No VS Code runtime required.)
+ */
+
+import * as assert from "assert";
+
+// ── Inline copies of types + function (no VS Code dep) ──────────────
+
+interface Finding {
+  rule_id: string;
+  severity: "low" | "medium" | "high" | "critical";
+  cwe: string | null;
+  description: string;
+  file: string;
+  line: number;
+  column: number;
+  end_line: number;
+  end_column: number;
+  snippet: string;
+  fix_suggestion?: string;
+}
+
+interface ReportEnvelope {
+  schema_version: string;
+  findings: Finding[];
+}
+
+function extractFindings(parsed: ReportEnvelope | Finding[]): Finding[] {
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+  return parsed.findings ?? [];
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const SAMPLE_FINDING: Finding = {
+  rule_id: "js/no-eval",
+  severity: "high",
+  cwe: "CWE-95",
+  description: "Use of eval()",
+  file: "src/app.js",
+  line: 10,
+  column: 3,
+  end_line: 10,
+  end_column: 15,
+  snippet: "eval(input)",
+};
+
+const ENVELOPE_OUTPUT: ReportEnvelope = {
+  schema_version: "1.0.0",
+  findings: [SAMPLE_FINDING],
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+// Versioned envelope (current CLI)
+{
+  const result = extractFindings(ENVELOPE_OUTPUT);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule_id, "js/no-eval");
+}
+
+// Legacy bare array (older CLI)
+{
+  const result = extractFindings([SAMPLE_FINDING]);
+  assert.strictEqual(result.length, 1);
+  assert.strictEqual(result[0].rule_id, "js/no-eval");
+}
+
+// Envelope with zero findings
+{
+  const result = extractFindings({ schema_version: "1.0.0", findings: [] });
+  assert.strictEqual(result.length, 0);
+}
+
+// Legacy empty array
+{
+  const result = extractFindings([]);
+  assert.strictEqual(result.length, 0);
+}
+
+// Simulated JSON.parse round-trip — envelope
+{
+  const raw = JSON.stringify(ENVELOPE_OUTPUT);
+  const parsed = JSON.parse(raw);
+  const result = extractFindings(parsed);
+  assert.strictEqual(result.length, 1);
+}
+
+// Simulated JSON.parse round-trip — bare array
+{
+  const raw = JSON.stringify([SAMPLE_FINDING]);
+  const parsed = JSON.parse(raw);
+  const result = extractFindings(parsed);
+  assert.strictEqual(result.length, 1);
+}
+
+console.log("All extractFindings tests passed.");


### PR DESCRIPTION
## Summary

- The CLI JSON reporter (`src/report/json.rs`) now emits a versioned `JsonReportEnvelope` with a `findings` field, but the VS Code extension (`vscode-extension/src/extension.ts`) was parsing stdout directly as a bare `Finding[]`. This broke scan-on-save and workspace scans when running current foxguard.
- Added `extractFindings()` helper that accepts both the new envelope and the legacy bare array format, keeping backward compatibility with older CLI versions.
- Added lightweight assertion-based tests (`extractFindings.test.ts`) covering envelope, legacy array, empty cases, and JSON round-trip scenarios.
- Updated `.foxguard/baseline.json` fingerprints for the shifted `execFile` call-site line numbers.

Closes #400

## Test plan

- [x] `npm run compile` passes cleanly in `vscode-extension/`
- [x] `npm test` passes all `extractFindings` assertions
- [x] Pre-commit hook (`foxguard --changed`) passes with updated baseline
- [ ] Manual: run extension against a CLI that emits the new envelope format and verify diagnostics appear
- [ ] Manual: run extension against an older CLI that emits a raw array and verify backward compatibility

none