### PR TITLE
fix(scan): make thresholds per-scan instead of process-global

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,8 @@
 use crate::baseline::{load_baseline, suppress_with_baseline_at_root, write_baseline_at_root};
 use crate::cli::{DiffArgs, OutputFormat, ScanArgs, SecretsArgs, TuiArgs};
 use crate::config::{
-    apply_scan_defaults, apply_scan_thresholds, apply_secrets_defaults, apply_severity_overrides,
-    load_for_scan, suppress_with_patterns, suppress_with_scan_ignores, FoxguardConfig,
+    apply_scan_defaults, apply_secrets_defaults, apply_severity_overrides, load_for_scan,
+    secret_scan_thresholds, suppress_with_patterns, suppress_with_scan_ignores, FoxguardConfig,
 };
 use crate::deps::{scan_dependency_vulnerabilities, DependencyScanOptions};
 use crate::diff::run_diff_with_coccinelle_warnings;
@@ -114,12 +114,8 @@ fn execute_scan_resolved(scan: ScanArgs) -> Result<ScanExecution, String> {
     validate_rules_path(scan.rules.as_deref())?;
     let identity_root = finding_identity_root(Path::new(&scan.path), config.as_ref());
 
-    // Install any `scan.thresholds.*` overrides into process-wide state
-    // before the rules run. Must happen after config load and before
-    // `scan_directory_with_notices` dispatches parallel rule execution.
-    apply_scan_thresholds(config.as_ref());
-
     let mut registry = build_registry(scan.no_builtins, scan.rules.as_deref())?;
+    registry.set_secret_thresholds(secret_scan_thresholds(config.as_ref()));
     let (mut coccinelle_rules, mut coccinelle_notices) = match scan.rules.as_deref() {
         Some(rules_path) => coccinelle::load_coccinelle_rules(Path::new(rules_path)),
         None => (Vec::new(), Vec::new()),
@@ -433,7 +429,6 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
     validate_root_path(&args.path)?;
     let config = load_for_scan(Path::new(&args.path), args.config.as_deref())?;
     let identity_root = finding_identity_root(Path::new(&args.path), config.as_ref());
-    apply_scan_thresholds(config.as_ref());
     let config_scan = config.as_ref().map(|config| &config.scan);
     let rules_path = args
         .rules
@@ -448,6 +443,7 @@ pub fn execute_diff(args: &DiffArgs) -> Result<DiffExecution, String> {
         .or_else(|| config_scan.and_then(|scan_config| scan_config.severity));
     let min_confidence = config_scan.and_then(|scan_config| scan_config.min_confidence);
     let mut registry = build_registry(no_builtins, rules_path)?;
+    registry.set_secret_thresholds(secret_scan_thresholds(config.as_ref()));
     let (mut coccinelle_rules, mut coccinelle_notices) = match rules_path {
         Some(rules_path) => coccinelle::load_coccinelle_rules(Path::new(rules_path)),
         None => (Vec::new(), Vec::new()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,5 @@
 use crate::cli::{ScanArgs, SecretsArgs, SeverityFilter};
-use crate::rules::common::{
-    set_hardcoded_secret_min_entropy_override, set_hardcoded_secret_min_length_override,
-};
+use crate::rules::common::SecretScanThresholds;
 use crate::{Finding, Severity};
 use regex::Regex;
 use serde::Deserialize;
@@ -553,16 +551,11 @@ pub fn suppress_with_patterns(
         .collect()
 }
 
-/// Install any [`ScanThresholds`] overrides from the loaded config into the
-/// scanner's process-wide state. Idempotent: calling with a fresh config
-/// overwrites any previous override, so repeated scans in the same
-/// process (e.g. the TUI) cannot leak a stale value.
-pub fn apply_scan_thresholds(config: Option<&FoxguardConfig>) {
-    let min_length = config.and_then(|cfg| cfg.scan.thresholds.secrets.min_length);
-    set_hardcoded_secret_min_length_override(min_length);
-
-    let min_entropy = config.and_then(|cfg| cfg.scan.thresholds.secrets.min_entropy);
-    set_hardcoded_secret_min_entropy_override(min_entropy);
+pub fn secret_scan_thresholds(config: Option<&FoxguardConfig>) -> SecretScanThresholds {
+    SecretScanThresholds::new(
+        config.and_then(|cfg| cfg.scan.thresholds.secrets.min_length),
+        config.and_then(|cfg| cfg.scan.thresholds.secrets.min_entropy),
+    )
 }
 
 pub fn editable_config_path(
@@ -1678,12 +1671,10 @@ mod tests {
     }
 
     #[test]
-    fn apply_scan_thresholds_installs_and_resets_min_length_override() {
-        use crate::rules::common::hardcoded_secret_min_length;
-
-        // Baseline: default value when no config present.
-        apply_scan_thresholds(None);
-        assert_eq!(hardcoded_secret_min_length(), 4);
+    fn secret_scan_thresholds_use_defaults_and_overrides() {
+        let defaults = secret_scan_thresholds(None);
+        assert_eq!(defaults.min_length, 4);
+        assert_eq!(defaults.min_entropy, None);
 
         // Override via loaded config.
         let repo = TempDir::new().expect("failed to create temp dir");
@@ -1695,8 +1686,9 @@ mod tests {
         let loaded = load_for_scan(repo.path(), None)
             .expect("failed to load config")
             .expect("expected config");
-        apply_scan_thresholds(Some(&loaded));
-        assert_eq!(hardcoded_secret_min_length(), 9);
+        let configured = secret_scan_thresholds(Some(&loaded));
+        assert_eq!(configured.min_length, 9);
+        assert_eq!(configured.min_entropy, None);
 
         // Re-applying a config without the override resets to the default,
         // so repeated scans in the same process (TUI) cannot leak state.
@@ -1709,8 +1701,9 @@ mod tests {
         let fresh = load_for_scan(repo2.path(), None)
             .expect("failed to load config")
             .expect("expected config");
-        apply_scan_thresholds(Some(&fresh));
-        assert_eq!(hardcoded_secret_min_length(), 4);
+        let reset = secret_scan_thresholds(Some(&fresh));
+        assert_eq!(reset.min_length, 4);
+        assert_eq!(reset.min_entropy, None);
     }
 
     // ── TUI triage helpers: severity override + disable rule writers ──────

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -747,6 +747,7 @@ fn scan_files(
 ) -> (ScanResult, Vec<String>) {
     let start = Instant::now();
     let warnings = Mutex::new(Vec::new());
+    let secret_thresholds = registry.secret_thresholds();
 
     let mut taint_specs_by_lang: HashMap<Language, Vec<crate::rules::RegistryTaintSpec>> =
         HashMap::new();
@@ -1198,6 +1199,7 @@ fn scan_files(
                 python_import_paths: python_import_paths.as_ref(),
                 javascript_import_paths: javascript_import_paths.as_ref(),
                 go_same_package_paths,
+                secret_thresholds,
             };
 
             let mut file_findings = Vec::new();
@@ -1425,7 +1427,7 @@ mod tests {
     use super::*;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Barrier,
     };
 
     struct CountingRule {
@@ -1557,6 +1559,73 @@ mod tests {
         assert!(findings.is_empty());
         assert_eq!(syntax_calls.load(Ordering::SeqCst), 1);
         assert_eq!(context_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn concurrent_scans_keep_secret_thresholds_per_registry() {
+        let repo = tempfile::tempdir().expect("failed to create temp dir");
+        for index in 0..64 {
+            std::fs::write(
+                repo.path().join(format!("file-{index}.js")),
+                "const apiKey = \"secret1\";\n",
+            )
+            .expect("failed to write fixture");
+        }
+
+        let barrier = Arc::new(Barrier::new(2));
+        let low_path = repo.path().to_path_buf();
+        let high_path = repo.path().to_path_buf();
+        let low_barrier = Arc::clone(&barrier);
+        let high_barrier = Arc::clone(&barrier);
+
+        let low_threshold = std::thread::spawn(move || {
+            let mut registry = RuleRegistry::empty();
+            registry.register(Box::new(crate::rules::javascript::NoHardcodedSecret));
+            registry.set_secret_thresholds(crate::rules::common::SecretScanThresholds::new(
+                Some(4),
+                None,
+            ));
+            low_barrier.wait();
+
+            for _ in 0..8 {
+                let (result, notices) = scan_directory_with_notices(
+                    low_path.to_str().expect("non-utf8 path"),
+                    &registry,
+                    1_000_000,
+                    None,
+                );
+                assert!(notices.is_empty());
+                assert_eq!(result.findings.len(), 64);
+            }
+        });
+
+        let high_threshold = std::thread::spawn(move || {
+            let mut registry = RuleRegistry::empty();
+            registry.register(Box::new(crate::rules::javascript::NoHardcodedSecret));
+            registry.set_secret_thresholds(crate::rules::common::SecretScanThresholds::new(
+                Some(9),
+                None,
+            ));
+            high_barrier.wait();
+
+            for _ in 0..8 {
+                let (result, notices) = scan_directory_with_notices(
+                    high_path.to_str().expect("non-utf8 path"),
+                    &registry,
+                    1_000_000,
+                    None,
+                );
+                assert!(notices.is_empty());
+                assert!(result.findings.is_empty());
+            }
+        });
+
+        low_threshold
+            .join()
+            .unwrap_or_else(|_| panic!("low-threshold scan panicked"));
+        high_threshold
+            .join()
+            .unwrap_or_else(|_| panic!("high-threshold scan panicked"));
     }
 
     #[test]

--- a/src/rules/common.rs
+++ b/src/rules/common.rs
@@ -1,37 +1,10 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
 
 use regex::Regex;
 
 use crate::{Finding, Severity};
-
-// ─── Min-entropy threshold (atomic global, same pattern as min_length) ────
-
-/// Process-wide override for the hardcoded-secret minimum entropy threshold.
-/// `0` bits (stored as `u32` via `f32::to_bits()`) means "no override".
-static HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE: std::sync::atomic::AtomicU32 =
-    std::sync::atomic::AtomicU32::new(0);
-
-/// Install a process-wide `scan.thresholds.secrets.min_entropy` override.
-pub fn set_hardcoded_secret_min_entropy_override(value: Option<f32>) {
-    let bits = match value {
-        Some(v) => v.to_bits(),
-        None => 0,
-    };
-    HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE.store(bits, Ordering::Relaxed);
-}
-
-/// Returns the configured min-entropy threshold, or `None` if unset.
-fn hardcoded_secret_min_entropy() -> Option<f32> {
-    let bits = HARDCODED_SECRET_MIN_ENTROPY_OVERRIDE.load(Ordering::Relaxed);
-    if bits == 0 {
-        None
-    } else {
-        Some(f32::from_bits(bits))
-    }
-}
 
 /// Compute Shannon entropy (bits per character) for a byte string.
 pub fn shannon_entropy(s: &str) -> f32 {
@@ -101,34 +74,25 @@ pub fn csharp_hardcoded_secret_re() -> &'static Regex {
 /// behavior is unchanged out of the box.
 pub const DEFAULT_HARDCODED_SECRET_MIN_LENGTH: usize = 4;
 
-/// Process-wide override for the hardcoded-secret minimum length threshold.
-///
-/// Stored as an atomic so rule checks (which run in a rayon thread pool)
-/// can read it without locking. `0` means "no override, use the default".
-/// Callers set this from the loaded `FoxguardConfig` before scanning.
-static HARDCODED_SECRET_MIN_LENGTH_OVERRIDE: AtomicUsize = AtomicUsize::new(0);
-
-/// Install a process-wide `scan.secrets.min_length` override. Pass `None` to
-/// clear (reverting to [`DEFAULT_HARDCODED_SECRET_MIN_LENGTH`]).
-///
-/// Intentionally process-scoped rather than per-scan because rule structs
-/// are zero-sized and the rule-trait `check` method does not take a config
-/// parameter. Keeping the override in an atomic avoids a wide-reaching
-/// refactor of the `Rule` trait while still giving users a single config
-/// knob. A per-rule `configure()` hook (see issue #210) would subsume this.
-pub fn set_hardcoded_secret_min_length_override(value: Option<usize>) {
-    HARDCODED_SECRET_MIN_LENGTH_OVERRIDE.store(value.unwrap_or(0), Ordering::Relaxed);
+/// Per-scan thresholds for `*-hardcoded-secret` rules.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SecretScanThresholds {
+    pub min_length: usize,
+    pub min_entropy: Option<f32>,
 }
 
-/// Minimum length (in bytes) a string must have before a `*-hardcoded-secret`
-/// rule will fire. Returns the configured override, falling back to
-/// [`DEFAULT_HARDCODED_SECRET_MIN_LENGTH`].
-pub fn hardcoded_secret_min_length() -> usize {
-    let override_value = HARDCODED_SECRET_MIN_LENGTH_OVERRIDE.load(Ordering::Relaxed);
-    if override_value == 0 {
-        DEFAULT_HARDCODED_SECRET_MIN_LENGTH
-    } else {
-        override_value
+impl SecretScanThresholds {
+    pub fn new(min_length: Option<usize>, min_entropy: Option<f32>) -> Self {
+        Self {
+            min_length: min_length.unwrap_or(DEFAULT_HARDCODED_SECRET_MIN_LENGTH),
+            min_entropy,
+        }
+    }
+}
+
+impl Default for SecretScanThresholds {
+    fn default() -> Self {
+        Self::new(None, None)
     }
 }
 
@@ -136,11 +100,11 @@ pub fn hardcoded_secret_min_length() -> usize {
 /// the configured thresholds for a `*-hardcoded-secret` rule:
 /// - `scan.thresholds.secrets.min_length` (default 4)
 /// - `scan.thresholds.secrets.min_entropy` (optional, disabled by default)
-pub fn is_secret_value_long_enough(inner: &str) -> bool {
-    if inner.len() < hardcoded_secret_min_length() {
+pub fn is_secret_value_long_enough(inner: &str, thresholds: SecretScanThresholds) -> bool {
+    if inner.len() < thresholds.min_length {
         return false;
     }
-    if let Some(min_ent) = hardcoded_secret_min_entropy() {
+    if let Some(min_ent) = thresholds.min_entropy {
         if shannon_entropy(inner) < min_ent {
             return false;
         }
@@ -477,6 +441,24 @@ mod tests {
         assert_eq!(confidence_for_hops(2), 0.8);
         assert_eq!(confidence_for_hops(3), 0.6);
         assert_eq!(confidence_for_hops(10), 0.6);
+    }
+
+    #[test]
+    fn secret_thresholds_default_to_legacy_min_length() {
+        let thresholds = SecretScanThresholds::default();
+
+        assert_eq!(thresholds.min_length, DEFAULT_HARDCODED_SECRET_MIN_LENGTH);
+        assert_eq!(thresholds.min_entropy, None);
+        assert!(is_secret_value_long_enough("abcd", thresholds));
+        assert!(!is_secret_value_long_enough("abc", thresholds));
+    }
+
+    #[test]
+    fn secret_thresholds_apply_min_entropy_per_scan() {
+        let thresholds = SecretScanThresholds::new(Some(4), Some(1.9));
+
+        assert!(is_secret_value_long_enough("Ab9$", thresholds));
+        assert!(!is_secret_value_long_enough("aaaa", thresholds));
     }
 
     #[test]

--- a/src/rules/csharp.rs
+++ b/src/rules/csharp.rs
@@ -720,7 +720,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::CSharp,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = csharp_hardcoded_secret_re();
@@ -741,7 +741,7 @@ impl_rule! {
                                 let val = &src[child.byte_range()];
                                 let trimmed = val.trim_matches(|c| c == '"' || c == '@');
                                 let trimmed = trimmed.trim_matches('"');
-                                if is_secret_value_long_enough(trimmed) {
+                                if is_secret_value_long_enough(trimmed, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -771,7 +771,7 @@ impl_rule! {
                                 let val = &src[right.byte_range()];
                                 let trimmed = val.trim_matches(|c| c == '"' || c == '@');
                                 let trimmed = trimmed.trim_matches('"');
-                                if is_secret_value_long_enough(trimmed) {
+                                if is_secret_value_long_enough(trimmed, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/go.rs
+++ b/src/rules/go.rs
@@ -290,7 +290,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Go,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -312,7 +312,7 @@ impl_rule! {
                         {
                             let val = &src[value_node.byte_range()];
                             let inner = val.trim_matches(|c| c == '"' || c == '`');
-                            if is_secret_value_long_enough(inner) {
+                            if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                 findings.push(make_finding(
                                     _self.id(),
                                     _self.severity(),
@@ -342,7 +342,7 @@ impl_rule! {
                             {
                                 let val = &src[value_node.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -373,7 +373,7 @@ impl_rule! {
                             {
                                 let val = &src[value_node.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '`');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/java.rs
+++ b/src/rules/java.rs
@@ -862,7 +862,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Java,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -877,7 +877,7 @@ impl_rule! {
                             if value.kind() == "string_literal" {
                                 let val = &src[value.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -905,7 +905,7 @@ impl_rule! {
                             if right.kind() == "string_literal" {
                                 let val = &src[right.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/javascript.rs
+++ b/src/rules/javascript.rs
@@ -200,7 +200,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::JavaScript,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -220,7 +220,7 @@ impl_rule! {
                         let val = &src[value_node.byte_range()];
                         // Skip empty strings and short placeholders
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-                        if is_secret_value_long_enough(inner)
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds)
                             && (looks_like_secret_value(inner)
                                 || is_high_signal_secret_name(name))
                         {
@@ -253,7 +253,7 @@ impl_rule! {
                     {
                         let val = &src[right.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-                        if is_secret_value_long_enough(inner)
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds)
                             && (looks_like_secret_value(inner)
                                 || is_high_signal_secret_name(left_text))
                         {
@@ -1112,7 +1112,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded session secret in express-session configuration",
     language = Language::JavaScript,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         walk_tree(tree.root_node(), source, &mut |node, src| {
@@ -1131,7 +1131,9 @@ impl_rule! {
                         // (e.g. mock data) is not a session-secret finding.
                         let val = &src[value.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                        if is_secret_value_long_enough(inner) && inside_session_call(node, src) {
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds)
+                            && inside_session_call(node, src)
+                        {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -1482,7 +1484,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "JWT signing or verification with a hardcoded secret",
     language = Language::JavaScript,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
 
@@ -1515,7 +1517,7 @@ impl_rule! {
 
             let secret = &src[secret_arg.byte_range()];
             let inner = secret.trim_matches(|c| c == '"' || c == '\'' || c == '`');
-            if !is_secret_value_long_enough(inner) {
+            if !is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                 return;
             }
 

--- a/src/rules/kotlin.rs
+++ b/src/rules/kotlin.rs
@@ -653,7 +653,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Kotlin,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -684,7 +684,7 @@ impl_rule! {
                             if child.kind() == "string_literal" {
                                 let val = &src[child.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),
@@ -715,7 +715,7 @@ impl_rule! {
                                 if right.kind() == "string_literal" {
                                     let val = &src[right.byte_range()];
                                     let inner = val.trim_matches('"');
-                                    if is_secret_value_long_enough(inner) {
+                                    if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                         findings.push(make_finding(
                                             _self.id(),
                                             _self.severity(),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -307,6 +307,8 @@ pub struct FileContext<'a> {
     /// share the same package and can call each other's functions.
     /// Excludes the current file itself.
     pub go_same_package_paths: Option<Vec<std::path::PathBuf>>,
+    /// Per-scan hardcoded-secret thresholds captured from the registry.
+    pub secret_thresholds: common::SecretScanThresholds,
 }
 
 /// A security rule that checks parsed source code for vulnerabilities.
@@ -363,6 +365,7 @@ pub struct RuleRegistry {
     rules: Vec<Box<dyn Rule>>,
     /// Rule IDs that are opt-in only (not active unless explicitly enabled).
     opt_in_ids: std::collections::HashSet<String>,
+    secret_thresholds: common::SecretScanThresholds,
 }
 
 impl Default for RuleRegistry {
@@ -376,6 +379,7 @@ impl RuleRegistry {
         Self {
             rules: Vec::new(),
             opt_in_ids: std::collections::HashSet::new(),
+            secret_thresholds: common::SecretScanThresholds::default(),
         }
     }
 
@@ -675,6 +679,14 @@ impl RuleRegistry {
 
     pub fn register(&mut self, rule: Box<dyn Rule>) {
         self.rules.push(rule);
+    }
+
+    pub fn set_secret_thresholds(&mut self, thresholds: common::SecretScanThresholds) {
+        self.secret_thresholds = thresholds;
+    }
+
+    pub fn secret_thresholds(&self) -> common::SecretScanThresholds {
+        self.secret_thresholds
     }
 
     /// Register a rule that is opt-in only (not active by default).

--- a/src/rules/php.rs
+++ b/src/rules/php.rs
@@ -464,7 +464,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Php,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -482,7 +482,7 @@ impl_rule! {
                             {
                                 let val = &src[right.byte_range()];
                                 let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/python.rs
+++ b/src/rules/python.rs
@@ -235,7 +235,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Python,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -255,7 +255,7 @@ impl_rule! {
                             .trim_start_matches("f\"")
                             .trim_start_matches("f'")
                             .trim_matches(|c| c == '"' || c == '\'');
-                        if is_secret_value_long_enough(inner)
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds)
                             && (looks_like_secret_value(inner)
                                 || is_high_signal_secret_name(left_text))
                         {
@@ -1036,7 +1036,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Django SECRET_KEY hardcoded in source code",
     language = Language::Python,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
 
@@ -1051,7 +1051,7 @@ impl_rule! {
                     if left_text == "SECRET_KEY" && right.kind() == "string" {
                         let val = &src[right.byte_range()];
                         let inner = val.trim_matches(|c| c == '"' || c == '\'');
-                        if is_secret_value_long_enough(inner) {
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),
@@ -1252,7 +1252,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Flask SECRET_KEY hardcoded in source code",
     language = Language::Python,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
 
@@ -1281,7 +1281,7 @@ impl_rule! {
 
             let val = &src[right.byte_range()];
             let inner = val.trim_matches(|c| c == '"' || c == '\'');
-            if !is_secret_value_long_enough(inner) {
+            if !is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                 return;
             }
 
@@ -1924,7 +1924,7 @@ impl_rule! {
             if secret_arg.kind() == "string" || secret_arg.kind() == "concatenated_string" {
                 let secret_text = &src[secret_arg.byte_range()];
                 let inner = secret_text.trim_matches(|c| c == '"' || c == '\'');
-                if is_secret_value_long_enough(inner) {
+                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                     findings.push(make_finding(
                         _self.id(),
                         _self.severity(),

--- a/src/rules/ruby.rs
+++ b/src/rules/ruby.rs
@@ -591,7 +591,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Ruby,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -610,7 +610,9 @@ impl_rule! {
                         let inner = val
                             .trim_start_matches(['"', '\''])
                             .trim_end_matches(['"', '\'']);
-                        if is_secret_value_long_enough(inner) && looks_like_secret_value(inner) {
+                        if is_secret_value_long_enough(inner, ctx.secret_thresholds)
+                            && looks_like_secret_value(inner)
+                        {
                             findings.push(make_finding(
                                 _self.id(),
                                 _self.severity(),

--- a/src/rules/rust_lang.rs
+++ b/src/rules/rust_lang.rs
@@ -466,7 +466,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Rust,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let secret_pattern = hardcoded_secret_re();
@@ -481,7 +481,7 @@ impl_rule! {
                             if value.kind() == "string_literal" {
                                 let val = &src[value.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if is_secret_value_long_enough(inner) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds) {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),

--- a/src/rules/swift.rs
+++ b/src/rules/swift.rs
@@ -230,7 +230,7 @@ impl_rule! {
     cwe = Some("CWE-798"),
     description = "Hardcoded secret or credential detected",
     language = Language::Swift,
-    fn check(_self, source, tree) {
+    fn check_with_context(_self, source, tree, ctx) {
 
         let mut findings = Vec::new();
         let mut reported_lines = std::collections::HashSet::new();
@@ -259,7 +259,9 @@ impl_rule! {
                         if has_string_value {
                             let inner = string_val.trim_matches('"');
                             let line = node.start_position().row;
-                            if is_secret_value_long_enough(inner) && reported_lines.insert(line) {
+                            if is_secret_value_long_enough(inner, ctx.secret_thresholds)
+                                && reported_lines.insert(line)
+                            {
                                 findings.push(make_finding(
                                     _self.id(),
                                     _self.severity(),
@@ -294,7 +296,9 @@ impl_rule! {
                             {
                                 let val = &src[child.byte_range()];
                                 let inner = val.trim_matches('"');
-                                if is_secret_value_long_enough(inner) && reported_lines.insert(line) {
+                                if is_secret_value_long_enough(inner, ctx.secret_thresholds)
+                                    && reported_lines.insert(line)
+                                {
                                     findings.push(make_finding(
                                         _self.id(),
                                         _self.severity(),


### PR DESCRIPTION
## Summary
- remove the process-global hardcoded-secret threshold atomics from the scan path
- store secret thresholds on the per-scan rule registry and thread them into FileContext
- convert the hardcoded-secret rules to read thresholds from scan-local context, and add a concurrent regression test

Closes #483.

## Validation
- cargo fmt
- cargo clippy --lib -- -D warnings
- cargo test secret_thresholds --lib
- cargo test concurrent_scans_keep_secret_thresholds_per_registry --lib
- cargo test --lib (still hits the existing host-dependent engine::process dd/sleep failures on this environment; unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved secret scan threshold configuration to be scoped per-scan rather than process-wide, enabling independent threshold settings across concurrent scans and preventing configuration interference between simultaneous scan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->