### PR TITLE
Remove public-facing pwnkit references

### DIFF
--- a/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
+++ b/rules/kernel/dirty-frag-class/esp-shared-frag-decrypt-guard-codeql.yaml
@@ -28,5 +28,4 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"
         - "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"

--- a/rules/kernel/dirty-frag-class/rxrpc-verify-response-dispatch.yaml
+++ b/rules/kernel/dirty-frag-class/rxrpc-verify-response-dispatch.yaml
@@ -44,8 +44,7 @@ rules:
       also be flagged by kernel/dirty-frag/skb-inplace-skcipher-no-cow
       when scanning the backend implementation.
 
-      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
-      issue #263.
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: WARNING
     languages: [c]
     paths:
@@ -56,4 +55,3 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl-authencesn.yaml
@@ -21,8 +21,7 @@ rules:
       spliced back into the shared SGL AFTER the AEAD authenticator
       validates.
 
-      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
-      issue #263.
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: ERROR
     languages: [c]
     paths:
@@ -33,4 +32,3 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
+++ b/rules/kernel/dirty-frag-class/scatterwalk-store-on-shared-sgl.yaml
@@ -58,8 +58,7 @@ rules:
       crypto/authencesn.c site is covered by the
       scatterwalk-store-on-shared-sgl-authencesn exception rule.
 
-      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
-      issue #263.
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: ERROR
     languages: [c]
     paths:
@@ -70,4 +69,3 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-aead-no-cow.yaml
@@ -56,8 +56,7 @@ rules:
       gate with `!skb_has_shared_frag(skb)` to defeat the MSG_SPLICE_PAGES
       shared-frag aliasing.
 
-      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
-      issue #263.
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: ERROR
     languages: [c]
     paths:
@@ -68,5 +67,4 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"
         - "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f4c50a4034e62ab75f1d5cdd191dd5f9c77fdff4"

--- a/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
+++ b/rules/kernel/dirty-frag-class/skb-inplace-skcipher-no-cow.yaml
@@ -57,8 +57,7 @@ rules:
       cow gate with a data_len / non-linear shared-frag check so
       MSG_SPLICE_PAGES-pinned pages cannot reach the in-place decrypt.
 
-      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel) and pwnkit
-      issue #263.
+      See oss-security 2026-05-07 advisory (Hyunwoo Kim @v4bel).
     severity: ERROR
     languages: [c]
     paths:
@@ -69,4 +68,3 @@ rules:
       references:
         - "https://www.openwall.com/lists/oss-security/2026/05/07/8"
         - "https://github.com/V4bel/dirtyfrag/blob/master/assets/write-up.md"
-        - "https://github.com/0sec-labs/pwnkit/issues/263"

--- a/www/src/content/blog/dirty-frag-rule-pack.md
+++ b/www/src/content/blog/dirty-frag-rule-pack.md
@@ -47,7 +47,7 @@ rules:
       (Dirty Frag class). Verify skb_cow_data / skb_unshare / skb_make_writable /
       pskb_expand_head is reached on the unsafe path before
       aead_request_set_crypt(req, sg, sg, ...) + crypto_aead_decrypt(req).
-      See oss-security 2026-05-07 advisory and pwnkit issue #263.
+      See oss-security 2026-05-07 advisory.
     severity: ERROR
     languages: [c]
     metadata:
@@ -76,7 +76,7 @@ Path-sensitive cow-gate analysis lives in two issues we have open:
 - [foxguard #295](https://github.com/0sec-labs/foxguard/issues/295) — Coccinelle integration. Coccinelle's `@@` metavariables can express `arg2 == arg3` directly, and SmPL has structural understanding of dominators. That's where the in-place property gets a real proof.
 - [foxguard #296](https://github.com/0sec-labs/foxguard/issues/296) — CodeQL integration. CodeQL's data-flow library can carry SGL provenance from `MSG_SPLICE_PAGES` to the AEAD call, which is the actual bug-class invariant.
 
-The variant-hunt orchestrator that walks a kernel tree, fans out to all three engines (foxguard regex, Coccinelle, CodeQL), and reconciles the hits is [pwnkit #263](https://github.com/0sec-labs/pwnkit/issues/263). The foxguard rules are the cheap fast-pass — first sieve, not last word.
+The variant-hunt orchestrator that walks a kernel tree, fans out to all three engines (foxguard regex, Coccinelle, CodeQL), and reconciles the hits is tracked internally. The foxguard rules are the cheap fast-pass — first sieve, not last word.
 
 ## Try it
 


### PR DESCRIPTION
## Summary
- PwnKit repo has gone closed-source (private). This removes all public-facing references to pwnkit from foxguard.
- Stripped "pwnkit issue #263" from user-facing rule `message:` fields in all 6 Dirty Frag YAML rules
- Removed `https://github.com/0sec-labs/pwnkit/issues/263` from rule `metadata.references` in all 6 YAML files
- Updated the Dirty Frag blog post to remove the pwnkit link and inline code example reference
- Internal references (test comments in `tests/kernel_dirty_frag.rs`, agent instructions in `AGENTS.md`) are intentionally kept -- they are not public-facing

## Test plan
- [x] `cargo test` -- all 737+ tests pass, 0 failures
- [x] `npm run build` in `www/` -- Astro static build succeeds (19 pages)
- [x] Verified no remaining pwnkit references in public-facing files
- [x] 0sec Labs branding and 0sec.ai links are untouched

none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security rule references and descriptions for improved accuracy.
  * Refreshed blog post content to align with updated rule documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0sec-labs/foxguard/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->