### PR TITLE
feat(compat): metavariable-comparison operator

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -68,6 +68,13 @@ Rule scoping:
 Metavariable filtering:
 
 - `metavariable-regex`
+- `metavariable-comparison` — supported subset:
+  - Expression shape: `$VAR <op> <number>` or `<number> <op> $VAR`
+  - Operators: `<`, `<=`, `>`, `>=`, `==`, `!=`
+  - Literals: decimal integers, floats, hex (`0x…`), binary (`0b…`); C-style suffixes (`L`, `UL`, `LL`, etc.) are stripped automatically
+  - If the bound metavariable text is not parseable as a number the constraint evaluates to false (no match) — identical to Semgrep behaviour
+  - `base: 10` (or absent) accepted; any other `base:` value is warn-skipped for that constraint entry only
+  - `strip:` field is accepted in YAML (not rejected) but is not required for correctness since suffix-stripping is always applied; unsupported `strip: true` behaviour beyond suffix stripping is silently ignored
 
 Taint rules (`mode: taint`):
 

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -76,6 +76,8 @@ pub struct PatternClause {
     pub pattern_either: Option<Vec<PatternEntry>>,
     #[serde(default, rename = "metavariable-regex")]
     pub metavariable_regex: Option<SemgrepMetavariableRegexClause>,
+    #[serde(default, rename = "metavariable-comparison")]
+    pub metavariable_comparison: Option<SemgrepMetavariableComparisonClause>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -103,6 +105,21 @@ pub struct SemgrepPaths {
 pub struct SemgrepMetavariableRegexClause {
     pub metavariable: String,
     pub regex: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct SemgrepMetavariableComparisonClause {
+    pub metavariable: String,
+    pub comparison: String,
+    /// Optional integer base for parsing (e.g. 16 for hex). Warn-skipped if
+    /// present — we only support base-10 by default.
+    #[serde(default)]
+    pub base: Option<u32>,
+    /// Optional strip flag (Semgrep strips L/U suffixes from integer literals).
+    /// Warn-skipped if true — the common C-integer suffix case is handled via
+    /// our own stripping logic.
+    #[serde(default)]
+    pub strip: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -141,6 +158,7 @@ pub enum PatternMatcher {
         inside: Option<CompiledAstPattern>,
         not_inside: Option<CompiledAstPattern>,
         metavariable_regexes: Vec<MetavariableRegexConstraint>,
+        metavariable_comparisons: Vec<MetavariableComparisonConstraint>,
     },
 }
 
@@ -177,6 +195,118 @@ pub struct PathFilter {
 pub struct MetavariableRegexConstraint {
     metavariable: String,
     regex: Regex,
+}
+
+/// Comparison operator for `metavariable-comparison`.
+#[derive(Debug, Clone, PartialEq)]
+enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+    Ne,
+}
+
+/// A compiled `metavariable-comparison` constraint.
+/// Supports: `$VAR <op> <number>` and `<number> <op> $VAR`,
+/// where `<number>` is an integer or float literal and `<op>` is one of
+/// `<`, `<=`, `>`, `>=`, `==`, `!=`.
+#[derive(Debug, Clone)]
+pub struct MetavariableComparisonConstraint {
+    metavariable: String,
+    op: CmpOp,
+    /// The literal value from the comparison string.
+    literal: f64,
+    /// If true, the expression is `literal <op> metavar` (operands flipped).
+    literal_is_lhs: bool,
+}
+
+// ─── Comparison parser ───────────────────────────────────────────────────────
+
+/// Parse a comparison string of the form `$VAR <op> <number>` or
+/// `<number> <op> $VAR`.  Returns `Err` with a human-readable message for
+/// anything outside that supported subset (caller will warn-skip it).
+fn parse_comparison(comparison: &str) -> Result<(String, CmpOp, f64, bool), String> {
+    let s = comparison.trim();
+
+    // Try longest operator first to avoid e.g. `<` matching `<=`.
+    const OPS: &[(&str, CmpOp)] = &[
+        ("<=", CmpOp::Le),
+        (">=", CmpOp::Ge),
+        ("!=", CmpOp::Ne),
+        ("==", CmpOp::Eq),
+        ("<", CmpOp::Lt),
+        (">", CmpOp::Gt),
+    ];
+
+    for (op_str, op) in OPS {
+        if let Some(idx) = s.find(op_str) {
+            let lhs = s[..idx].trim();
+            let rhs = s[idx + op_str.len()..].trim();
+
+            // Figure out which side is the metavar and which is the literal.
+            let (metavar, literal_str, literal_is_lhs) = if lhs.starts_with('$') {
+                (lhs, rhs, false)
+            } else if rhs.starts_with('$') {
+                (rhs, lhs, true)
+            } else {
+                return Err(format!("metavariable-comparison: no metavariable in '{s}'"));
+            };
+
+            // Validate the metavar token.
+            if metavariable_key(metavar).is_none() {
+                return Err(format!(
+                    "metavariable-comparison: invalid metavariable token '{metavar}' in '{s}'"
+                ));
+            }
+
+            // Strip common C integer suffixes (L, UL, LL, etc.) and leading
+            // 0x/0b so we can parse as f64.
+            let literal_str = strip_numeric_suffixes(literal_str);
+            let literal: f64 = parse_numeric(&literal_str).ok_or_else(|| {
+                format!(
+                    "metavariable-comparison: cannot parse numeric literal '{literal_str}' in '{s}'"
+                )
+            })?;
+
+            return Ok((metavar.to_string(), op.clone(), literal, literal_is_lhs));
+        }
+    }
+
+    Err(format!(
+        "metavariable-comparison: unsupported comparison expression '{s}'"
+    ))
+}
+
+/// Strip trailing C-style suffixes (`L`, `U`, `UL`, `LL`, `ULL`, etc.)
+/// from an integer-literal string (case-insensitive), so `10L` parses as `10`.
+fn strip_numeric_suffixes(s: &str) -> String {
+    let upper = s.to_uppercase();
+    let stripped = upper.trim_end_matches(['L', 'U']);
+    stripped.to_string()
+}
+
+/// Parse a numeric string (decimal int, hex `0x…`, binary `0b…`, or float)
+/// into an `f64`.
+fn parse_numeric(s: &str) -> Option<f64> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+
+    // Hex integer
+    if let Some(hex) = s.strip_prefix("0X").or_else(|| s.strip_prefix("0x")) {
+        return i64::from_str_radix(hex, 16).ok().map(|v| v as f64);
+    }
+
+    // Binary integer
+    if let Some(bin) = s.strip_prefix("0B").or_else(|| s.strip_prefix("0b")) {
+        return i64::from_str_radix(bin, 2).ok().map(|v| v as f64);
+    }
+
+    // Float or decimal integer — let Rust's built-in parser handle it.
+    s.parse::<f64>().ok()
 }
 
 impl Rule for SemgrepRule {
@@ -297,6 +427,67 @@ impl MetavariableRegexConstraint {
     }
 }
 
+impl MetavariableComparisonConstraint {
+    /// Build a constraint from a parsed YAML clause.
+    ///
+    /// Returns `Err` (caller should warn-skip) for:
+    /// - unsupported expression shapes (no metavar, non-numeric literal, etc.)
+    /// - `base:` values other than 10 (warn-skip only the constraint entry)
+    fn from_yaml(clause: &SemgrepMetavariableComparisonClause) -> Result<Self, String> {
+        // Warn-skip non-base-10 requests — we accept base:10 or absent.
+        if let Some(base) = clause.base {
+            if base != 10 {
+                return Err(format!(
+                    "metavariable-comparison: base:{base} is not supported (only base:10); skipping constraint"
+                ));
+            }
+        }
+
+        let (metavariable, op, literal, literal_is_lhs) = parse_comparison(&clause.comparison)?;
+
+        Ok(Self {
+            metavariable,
+            op,
+            literal,
+            literal_is_lhs,
+        })
+    }
+
+    /// Evaluate the comparison against the bound metavariable.
+    ///
+    /// Returns `false` (no match) if:
+    /// - the metavariable is not bound in `bindings`
+    /// - the bound text is not parseable as a number after suffix stripping
+    fn matches(&self, bindings: &HashMap<String, String>) -> bool {
+        let Some(value_text) = bindings.get(&self.metavariable) else {
+            return false;
+        };
+
+        // Attempt to parse the bound text as a number.
+        let stripped = strip_numeric_suffixes(value_text.trim());
+        let Some(value) = parse_numeric(&stripped) else {
+            return false;
+        };
+
+        // `literal_is_lhs` means the original expression was `literal <op> $VAR`.
+        // We flip the operand order so `lhs` and `rhs` are consistent.
+        let (lhs, rhs) = if self.literal_is_lhs {
+            (self.literal, value)
+        } else {
+            (value, self.literal)
+        };
+
+        match self.op {
+            CmpOp::Lt => lhs < rhs,
+            CmpOp::Le => lhs <= rhs,
+            CmpOp::Gt => lhs > rhs,
+            CmpOp::Ge => lhs >= rhs,
+            CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
+            CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+        }
+    }
+}
+
 impl CompiledAstPattern {
     fn new(source: String, lang: Language) -> Self {
         let source = prepare_pattern_for_grammar(source, lang);
@@ -414,6 +605,7 @@ fn match_pattern_in_tree(
             inside,
             not_inside,
             metavariable_regexes,
+            metavariable_comparisons,
         } => {
             // If we have an inside pattern, only search within matching contexts
             let search_roots = if let Some(inside_pat) = inside {
@@ -472,6 +664,10 @@ fn match_pattern_in_tree(
             }
 
             for constraint in metavariable_regexes {
+                results.retain(|r| constraint.matches(&r.bindings));
+            }
+
+            for constraint in metavariable_comparisons {
                 results.retain(|r| constraint.matches(&r.bindings));
             }
 
@@ -997,6 +1193,7 @@ fn build_matcher(yaml: &SemgrepRuleYaml, lang: Language) -> Result<PatternMatche
         let mut inside = None;
         let mut not_inside = None;
         let mut metavariable_regexes = Vec::new();
+        let mut metavariable_comparisons = Vec::new();
 
         for clause in clauses {
             if let Some(ref p) = clause.pattern {
@@ -1030,6 +1227,12 @@ fn build_matcher(yaml: &SemgrepRuleYaml, lang: Language) -> Result<PatternMatche
             if let Some(ref mr) = clause.metavariable_regex {
                 metavariable_regexes.push(MetavariableRegexConstraint::from_yaml(mr)?);
             }
+            if let Some(ref mc) = clause.metavariable_comparison {
+                match MetavariableComparisonConstraint::from_yaml(mc) {
+                    Ok(constraint) => metavariable_comparisons.push(constraint),
+                    Err(e) => eprintln!("Warning: {e}"),
+                }
+            }
         }
 
         return Ok(PatternMatcher::Combined {
@@ -1038,6 +1241,7 @@ fn build_matcher(yaml: &SemgrepRuleYaml, lang: Language) -> Result<PatternMatche
             inside,
             not_inside,
             metavariable_regexes,
+            metavariable_comparisons,
         });
     }
 
@@ -1087,6 +1291,7 @@ fn build_matcher(yaml: &SemgrepRuleYaml, lang: Language) -> Result<PatternMatche
                 .as_ref()
                 .map(|pattern| CompiledAstPattern::new(pattern.clone(), lang)),
             metavariable_regexes: Vec::new(),
+            metavariable_comparisons: Vec::new(),
         });
     }
 
@@ -1645,5 +1850,210 @@ rules:
         let findings = rules[0].check(source, &tree);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].line, 5);
+    }
+
+    // ─── metavariable-comparison unit tests ─────────────────────────────────
+
+    #[test]
+    fn test_parse_comparison_lt() {
+        let (mv, op, lit, flip) = parse_comparison("$X < 10").unwrap();
+        assert_eq!(mv, "$X");
+        assert_eq!(op, CmpOp::Lt);
+        assert!((lit - 10.0).abs() < f64::EPSILON);
+        assert!(!flip);
+    }
+
+    #[test]
+    fn test_parse_comparison_le() {
+        let (mv, op, lit, _flip) = parse_comparison("$X <= 5.5").unwrap();
+        assert_eq!(op, CmpOp::Le);
+        assert!((lit - 5.5).abs() < f64::EPSILON);
+        assert_eq!(mv, "$X");
+    }
+
+    #[test]
+    fn test_parse_comparison_gt() {
+        let (_mv, op, lit, _flip) = parse_comparison("$N > 100").unwrap();
+        assert_eq!(op, CmpOp::Gt);
+        assert!((lit - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_comparison_ge() {
+        let (_mv, op, lit, _flip) = parse_comparison("$N >= 0").unwrap();
+        assert_eq!(op, CmpOp::Ge);
+        assert!((lit - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_comparison_eq() {
+        let (mv, op, lit, _flip) = parse_comparison("$VAL == 42").unwrap();
+        assert_eq!(op, CmpOp::Eq);
+        assert!((lit - 42.0).abs() < f64::EPSILON);
+        assert_eq!(mv, "$VAL");
+    }
+
+    #[test]
+    fn test_parse_comparison_ne() {
+        let (_mv, op, lit, _flip) = parse_comparison("$VAL != 0").unwrap();
+        assert_eq!(op, CmpOp::Ne);
+        assert!((lit - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_parse_comparison_literal_lhs() {
+        let (mv, op, lit, flip) = parse_comparison("10 < $X").unwrap();
+        assert_eq!(mv, "$X");
+        // op is stored as-is from the expression; `flip` indicates literal is LHS
+        assert_eq!(op, CmpOp::Lt);
+        assert!((lit - 10.0).abs() < f64::EPSILON);
+        assert!(flip);
+    }
+
+    #[test]
+    fn test_parse_comparison_no_metavar_is_err() {
+        assert!(parse_comparison("10 < 20").is_err());
+    }
+
+    #[test]
+    fn test_parse_comparison_no_operator_is_err() {
+        assert!(parse_comparison("$X 10").is_err());
+    }
+
+    #[test]
+    fn test_constraint_matches_numeric_match() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X < 10".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut bindings = HashMap::new();
+        bindings.insert("$X".to_string(), "5".to_string());
+        assert!(constraint.matches(&bindings));
+    }
+
+    #[test]
+    fn test_constraint_non_match() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X < 10".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut bindings = HashMap::new();
+        bindings.insert("$X".to_string(), "15".to_string());
+        assert!(!constraint.matches(&bindings));
+    }
+
+    #[test]
+    fn test_constraint_non_numeric_binding_no_match() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X < 10".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut bindings = HashMap::new();
+        bindings.insert("$X".to_string(), "not_a_number".to_string());
+        assert!(!constraint.matches(&bindings));
+    }
+
+    #[test]
+    fn test_constraint_unbound_metavar_no_match() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X < 10".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let bindings = HashMap::new(); // $X not bound
+        assert!(!constraint.matches(&bindings));
+    }
+
+    #[test]
+    fn test_constraint_float_comparison() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X >= 3.14".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut bindings = HashMap::new();
+        bindings.insert("$X".to_string(), "3.14".to_string());
+        assert!(constraint.matches(&bindings));
+        let mut bindings2 = HashMap::new();
+        bindings2.insert("$X".to_string(), "2.0".to_string());
+        assert!(!constraint.matches(&bindings2));
+    }
+
+    #[test]
+    fn test_constraint_unsupported_base_warn_skip() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X < 10".to_string(),
+            base: Some(16),
+            strip: None,
+        };
+        // Should return Err, not panic
+        assert!(MetavariableComparisonConstraint::from_yaml(&clause).is_err());
+    }
+
+    #[test]
+    fn test_metavariable_comparison_filters_matches_end_to_end() {
+        // Full pipeline: parse rule YAML → build matcher → check source
+        let yaml = r#"
+rules:
+  - id: small-arg
+    patterns:
+      - pattern: foo($X)
+      - metavariable-comparison:
+          metavariable: $X
+          comparison: $X < 10
+    message: foo called with small arg
+    severity: WARNING
+    languages: [python]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        assert_eq!(rules.len(), 1);
+
+        // foo(5) → match (5 < 10)
+        // foo(20) → no match (20 >= 10)
+        // foo(bar) → no match (non-numeric)
+        let source = "foo(5)\nfoo(20)\nfoo(bar)\n";
+        let tree = parse_file(source, Language::Python).unwrap();
+        let findings = rules[0].check(source, &tree);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 1);
+    }
+
+    #[test]
+    fn test_metavariable_comparison_eq_operator_end_to_end() {
+        let yaml = r#"
+rules:
+  - id: exact-zero
+    patterns:
+      - pattern: check($N)
+      - metavariable-comparison:
+          metavariable: $N
+          comparison: $N == 0
+    message: called with zero
+    severity: WARNING
+    languages: [python]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+
+        let source = "check(0)\ncheck(1)\ncheck(2)\n";
+        let tree = parse_file(source, Language::Python).unwrap();
+        let findings = rules[0].check(source, &tree);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].line, 1);
     }
 }

