### PR TITLE
fix(tests): isolate cnsa2_compliance tests from local baseline

### DIFF
--- a/.foxguard/baseline.json
+++ b/.foxguard/baseline.json
@@ -2930,60 +2930,6 @@
       "line": 30
     },
     {
-      "fingerprint": "0a42b62356bcfda1e3101c7a3984d2142b3c47ae38e6d4833d424f9aa9c69e45",
-      "rule_id": "rs/no-command-injection",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 17
-    },
-    {
-      "fingerprint": "65d13a0f10ee8816cb77a05dead5b3a17f47f84248740d9574bc06669a91ac9e",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "433cd3f0889bffe7b0592e65d9298cea78c5848114aae9056795cf2315131222",
-      "rule_id": "rs/no-path-traversal",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 21
-    },
-    {
-      "fingerprint": "1ec6ba7f3356078b65dec9cdba0551d57bba879602eef81a966ab1dc194e3854",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 30
-    },
-    {
-      "fingerprint": "835e315c53de1f3f03873ab092be6e1e41976c6ab2b42a97eb79d35205d1f82f",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 106
-    },
-    {
-      "fingerprint": "7465caf895f2654f1c71af53511394515712c5027f02d4ca0286582c8f5fed8d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 168
-    },
-    {
-      "fingerprint": "2eb8cb29cf86689a3a3adc2cc78b9296f2df4ba132650cb523e5790421888554",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 195
-    },
-    {
-      "fingerprint": "a8c019ee62c699770dc3ca5d4ae948ee0c480ed869ea3e4b7698eecc52af2f4d",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 226
-    },
-    {
-      "fingerprint": "0fbfee7b7fb457db978e237d5badd726e1b371486c62933e6c1ad003d6c12d95",
-      "rule_id": "rs/no-unwrap-in-lib",
-      "file": "tests/cnsa2_compliance.rs",
-      "line": 244
-    },
-    {
       "fingerprint": "e4c1e998ff0addd04964f8ef0ff3415760c5e38077fa5e83dfdeb1797be61b55",
       "rule_id": "rs/no-command-injection",
       "file": "tests/coccinelle_integration.rs",
@@ -9774,6 +9720,60 @@
       "rule_id": "js/no-command-injection",
       "file": "vscode-extension/src/extension.ts",
       "line": 368
+    },
+    {
+      "fingerprint": "0a42b62356bcfda1e3101c7a3984d2142b3c47ae38e6d4833d424f9aa9c69e45",
+      "rule_id": "rs/no-command-injection",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 17
+    },
+    {
+      "fingerprint": "65d13a0f10ee8816cb77a05dead5b3a17f47f84248740d9574bc06669a91ac9e",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "433cd3f0889bffe7b0592e65d9298cea78c5848114aae9056795cf2315131222",
+      "rule_id": "rs/no-path-traversal",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 21
+    },
+    {
+      "fingerprint": "1ec6ba7f3356078b65dec9cdba0551d57bba879602eef81a966ab1dc194e3854",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 30
+    },
+    {
+      "fingerprint": "835e315c53de1f3f03873ab092be6e1e41976c6ab2b42a97eb79d35205d1f82f",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 106
+    },
+    {
+      "fingerprint": "5d8d2215e927118481183ba827af1f4d02dd3d4695bc8d1ce35cce54a030635e",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 168
+    },
+    {
+      "fingerprint": "a62240bed8ea912db2bd39862589c3bfb4f0d0757ad8efc7db41adc8b4f4ce69",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 196
+    },
+    {
+      "fingerprint": "e20add3e29c2fb0127d43df4f31676df8718a260db3fbafbe9e5ba46aef14dc7",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 228
+    },
+    {
+      "fingerprint": "a15e12330ecf25d84493d1e21b982ba36ffc047da6cb5cd24203984ccf5d9201",
+      "rule_id": "rs/no-unwrap-in-lib",
+      "file": "tests/cnsa2_compliance.rs",
+      "line": 246
     }
   ]
 }

--- a/tests/cnsa2_compliance.rs
+++ b/tests/cnsa2_compliance.rs
@@ -167,6 +167,7 @@ fn non_pq_findings_in_json_have_no_cnsa2_deadline() {
 fn cnsa2_flag_off_does_not_mention_cnsa_in_terminal() {
     let out = foxguard_cmd()
         .arg(fixture("vulnerable.py"))
+        .args(["--config", "/dev/null"])
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);
@@ -195,6 +196,7 @@ fn cnsa2_flag_on_adds_deadline_annotation_and_summary() {
     let out = foxguard_cmd()
         .arg(fixture("vulnerable.py"))
         .arg("--cnsa2")
+        .args(["--config", "/dev/null"])
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);
@@ -225,7 +227,7 @@ fn sarif_always_includes_cnsa2_deadline_in_properties() {
     // `cnsa2Deadline` per SARIF convention — not snake_case.
     let out = foxguard_cmd()
         .arg(fixture("vulnerable.py"))
-        .args(["--format", "sarif"])
+        .args(["--format", "sarif", "--config", "/dev/null"])
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);
@@ -243,7 +245,7 @@ fn sarif_always_includes_cnsa2_deadline_in_properties() {
 fn sarif_includes_dep_name_in_properties() {
     let out = foxguard_cmd()
         .arg(fixture("deps/requirements.txt"))
-        .args(["--format", "sarif"])
+        .args(["--format", "sarif", "--config", "/dev/null"])
         .output()
         .expect("foxguard should run");
     let text = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
## Summary

- Four end-to-end tests in `tests/cnsa2_compliance.rs` were failing because they were missing `--config /dev/null`, causing them to pick up the repo's `.foxguard.yml` baseline which suppresses all fixture findings
- Added `--config /dev/null` to the terminal (`--cnsa2` on/off), SARIF deadline, and SARIF dep_name test invocations, matching the pattern already used by the JSON tests via `scan_json_findings()`
- Updated `.foxguard/baseline.json` entries for the shifted line numbers in the test file

## Root cause

The `scan_json_findings()` helper already passed `--config /dev/null` to isolate JSON tests from developer-local config (with an inline comment explaining why). The four failing tests — `cnsa2_flag_on_adds_deadline_annotation_and_summary`, `sarif_always_includes_cnsa2_deadline_in_properties`, `sarif_includes_dep_name_in_properties`, and `cnsa2_flag_off_does_not_mention_cnsa_in_terminal` — invoked `foxguard_cmd()` directly without that flag, so the baseline suppressed all findings and the scans returned zero results.

## Test plan

- [x] `cargo test --all-features --test cnsa2_compliance` — all 8 tests pass
- [ ] CI green on this branch

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced CNSA2 compliance test isolation to ensure consistent results independent of local development configuration.

* **Chores**
  * Updated CNSA2 compliance baselines with refined security rule tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->