### PR TITLE
fix(sca): use ecosystem-aware OSV version matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,10 +858,12 @@ dependencies = [
  "ignore",
  "include_dir",
  "jsonwebtoken",
+ "pep440_rs",
  "ratatui",
  "rayon",
  "regex",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -1861,6 +1863,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
+]
+
+[[package]]
+name = "pep440_rs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
+dependencies = [
+ "once_cell",
+ "serde",
+ "unicode-width",
+ "unscanny",
 ]
 
 [[package]]
@@ -3470,6 +3484,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,8 @@ unicode-width = "0.2"
 wait-timeout = "0.2.1"
 include_dir = "0.7"
 reqwest = { version = "0.13.3", default-features = false, features = ["blocking", "json", "rustls"] }
+semver = "1"
+pep440_rs = "0.7"
 
 # Optional deps for the GitHub App webhook receiver (gated behind the
 # `github-app` feature). Off by default so the core scanner build stays

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -919,10 +919,9 @@ fn version_in_range(package: &PackageRef, range: &OsvRange) -> bool {
     let mut vulnerable = false;
     for event in &range.events {
         if let Some(introduced) = event.introduced.as_deref() {
-            if introduced == "0" {
-                vulnerable = true;
-            } else if compare_versions_for_package(package, range.range_type.as_deref(), introduced)
-                .is_some_and(|ordering| ordering != Ordering::Less)
+            if introduced == "0"
+                || compare_versions_for_package(package, range.range_type.as_deref(), introduced)
+                    .is_some_and(|ordering| ordering != Ordering::Less)
             {
                 vulnerable = true;
             }
@@ -1421,7 +1420,6 @@ mod tests {
                     ..OsvEvent::default()
                 },
             ],
-            ..OsvRange::default()
         };
         let matching = package_ref(
             "crates.io",

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,12 +1,15 @@
 use crate::engine::PathExcludeMatcher;
 use crate::{Finding, Severity};
 use ignore::WalkBuilder;
+use pep440_rs::Version as Pep440Version;
+use semver::Version as SemverVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::Duration;
 
 pub const OSV_RULE_ID: &str = "manifest/osv-vulnerable-dep";
@@ -79,6 +82,7 @@ struct OsvEvent {
     introduced: Option<String>,
     fixed: Option<String>,
     last_affected: Option<String>,
+    limit: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -882,53 +886,100 @@ fn affected_package_matches(package: &PackageRef, affected: &OsvAffected) -> boo
 }
 
 fn affected_version_matches(package: &PackageRef, affected: &OsvAffected) -> bool {
-    if !affected.versions.is_empty() {
-        return affected
-            .versions
-            .iter()
-            .any(|version| version == &package.version);
+    if affected
+        .versions
+        .iter()
+        .any(|version| version_matches(package, version))
+    {
+        return true;
     }
 
     if affected.ranges.is_empty() {
-        return true;
+        return affected.versions.is_empty();
     }
 
     affected
         .ranges
         .iter()
-        .any(|range| version_in_range(&package.version, range))
+        .any(|range| version_in_range(package, range))
 }
 
-fn version_in_range(version: &str, range: &OsvRange) -> bool {
-    let mut active = false;
+fn version_matches(package: &PackageRef, advisory_version: &str) -> bool {
+    compare_versions_for_package(package, None, advisory_version)
+        .map_or(package.version == advisory_version, |ordering| {
+            ordering == Ordering::Equal
+        })
+}
+
+fn version_in_range(package: &PackageRef, range: &OsvRange) -> bool {
+    if !version_before_limits(package, range) {
+        return false;
+    }
+
+    let mut vulnerable = false;
     for event in &range.events {
         if let Some(introduced) = event.introduced.as_deref() {
-            active = introduced == "0" || compare_versions(version, introduced) != Ordering::Less;
+            if introduced == "0" {
+                vulnerable = true;
+            } else if compare_versions_for_package(package, range.range_type.as_deref(), introduced)
+                .is_some_and(|ordering| ordering != Ordering::Less)
+            {
+                vulnerable = true;
+            }
         }
         if let Some(fixed) = event.fixed.as_deref() {
-            if active && compare_versions(version, fixed) == Ordering::Less {
-                return true;
-            }
-            if compare_versions(version, fixed) != Ordering::Less {
-                active = false;
+            if compare_versions_for_package(package, range.range_type.as_deref(), fixed)
+                .is_some_and(|ordering| ordering != Ordering::Less)
+            {
+                vulnerable = false;
             }
         }
         if let Some(last_affected) = event.last_affected.as_deref() {
-            if active && compare_versions(version, last_affected) != Ordering::Greater {
-                return true;
+            if compare_versions_for_package(package, range.range_type.as_deref(), last_affected)
+                .is_some_and(|ordering| ordering == Ordering::Greater)
+            {
+                vulnerable = false;
             }
         }
     }
-    active
+    vulnerable
+}
+
+fn version_before_limits(package: &PackageRef, range: &OsvRange) -> bool {
+    let mut saw_limit = false;
+    for event in &range.events {
+        let Some(limit) = event.limit.as_deref() else {
+            continue;
+        };
+        saw_limit = true;
+        if compare_versions_for_package(package, range.range_type.as_deref(), limit)
+            .is_some_and(|ordering| ordering == Ordering::Less)
+        {
+            return true;
+        }
+    }
+    !saw_limit
 }
 
 fn first_fixed_version(package: &PackageRef, vuln: &OsvVulnerability) -> Option<String> {
-    vuln.affected
+    let mut fallback = None;
+    for affected in vuln
+        .affected
         .iter()
         .filter(|affected| affected_package_matches(package, affected))
-        .flat_map(|affected| affected.ranges.iter())
-        .flat_map(|range| range.events.iter())
-        .find_map(|event| event.fixed.clone())
+        .filter(|affected| affected_version_matches(package, affected))
+    {
+        for range in &affected.ranges {
+            let fixed = range.events.iter().find_map(|event| event.fixed.clone());
+            if fallback.is_none() {
+                fallback = fixed.clone();
+            }
+            if version_in_range(package, range) {
+                return fixed;
+            }
+        }
+    }
+    fallback
 }
 
 fn finding_for_vulnerability(package: &PackageRef, vuln: &OsvVulnerability) -> Finding {
@@ -1103,27 +1154,82 @@ fn ecosystems_equal(left: &str, right: &str) -> bool {
         || (left.eq_ignore_ascii_case("cargo") && right.eq_ignore_ascii_case("crates.io"))
 }
 
-fn compare_versions(left: &str, right: &str) -> Ordering {
-    let left_parts = version_parts(left);
-    let right_parts = version_parts(right);
-    for (left, right) in left_parts.iter().zip(right_parts.iter()) {
-        let ordering = match (left.parse::<u64>(), right.parse::<u64>()) {
-            (Ok(left), Ok(right)) => left.cmp(&right),
-            _ => left.cmp(right),
-        };
-        if ordering != Ordering::Equal {
-            return ordering;
-        }
-    }
-    left_parts.len().cmp(&right_parts.len())
+fn compare_versions_for_package(
+    package: &PackageRef,
+    range_type: Option<&str>,
+    advisory_version: &str,
+) -> Option<Ordering> {
+    compare_versions(
+        &package.ecosystem,
+        range_type,
+        &package.version,
+        advisory_version,
+    )
 }
 
-fn version_parts(value: &str) -> Vec<String> {
-    value
-        .split(|ch: char| !ch.is_ascii_alphanumeric())
-        .filter(|part| !part.is_empty())
-        .map(ToString::to_string)
-        .collect()
+fn compare_versions(
+    ecosystem: &str,
+    range_type: Option<&str>,
+    left: &str,
+    right: &str,
+) -> Option<Ordering> {
+    match range_type {
+        Some(range_type) if range_type.eq_ignore_ascii_case("GIT") => None,
+        Some(range_type) if range_type.eq_ignore_ascii_case("SEMVER") => {
+            compare_semver_versions(left, right)
+        }
+        Some(range_type) if range_type.eq_ignore_ascii_case("ECOSYSTEM") => {
+            compare_ecosystem_versions(ecosystem, left, right)
+        }
+        _ => compare_ecosystem_versions(ecosystem, left, right),
+    }
+}
+
+fn compare_ecosystem_versions(ecosystem: &str, left: &str, right: &str) -> Option<Ordering> {
+    if ecosystem.eq_ignore_ascii_case("PyPI") {
+        return compare_pep440_versions(left, right);
+    }
+    if ecosystem.eq_ignore_ascii_case("npm")
+        || ecosystem.eq_ignore_ascii_case("crates.io")
+        || ecosystem.eq_ignore_ascii_case("cargo")
+    {
+        return compare_semver_versions(left, right);
+    }
+    None
+}
+
+fn compare_pep440_versions(left: &str, right: &str) -> Option<Ordering> {
+    Some(
+        Pep440Version::from_str(left)
+            .ok()?
+            .cmp(&Pep440Version::from_str(right).ok()?),
+    )
+}
+
+fn compare_semver_versions(left: &str, right: &str) -> Option<Ordering> {
+    Some(parse_relaxed_semver(left)?.cmp(&parse_relaxed_semver(right)?))
+}
+
+fn parse_relaxed_semver(value: &str) -> Option<SemverVersion> {
+    let value = value.trim();
+    SemverVersion::parse(value).ok().or_else(|| {
+        let value = value.strip_prefix('v').unwrap_or(value);
+        let suffix_start = value.find(['-', '+']).unwrap_or(value.len());
+        let (core, suffix) = value.split_at(suffix_start);
+        let mut parts = core.split('.').collect::<Vec<_>>();
+        if parts.is_empty()
+            || parts.len() > 3
+            || parts
+                .iter()
+                .any(|part| part.is_empty() || !part.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            return None;
+        }
+        while parts.len() < 3 {
+            parts.push("0");
+        }
+        SemverVersion::parse(&format!("{}{}", parts.join("."), suffix)).ok()
+    })
 }
 
 fn find_name_version_offset(source: &str, name_pat: &str, ver_pat: &str) -> Option<(usize, usize)> {
@@ -1304,6 +1410,7 @@ mod tests {
     #[test]
     fn range_matching_respects_fixed_event() {
         let range = OsvRange {
+            range_type: Some("SEMVER".to_string()),
             events: vec![
                 OsvEvent {
                     introduced: Some("1.0.0".to_string()),
@@ -1316,7 +1423,217 @@ mod tests {
             ],
             ..OsvRange::default()
         };
-        assert!(version_in_range("1.1.9", &range));
-        assert!(!version_in_range("1.2.0", &range));
+        let matching = package_ref(
+            "crates.io",
+            "demo",
+            "1.1.9",
+            "demo = 1.1.9\n",
+            Path::new("Cargo.lock"),
+            0,
+            12,
+        );
+        let fixed = package_ref(
+            "crates.io",
+            "demo",
+            "1.2.0",
+            "demo = 1.2.0\n",
+            Path::new("Cargo.lock"),
+            0,
+            12,
+        );
+        assert!(version_in_range(&matching, &range));
+        assert!(!version_in_range(&fixed, &range));
+    }
+
+    #[test]
+    fn pypi_prerelease_range_matches_before_final_release() {
+        let package = package_ref(
+            "PyPI",
+            "mypkg",
+            "1.0.0rc1",
+            "mypkg==1.0.0rc1\n",
+            Path::new("requirements.txt"),
+            0,
+            16,
+        );
+        let affected = OsvAffected {
+            package: Some(OsvPackage {
+                name: Some("mypkg".to_string()),
+                ecosystem: Some("PyPI".to_string()),
+                purl: None,
+            }),
+            ranges: vec![OsvRange {
+                range_type: Some("ECOSYSTEM".to_string()),
+                events: vec![
+                    OsvEvent {
+                        introduced: Some("0".to_string()),
+                        ..OsvEvent::default()
+                    },
+                    OsvEvent {
+                        fixed: Some("1.0.0".to_string()),
+                        ..OsvEvent::default()
+                    },
+                ],
+            }],
+            ..OsvAffected::default()
+        };
+
+        assert!(affected_version_matches(&package, &affected));
+    }
+
+    #[test]
+    fn pypi_exact_versions_use_pep440_equality() {
+        let package = package_ref(
+            "PyPI",
+            "mypkg",
+            "1.0",
+            "mypkg==1.0\n",
+            Path::new("requirements.txt"),
+            0,
+            10,
+        );
+        let affected = OsvAffected {
+            package: Some(OsvPackage {
+                name: Some("mypkg".to_string()),
+                ecosystem: Some("PyPI".to_string()),
+                purl: None,
+            }),
+            versions: vec!["1.0.0".to_string()],
+            ..OsvAffected::default()
+        };
+
+        assert!(affected_version_matches(&package, &affected));
+    }
+
+    #[test]
+    fn semver_prerelease_range_matches_before_final_release() {
+        let package = package_ref(
+            "npm",
+            "demo",
+            "1.0.0-rc.1",
+            "demo@1.0.0-rc.1\n",
+            Path::new("package-lock.json"),
+            0,
+            15,
+        );
+        let affected = OsvAffected {
+            package: Some(OsvPackage {
+                name: Some("demo".to_string()),
+                ecosystem: Some("npm".to_string()),
+                purl: None,
+            }),
+            ranges: vec![OsvRange {
+                range_type: Some("SEMVER".to_string()),
+                events: vec![
+                    OsvEvent {
+                        introduced: Some("0".to_string()),
+                        ..OsvEvent::default()
+                    },
+                    OsvEvent {
+                        fixed: Some("1.0.0".to_string()),
+                        ..OsvEvent::default()
+                    },
+                ],
+            }],
+            ..OsvAffected::default()
+        };
+
+        assert!(affected_version_matches(&package, &affected));
+    }
+
+    #[test]
+    fn range_matching_respects_limit_event() {
+        let range = OsvRange {
+            range_type: Some("SEMVER".to_string()),
+            events: vec![
+                OsvEvent {
+                    introduced: Some("1.0.0".to_string()),
+                    ..OsvEvent::default()
+                },
+                OsvEvent {
+                    limit: Some("2.0.0".to_string()),
+                    ..OsvEvent::default()
+                },
+            ],
+        };
+        let inside = package_ref(
+            "crates.io",
+            "demo",
+            "1.5.0",
+            "demo = 1.5.0\n",
+            Path::new("Cargo.lock"),
+            0,
+            12,
+        );
+        let at_limit = package_ref(
+            "crates.io",
+            "demo",
+            "2.0.0",
+            "demo = 2.0.0\n",
+            Path::new("Cargo.lock"),
+            0,
+            12,
+        );
+
+        assert!(version_in_range(&inside, &range));
+        assert!(!version_in_range(&at_limit, &range));
+    }
+
+    #[test]
+    fn first_fixed_version_uses_matching_range() {
+        let package = package_ref(
+            "npm",
+            "demo",
+            "3.1.0",
+            "demo@3.1.0\n",
+            Path::new("package-lock.json"),
+            0,
+            10,
+        );
+        let vuln = OsvVulnerability {
+            id: "GHSA-test-0001".to_string(),
+            affected: vec![OsvAffected {
+                package: Some(OsvPackage {
+                    name: Some("demo".to_string()),
+                    ecosystem: Some("npm".to_string()),
+                    purl: None,
+                }),
+                ranges: vec![
+                    OsvRange {
+                        range_type: Some("SEMVER".to_string()),
+                        events: vec![
+                            OsvEvent {
+                                introduced: Some("1.0.0".to_string()),
+                                ..OsvEvent::default()
+                            },
+                            OsvEvent {
+                                fixed: Some("1.2.0".to_string()),
+                                ..OsvEvent::default()
+                            },
+                        ],
+                    },
+                    OsvRange {
+                        range_type: Some("SEMVER".to_string()),
+                        events: vec![
+                            OsvEvent {
+                                introduced: Some("3.0.0".to_string()),
+                                ..OsvEvent::default()
+                            },
+                            OsvEvent {
+                                fixed: Some("3.2.5".to_string()),
+                                ..OsvEvent::default()
+                            },
+                        ],
+                    },
+                ],
+                ..OsvAffected::default()
+            }],
+            ..OsvVulnerability::default()
+        };
+
+        assert_eq!(
+            first_fixed_version(&package, &vuln).as_deref(),
+            Some("3.2.5")
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5250,6 +5250,73 @@ mod config_files {
     }
 
     #[test]
+    fn sca_offline_matches_pypi_prerelease_range_before_final_release() {
+        let dir = TempDir::new().expect("temp dir");
+        let db_path = dir.path().join("advisory.json");
+        fs::write(dir.path().join("requirements.txt"), "mypkg==1.0.0rc1\n")
+            .expect("write requirements fixture");
+        let advisories = serde_json::json!([
+            {
+                "id": "GHSA-test-prerelease",
+                "summary": "pre-release should still be below 1.0.0",
+                "affected": [{
+                    "package": {
+                        "ecosystem": "PyPI",
+                        "name": "mypkg"
+                    },
+                    "ranges": [{
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "0"},
+                            {"fixed": "1.0.0"}
+                        ]
+                    }]
+                }],
+                "database_specific": {
+                    "severity": "HIGH"
+                }
+            }
+        ]);
+        fs::write(
+            &db_path,
+            serde_json::to_string_pretty(&advisories).expect("json"),
+        )
+        .expect("write osv fixture");
+
+        let output = foxguard_cmd()
+            .args([
+                "sca",
+                "--config",
+                "/dev/null",
+                dir.path().to_str().expect("utf8 dir"),
+                "--sca-offline",
+                "--sca-db",
+                db_path.to_str().expect("utf8 path"),
+                "-f",
+                "json",
+            ])
+            .output()
+            .expect("failed to execute foxguard");
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "expected findings; stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let findings: Vec<serde_json::Value> = scan_json_findings_from_slice(&output.stdout);
+        assert_sca_finding(
+            &findings,
+            "requirements.txt",
+            "mypkg",
+            "1.0.0rc1",
+            "PyPI",
+            "GHSA-test-prerelease",
+            "1.0.0",
+        );
+    }
+
+    #[test]
     fn sca_offline_without_db_does_not_disable_pq_manifest_rules() {
         let output = foxguard_cmd()
             .args([


### PR DESCRIPTION
## Summary
- replace the naive OSV version tokenizer with explicit ecosystem-aware comparison for PyPI and semver-based ecosystems
- evaluate OSV `versions` and `ranges` as a union, honor `range.type`, and support `limit` events
- add unit and integration regressions for the PyPI prerelease case from #479 and for matching the correct fixed version across multiple ranges

Closes #479

## Testing
- cargo fmt
- cargo test deps::tests --lib
- cargo test sca_offline_matches_pypi_prerelease_range_before_final_release --test integration
- cargo test sca_reports_osv_vulnerabilities_for_supported_lockfiles --test integration
- full `cargo test` was not rerun here because `origin/main` still carries the known unrelated process-wrapper failures tracked by #482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced vulnerability detection with improved, ecosystem-aware version comparison.
  * Better handling of prerelease versions and range limit events when matching advisories.
  * More accurate selection of fixed versions from advisory ranges.

* **Tests**
  * Added integration and unit tests covering PyPI prerelease and range/limit matching.

* **Chores**
  * Added libraries to improve version parsing and comparison across ecosystems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->