### PR TITLE
fix(github-app): bundle PR findings into one review

### DIFF
--- a/src/github_app/review.rs
+++ b/src/github_app/review.rs
@@ -1,6 +1,8 @@
 //! Pull request review posting for the GitHub App receiver.
 
-use crate::report::github_pr::{review_comments_for_commentable_lines, COMMENT_MARKER};
+use crate::report::github_pr::{
+    review_body_for_findings, review_comments_for_commentable_lines, COMMENT_MARKER,
+};
 use crate::{Finding, Severity};
 use reqwest::Url;
 use serde::Deserialize;
@@ -107,8 +109,9 @@ impl GitHubReviewClient {
                 &owned_lines
             }
         };
+        let review_findings = filter_findings_to_changed_lines(findings, commentable_lines);
         let comments =
-            review_comments_for_commentable_lines(findings, commentable_lines, scan_root);
+            review_comments_for_commentable_lines(&review_findings, commentable_lines, scan_root);
         if comments.is_empty() {
             let deleted_comments = self
                 .delete_foxguard_comment_ids(&repo, &existing_comment_ids, installation_token)
@@ -120,10 +123,15 @@ impl GitHubReviewClient {
         }
 
         let posted_comments = comments.len();
-        for comment in comments {
-            self.post_inline_comment(&repo, pr_number, head_sha, comment, installation_token)
-                .await?;
-        }
+        self.post_review(
+            &repo,
+            pr_number,
+            head_sha,
+            &review_findings,
+            comments,
+            installation_token,
+        )
+        .await?;
 
         let deleted_comments = self
             .delete_foxguard_comment_ids(&repo, &existing_comment_ids, installation_token)
@@ -256,25 +264,20 @@ impl GitHubReviewClient {
             .collect())
     }
 
