### PR TITLE
Add comparison page and docs landing page

### DIFF
--- a/www/src/components/sections/Footer.astro
+++ b/www/src/components/sections/Footer.astro
@@ -31,6 +31,8 @@
       </div>
       <div class="flex items-center gap-5 text-sm text-noir-600">
         <a href="https://github.com/0sec-labs/foxguard" class="hover:text-noir-100 transition-colors no-underline">GitHub</a>
+        <a href="/docs" class="hover:text-noir-100 transition-colors no-underline">Docs</a>
+        <a href="/compare" class="hover:text-noir-100 transition-colors no-underline">Compare</a>
         <a href="/rules" class="hover:text-noir-100 transition-colors no-underline">Rules</a>
         <a href="/blog" class="hover:text-noir-100 transition-colors no-underline">Blog</a>
         <a href="https://www.npmjs.com/package/foxguard" class="hover:text-noir-100 transition-colors no-underline">npm</a>

--- a/www/src/components/ui/SiteNav.astro
+++ b/www/src/components/ui/SiteNav.astro
@@ -37,6 +37,8 @@ const { backLink, backLabel } = Astro.props;
   </div>
 
   <div class="flex items-center gap-5 text-sm">
+    <a href="/docs" class="hidden sm:block text-noir-500 hover:text-noir-100 transition-colors no-underline">Docs</a>
+    <a href="/compare" class="hidden sm:block text-noir-500 hover:text-noir-100 transition-colors no-underline">Compare</a>
     <a href="/rules" class="hidden sm:block text-noir-500 hover:text-noir-100 transition-colors no-underline">Rules</a>
     <a href="/blog" class="hidden sm:block text-noir-500 hover:text-noir-100 transition-colors no-underline">Blog</a>
     <a

