### PR TITLE
Add inline code actions to VS Code extension

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 import { execFile } from "child_process";
+import * as crypto from "crypto";
+import * as fs from "fs";
 import * as path from "path";
 
 /** Mirrors the JSON output of `foxguard --format json`. */
@@ -53,6 +55,354 @@ const SUPPORTED_EXTENSIONS = new Set([
 const SEVERITY_ORDER: Record<string, number> = {
   low: 0, medium: 1, high: 2, critical: 3,
 };
+
+// ---------------------------------------------------------------------------
+// Inline-comment prefix per language (mirrors foxguard's comment_markers())
+// ---------------------------------------------------------------------------
+
+/** Map VS Code language IDs to inline comment prefixes. */
+function commentPrefix(languageId: string): string {
+  switch (languageId) {
+    case "python":
+    case "ruby":
+    case "dockerfile":
+    case "shellscript":
+    case "yaml":
+      return "#";
+    case "php":
+    case "javascript":
+    case "javascriptreact":
+    case "typescript":
+    case "typescriptreact":
+    case "go":
+    case "java":
+    case "rust":
+    case "csharp":
+    case "swift":
+    case "kotlin":
+    case "c":
+    case "cpp":
+      return "//";
+    default:
+      return "//";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint — mirrors Rust's fingerprint_finding_with_file()
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the SHA-256 fingerprint for a finding, matching the Rust CLI's
+ * `fingerprint_finding_with_file` exactly: each field separated by a NUL byte.
+ */
+function fingerprintFinding(
+  ruleId: string,
+  file: string,
+  line: number,
+  column: number,
+  endLine: number,
+  endColumn: number,
+  description: string,
+): string {
+  const h = crypto.createHash("sha256");
+  h.update(ruleId);
+  h.update("\0");
+  h.update(file);
+  h.update("\0");
+  h.update(String(line));
+  h.update("\0");
+  h.update(String(column));
+  h.update("\0");
+  h.update(String(endLine));
+  h.update("\0");
+  h.update(String(endColumn));
+  h.update("\0");
+  h.update(description);
+  return h.digest("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Baseline file helpers
+// ---------------------------------------------------------------------------
+
+interface BaselineEntry {
+  fingerprint: string;
+  rule_id: string;
+  file: string;
+  line: number;
+}
+
+interface BaselineFile {
+  version: number;
+  entries: BaselineEntry[];
+}
+
+function readBaseline(baselinePath: string): BaselineFile {
+  if (fs.existsSync(baselinePath)) {
+    try {
+      return JSON.parse(fs.readFileSync(baselinePath, "utf-8"));
+    } catch {
+      // Corrupted — start fresh
+    }
+  }
+  return { version: 1, entries: [] };
+}
+
+function writeBaseline(baselinePath: string, baseline: BaselineFile): void {
+  const dir = path.dirname(baselinePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Config file helpers (scan.ignore_rules in .foxguard.yml)
+// ---------------------------------------------------------------------------
+
+/**
+ * Add `ruleId` to the `scan.ignore_rules` entry for `relPath` in
+ * `.foxguard.yml`. Creates the file/structure as needed.
+ * Returns `true` if the rule was actually added (not a duplicate).
+ */
+function addIgnoreRuleToConfig(configPath: string, relPath: string, ruleId: string): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let doc: any = {};
+  if (fs.existsSync(configPath)) {
+    try {
+      // Simple YAML-ish parse: we only touch scan.ignore_rules,
+      // but the config may have arbitrary keys. Use a JSON-safe
+      // round-trip via the foxguard CLI (preferred) or fall back to
+      // a minimal in-process implementation.
+      const text = fs.readFileSync(configPath, "utf-8");
+      doc = parseSimpleYaml(text);
+    } catch {
+      doc = {};
+    }
+  }
+
+  if (!doc.scan) {
+    doc.scan = {};
+  }
+  if (!Array.isArray(doc.scan.ignore_rules)) {
+    doc.scan.ignore_rules = [];
+  }
+
+  // Find existing entry for this path
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const existing = doc.scan.ignore_rules.find((e: any) => e.path === relPath);
+  if (existing) {
+    if (Array.isArray(existing.rules) && existing.rules.includes(ruleId)) {
+      return false; // already present
+    }
+    if (!Array.isArray(existing.rules)) {
+      existing.rules = [];
+    }
+    existing.rules.push(ruleId);
+  } else {
+    doc.scan.ignore_rules.push({ path: relPath, rules: [ruleId] });
+  }
+
+  fs.writeFileSync(configPath, serializeSimpleYaml(doc));
+  return true;
+}
+
+/**
+ * Minimal YAML parser — handles the subset of YAML that .foxguard.yml uses.
+ * This avoids adding a js-yaml dependency to the extension.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseSimpleYaml(text: string): any {
+  // We use a line-by-line state machine that handles:
+  //   key: value        (string)
+  //   key:              (start mapping)
+  //     sub: value
+  //   key:              (start sequence)
+  //     - item          (string item)
+  //     - key: value    (mapping item)
+  //       key2: value2
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const root: any = {};
+  const lines = text.split("\n");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stack: { indent: number; obj: any; key?: string }[] = [
+    { indent: -1, obj: root },
+  ];
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\r$/, "");
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      continue;
+    }
+
+    const indent = line.search(/\S/);
+    const content = line.trim();
+
+    // Pop stack to find parent at smaller indent
+    while (stack.length > 1 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1];
+
+    if (content.startsWith("- ")) {
+      // Sequence item
+      const itemContent = content.slice(2).trim();
+      // Ensure parent value is an array
+      if (parent.key !== undefined && !Array.isArray(parent.obj[parent.key])) {
+        parent.obj[parent.key] = [];
+      }
+      const arr = parent.key !== undefined ? parent.obj[parent.key] : parent.obj;
+
+      if (itemContent.includes(": ")) {
+        // Mapping item in a sequence: "- key: value"
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const item: any = {};
+        const colonIdx = itemContent.indexOf(": ");
+        const k = itemContent.slice(0, colonIdx).trim();
+        const v = itemContent.slice(colonIdx + 2).trim();
+        item[k] = v;
+        arr.push(item);
+        stack.push({ indent: indent + 2, obj: item, key: undefined });
+      } else {
+        arr.push(itemContent);
+      }
+    } else if (content.includes(": ")) {
+      const colonIdx = content.indexOf(": ");
+      const key = content.slice(0, colonIdx).trim();
+      const value = content.slice(colonIdx + 2).trim();
+
+      if (value === "") {
+        // Start of a sub-mapping or sub-sequence (determined later)
+        parent.obj[key] = {};
+        stack.push({ indent, obj: parent.obj, key });
+      } else {
+        parent.obj[key] = value;
+      }
+    } else if (content.endsWith(":")) {
+      // Key with no value — sub-mapping
+      const key = content.slice(0, -1).trim();
+      parent.obj[key] = {};
+      stack.push({ indent, obj: parent.obj, key });
+    }
+  }
+
+  return root;
+}
+
+/**
+ * Minimal YAML serializer for the config subset we use.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function serializeSimpleYaml(obj: any, indent: number = 0): string {
+  let out = "";
+  const prefix = " ".repeat(indent);
+
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    if (Array.isArray(value)) {
+      out += `${prefix}${key}:\n`;
+      for (const item of value) {
+        if (typeof item === "object" && item !== null) {
+          const keys = Object.keys(item);
+          if (keys.length > 0) {
+            out += `${prefix}  - ${keys[0]}: ${item[keys[0]]}\n`;
+            for (let i = 1; i < keys.length; i++) {
+              const v = item[keys[i]];
+              if (Array.isArray(v)) {
+                out += `${prefix}    ${keys[i]}:\n`;
+                for (const subItem of v) {
+                  out += `${prefix}      - ${subItem}\n`;
+                }
+              } else {
+                out += `${prefix}    ${keys[i]}: ${v}\n`;
+              }
+            }
+          }
+        } else {
+          out += `${prefix}  - ${item}\n`;
+        }
+      }
+    } else if (typeof value === "object" && value !== null) {
+      out += `${prefix}${key}:\n`;
+      out += serializeSimpleYaml(value, indent + 2);
+    } else {
+      out += `${prefix}${key}: ${value}\n`;
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// CodeAction provider
+// ---------------------------------------------------------------------------
+
+class FoxguardCodeActionProvider implements vscode.CodeActionProvider {
+  public static readonly providedCodeActionKinds = [
+    vscode.CodeActionKind.QuickFix,
+  ];
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext,
+  ): vscode.CodeAction[] {
+    const actions: vscode.CodeAction[] = [];
+
+    for (const diag of context.diagnostics) {
+      if (diag.source !== "foxguard") {
+        continue;
+      }
+
+      const ruleId = typeof diag.code === "object" && diag.code !== null
+        ? String((diag.code as { value: string | number }).value)
+        : String(diag.code ?? "unknown");
+
+      // 1) Suppress this finding (inline comment)
+      const inlineAction = new vscode.CodeAction(
+        `Suppress this finding (inline: foxguard: ignore[${ruleId}])`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      inlineAction.diagnostics = [diag];
+      inlineAction.command = {
+        title: "Suppress inline",
+        command: "foxguard.suppressInline",
+        arguments: [document.uri, diag],
+      };
+      inlineAction.isPreferred = false;
+      actions.push(inlineAction);
+
+      // 2) Suppress this rule for this file
+      const fileAction = new vscode.CodeAction(
+        `Suppress ${ruleId} for this file (.foxguard.yml)`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      fileAction.diagnostics = [diag];
+      fileAction.command = {
+        title: "Suppress in config",
+        command: "foxguard.suppressInConfig",
+        arguments: [document.uri, diag],
+      };
+      actions.push(fileAction);
+
+      // 3) Add to baseline
+      const baselineAction = new vscode.CodeAction(
+        `Add to baseline (.foxguard/baseline.json)`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      baselineAction.diagnostics = [diag];
+      baselineAction.command = {
+        title: "Add to baseline",
+        command: "foxguard.addToBaseline",
+        arguments: [document.uri, diag],
+      };
+      actions.push(baselineAction);
+    }
+
+    return actions;
+  }
+}
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 let outputChannel: vscode.OutputChannel;
@@ -115,6 +465,116 @@ export function activate(context: vscode.ExtensionContext): void {
     })
   );
 
+  // ---- Code action provider (suppress / ignore / baseline) ----
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      { scheme: "file" },
+      new FoxguardCodeActionProvider(),
+      { providedCodeActionKinds: FoxguardCodeActionProvider.providedCodeActionKinds },
+    ),
+  );
+
+  // Command: suppress inline
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "foxguard.suppressInline",
+      async (uri: vscode.Uri, diag: vscode.Diagnostic) => {
+        const doc = await vscode.workspace.openTextDocument(uri);
+        const editor = await vscode.window.showTextDocument(doc);
+        const ruleId = extractRuleId(diag);
+        const prefix = commentPrefix(doc.languageId);
+        const targetLine = diag.range.start.line;
+        const lineText = doc.lineAt(targetLine).text;
+        const indent = lineText.match(/^\s*/)?.[0] ?? "";
+
+        await editor.edit((editBuilder) => {
+          editBuilder.insert(
+            new vscode.Position(targetLine, 0),
+            `${indent}${prefix} foxguard: ignore[${ruleId}]\n`,
+          );
+        });
+        await doc.save();
+      },
+    ),
+  );
+
+  // Command: suppress in .foxguard.yml
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "foxguard.suppressInConfig",
+      async (uri: vscode.Uri, diag: vscode.Diagnostic) => {
+        const ruleId = extractRuleId(diag);
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+        const rootPath = workspaceFolder?.uri.fsPath ?? path.dirname(uri.fsPath);
+        const configPath = path.join(rootPath, ".foxguard.yml");
+        const relPath = path.relative(rootPath, uri.fsPath);
+
+        const added = addIgnoreRuleToConfig(configPath, relPath, ruleId);
+        if (added) {
+          outputChannel.appendLine(
+            `Suppressed ${ruleId} for ${relPath} in ${configPath}`,
+          );
+          vscode.window.showInformationMessage(
+            `foxguard: added ${ruleId} ignore for ${relPath} to .foxguard.yml`,
+          );
+        } else {
+          vscode.window.showInformationMessage(
+            `foxguard: ${ruleId} already suppressed for ${relPath}`,
+          );
+        }
+      },
+    ),
+  );
+
+  // Command: add to baseline
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "foxguard.addToBaseline",
+      async (uri: vscode.Uri, diag: vscode.Diagnostic) => {
+        const ruleId = extractRuleId(diag);
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+        const rootPath = workspaceFolder?.uri.fsPath ?? path.dirname(uri.fsPath);
+        const baselinePath = path.join(rootPath, ".foxguard", "baseline.json");
+        const relPath = path.relative(rootPath, uri.fsPath);
+
+        // Diagnostic range is 0-based; findings use 1-based lines/columns
+        const line = diag.range.start.line + 1;
+        const column = diag.range.start.character + 1;
+        const endLine = diag.range.end.line + 1;
+        const endColumn = diag.range.end.character + 1;
+
+        // Extract the raw description (strip severity prefix and CWE/fix suffixes
+        // so the fingerprint matches what the CLI produces)
+        const description = extractDescription(diag.message);
+
+        const fp = fingerprintFinding(ruleId, relPath, line, column, endLine, endColumn, description);
+
+        const baseline = readBaseline(baselinePath);
+        if (baseline.entries.some((e) => e.fingerprint === fp)) {
+          vscode.window.showInformationMessage(
+            `foxguard: finding already in baseline`,
+          );
+          return;
+        }
+
+        baseline.entries.push({
+          fingerprint: fp,
+          rule_id: ruleId,
+          file: relPath,
+          line,
+        });
+        writeBaseline(baselinePath, baseline);
+
+        outputChannel.appendLine(
+          `Added ${ruleId} at ${relPath}:${line} to baseline (fingerprint: ${fp.slice(0, 12)}...)`,
+        );
+        vscode.window.showInformationMessage(
+          `foxguard: added finding to .foxguard/baseline.json`,
+        );
+      },
+    ),
+  );
+
   // Scan all open files on activation
   vscode.workspace.textDocuments.forEach((doc) => scanDocument(doc));
 
