### PR TITLE
fix(release): verify SHA-256 checksums on binary downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,13 @@ jobs:
           find artifacts -type f -exec cp {} release/ \;
           ls -la release/
 
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > checksums.txt
+          echo "--- checksums.txt ---"
+          cat checksums.txt
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -42,16 +42,51 @@ fi
 # ─── Download binary ────────────────────────────────────────────────────────
 
 echo "::group::Downloading foxguard ${VERSION} for ${PLATFORM}-${ARCH_SUFFIX}"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_NAME}"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+DOWNLOAD_URL="${BASE_URL}/${BINARY_NAME}"
+CHECKSUMS_URL="${BASE_URL}/checksums.txt"
 echo "URL: ${DOWNLOAD_URL}"
 
 INSTALL_DIR="${RUNNER_TEMP:-/tmp}/foxguard"
 mkdir -p "${INSTALL_DIR}"
 
+CHECKSUMS_FILE="${INSTALL_DIR}/checksums.txt"
+curl -sL "${CHECKSUMS_URL}" -o "${CHECKSUMS_FILE}"
+if [ ! -s "${CHECKSUMS_FILE}" ]; then
+    echo "::error::Failed to download checksums.txt from ${CHECKSUMS_URL}"
+    exit 1
+fi
+
 curl --fail -sL "${DOWNLOAD_URL}" -o "${INSTALL_DIR}/${EXECUTABLE_NAME}"
+
+# Verify SHA-256 checksum
+EXPECTED_HASH="$(grep "  ${BINARY_NAME}\$" "${CHECKSUMS_FILE}" | cut -d ' ' -f 1)"
+if [ -z "${EXPECTED_HASH}" ]; then
+    EXPECTED_HASH="$(grep " ${BINARY_NAME}\$" "${CHECKSUMS_FILE}" | cut -d ' ' -f 1)"
+fi
+if [ -z "${EXPECTED_HASH}" ]; then
+    echo "::error::No checksum found for ${BINARY_NAME} in checksums.txt"
+    exit 1
+fi
+
+if command -v sha256sum &>/dev/null; then
+    ACTUAL_HASH="$(sha256sum "${INSTALL_DIR}/${EXECUTABLE_NAME}" | cut -d ' ' -f 1)"
+elif command -v shasum &>/dev/null; then
+    ACTUAL_HASH="$(shasum -a 256 "${INSTALL_DIR}/${EXECUTABLE_NAME}" | cut -d ' ' -f 1)"
+else
+    echo "::error::Neither sha256sum nor shasum found — cannot verify binary integrity"
+    exit 1
+fi
+
+if [ "${ACTUAL_HASH}" != "${EXPECTED_HASH}" ]; then
+    echo "::error::SHA-256 mismatch for ${BINARY_NAME} (expected: ${EXPECTED_HASH}, actual: ${ACTUAL_HASH})"
+    exit 1
+fi
+echo "Checksum verified: ${EXPECTED_HASH}"
 if [ "${PLATFORM}" != "windows" ]; then
     chmod +x "${INSTALL_DIR}/${EXECUTABLE_NAME}"
 fi
+rm -f "${CHECKSUMS_FILE}"
 echo "::endgroup::"
 
 # ─── Build arguments ────────────────────────────────────────────────────────

--- a/packages/npm/bin/foxguard
+++ b/packages/npm/bin/foxguard
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { execFileSync } = require("child_process");
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
@@ -72,6 +73,22 @@ function download(url) {
   });
 }
 