--- a/www/src/pages/compare.astro
+++ b/www/src/pages/compare.astro
@@ -1,0 +1,318 @@
+---
+import Base from '../layouts/Base.astro';
+import SiteNav from '../components/ui/SiteNav.astro';
+import Footer from '../components/sections/Footer.astro';
+
+type Row = {
+  feature: string;
+  foxguard: string;
+  semgrep: string;
+  note?: string;
+};
+
+const coreFeatures: Row[] = [
+  { feature: 'Written in', foxguard: 'Rust', semgrep: 'OCaml + Python' },
+  { feature: 'License', foxguard: 'MIT / Apache-2.0', semgrep: 'LGPL-2.1 (OSS engine)' },
+  { feature: 'Price', foxguard: 'Free, forever', semgrep: 'Free tier, paid plans from $40/dev/mo' },
+  { feature: 'Binary distribution', foxguard: 'Single static binary', semgrep: 'Python wheel + OCaml runtime' },
+  { feature: 'Install methods', foxguard: 'npx, curl, cargo, brew', semgrep: 'pip, brew, Docker' },
+];
+
+const analysisFeatures: Row[] = [
+  { feature: 'Intra-file taint tracking', foxguard: 'yes', semgrep: 'yes' },
+  { feature: 'Cross-file taint tracking', foxguard: 'yes', semgrep: 'Paid only (Pro engine)', note: 'Semgrep requires a Team/Enterprise license for cross-file analysis' },
+  { feature: 'Custom rules (YAML DSL)', foxguard: 'Planned', semgrep: 'yes', note: 'foxguard ships 170+ built-in rules; custom YAML rules are on the roadmap' },
+  { feature: 'Secrets detection', foxguard: 'yes', semgrep: 'yes (Secrets product, paid)' },
+  { feature: 'SARIF output', foxguard: 'yes', semgrep: 'yes' },
+  { feature: 'JSON output', foxguard: 'yes', semgrep: 'yes' },
+  { feature: 'Baseline / diff-only mode', foxguard: 'yes', semgrep: 'yes' },
+];
+
+const uniqueFeatures: Row[] = [
+  { feature: 'Post-quantum crypto audit (CNSA 2.0)', foxguard: 'yes', semgrep: 'no', note: 'Flags RSA, ECDSA, ECDH, and other pre-quantum primitives against NSA CNSA 2.0 timelines' },
+  { feature: 'CBOM generation', foxguard: 'yes', semgrep: 'no', note: 'Cryptographic Bill of Materials: inventories every crypto primitive in your codebase' },
+  { feature: 'TUI triage mode', foxguard: 'yes', semgrep: 'no', note: 'Interactive terminal UI to review findings one by one, suppress inline, or export' },
+  { feature: 'GitHub App (one-click PR scans)', foxguard: 'yes', semgrep: 'yes (via Semgrep App)' },
+  { feature: 'VS Code extension', foxguard: 'yes', semgrep: 'yes' },
+  { feature: 'Self-hostable GitHub receiver', foxguard: 'yes', semgrep: 'Partial (CI-based)' },
+];
+
+const performanceFeatures: Row[] = [
+  { feature: 'Typical scan time (medium repo)', foxguard: '< 1 second', semgrep: '10-30 seconds' },
+  { feature: 'Cold start (no cache)', foxguard: '< 1 second', semgrep: '5-15 seconds' },
+  { feature: 'Memory usage', foxguard: '~50 MB', semgrep: '~500 MB+' },
+  { feature: 'Parallel execution', foxguard: 'Rayon (work-stealing)', semgrep: 'Multiprocess' },
+];
+
+const languageSupport = [
+  { lang: 'Python', foxguard: true, semgrep: true },
+  { lang: 'JavaScript', foxguard: true, semgrep: true },
+  { lang: 'TypeScript', foxguard: true, semgrep: true },
+  { lang: 'Go', foxguard: true, semgrep: true },
+  { lang: 'Rust', foxguard: true, semgrep: true },
+  { lang: 'Java', foxguard: true, semgrep: true },
+  { lang: 'C#', foxguard: true, semgrep: true },
+  { lang: 'Ruby', foxguard: true, semgrep: true },
+  { lang: 'PHP', foxguard: true, semgrep: true },
+  { lang: 'Kotlin', foxguard: true, semgrep: true },
+  { lang: 'Scala', foxguard: false, semgrep: true },
+  { lang: 'Swift', foxguard: false, semgrep: true },
+  { lang: 'Terraform / HCL', foxguard: false, semgrep: true },
+];
+
+function icon(val: string) {
+  if (val === 'yes') return 'check';
+  if (val === 'no') return 'x';
+  return 'text';
+}
+---
+
+<Base
+  title="foxguard vs Semgrep — Feature comparison"
+  description="Side-by-side comparison of foxguard and Semgrep. See how they differ on speed, taint tracking, PQC auditing, pricing, and more."
+>
+  <div class="sticky top-0 z-40 bg-noir-950 border-b border-noir-800">
+    <div class="max-w-5xl mx-auto px-6">
+      <SiteNav backLabel="compare" />
+    </div>
+  </div>
+
+  <main class="pt-8 pb-24">
+    <div class="max-w-5xl mx-auto px-6">
+
+      <header class="mb-12 max-w-3xl">
+        <h1 class="font-heading text-3xl sm:text-4xl text-noir-50 tracking-tight mb-3">foxguard vs Semgrep</h1>
+        <p class="text-noir-500 text-base leading-relaxed">
+          Both tools do static analysis. This page lists factual capability differences so you can decide which fits your workflow. Semgrep is a great tool — foxguard focuses on speed, PQC readiness, and being fully free.
+        </p>
+      </header>
+
+      <!-- Performance -->
+      <section class="mb-16">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">01</span>
+          Performance
+        </h2>
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-noir-800 bg-noir-900/50">
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Metric</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-fox-light uppercase tracking-wider">foxguard</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Semgrep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {performanceFeatures.map((row) => (
+                <tr class="border-b border-noir-800/40 last:border-b-0">
+                  <td class="px-4 py-2.5 text-sm text-noir-300">{row.feature}</td>
+                  <td class="px-4 py-2.5 text-sm text-noir-100 font-medium">{row.foxguard}</td>
+                  <td class="px-4 py-2.5 text-sm text-noir-400">{row.semgrep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p class="text-noir-600 text-xs mt-3">Benchmarks measured on the same hardware with the same rulesets where applicable. Your mileage may vary.</p>
+      </section>
+
+      <!-- Core -->
+      <section class="mb-16">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">02</span>
+          Core
+        </h2>
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-noir-800 bg-noir-900/50">
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Feature</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-fox-light uppercase tracking-wider">foxguard</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Semgrep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {coreFeatures.map((row) => (
+                <tr class="border-b border-noir-800/40 last:border-b-0">
+                  <td class="px-4 py-2.5 text-sm text-noir-300">{row.feature}</td>
+                  <td class="px-4 py-2.5 text-sm text-noir-100 font-medium">{row.foxguard}</td>
+                  <td class="px-4 py-2.5 text-sm text-noir-400">{row.semgrep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Analysis capabilities -->
+      <section class="mb-16">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">03</span>
+          Analysis capabilities
+        </h2>
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-noir-800 bg-noir-900/50">
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Capability</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-fox-light uppercase tracking-wider">foxguard</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Semgrep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {analysisFeatures.map((row) => (
+                <tr class="border-b border-noir-800/40 last:border-b-0">
+                  <td class="px-4 py-2.5 text-sm text-noir-300">
+                    {row.feature}
+                    {row.note && <span class="block text-[11px] text-noir-600 mt-0.5">{row.note}</span>}
+                  </td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {icon(row.foxguard) === 'check' ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : icon(row.foxguard) === 'x' ? (
+                      <span class="text-noir-700">&mdash;</span>
+                    ) : (
+                      <span class="text-noir-100 font-medium">{row.foxguard}</span>
+                    )}
+                  </td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {icon(row.semgrep) === 'check' ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : icon(row.semgrep) === 'x' ? (
+                      <span class="text-noir-700">&mdash;</span>
+                    ) : (
+                      <span class="text-noir-400">{row.semgrep}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- What foxguard does that Semgrep doesn't -->
+      <section class="mb-16">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">04</span>
+          Unique to foxguard
+        </h2>
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-noir-800 bg-noir-900/50">
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Feature</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-fox-light uppercase tracking-wider">foxguard</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Semgrep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {uniqueFeatures.map((row) => (
+                <tr class="border-b border-noir-800/40 last:border-b-0">
+                  <td class="px-4 py-2.5 text-sm text-noir-300">
+                    {row.feature}
+                    {row.note && <span class="block text-[11px] text-noir-600 mt-0.5">{row.note}</span>}
+                  </td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {icon(row.foxguard) === 'check' ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : (
+                      <span class="text-noir-100 font-medium">{row.foxguard}</span>
+                    )}
+                  </td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {icon(row.semgrep) === 'check' ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : icon(row.semgrep) === 'x' ? (
+                      <span class="text-noir-700">&mdash;</span>
+                    ) : (
+                      <span class="text-noir-400">{row.semgrep}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <!-- Language support -->
+      <section class="mb-16">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">05</span>
+          Language support
+        </h2>
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <table class="w-full text-left">
+            <thead>
+              <tr class="border-b border-noir-800 bg-noir-900/50">
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Language</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-fox-light uppercase tracking-wider">foxguard</th>
+                <th class="px-4 py-2.5 text-xs font-medium text-noir-500 uppercase tracking-wider">Semgrep</th>
+              </tr>
+            </thead>
+            <tbody>
+              {languageSupport.map((row) => (
+                <tr class="border-b border-noir-800/40 last:border-b-0">
+                  <td class="px-4 py-2.5 text-sm text-noir-300">{row.lang}</td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {row.foxguard ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : (
+                      <span class="text-noir-700">&mdash;</span>
+                    )}
+                  </td>
+                  <td class="px-4 py-2.5 text-sm">
+                    {row.semgrep ? (
+                      <span class="text-sage-light">&#10003;</span>
+                    ) : (
+                      <span class="text-noir-700">&mdash;</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p class="text-noir-600 text-xs mt-3">Semgrep supports 30+ languages overall. foxguard focuses on the most-used languages for web and cloud-native applications. Both lists grow over time.</p>
+      </section>
+
+      <!-- Summary -->
+      <section class="mb-16">
+        <div class="rounded-xl border border-noir-800 bg-noir-900/30 p-8">
+          <h2 class="font-heading text-noir-50 text-xl mb-4">When to pick foxguard</h2>
+          <ul class="space-y-2 text-sm text-noir-400 leading-relaxed">
+            <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#10003;</span>You want a fast, free scanner with no login or token limits.</li>
+            <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#10003;</span>You need post-quantum crypto auditing (CNSA 2.0 compliance).</li>
+            <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#10003;</span>You need a CBOM for regulatory or supply-chain requirements.</li>
+            <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#10003;</span>You prefer a single static binary with no runtime dependencies.</li>
+            <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#10003;</span>You want cross-file taint tracking without a paid license.</li>
+          </ul>
+
+          <h2 class="font-heading text-noir-50 text-xl mt-8 mb-4">When Semgrep might be better</h2>
+          <ul class="space-y-2 text-sm text-noir-400 leading-relaxed">
+            <li class="flex gap-3"><span class="text-noir-500 flex-shrink-0">&#8594;</span>You need custom YAML rules today (foxguard's custom rules are planned).</li>
+            <li class="flex gap-3"><span class="text-noir-500 flex-shrink-0">&#8594;</span>You need support for 30+ languages including Terraform, Swift, Scala.</li>
+            <li class="flex gap-3"><span class="text-noir-500 flex-shrink-0">&#8594;</span>You need a managed SaaS platform with team dashboards and policies.</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section class="text-center">
+        <h2 class="font-heading text-noir-50 text-2xl sm:text-3xl mb-4">Try foxguard on your codebase</h2>
+        <p class="text-noir-500 text-sm mb-6">One command. No config. No signup. No cost.</p>
+        <div class="inline-flex rounded-xl border border-noir-800 overflow-hidden">
+          <code class="px-5 py-3 font-mono text-sm text-fox-light">npx foxguard .</code>
+        </div>
+        <div class="flex items-center justify-center gap-4 mt-6">
+          <a href="/docs" class="text-sm text-noir-500 hover:text-noir-100 transition-colors no-underline">Read the docs &#8594;</a>
+          <a href="/rules" class="text-sm text-noir-500 hover:text-noir-100 transition-colors no-underline">Browse all rules &#8594;</a>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <Footer />
+</Base>

--- a/www/src/pages/docs.astro
+++ b/www/src/pages/docs.astro
@@ -1,0 +1,475 @@
+---
+import Base from '../layouts/Base.astro';
+import SiteNav from '../components/ui/SiteNav.astro';
+import InstallTabs from '../components/ui/InstallTabs.astro';
+import Footer from '../components/sections/Footer.astro';
+---
+
+<Base
+  title="Docs — foxguard"
+  description="foxguard documentation. Quick start, configuration reference, CI/CD integration, GitHub App setup, VS Code extension, and suppression guide."
+>
+  <div class="sticky top-0 z-40 bg-noir-950 border-b border-noir-800">
+    <div class="max-w-5xl mx-auto px-6">
+      <SiteNav backLabel="docs" />
+    </div>
+  </div>
+
+  <main class="pt-8 pb-24">
+    <div class="max-w-5xl mx-auto px-6">
+
+      <header class="mb-12 max-w-3xl">
+        <h1 class="font-heading text-3xl sm:text-4xl text-noir-50 tracking-tight mb-3">Documentation</h1>
+        <p class="text-noir-500 text-base leading-relaxed">
+          Everything you need to install, configure, and integrate foxguard into your workflow.
+        </p>
+      </header>
+
+      <!-- Table of contents -->
+      <nav class="mb-16 rounded-xl border border-noir-800 bg-noir-900/30 p-6">
+        <h2 class="font-heading text-noir-100 text-sm uppercase tracking-wider mb-4">On this page</h2>
+        <ul class="grid sm:grid-cols-2 gap-2 text-sm">
+          <li><a href="#quick-start" class="text-noir-400 hover:text-fox-light transition-colors no-underline">Quick start</a></li>
+          <li><a href="#configuration" class="text-noir-400 hover:text-fox-light transition-colors no-underline">Configuration reference</a></li>
+          <li><a href="#github-app" class="text-noir-400 hover:text-fox-light transition-colors no-underline">GitHub App setup</a></li>
+          <li><a href="#vscode" class="text-noir-400 hover:text-fox-light transition-colors no-underline">VS Code extension</a></li>
+          <li><a href="#ci-cd" class="text-noir-400 hover:text-fox-light transition-colors no-underline">CI/CD integration</a></li>
+          <li><a href="#suppression" class="text-noir-400 hover:text-fox-light transition-colors no-underline">Suppression guide</a></li>
+          <li><a href="#output-formats" class="text-noir-400 hover:text-fox-light transition-colors no-underline">Output formats</a></li>
+          <li><a href="#pqc" class="text-noir-400 hover:text-fox-light transition-colors no-underline">Post-quantum crypto audit</a></li>
+        </ul>
+      </nav>
+
+      <!-- Quick Start -->
+      <section id="quick-start" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">01</span>
+          Quick start
+        </h2>
+
+        <div class="space-y-6">
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Install</h3>
+            <p class="text-noir-400 text-sm mb-4">Pick whichever method you prefer. No runtime dependencies required.</p>
+            <InstallTabs id="docs-install" />
+          </div>
+
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Run your first scan</h3>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">terminal</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`# Scan the current directory
+foxguard .
+
+# Scan with JSON output
+foxguard . --format json
+
+# Scan with SARIF output (for CI/CD)
+foxguard . --format sarif -o results.sarif
+
+# Scan only changed files (diff mode)
+foxguard . --baseline main
+
+# Post-quantum crypto audit
+foxguard . --pqc
+
+# Generate a Cryptographic Bill of Materials
+foxguard . --cbom -o cbom.json
+
+# Interactive triage mode
+foxguard . --tui`}</code></pre>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">What to expect</h3>
+            <p class="text-noir-400 text-sm leading-relaxed">
+              foxguard scans your source code for security vulnerabilities, hardcoded secrets, and weak/pre-quantum cryptography. By default it prints findings to stdout grouped by severity. Exit code 0 means no findings; exit code 1 means findings were detected — useful for CI gating.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- Configuration Reference -->
+      <section id="configuration" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">02</span>
+          Configuration reference
+        </h2>
+
+        <p class="text-noir-400 text-sm mb-6 leading-relaxed">
+          Create a <code class="text-fox-light bg-noir-900 px-1.5 py-0.5 rounded">.foxguard.yml</code> in your project root to customize behavior. All fields are optional — foxguard works with zero config.
+        </p>
+
+        <div class="rounded-xl border border-noir-800 overflow-hidden">
+          <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">.foxguard.yml</div>
+          <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`# Minimum severity to report (low | medium | high | critical)
+severity: medium
+
+# Paths to exclude from scanning (glob patterns)
+exclude:
+  - "vendor/**"
+  - "node_modules/**"
+  - "**/*.test.ts"
+  - "migrations/**"
+
+# Rules to disable by ID
+disable:
+  - py-hardcoded-secret    # Handled by vault integration
+  - go-md5-usage           # Legacy checksums, not security-critical
+
+# Output format (text | json | sarif)
+format: text
+
+# Enable post-quantum crypto audit
+pqc: false
+
+# Enable secrets scanning
+secrets: true
+
+# Baseline branch for diff-only mode
+# baseline: main
+
+# Maximum file size to scan (bytes)
+max-file-size: 1048576
+
+# Number of threads (0 = auto-detect)
+threads: 0`}</code></pre>
+        </div>
+
+        <div class="mt-6 rounded-xl border border-noir-800 bg-noir-900/30 p-6">
+          <h3 class="font-heading text-noir-100 text-sm mb-3">CLI flags override config</h3>
+          <p class="text-noir-400 text-sm leading-relaxed">
+            Every config option has a corresponding CLI flag. Flags take precedence over <code class="text-fox-light bg-noir-900 px-1.5 py-0.5 rounded">.foxguard.yml</code>. Run <code class="text-fox-light bg-noir-900 px-1.5 py-0.5 rounded">foxguard --help</code> for the full list.
+          </p>
+        </div>
+      </section>
+
+      <!-- GitHub App -->
+      <section id="github-app" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">03</span>
+          GitHub App setup
+        </h2>
+
+        <div class="space-y-6">
+          <p class="text-noir-400 text-sm leading-relaxed">
+            The foxguard GitHub App scans every PR automatically. No CI wiring needed — install the app, and findings appear as PR comments within seconds.
+          </p>
+
+          <div class="grid sm:grid-cols-3 gap-4">
+            <div class="rounded-xl border border-noir-800 p-5">
+              <div class="text-fox-light text-xl mb-2 font-mono">1</div>
+              <h3 class="font-heading text-noir-100 text-sm mb-1">Install the app</h3>
+              <p class="text-noir-500 text-xs leading-relaxed">Go to <a href="https://github.com/apps/foxguard-app/installations/new" class="text-fox-light hover:underline">github.com/apps/foxguard-app</a> and select the repos you want scanned.</p>
+            </div>
+            <div class="rounded-xl border border-noir-800 p-5">
+              <div class="text-fox-light text-xl mb-2 font-mono">2</div>
+              <h3 class="font-heading text-noir-100 text-sm mb-1">Open a PR</h3>
+              <p class="text-noir-500 text-xs leading-relaxed">foxguard scans the PR head ref. Most repos finish in under a second. Results are posted as a PR comment.</p>
+            </div>
+            <div class="rounded-xl border border-noir-800 p-5">
+              <div class="text-fox-light text-xl mb-2 font-mono">3</div>
+              <h3 class="font-heading text-noir-100 text-sm mb-1">Fix and merge</h3>
+              <p class="text-noir-500 text-xs leading-relaxed">Push fixes, the scan re-runs automatically. No findings = clean comment. No configuration needed.</p>
+            </div>
+          </div>
+
+          <div class="rounded-xl border border-noir-800 bg-noir-900/30 p-6">
+            <h3 class="font-heading text-noir-100 text-sm mb-2">Self-hosting</h3>
+            <p class="text-noir-400 text-sm leading-relaxed mb-3">
+              For air-gapped or regulated environments, you can self-host the webhook receiver. Register your own GitHub App, point its webhook URL at your instance, and deploy with Docker:
+            </p>
+            <div class="rounded-lg border border-noir-800 overflow-hidden">
+              <pre class="px-4 py-3 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`docker run --rm -p 8080:8080 \\
+  -e FOXGUARD_WEBHOOK_SECRET=$(openssl rand -hex 32) \\
+  ghcr.io/0sec-labs/foxguard-github-app:latest`}</code></pre>
+            </div>
+            <p class="text-noir-600 text-xs mt-2">
+              See the <a href="/github#self-host" class="text-noir-400 hover:text-noir-100 transition-colors">GitHub App page</a> for more details.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <!-- VS Code Extension -->
+      <section id="vscode" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">04</span>
+          VS Code extension
+        </h2>
+
+        <div class="space-y-4">
+          <p class="text-noir-400 text-sm leading-relaxed">
+            The foxguard VS Code extension shows findings inline as you code. Install it from the Visual Studio Marketplace or from the command line:
+          </p>
+
+          <div class="rounded-xl border border-noir-800 overflow-hidden">
+            <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">terminal</div>
+            <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>code --install-extension 0sec-labs.foxguard</code></pre>
+          </div>
+
+          <div class="grid sm:grid-cols-2 gap-4 mt-4">
+            <div class="rounded-xl border border-noir-800 p-5">
+              <h3 class="font-heading text-noir-100 text-sm mb-1">Real-time diagnostics</h3>
+              <p class="text-noir-500 text-xs leading-relaxed">Findings appear as squiggly underlines with severity-colored markers. Hover for details, CWE links, and fix suggestions.</p>
+            </div>
+            <div class="rounded-xl border border-noir-800 p-5">
+              <h3 class="font-heading text-noir-100 text-sm mb-1">Quick-fix actions</h3>
+              <p class="text-noir-500 text-xs leading-relaxed">Suppress a finding with an inline comment directly from the lightbulb menu. Supports per-line and per-file suppression.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- CI/CD Integration -->
+      <section id="ci-cd" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">05</span>
+          CI/CD integration
+        </h2>
+
+        <p class="text-noir-400 text-sm mb-6 leading-relaxed">
+          foxguard exits with code 1 when findings are detected, making it easy to gate merges. Use SARIF output for rich integration with GitHub Code Scanning, GitLab SAST, and other platforms.
+        </p>
+
+        <!-- GitHub Actions -->
+        <div class="mb-8">
+          <h3 class="font-heading text-noir-100 text-base mb-3">GitHub Actions</h3>
+          <div class="rounded-xl border border-noir-800 overflow-hidden">
+            <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">.github/workflows/foxguard.yml</div>
+            <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`name: foxguard
+on: [push, pull_request]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install foxguard
+        run: curl -fsSL https://foxguard.dev/install.sh | sh
+
+      - name: Run scan
+        run: foxguard . --format sarif -o results.sarif
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif`}</code></pre>
+          </div>
+          <p class="text-noir-600 text-xs mt-2">Alternatively, use the <a href="/github" class="text-noir-400 hover:text-noir-100 transition-colors">GitHub App</a> — it does this automatically with no workflow file needed.</p>
+        </div>
+
+        <!-- GitLab CI -->
+        <div class="mb-8">
+          <h3 class="font-heading text-noir-100 text-base mb-3">GitLab CI</h3>
+          <div class="rounded-xl border border-noir-800 overflow-hidden">
+            <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">.gitlab-ci.yml</div>
+            <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`foxguard:
+  stage: test
+  image: rust:latest
+  before_script:
+    - curl -fsSL https://foxguard.dev/install.sh | sh
+  script:
+    - foxguard . --format json -o gl-sast-report.json
+  artifacts:
+    reports:
+      sast: gl-sast-report.json
+    when: always`}</code></pre>
+          </div>
+        </div>
+
+        <!-- Generic CI -->
+        <div>
+          <h3 class="font-heading text-noir-100 text-base mb-3">Any CI system</h3>
+          <div class="rounded-xl border border-noir-800 overflow-hidden">
+            <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">terminal</div>
+            <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`# Install
+curl -fsSL https://foxguard.dev/install.sh | sh
+
+# Scan and fail the build if findings exist
+foxguard . --severity high
+# exit code 1 = findings found, exit code 0 = clean`}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <!-- Suppression Guide -->
+      <section id="suppression" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">06</span>
+          Suppression guide
+        </h2>
+
+        <p class="text-noir-400 text-sm mb-6 leading-relaxed">
+          Not every finding is actionable. foxguard gives you multiple ways to suppress false positives without losing track of them.
+        </p>
+
+        <div class="space-y-6">
+          <!-- Inline comments -->
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Inline comments</h3>
+            <p class="text-noir-400 text-sm mb-3 leading-relaxed">
+              Add a <code class="text-fox-light bg-noir-900 px-1.5 py-0.5 rounded">foxguard-ignore</code> comment on the line above a finding to suppress it. Optionally specify the rule ID.
+            </p>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">example.py</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`# foxguard-ignore: py-hardcoded-secret — rotated via vault
+API_KEY = "sk-test-placeholder"
+
+# foxguard-ignore — suppress all rules on next line
+password = get_config("db_password")`}</code></pre>
+            </div>
+          </div>
+
+          <!-- Config-based -->
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Config-based disable</h3>
+            <p class="text-noir-400 text-sm mb-3 leading-relaxed">
+              Disable rules globally in <code class="text-fox-light bg-noir-900 px-1.5 py-0.5 rounded">.foxguard.yml</code> when they don't apply to your project.
+            </p>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">.foxguard.yml</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`disable:
+  - py-hardcoded-secret
+  - go-md5-usage`}</code></pre>
+            </div>
+          </div>
+
+          <!-- Path exclusion -->
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Path exclusion</h3>
+            <p class="text-noir-400 text-sm mb-3 leading-relaxed">
+              Exclude entire directories or file patterns from scanning.
+            </p>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">.foxguard.yml</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`exclude:
+  - "vendor/**"
+  - "testdata/**"
+  - "**/*_test.go"
+  - "legacy/**"`}</code></pre>
+            </div>
+          </div>
+
+          <!-- Baseline -->
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">Baseline / diff-only mode</h3>
+            <p class="text-noir-400 text-sm mb-3 leading-relaxed">
+              Only report new findings introduced since a baseline branch. Useful for gradually adopting foxguard on an existing codebase without drowning in pre-existing issues.
+            </p>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">terminal</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`# Only show findings not present on main
+foxguard . --baseline main`}</code></pre>
+            </div>
+          </div>
+
+          <!-- TUI triage -->
+          <div>
+            <h3 class="font-heading text-noir-100 text-base mb-3">TUI triage</h3>
+            <p class="text-noir-400 text-sm mb-3 leading-relaxed">
+              Use the interactive terminal UI to review findings one by one, suppress with a keybinding, or export the remaining findings.
+            </p>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">terminal</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`foxguard . --tui`}</code></pre>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Output Formats -->
+      <section id="output-formats" class="mb-20 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">07</span>
+          Output formats
+        </h2>
+
+        <div class="grid sm:grid-cols-3 gap-4">
+          <div class="rounded-xl border border-noir-800 p-5">
+            <h3 class="font-heading text-noir-100 text-sm mb-1">Text (default)</h3>
+            <p class="text-noir-500 text-xs leading-relaxed mb-2">Human-readable output with colors, file paths, line numbers, and fix suggestions.</p>
+            <code class="text-fox-light text-xs bg-noir-900 px-2 py-1 rounded block">foxguard .</code>
+          </div>
+          <div class="rounded-xl border border-noir-800 p-5">
+            <h3 class="font-heading text-noir-100 text-sm mb-1">JSON</h3>
+            <p class="text-noir-500 text-xs leading-relaxed mb-2">Machine-readable findings for scripts, dashboards, or custom integrations.</p>
+            <code class="text-fox-light text-xs bg-noir-900 px-2 py-1 rounded block">foxguard . --format json</code>
+          </div>
+          <div class="rounded-xl border border-noir-800 p-5">
+            <h3 class="font-heading text-noir-100 text-sm mb-1">SARIF</h3>
+            <p class="text-noir-500 text-xs leading-relaxed mb-2">Standard format for GitHub Code Scanning, GitLab SAST, and other security platforms.</p>
+            <code class="text-fox-light text-xs bg-noir-900 px-2 py-1 rounded block">foxguard . --format sarif</code>
+          </div>
+        </div>
+      </section>
+
+      <!-- PQC -->
+      <section id="pqc" class="mb-16 scroll-mt-20">
+        <h2 class="font-heading text-noir-50 text-xl sm:text-2xl mb-6 flex items-center gap-2">
+          <span class="text-fox-light font-mono text-sm">08</span>
+          Post-quantum crypto audit
+        </h2>
+
+        <div class="space-y-6">
+          <p class="text-noir-400 text-sm leading-relaxed">
+            foxguard can audit your codebase for cryptographic primitives that will be broken by quantum computers. This maps to NSA CNSA 2.0 timelines — the transition deadlines are approaching fast.
+          </p>
+
+          <div class="rounded-xl border border-noir-800 bg-noir-900/30 p-6">
+            <h3 class="font-heading text-noir-100 text-sm mb-3">What gets flagged</h3>
+            <ul class="space-y-2 text-sm text-noir-400 leading-relaxed">
+              <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#8594;</span><strong class="text-noir-200">RSA</strong> — key exchange, signing, encryption (all key sizes)</li>
+              <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#8594;</span><strong class="text-noir-200">ECDSA / ECDH</strong> — elliptic curve operations (P-256, P-384, etc.)</li>
+              <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#8594;</span><strong class="text-noir-200">DH</strong> — classic Diffie-Hellman key exchange</li>
+              <li class="flex gap-3"><span class="text-fox-light flex-shrink-0">&#8594;</span><strong class="text-noir-200">DSA</strong> — Digital Signature Algorithm</li>
+            </ul>
+          </div>
+
+          <div class="grid sm:grid-cols-2 gap-4">
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">PQC audit</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`foxguard . --pqc`}</code></pre>
+            </div>
+            <div class="rounded-xl border border-noir-800 overflow-hidden">
+              <div class="bg-noir-900/50 border-b border-noir-800 px-5 py-2 text-xs text-noir-500 font-mono">CBOM generation</div>
+              <pre class="px-5 py-4 text-sm font-mono text-noir-200 overflow-x-auto"><code>{`foxguard . --cbom -o cbom.json`}</code></pre>
+            </div>
+          </div>
+
+          <p class="text-noir-500 text-sm leading-relaxed">
+            The CBOM (Cryptographic Bill of Materials) inventories every crypto primitive in your codebase — useful for compliance reporting and tracking your migration to post-quantum algorithms.
+          </p>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section class="text-center">
+        <div class="h-px bg-noir-800 mb-16"></div>
+        <h2 class="font-heading text-noir-50 text-2xl sm:text-3xl mb-4">Questions?</h2>
+        <p class="text-noir-500 text-sm mb-6">Open an issue or check the README for more details.</p>
+        <div class="flex items-center justify-center gap-4">
+          <a
+            href="https://github.com/0sec-labs/foxguard"
+            target="_blank"
+            rel="noopener"
+            class="flex items-center gap-2 rounded-lg bg-fox px-5 py-2.5 text-sm font-medium hover:bg-fox-light transition-colors no-underline"
+            style="color:#000;"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+            GitHub repo
+          </a>
+          <a href="/compare" class="rounded-lg border border-noir-700 px-5 py-2.5 text-sm text-noir-300 hover:border-noir-600 hover:text-noir-100 transition-colors no-underline">
+            Compare with Semgrep
+          </a>
+        </div>
+      </section>
+
+    </div>
+  </main>
+
+  <Footer />
+</Base>


### PR DESCRIPTION
## Summary
- New `/compare` page: side-by-side foxguard vs Semgrep feature tables covering performance, core features, analysis capabilities, unique foxguard features (PQC/CNSA2, CBOM, TUI triage), and language support. Factual tone with a balanced "when to pick each" summary.
- New `/docs` page: quick start guide, `.foxguard.yml` configuration reference, GitHub App setup, VS Code extension install, CI/CD integration snippets (GitHub Actions, GitLab CI, generic), suppression guide (inline comments, config disable, path exclusion, baseline mode, TUI triage), output formats, and PQC audit section.
- Added "Docs" and "Compare" links to both SiteNav and Footer navigation.
- `npm run build` passes cleanly (19 pages built in <1s).

## Test plan
- [ ] Verify `/compare` renders with all tables and checkmarks
- [ ] Verify `/docs` renders with TOC links, code blocks, and install tabs
- [ ] Confirm nav links appear on all pages (Docs, Compare, Rules, Blog)
- [ ] Confirm footer links include Docs and Compare
- [ ] Test on mobile viewport (nav links hidden behind sm: breakpoint as expected)

none