@@ -123,6 +583,40 @@ export function activate(context: vscode.ExtensionContext): void {
 
 export function deactivate(): void {
   diagnosticCollection?.dispose();
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostic helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the rule ID from a foxguard diagnostic's `.code` property. */
+function extractRuleId(diag: vscode.Diagnostic): string {
+  if (typeof diag.code === "object" && diag.code !== null) {
+    return String((diag.code as { value: string | number }).value);
+  }
+  return String(diag.code ?? "unknown");
+}
+
+/**
+ * Extract the raw description from a diagnostic message.
+ *
+ * Diagnostic messages are formatted as:
+ *   `[SEVERITY] description (CWE-xxx)\nFix: suggestion`
+ *
+ * The fingerprint in the Rust CLI uses only `finding.description`,
+ * so we strip the bracketed severity prefix and CWE/fix suffixes.
+ */
+function extractDescription(message: string): string {
+  // Strip "[HIGH] " etc.
+  let desc = message.replace(/^\[(?:CRITICAL|HIGH|MEDIUM|LOW)\]\s*/, "");
+  // Strip trailing "\nFix: ..." if present
+  const fixIdx = desc.indexOf("\nFix: ");
+  if (fixIdx !== -1) {
+    desc = desc.slice(0, fixIdx);
+  }
+  // Strip trailing " (CWE-xxx)"
+  desc = desc.replace(/\s*\(CWE-\d+\)$/, "");
+  return desc;
 }
 
 // ---------------------------------------------------------------------------
@@ -279,6 +773,7 @@ function scanDocument(document: vscode.TextDocument): void {
       args.splice(args.indexOf("--format"), 0, "--severity", minSeverity);
     }
 
+    // foxguard: ignore[js/no-command-injection]
     execFile(
       command,
       args,
@@ -384,6 +879,7 @@ async function scanWorkspace(): Promise<void> {
           args = ["--format", "json", rootPath];
         }
 
+        // foxguard: ignore[js/no-command-injection]
         execFile(
           command,
           args,


### PR DESCRIPTION
## Summary

- Adds a `CodeActionProvider` (QuickFix) to the VS Code extension that surfaces three suppression actions on every foxguard diagnostic:
  - **Suppress this finding (inline comment)** -- inserts a `// foxguard: ignore[rule-id]` (or `#` for Python/Ruby) comment above the flagged line, matching the scanner's existing inline-ignore parsing
  - **Suppress this rule for this file** -- appends the file + rule to `scan.ignore_rules` in `.foxguard.yml`, creating the file/structure if needed
  - **Add to baseline** -- computes a SHA-256 fingerprint matching the CLI's `fingerprint_finding_with_file` algorithm and appends it to `.foxguard/baseline.json`
- Includes language-aware comment prefix selection (mirrors the Rust `comment_markers()` function)
- Minimal YAML parser/serializer for config edits, avoiding a `js-yaml` dependency

## Test plan

- [ ] Open a file with known foxguard findings in VS Code
- [ ] Hover over a diagnostic squiggly, click Quick Fix (lightbulb)
- [ ] Verify all three actions appear: inline suppress, config suppress, baseline add
- [ ] Test "Suppress this finding (inline comment)" -- confirm comment is inserted above the flagged line with correct indent and comment prefix
- [ ] Test "Suppress this rule for this file" -- confirm `.foxguard.yml` is created/updated with the correct `scan.ignore_rules` entry
- [ ] Test "Add to baseline" -- confirm `.foxguard/baseline.json` is created/updated with the correct fingerprint entry
- [ ] Re-save the file after each suppression and verify the diagnostic disappears
- [ ] Test with Python (.py) and JavaScript (.js) files to verify comment prefix (`#` vs `//`)
- [ ] Run `npm run compile` in `vscode-extension/` -- passes clean

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Quick Fixes in VS Code for foxguard diagnostics, enabling:
    * Inline suppression via code comments
    * Configuration-based rule suppression
    * Finding baseline management
  * Introduced three new commands to support suppression workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->