+function parseChecksums(text) {
+  // Parse checksums.txt format: "<hash>  <filename>" or "<hash> <filename>"
+  const map = {};
+  for (const line of text.split("\n")) {
+    const match = line.match(/^([0-9a-f]{64})\s+(.+)$/);
+    if (match) {
+      map[match[2]] = match[1];
+    }
+  }
+  return map;
+}
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
 async function downloadBinary() {
   const target = getPlatformKey();
   const cacheDir = getCacheDir();
@@ -97,12 +114,34 @@ async function downloadBinary() {
   } else {
     throw new Error(`unsupported release target: ${target}`);
   }
-  const url = `https://github.com/${REPO}/releases/download/v${VERSION}/${assetName}`;
+  const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
+  const url = `${baseUrl}/${assetName}`;
 
   console.error(`foxguard: downloading v${VERSION} for ${target}...`);
 
   try {
-    const data = await download(url);
+    // Download checksums and binary in parallel
+    const [checksumData, data] = await Promise.all([
+      download(`${baseUrl}/checksums.txt`),
+      download(url),
+    ]);
+
+    // Verify integrity
+    const checksums = parseChecksums(checksumData.toString("utf8"));
+    const expected = checksums[assetName];
+    if (!expected) {
+      console.error(`foxguard: integrity error — no checksum found for ${assetName} in checksums.txt`);
+      process.exit(1);
+    }
+
+    const actual = sha256(data);
+    if (actual !== expected) {
+      console.error(`foxguard: integrity error — SHA-256 mismatch for ${assetName}`);
+      console.error(`  expected: ${expected}`);
+      console.error(`  actual:   ${actual}`);
+      process.exit(1);
+    }
+
     fs.writeFileSync(cachedBin, data);
 
     // Make executable

--- a/www/public/install.sh
+++ b/www/public/install.sh
@@ -52,17 +52,49 @@ printf 'installing foxguard %s for %s-%s...\n' "$tag" "$os_name" "$arch_name"
 
 mkdir -p "$INSTALL_DIR"
 
-download_url="https://github.com/${REPO}/releases/download/${tag}/${binary_name}"
+base_url="https://github.com/${REPO}/releases/download/${tag}"
+download_url="${base_url}/${binary_name}"
+checksums_url="${base_url}/checksums.txt"
+
 tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
+checksums_tmp="$(mktemp)"
+trap 'rm -f "$tmp" "$checksums_tmp"' EXIT
+
+if ! curl -fsSL -o "$checksums_tmp" "$checksums_url"; then
+  err "failed to download checksums.txt from $checksums_url"
+fi
 
 if ! curl -fsSL -o "$tmp" "$download_url"; then
   err "failed to download $download_url"
 fi
 
+# Verify SHA-256 checksum
+expected_hash="$(grep "  ${binary_name}\$" "$checksums_tmp" | cut -d ' ' -f 1)"
+if [ -z "$expected_hash" ]; then
+  # Also try single-space separator
+  expected_hash="$(grep " ${binary_name}\$" "$checksums_tmp" | cut -d ' ' -f 1)"
+fi
+[ -n "$expected_hash" ] || err "no checksum found for ${binary_name} in checksums.txt"
+
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_hash="$(sha256sum "$tmp" | cut -d ' ' -f 1)"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_hash="$(shasum -a 256 "$tmp" | cut -d ' ' -f 1)"
+else
+  err "neither sha256sum nor shasum found — cannot verify binary integrity"
+fi
+
+if [ "$actual_hash" != "$expected_hash" ]; then
+  err "SHA-256 mismatch for ${binary_name}
+  expected: ${expected_hash}
+  actual:   ${actual_hash}"
+fi
+
+printf 'checksum verified: %s\n' "$expected_hash"
+
 chmod +x "$tmp"
 mv "$tmp" "$INSTALL_DIR/foxguard"
-trap - EXIT
+trap 'rm -f "$checksums_tmp"' EXIT
 
 printf '\ninstalled foxguard %s to %s/foxguard\n' "$tag" "$INSTALL_DIR"
 


### PR DESCRIPTION
## Summary

Closes #406.

All three install paths (npm wrapper, `install.sh`, GitHub Action) downloaded release binaries and executed them without any integrity verification. For a security scanner, this is a supply-chain gap.

- **Release workflow** (`release.yml`): added a "Generate checksums" step that runs `sha256sum *` over all built binaries and uploads `checksums.txt` alongside them in the GitHub Release.
- **npm wrapper** (`packages/npm/bin/foxguard`): downloads `checksums.txt` in parallel with the binary, computes SHA-256 via Node `crypto`, and fails with a clear error on mismatch or missing checksum.
- **Install script** (`www/public/install.sh`): downloads `checksums.txt`, verifies with `sha256sum` (Linux) or `shasum -a 256` (macOS), fails closed if neither tool is available or if hashes do not match.
- **GitHub Action** (`action/entrypoint.sh`): downloads `checksums.txt`, verifies with `sha256sum`/`shasum`, fails with `::error::` annotation on mismatch.

All three paths **fail closed** — missing checksums file, missing entry for the binary, or hash mismatch all abort before execution.

## Test plan

- [x] `node -c packages/npm/bin/foxguard` — syntax OK
- [x] `bash -n action/entrypoint.sh` — syntax OK
- [x] `sh -n www/public/install.sh` — syntax OK
- [x] `python3 -c "import yaml; yaml.safe_load(open('release.yml'))"` — valid YAML
- [x] `cargo test` — 473 passed (2 pre-existing failures unrelated to this change)
- [ ] End-to-end: next tagged release will produce `checksums.txt` and all three install paths will verify it

none