-    async fn post_inline_comment(
+    async fn post_review(
         &self,
         repo: &RepositoryPath,
         pr_number: u64,
         head_sha: &str,
-        comment: Value,
+        findings: &[Finding],
+        comments: Vec<Value>,
         installation_token: &str,
     ) -> Result<(), ReviewError> {
         let url = self.endpoint(&format!(
-            "repos/{}/{}/pulls/{pr_number}/comments",
+            "repos/{}/{}/pulls/{pr_number}/reviews",
             repo.owner, repo.name
         ))?;
-        let body = serde_json::json!({
-            "body": comment["body"],
-            "commit_id": head_sha,
-            "path": comment["path"],
-            "line": comment["line"],
-            "side": comment["side"],
-        });
+        let body = review_request_body(head_sha, findings, comments);
         // URL construction is restricted to a validated GitHub API base URL plus
         // repository path segments parsed by `RepositoryPath::parse`.
         let request = self.http.post(url); // foxguard: ignore[rs/no-ssrf]
@@ -569,6 +572,14 @@ fn check_run_annotations(findings: &[Finding]) -> Vec<Value> {
         .collect()
 }
 
+fn review_request_body(head_sha: &str, findings: &[Finding], comments: Vec<Value>) -> Value {
+    let mut body = review_body_for_findings(findings, comments);
+    if let Some(object) = body.as_object_mut() {
+        object.insert("commit_id".to_string(), Value::String(head_sha.to_string()));
+    }
+    body
+}
+
 fn annotation_level(severity: Severity) -> &'static str {
     match severity {
         Severity::Low => "notice",
@@ -723,6 +734,38 @@ mod tests {
         assert_eq!(annotations[0]["path"], "src/app.js");
         assert_eq!(annotations[0]["start_line"], 1);
         assert_eq!(annotations[0]["annotation_level"], "failure");
+    }
+
+    #[test]
+    fn review_request_body_bundles_comments_into_single_review() {
+        let findings = vec![
+            finding(Severity::High, 10),
+            finding_in_file(Severity::Medium, "src/other.js", 12),
+        ];
+        let comments = vec![
+            serde_json::json!({
+                "path": "src/app.js",
+                "line": 10,
+                "side": "RIGHT",
+                "body": "<!-- foxguard:pr-review -->\n\none",
+            }),
+            serde_json::json!({
+                "path": "src/other.js",
+                "line": 12,
+                "side": "RIGHT",
+                "body": "<!-- foxguard:pr-review -->\n\ntwo",
+            }),
+        ];
+
+        let body = review_request_body("deadbeef", &findings, comments);
+        assert_eq!(body["event"], "COMMENT");
+        assert_eq!(body["commit_id"], "deadbeef");
+        assert_eq!(body["comments"].as_array().map(Vec::len), Some(2));
+        let summary = body["body"]
+            .as_str()
+            .unwrap_or_else(|| panic!("review summary should be a string"));
+        assert!(summary.contains("**By class**"));
+        assert!(summary.contains("**By severity**"));
     }
 
     #[test]

--- a/src/report/github_pr.rs
+++ b/src/report/github_pr.rs
@@ -1,5 +1,5 @@
 use crate::{Finding, Severity};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
 
 pub const COMMENT_MARKER: &str = "<!-- foxguard:pr-review -->";
@@ -167,12 +167,133 @@ pub fn review_comments_for_commentable_lines(
         .collect()
 }
 
-pub fn review_body_for_comments(comments: Vec<serde_json::Value>) -> serde_json::Value {
+/// Findings that land on a commentable (added/context) line of the PR diff.
+pub fn findings_on_commentable_lines(
+    findings: &[Finding],
+    commentable_lines: &HashMap<String, HashSet<usize>>,
+    scan_root: Option<&Path>,
+) -> Vec<Finding> {
+    findings
+        .iter()
+        .filter(|f| {
+            commentable_lines
+                .get(&relative_path(&f.file, scan_root))
+                .is_some_and(|lines| lines.contains(&f.line))
+        })
+        .cloned()
+        .collect()
+}
+
+pub fn review_body_for_findings(
+    findings: &[Finding],
+    comments: Vec<serde_json::Value>,
+) -> serde_json::Value {
     serde_json::json!({
         "event": "COMMENT",
-        "body": format!("{COMMENT_MARKER}\n\n**foxguard** found {} issue(s) in this PR", comments.len()),
+        "body": review_summary_body(findings),
         "comments": comments,
     })
+}
+
+fn review_summary_body(findings: &[Finding]) -> String {
+    let mut low = 0;
+    let mut medium = 0;
+    let mut high = 0;
+    let mut critical = 0;
+    let mut class_counts: BTreeMap<String, (usize, BTreeSet<String>)> = BTreeMap::new();
+
+    for finding in findings {
+        match finding.severity {
+            Severity::Low => low += 1,
+            Severity::Medium => medium += 1,
+            Severity::High => high += 1,
+            Severity::Critical => critical += 1,
+        }
+
+        let class = finding_class_label(&finding.rule_id);
+        let entry = class_counts
+            .entry(class)
+            .or_insert_with(|| (0, BTreeSet::new()));
+        entry.0 += 1;
+        entry.1.insert(finding.rule_id.clone());
+    }
+
+    let mut classes: Vec<(String, usize, BTreeSet<String>)> = class_counts
+        .into_iter()
+        .map(|(class, (count, rule_ids))| (class, count, rule_ids))
+        .collect();
+    classes.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let mut body = format!(
+        "{COMMENT_MARKER}\n\n**foxguard** found {} issue(s) in this PR",
+        findings.len()
+    );
+    body.push_str(&format!(
+        "\n\n**By severity**\n- `CRITICAL`: {critical}\n- `HIGH`: {high}\n- `MEDIUM`: {medium}\n- `LOW`: {low}"
+    ));
+
+    if !classes.is_empty() {
+        body.push_str("\n\n**By class**");
+        for (class, count, rule_ids) in classes {
+            let rules = rule_ids.into_iter().collect::<Vec<_>>().join("`, `");
+            body.push_str(&format!("\n- `{class}`: {count} (`{rules}`)"));
+        }
+    }
+
+    body
+}
+
+fn finding_class_label(rule_id: &str) -> String {
+    let family = rule_id
+        .split_once('/')
+        .map(|(_, suffix)| suffix)
+        .unwrap_or(rule_id);
+    let mut parts: Vec<&str> = family.split('-').collect();
+    while parts
+        .first()
+        .is_some_and(|part| matches!(*part, "no" | "taint" | "detect"))
+    {
+        parts.remove(0);
+    }
+    if parts.is_empty() {
+        parts = family.split('-').collect();
+    }
+    parts
+        .into_iter()
+        .map(display_class_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn display_class_token(token: &str) -> String {
+    match token {
+        "api" => "API".to_string(),
+        "cbom" => "CBOM".to_string(),
+        "cli" => "CLI".to_string(),
+        "cors" => "CORS".to_string(),
+        "csrf" => "CSRF".to_string(),
+        "dos" => "DoS".to_string(),
+        "html" => "HTML".to_string(),
+        "http" => "HTTP".to_string(),
+        "https" => "HTTPS".to_string(),
+        "jwt" => "JWT".to_string(),
+        "osv" => "OSV".to_string(),
+        "pq" => "PQ".to_string(),
+        "pqc" => "PQC".to_string(),
+        "sarif" => "SARIF".to_string(),
+        "sql" => "SQL".to_string(),
+        "ssrf" => "SSRF".to_string(),
+        "tls" => "TLS".to_string(),
+        "xss" => "XSS".to_string(),
+        "xxe" => "XXE".to_string(),
+        _ => {
+            let mut chars = token.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        }
+    }
 }
 
 fn gh_pull_request_files(stdout: &[u8]) -> Result<Vec<PullRequestFile>, String> {
@@ -284,7 +405,10 @@ pub fn post_pr_review(
     }
 
     let commentable_lines = commentable_lines_by_file(&diff_output.stdout)?;
-    let comments = review_comments_for_commentable_lines(findings, &commentable_lines, scan_root);
+    let commentable_findings =
+        findings_on_commentable_lines(findings, &commentable_lines, scan_root);
+    let comments =
+        review_comments_for_commentable_lines(&commentable_findings, &commentable_lines, scan_root);
 
     if comments.is_empty() {
         let deleted = delete_existing_foxguard_comments(&repo, pr_number)?;
@@ -307,7 +431,7 @@ pub fn post_pr_review(
     }
 
     let comment_count = comments.len();
-    let review_body = review_body_for_comments(comments);
+    let review_body = review_body_for_findings(&commentable_findings, comments);
 
     let json_str = serde_json::to_string(&review_body)
         .map_err(|e| format!("Failed to serialize review body: {e}"))?;
@@ -524,5 +648,40 @@ mod tests {
         assert_eq!(comments.len(), 1);
         assert_eq!(comments[0]["path"], "src/app.py");
         assert_eq!(comments[0]["line"], 42);
+    }
+
+    #[test]
+    fn test_review_body_for_findings_groups_by_class_and_severity() {
+        let mut secret = sample_finding();
+        secret.rule_id = "js/no-hardcoded-secret".to_string();
+        secret.severity = Severity::High;
+        secret.description = "Hardcoded secret".to_string();
+
+        let mut taint = sample_finding();
+        taint.rule_id = "py/taint-sql-injection".to_string();
+        taint.description = "Tainted SQL".to_string();
+
+        let mut direct = sample_finding();
+        direct.rule_id = "py/no-sql-injection".to_string();
+        direct.description = "Direct SQL".to_string();
+        direct.severity = Severity::Medium;
+
+        let comments =
+            vec![serde_json::json!({"path":"src/app.py","line":1,"side":"RIGHT","body":"x"})];
+        let review = review_body_for_findings(&[secret, taint, direct], comments);
+        let body = review["body"]
+            .as_str()
+            .unwrap_or_else(|| panic!("review body should be a string"));
+
+        assert!(body.contains("**foxguard** found 3 issue(s)"));
+        assert!(body.contains("**By severity**"));
+        assert!(body.contains("`CRITICAL`: 1"));
+        assert!(body.contains("`HIGH`: 1"));
+        assert!(body.contains("`MEDIUM`: 1"));
+        assert!(body.contains("**By class**"));
+        assert!(body.contains("`SQL Injection`: 2"));
+        assert!(body.contains("`py/no-sql-injection`"));
+        assert!(body.contains("`py/taint-sql-injection`"));
+        assert!(body.contains("`Hardcoded Secret`: 1"));
     }
 }


### PR DESCRIPTION
## Summary
- submit one GitHub App PR review instead of posting one review comment per finding
- add a grouped top-level summary broken out by severity and finding class
- keep inline comments scoped to changed/commentable PR lines

Closes #487

## Testing
- cargo fmt
- cargo test report::github_pr::tests --lib
- cargo test on this main-based branch still hits the known pre-existing dd/sleep failures tracked by #482
- cargo test passed earlier with this change applied on top of the already-open #482 fix branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR review summaries grouped by severity and rule class for clearer reports
  * Reviews now submitted as a single GitHub review request (bundled comments) including commit context
  * Review scope limited to changed/commentable lines in the PR

* **Tests**
  * Added coverage to assert bundled review payload contains event/commit and combined comments array
<!-- end of auto-generated comment: release notes by coderabbit.ai -->