### PR TITLE
Publish release provenance attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
 
@@ -153,6 +157,16 @@ jobs:
           sha256sum * > checksums.txt
           echo "--- checksums.txt ---"
           cat checksums.txt
+
+      - name: Attest release binaries
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-checksums: release/checksums.txt
+
+      - name: Attest checksum manifest
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: release/checksums.txt
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ curl -fsSL https://foxguard.dev/install.sh | sh     # prebuilt binary (macOS/Lin
 cargo install foxguard                              # from source
 ```
 
+Prebuilt installs verify release SHA-256 checksums before using downloaded
+binaries. Signed GitHub artifact attestations are published for release binaries;
+see [release provenance](docs/release-provenance.md) for manual verification.
+
 **GitHub Action:**
 
 ```yaml
@@ -57,6 +61,9 @@ cargo install foxguard                              # from source
     fail-on-findings: "true"
     upload-sarif: "true"
 ```
+
+The action verifies the downloaded binary against `checksums.txt`. Provenance
+verification is available as a separate `gh attestation verify` policy step.
 
 **pre-commit:**
 

--- a/docs/release-provenance.md
+++ b/docs/release-provenance.md
@@ -1,0 +1,71 @@
+# Release provenance
+
+foxguard publishes prebuilt binaries through GitHub Releases. Each release
+contains platform binaries plus `checksums.txt`.
+
+## What is published
+
+The release workflow publishes GitHub artifact attestations for:
+
+- every platform binary listed in `checksums.txt`
+- the `checksums.txt` manifest itself
+
+The binary attestations are generated from the checksum manifest, so each
+attestation subject is the exact SHA-256 digest users download. The checksum
+manifest is attested separately so users can verify both the binary and the
+integrity manifest.
+
+## What installers verify
+
+The GitHub Action, npm wrapper, and `install.sh` download `checksums.txt` and
+verify the selected binary's SHA-256 digest before executing or caching it. A
+missing checksum, failed checksum download, missing digest, or digest mismatch
+is a hard install failure.
+
+Those installers do not require provenance verification at runtime. Provenance
+verification needs GitHub's attestation service and a networked verifier such as
+the GitHub CLI, so it is an explicit user or CI policy step.
+
+## Manual verification
+
+Download the release asset and checksum manifest, then verify them with the
+GitHub CLI:
+
+```sh
+gh attestation verify foxguard-linux-x86_64 --repo 0sec-labs/foxguard
+gh attestation verify checksums.txt --repo 0sec-labs/foxguard
+```
+
+After provenance verification succeeds, verify the local digest:
+
+```sh
+sha256sum -c checksums.txt --ignore-missing
+```
+
+On macOS:
+
+```sh
+grep '  foxguard-macos-aarch64$' checksums.txt
+shasum -a 256 foxguard-macos-aarch64
+```
+
+## Failure modes
+
+- If `checksums.txt` is missing or does not contain the selected binary, treat
+  the install as untrusted.
+- If the binary digest does not match `checksums.txt`, do not use the binary.
+- If `gh attestation verify` fails or no attestation is found, treat the binary
+  as lacking release provenance even if its checksum matches.
+- If GitHub artifact attestations are unavailable for the repository or
+  organization, the release workflow fails before publishing the GitHub Release.
+
+## Trust model
+
+Checksums protect against accidental corruption and simple mirror tampering.
+GitHub artifact attestations bind a downloaded digest to the `0sec-labs/foxguard`
+repository, the release workflow identity, and the tag build that produced it.
+
+This does not prove the source code is bug-free and does not protect against a
+compromised repository, compromised release workflow, or compromised GitHub
+identity. It gives users evidence that a release asset came from the expected
+GitHub Actions build path.

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -21,6 +21,11 @@ It scans for SQL injection, XSS, SSRF, hardcoded secrets, command injection, wea
 
 This is the npm wrapper. It downloads the correct prebuilt Rust binary for your platform from GitHub Releases and caches it locally.
 
+The wrapper verifies the downloaded binary against the release `checksums.txt`
+before caching it. Release binaries also have GitHub artifact attestations for
+manual or CI verification with `gh attestation verify`; see the repository's
+release provenance documentation for the trust model and failure modes.
+
 ```sh
 npx foxguard .                    # scan everything
 npx foxguard --changed .          # only modified files

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -98,4 +98,4 @@ git push origin "${TAG}"
 
 echo ""
 echo "=== ${TAG} queued ==="
-echo "GitHub Actions release workflow will build binaries and publish GitHub, crates.io, npm, and VS Code if the required secrets are configured."
+echo "GitHub Actions release workflow will build binaries, publish artifact attestations, and publish GitHub, crates.io, npm, and VS Code if the required secrets are configured."

--- a/tests/release_provenance.rs
+++ b/tests/release_provenance.rs
@@ -1,0 +1,46 @@
+const RELEASE_WORKFLOW: &str = include_str!("../.github/workflows/release.yml");
+const README: &str = include_str!("../README.md");
+const NPM_README: &str = include_str!("../packages/npm/README.md");
+const PROVENANCE_DOCS: &str = include_str!("../docs/release-provenance.md");
+
+fn index_of(haystack: &str, needle: &str) -> usize {
+    match haystack.find(needle) {
+        Some(index) => index,
+        None => panic!("missing expected release provenance text: {needle}"),
+    }
+}
+
+#[test]
+fn release_workflow_attests_binaries_before_publishing_release() {
+    assert!(RELEASE_WORKFLOW.contains("id-token: write"));
+    assert!(RELEASE_WORKFLOW.contains("attestations: write"));
+    assert!(RELEASE_WORKFLOW.contains("contents: write"));
+
+    assert_eq!(
+        RELEASE_WORKFLOW
+            .matches("uses: actions/attest-build-provenance@v2")
+            .count(),
+        2
+    );
+    assert!(RELEASE_WORKFLOW.contains("subject-checksums: release/checksums.txt"));
+    assert!(RELEASE_WORKFLOW.contains("subject-path: release/checksums.txt"));
+
+    let checksum_step = index_of(RELEASE_WORKFLOW, "name: Generate checksums");
+    let attest_step = index_of(RELEASE_WORKFLOW, "name: Attest release binaries");
+    let release_step = index_of(RELEASE_WORKFLOW, "uses: softprops/action-gh-release@v2");
+
+    assert!(checksum_step < attest_step);
+    assert!(attest_step < release_step);
+}
+
+#[test]
+fn installer_docs_explain_checksum_and_provenance_behavior() {
+    for docs in [README, NPM_README, PROVENANCE_DOCS] {
+        assert!(docs.contains("checksums.txt"));
+        assert!(docs.contains("gh attestation verify"));
+    }
+
+    assert!(PROVENANCE_DOCS.contains("SHA-256"));
+    assert!(PROVENANCE_DOCS.contains("Failure modes"));
+    assert!(PROVENANCE_DOCS.contains("Trust model"));
+}


### PR DESCRIPTION
## Summary
- add GitHub artifact attestation steps for release binaries from checksums.txt and for the checksum manifest
- document checksum verification, manual provenance verification, failure modes, and trust model
- add regression tests that keep the release workflow and installer docs wired to provenance

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- bash -n scripts/release.sh
- cargo test --test release_provenance
- PATH=/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:/Users/darkroom/.cargo/bin cargo test

Closes #450