### PR TITLE
fix(engine): drain child pipes concurrently to prevent deadlock

### DIFF
--- a/src/bin/foxguard_github_app.rs
+++ b/src/bin/foxguard_github_app.rs
@@ -38,7 +38,6 @@ use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
-use wait_timeout::ChildExt;
 
 /// Hard cap on incoming webhook body size. GitHub's largest legitimate
 /// `pull_request` payload sits around 200 KB; 1 MiB leaves comfortable
@@ -646,38 +645,36 @@ fn run_command_with_timeout(
     timeout: Duration,
     label: &str,
 ) -> Result<String, String> {
-    let mut child = command
+    use foxguard::engine::process::{wait_with_output_timeout, TimedOutput};
+
+    let child = command
         .spawn()
         .map_err(|error| format!("failed to run {label}: {error}"))?;
-    let status = match child
-        .wait_timeout(timeout)
-        .map_err(|error| format!("failed to wait for {label}: {error}"))?
-    {
-        Some(status) => status,
-        None => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!("{label} timed out after {}s", timeout.as_secs()));
+
+    let result = wait_with_output_timeout(child, timeout)
+        .map_err(|error| format!("failed to wait for {label}: {error}"))?;
+
+    match result {
+        TimedOutput::TimedOut { .. } => {
+            Err(format!("{label} timed out after {}s", timeout.as_secs()))
         }
-    };
-
-    let output = child
-        .wait_with_output()
-        .map_err(|error| format!("failed to collect {label} output: {error}"))?;
-    if !status.success() && label != "foxguard" {
-        return Err(format!(
-            "{label} failed with {status}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
+        TimedOutput::Finished(output) => {
+            let status = output.status;
+            if !status.success() && label != "foxguard" {
+                return Err(format!(
+                    "{label} failed with {status}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            if label == "foxguard" && !matches!(status.code(), Some(0) | Some(1)) {
+                return Err(format!(
+                    "{label} failed with {status}: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
     }
-    if label == "foxguard" && !matches!(status.code(), Some(0) | Some(1)) {
-        return Err(format!(
-            "{label} failed with {status}: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 fn parse_json_findings(output: &str) -> Result<Vec<Finding>, String> {

--- a/src/engine/coccinelle.rs
+++ b/src/engine/coccinelle.rs
@@ -6,12 +6,11 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_yaml_ng::Value as YamlValue;
 use std::collections::HashSet;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::time::Duration;
-use wait_timeout::ChildExt;
 
 #[derive(Debug, Clone)]
 pub struct CoccinelleRule {
@@ -350,8 +349,10 @@ fn scan_candidates(
 }
 
 fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
+    use crate::engine::process::{wait_with_output_timeout, TimedOutput};
+
     let timeout = spatch_timeout();
-    let mut child = Command::new("spatch")
+    let child = Command::new("spatch")
         .arg("--very-quiet")
         .arg("--sp-file")
         .arg(script_path)
@@ -361,31 +362,18 @@ fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
         .spawn()
         .map_err(|e| format!("failed to run spatch: {}", e))?;
 
-    let status = match child
-        .wait_timeout(timeout)
-        .map_err(|e| format!("failed to wait for spatch: {}", e))?
-    {
-        Some(status) => status,
-        None => {
-            let _ = child.kill();
-            let _ = child.wait();
+    let result = wait_with_output_timeout(child, timeout)
+        .map_err(|e| format!("failed to wait for spatch: {}", e))?;
+
+    let (status_ok, raw_stdout, raw_stderr) = match result {
+        TimedOutput::TimedOut { .. } => {
             return Err(format!("spatch timed out after {}s", timeout.as_secs()));
         }
+        TimedOutput::Finished(output) => (output.status.success(), output.stdout, output.stderr),
     };
 
-    let mut stdout = Vec::new();
-    if let Some(mut pipe) = child.stdout.take() {
-        pipe.read_to_end(&mut stdout)
-            .map_err(|e| format!("failed to read spatch stdout: {}", e))?;
-    }
-    let mut stderr = Vec::new();
-    if let Some(mut pipe) = child.stderr.take() {
-        pipe.read_to_end(&mut stderr)
-            .map_err(|e| format!("failed to read spatch stderr: {}", e))?;
-    }
-
-    let stdout = String::from_utf8_lossy(&stdout);
-    let stderr = String::from_utf8_lossy(&stderr);
+    let stdout = String::from_utf8_lossy(&raw_stdout);
+    let stderr = String::from_utf8_lossy(&raw_stderr);
     let combined = if stderr.trim().is_empty() {
         stdout.to_string()
     } else if stdout.trim().is_empty() {
@@ -394,7 +382,7 @@ fn run_spatch(script_path: &Path, target: &Path) -> Result<String, String> {
         format!("{stdout}\n{stderr}")
     };
 
-    if status.success()
+    if status_ok
         || combined.contains("\n@@ ")
         || combined.starts_with("@@ ")
         || combined.contains("\n--- ")

--- a/src/engine/codeql.rs
+++ b/src/engine/codeql.rs
@@ -4,12 +4,10 @@ use serde_json::Value as JsonValue;
 use serde_yaml_ng::Value as YamlValue;
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Duration;
 use tempfile::TempDir;
-use wait_timeout::ChildExt;
 
 #[derive(Debug, Clone)]
 pub struct CodeQlRule {
@@ -367,6 +365,8 @@ pub fn scan_with_notices_for_target(
 }
 
 fn run_codeql_database_analyze(database: &Path, query: &Path) -> Result<String, String> {
+    use crate::engine::process::{wait_with_output_timeout, TimedOutput};
+
     let output = tempfile::NamedTempFile::new()
         .map_err(|e| format!("failed to create temporary SARIF output: {}", e))?;
     let output_path = output.path().to_path_buf();
@@ -375,7 +375,7 @@ fn run_codeql_database_analyze(database: &Path, query: &Path) -> Result<String, 
     output_arg.push(output_path.as_os_str());
 
     let timeout = codeql_timeout();
-    let mut child = Command::new("codeql")
+    let child = Command::new("codeql")
         .arg("database")
         .arg("analyze")
         .arg(database)
@@ -387,45 +387,29 @@ fn run_codeql_database_analyze(database: &Path, query: &Path) -> Result<String, 
         .spawn()
         .map_err(|e| format!("failed to run codeql: {}", e))?;
 
-    let status = match child
-        .wait_timeout(timeout)
-        .map_err(|e| format!("failed to wait for codeql: {}", e))?
-    {
-        Some(status) => status,
-        None => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!("codeql timed out after {}s", timeout.as_secs()));
+    let result = wait_with_output_timeout(child, timeout)
+        .map_err(|e| format!("failed to wait for codeql: {}", e))?;
+
+    match result {
+        TimedOutput::TimedOut { .. } => {
+            Err(format!("codeql timed out after {}s", timeout.as_secs()))
         }
-    };
-
-    let mut stdout = Vec::new();
-    if let Some(mut pipe) = child.stdout.take() {
-        pipe.read_to_end(&mut stdout)
-            .map_err(|e| format!("failed to read codeql stdout: {}", e))?;
+        TimedOutput::Finished(ref output) if !output.status.success() => {
+            let message = process_message(&output.stdout, &output.stderr);
+            if message.is_empty() {
+                Err("codeql exited without output".to_string())
+            } else {
+                Err(message)
+            }
+        }
+        TimedOutput::Finished(_) => std::fs::read_to_string(&output_path).map_err(|e| {
+            format!(
+                "failed to read CodeQL SARIF output {}: {}",
+                output_path.display(),
+                e
+            )
+        }),
     }
-    let mut stderr = Vec::new();
-    if let Some(mut pipe) = child.stderr.take() {
-        pipe.read_to_end(&mut stderr)
-            .map_err(|e| format!("failed to read codeql stderr: {}", e))?;
-    }
-
-    if !status.success() {
-        let message = process_message(&stdout, &stderr);
-        return if message.is_empty() {
-            Err("codeql exited without output".to_string())
-        } else {
-            Err(message)
-        };
-    }
-
-    std::fs::read_to_string(&output_path).map_err(|e| {
-        format!(
-            "failed to read CodeQL SARIF output {}: {}",
-            output_path.display(),
-            e
-        )
-    })
 }
 
 fn parse_sarif_findings(rule: &CodeQlRule, sarif: &str) -> Vec<Finding> {
@@ -600,6 +584,8 @@ fn language_from_source_root(scan_target: &Path) -> Option<String> {
 /// `TempDir` whose `path().join("db")` is the resulting database. Dropping
 /// the returned handle removes the temp tree.
 fn build_auto_database(scan_target: &Path, language: &str) -> Result<TempDir, String> {
+    use crate::engine::process::{wait_with_output_timeout, TimedOutput};
+
     let parent = TempDir::new().map_err(|e| format!("failed to create codeql temp dir: {}", e))?;
     let db_path = parent.path().join("db");
     let mut language_arg = OsString::from("--language=");
@@ -608,7 +594,7 @@ fn build_auto_database(scan_target: &Path, language: &str) -> Result<TempDir, St
     source_arg.push(scan_target.as_os_str());
 
     let timeout = codeql_create_timeout();
-    let mut child = Command::new("codeql")
+    let child = Command::new("codeql")
         .arg("database")
         .arg("create")
         .arg(&db_path)
@@ -620,40 +606,24 @@ fn build_auto_database(scan_target: &Path, language: &str) -> Result<TempDir, St
         .spawn()
         .map_err(|e| format!("failed to spawn codeql: {}", e))?;
 
-    let status = match child
-        .wait_timeout(timeout)
-        .map_err(|e| format!("failed to wait for codeql: {}", e))?
-    {
-        Some(status) => status,
-        None => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!(
-                "codeql database create timed out after {}s",
-                timeout.as_secs()
-            ));
+    let result = wait_with_output_timeout(child, timeout)
+        .map_err(|e| format!("failed to wait for codeql: {}", e))?;
+
+    match result {
+        TimedOutput::TimedOut { .. } => Err(format!(
+            "codeql database create timed out after {}s",
+            timeout.as_secs()
+        )),
+        TimedOutput::Finished(ref output) if !output.status.success() => {
+            let message = process_message(&output.stdout, &output.stderr);
+            if message.is_empty() {
+                Err("codeql database create exited without output".to_string())
+            } else {
+                Err(message)
+            }
         }
-    };
-
-    let mut stdout = Vec::new();
-    if let Some(mut pipe) = child.stdout.take() {
-        pipe.read_to_end(&mut stdout).ok();
+        TimedOutput::Finished(_) => Ok(parent),
     }
-    let mut stderr = Vec::new();
-    if let Some(mut pipe) = child.stderr.take() {
-        pipe.read_to_end(&mut stderr).ok();
-    }
-
-    if !status.success() {
-        let message = process_message(&stdout, &stderr);
-        return if message.is_empty() {
-            Err("codeql database create exited without output".to_string())
-        } else {
-            Err(message)
-        };
-    }
-
-    Ok(parent)
 }
 
 fn codeql_create_timeout() -> Duration {

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -1,6 +1,7 @@
 pub mod coccinelle;
 pub mod codeql;
 pub mod parser;
+pub mod process;
 pub mod scanner;
 
 pub use parser::{parse_file, parse_path};

--- a/src/engine/process.rs
+++ b/src/engine/process.rs
@@ -1,0 +1,157 @@
+//! Shared helper for running child processes with piped stdout/stderr
+//! while enforcing a timeout.
+//!
+//! The classic pitfall with `Command::new(..).stdout(Stdio::piped()).spawn()`
+//! is that the parent waits for the child to exit *before* draining the pipes.
+//! If the child produces more output than the OS pipe buffer (~64 KB), the
+//! child blocks on its write and the parent blocks on its wait -- a deadlock.
+//!
+//! [`wait_with_output_timeout`] avoids this by spawning reader threads that
+//! drain stdout and stderr concurrently while the main thread enforces the
+//! timeout.
+
+use std::io::Read;
+use std::process::{Child, ExitStatus, Output};
+use std::time::Duration;
+
+use wait_timeout::ChildExt;
+
+/// Outcome of [`wait_with_output_timeout`].
+pub enum TimedOutput {
+    /// The child exited (possibly unsuccessfully) within the deadline.
+    Finished(Output),
+    /// The child did not exit in time and was killed. The captured output
+    /// contains whatever was read before the kill.
+    TimedOut {
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+    },
+}
+
+impl TimedOutput {
+    /// Returns `true` when the child exceeded the deadline.
+    pub fn timed_out(&self) -> bool {
+        matches!(self, TimedOutput::TimedOut { .. })
+    }
+
+    /// Consume into the captured stdout bytes regardless of outcome.
+    pub fn stdout(self) -> Vec<u8> {
+        match self {
+            TimedOutput::Finished(output) => output.stdout,
+            TimedOutput::TimedOut { stdout, .. } => stdout,
+        }
+    }
+
+    /// Borrow the exit status (only available when the child finished).
+    pub fn status(&self) -> Option<ExitStatus> {
+        match self {
+            TimedOutput::Finished(output) => Some(output.status),
+            TimedOutput::TimedOut { .. } => None,
+        }
+    }
+}
+
+/// Drain stdout/stderr of `child` on background threads while enforcing
+/// `timeout` on the child process.
+///
+/// Returns [`TimedOutput::Finished`] when the child exits in time, or
+/// [`TimedOutput::TimedOut`] after killing a child that exceeded the deadline.
+///
+/// # Errors
+///
+/// Returns `Err` only for OS-level failures (e.g. the child could not be
+/// waited on). Callers are expected to inspect the exit status themselves.
+pub fn wait_with_output_timeout(
+    mut child: Child,
+    timeout: Duration,
+) -> Result<TimedOutput, std::io::Error> {
+    // Take the pipe handles so the reader threads own them.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+
+    let stdout_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stdout_pipe {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let stderr_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut pipe) = stderr_pipe {
+            let _ = pipe.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let status = child.wait_timeout(timeout)?;
+
+    match status {
+        Some(exit_status) => {
+            // Child exited within the deadline. The reader threads will
+            // finish once the pipes hit EOF (which happens on child exit).
+            let stdout = stdout_thread.join().unwrap_or_default();
+            let stderr = stderr_thread.join().unwrap_or_default();
+
+            Ok(TimedOutput::Finished(Output {
+                status: exit_status,
+                stdout,
+                stderr,
+            }))
+        }
+        None => {
+            // Timed out -- kill the child so the pipes close.
+            let _ = child.kill();
+            let _ = child.wait();
+
+            let stdout = stdout_thread.join().unwrap_or_default();
+            let stderr = stderr_thread.join().unwrap_or_default();
+
+            Ok(TimedOutput::TimedOut { stdout, stderr })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn child_producing_large_output_does_not_deadlock() {
+        // Generate well over 64 KB of output.
+        let child = Command::new("dd")
+            .args(["if=/dev/zero", "bs=1024", "count=256"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn dd");
+
+        let result =
+            wait_with_output_timeout(child, Duration::from_secs(10)).expect("IO error");
+
+        match result {
+            TimedOutput::Finished(output) => {
+                assert!(output.status.success());
+                assert_eq!(output.stdout.len(), 256 * 1024);
+            }
+            TimedOutput::TimedOut { .. } => panic!("should not have timed out"),
+        }
+    }
+
+    #[test]
+    fn timeout_kills_long_running_child() {
+        let child = Command::new("sleep")
+            .arg("60")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn sleep");
+
+        let result =
+            wait_with_output_timeout(child, Duration::from_millis(200)).expect("IO error");
+
+        assert!(result.timed_out());
+    }
+}

--- a/src/engine/process.rs
+++ b/src/engine/process.rs
@@ -22,10 +22,7 @@ pub enum TimedOutput {
     Finished(Output),
     /// The child did not exit in time and was killed. The captured output
     /// contains whatever was read before the kill.
-    TimedOut {
-        stdout: Vec<u8>,
-        stderr: Vec<u8>,
-    },
+    TimedOut { stdout: Vec<u8>, stderr: Vec<u8> },
 }
 
 impl TimedOutput {
@@ -128,8 +125,7 @@ mod tests {
             .spawn()
             .expect("failed to spawn dd");
 
-        let result =
-            wait_with_output_timeout(child, Duration::from_secs(10)).expect("IO error");
+        let result = wait_with_output_timeout(child, Duration::from_secs(10)).expect("IO error");
 
         match result {
             TimedOutput::Finished(output) => {
@@ -149,8 +145,7 @@ mod tests {
             .spawn()
             .expect("failed to spawn sleep");
 
-        let result =
-            wait_with_output_timeout(child, Duration::from_millis(200)).expect("IO error");
+        let result = wait_with_output_timeout(child, Duration::from_millis(200)).expect("IO error");
 
         assert!(result.timed_out());
     }


### PR DESCRIPTION
## Summary

- Add shared `engine::process::wait_with_output_timeout()` helper that spawns reader threads to drain stdout/stderr concurrently while enforcing a timeout on the child process, preventing the classic pipe-buffer deadlock (~64 KB)
- Replace the wait-then-read pattern in all four affected call sites: `foxguard_github_app.rs::run_command_with_timeout`, `codeql.rs::run_codeql_database_analyze`, `codeql.rs::build_auto_database`, and `coccinelle.rs::run_spatch`
- Include two unit tests: one proving 256 KB of child output does not deadlock, another verifying timeout + kill behavior

## Test plan

- [x] `cargo test --all-features` passes (all 753+ tests, including 2 new process module tests)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [ ] Manual: run foxguard-github-app against a verbose repo to confirm no timeout regressions
- [ ] Manual: run CodeQL rules against a project that produces verbose codeql output

Closes #403

none