--- a/tests/semgrep_parity.rs
+++ b/tests/semgrep_parity.rs
@@ -188,3 +188,34 @@ rules:
 
     assert_parity(repo.path(), &rules, ".");
 }
+
+#[test]
+fn test_parity_metavariable_comparison() {
+    if skip_if_semgrep_missing() {
+        return;
+    }
+
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/small-arg.yaml",
+        r#"
+rules:
+  - id: small-numeric-arg
+    patterns:
+      - pattern: foo($X)
+      - metavariable-comparison:
+          metavariable: $X
+          comparison: $X < 10
+    message: foo called with a small numeric argument
+    severity: WARNING
+    languages: [python]
+"#,
+    );
+    // foo(5)  → match  (5 < 10)
+    // foo(20) → no match
+    // foo(bar) → no match (non-numeric)
+    write_file(repo.path(), "app.py", "foo(5)\nfoo(20)\nfoo(bar)\n");
+
+    assert_parity(repo.path(), &rules, "app.py");
+}


### PR DESCRIPTION
Adds the Semgrep `metavariable-comparison` operator to the YAML-compat loader, inside `patterns:` AND-blocks — modeled on the existing `metavariable-regex` constraint.

## Supported
- Integer & float literals; operators `<` `<=` `>` `>=` `==` `!=`; metavar on either side (`$X < 10` or `10 < $X`); C-style integer-suffix stripping.
- Non-numeric binding → no match (no crash). `base:` ≠ 10 and complex boolean/string expressions → warn-skip that single constraint, siblings unaffected (matches the loader's graceful-degradation contract).

## Tests / verification (local)
- 18 unit tests (per-operator parse, error paths, numeric/float/unbound/non-numeric match, two end-to-end) + `test_parity_metavariable_comparison` — all pass.
- `cargo build --release` ✓ · dogfood `--severity high src/` & `secrets src/` clean ✓ · `clippy --all-targets -D warnings` clean ✓.

Round 1 of the Semgrep-parity push. Sibling: #492 (Java taint). `metavariable-pattern` follows once this lands (it overlaps the same eval regions, so it's sequenced on top).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metavariable-comparison support for Semgrep rules, enabling numeric filtering of matched variables using operators (<, <=, >, >=, ==, !=). Supports decimal, hexadecimal, binary, and floating-point literals.

* **Documentation**
  * Updated compatibility documentation with metavariable-comparison details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->