### PR TITLE
test(secrets): add unit and hidden-directory tests for #401 fix

### DIFF
--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -346,4 +346,47 @@ mod tests {
         let result = redact_match(line, 0, 1);
         assert_eq!(result, "[REDACTED]secret");
     }
+
+    /// Issue #401: `scan_directory` must include hidden files such as `.env`.
+    #[test]
+    fn scan_directory_includes_dotenv() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let github = ["ghp_", "abcdefghijklmnopqrstuvwxyz1234567890"].concat();
+        std::fs::write(dir.path().join(".env"), format!("TOKEN={github}\n"))
+            .expect("failed to write .env");
+
+        let findings = scan_directory(dir.path().to_str().unwrap(), 1_000_000);
+        assert!(
+            !findings.is_empty(),
+            "scan_directory must detect secrets inside .env"
+        );
+        assert!(
+            findings.iter().any(|f| f.file.contains(".env")),
+            "at least one finding should reference .env"
+        );
+    }
+
+    /// Issue #401: `scan_directory` must descend into hidden directories.
+    #[test]
+    fn scan_directory_includes_hidden_dirs() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let hidden = dir.path().join(".secrets");
+        std::fs::create_dir_all(&hidden).expect("failed to create hidden dir");
+        let github = ["ghp_", "abcdefghijklmnopqrstuvwxyz1234567890"].concat();
+        std::fs::write(hidden.join("creds.txt"), format!("TOKEN={github}\n"))
+            .expect("failed to write creds.txt");
+
+        let findings = scan_directory(dir.path().to_str().unwrap(), 1_000_000);
+        assert!(
+            !findings.is_empty(),
+            "scan_directory must detect secrets inside hidden directories"
+        );
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.file.contains(".secrets/creds.txt")
+                    || f.file.contains(".secrets\\creds.txt")),
+            "at least one finding should reference .secrets/creds.txt"
+        );
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3864,6 +3864,69 @@ rules:
         assert!(findings.is_empty(), "expected excluded file to be skipped");
     }
 
+    /// Issue #401: secrets mode must scan hidden files (e.g. `.env`) by default.
+    #[test]
+    fn test_secrets_mode_scans_dotenv_files() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        write_secret_file(repo.path(), ".env");
+
+        let output = foxguard_cmd()
+            .args([
+                "secrets",
+                repo.path().to_str().expect("non-utf8 path"),
+                "-f",
+                "json",
+            ])
+            .output()
+            .expect("failed to execute foxguard secrets");
+
+        assert!(
+            !output.status.success(),
+            "secrets mode should detect tokens in .env files"
+        );
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f["file"].as_str().unwrap_or_default().ends_with(".env")),
+            "at least one finding should reference .env; findings={findings:?}"
+        );
+    }
+
+    /// Issue #401: secrets mode must also traverse hidden directories.
+    #[test]
+    fn test_secrets_mode_scans_hidden_directories() {
+        let repo = TempDir::new().expect("failed to create temp dir");
+        let hidden_dir = repo.path().join(".config");
+        fs::create_dir_all(&hidden_dir).expect("failed to create .config dir");
+        write_secret_file(&hidden_dir, "credentials");
+
+        let output = foxguard_cmd()
+            .args([
+                "secrets",
+                repo.path().to_str().expect("non-utf8 path"),
+                "-f",
+                "json",
+            ])
+            .output()
+            .expect("failed to execute foxguard secrets");
+
+        assert!(
+            !output.status.success(),
+            "secrets mode should detect tokens inside hidden directories"
+        );
+
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert!(
+            findings.iter().any(|f| f["file"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(".config")),
+            "at least one finding should reference .config/; findings={findings:?}"
+        );
+    }
+
     #[test]
     fn test_secrets_mode_scans_hidden_files() {
         let repo = TempDir::new().expect("failed to create temp dir");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3919,10 +3919,9 @@ rules:
 
         let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
         assert!(
-            findings.iter().any(|f| f["file"]
-                .as_str()
-                .unwrap_or_default()
-                .contains(".config")),
+            findings
+                .iter()
+                .any(|f| f["file"].as_str().unwrap_or_default().contains(".config")),
             "at least one finding should reference .config/; findings={findings:?}"
         );
     }


### PR DESCRIPTION
## Summary
- Adds unit tests to `src/secrets.rs` verifying `scan_directory` now includes `.env` files and hidden directories (covering the `.hidden(false)` change merged in #416).
- Adds a hidden-directory integration test (`test_secrets_mode_scans_hidden_directories`) exercising the CLI `secrets` subcommand against a `.config/credentials` path.
- Adds a second `.env` integration test with a doc comment referencing #401 for traceability.

Follows up on #416 which fixed the core issue; this PR extends test coverage to hidden directories (not just hidden files) and adds library-level unit tests.

## Test plan
- [x] `cargo test secrets::tests` passes (4 tests including 2 new)
- [x] `cargo test --test integration test_secrets_mode_scans` passes (3 tests including 2 new)
- [x] Full `cargo test` passes with zero failures

none