### PR TITLE
feat(compat): C + Kotlin taint-mode rules in the Semgrep bridge

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -86,7 +86,7 @@ Metavariable filtering:
 
 Taint rules (`mode: taint`):
 
-- `mode: taint` for Python, JavaScript/TypeScript, Go, and Java; taint rules targeting other languages are skipped with a warning
+- `mode: taint` for Python, JavaScript/TypeScript, Go, Java, C, and Kotlin; taint rules targeting other languages are skipped with a warning
 - `pattern-sources`, `pattern-sinks`, `pattern-sanitizers` — each entry must be either a single `pattern:` string or a `pattern-either:` list (nested `pattern-either:` is supported and flattens recursively)
 - Supported `pattern:` shapes:
   - bare identifier (`request`) — a source-only shape compiled to a parameter-name match
@@ -95,6 +95,8 @@ Taint rules (`mode: taint`):
 - Severity mapping matches the pattern-rule bridge (`ERROR` → Critical, `WARNING` → High, `INFO` → Medium) and `metadata.cwe` is propagated to findings
 - Rules that use anything outside this subset (`patterns:` / `pattern-inside:` / `metavariable-pattern:` inside a source/sink/sanitizer block, unsupported pattern shapes, unsupported languages, missing sources or sinks) are skipped with a warning — other rules in the same file still load. Entries with unsupported keys are dropped individually so a single bad entry will not disable sibling entries in the same block.
 - Java taint rules match `Call { canonical }` patterns via receiver+method (e.g. `request.getParameter($X)` matches any method invocation where the receiver contains `request` and the method is `getParameter`); `Attribute` matchers are also accepted and compiled but the Java engine resolves them via method-invocation chains
+- C taint rules match `Call { canonical }` patterns as bare function-call callees (e.g. `getenv($X)` matches any `call_expression` whose callee identifier is `getenv`); the C engine recognises `argv` as a `ParamName` source and all libc/POSIX input functions as `Call` sources
+- Kotlin taint rules match `Call { canonical }` patterns using a receiver-substring rule (e.g. `call.receiveText($X)` matches any `call_expression` whose receiver contains `call` and whose method is `receiveText`); constructor-style calls (`Runtime`, `URL`, `ProcessBuilder`) are matched as bare `canonical` names; `Attribute` matchers are accepted and compiled but are reserved for forward compatibility (no current Kotlin rule uses them); language tag `kt` is accepted as an alias for `kotlin`
 
 Language mapping:
 

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -8,7 +8,8 @@
 //!
 //! - `mode: taint` with `languages: [python]`, `languages: [javascript]` /
 //!   `[typescript]` / `[js]` / `[ts]`, `languages: [go]` / `[golang]`,
-//!   or `languages: [java]`.
+//!   `languages: [java]`, `languages: [c]`, or `languages: [kotlin]` /
+//!   `[kt]`.
 //!   Other languages are rejected with a warning and the rule is skipped;
 //!   non-taint rules fall through to the regular Semgrep bridge.
 //! - `pattern-sources`, `pattern-sinks`, `pattern-sanitizers` as lists of
@@ -23,7 +24,7 @@
 //! - `pattern-inside:`, `metavariable-pattern:`, `patterns:` inside
 //!   source/sink blocks.
 //! - Any `mode: taint` rule that does not target Python, JavaScript/TypeScript,
-//!   Go, or Java.
+//!   Go, Java, C, or Kotlin.
 //! - Any `pattern:` string whose shape is not one of:
 //!   - bare identifier (`request`) — compiled to `ParamName`
 //!   - dotted attribute chain (`request.data`, `request.json`) — compiled
@@ -38,10 +39,12 @@
 //! rule* to be skipped (with an explanatory warning) so the user sees a
 //! clear signal rather than a silently-degraded match surface.
 
+use crate::rules::c_taint;
 use crate::rules::common::get_source_line;
 use crate::rules::go_taint;
 use crate::rules::java_taint;
 use crate::rules::javascript_taint;
+use crate::rules::kotlin_taint;
 use crate::rules::python_taint;
 use crate::rules::{FileContext, Rule};
 use crate::{Finding, Language, Severity};
@@ -217,6 +220,74 @@ fn to_java_matcher(m: &GenericMatcher) -> java_taint::NodeMatcher {
     }
 }
 
+/// Convert the generic spec into a C taint spec.
+fn to_c_spec(g: &GenericSpec) -> c_taint::TaintSpec {
+    c_taint::TaintSpec {
+        sources: g.sources.iter().map(to_c_matcher).collect(),
+        sinks: g.sinks.iter().map(to_c_matcher).collect(),
+        sanitizers: g.sanitizers.iter().map(to_c_matcher).collect(),
+    }
+}
+
+fn to_c_matcher(m: &GenericMatcher) -> c_taint::NodeMatcher {
+    match m {
+        GenericMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => c_taint::NodeMatcher::Attribute {
+            root: root.clone(),
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Call {
+            canonical,
+            description,
+        } => c_taint::NodeMatcher::Call {
+            canonical: canonical.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ParamName { names, description } => c_taint::NodeMatcher::ParamName {
+            names: names.clone(),
+            description: description.clone(),
+        },
+    }
+}
+
+/// Convert the generic spec into a Kotlin taint spec.
+fn to_kotlin_spec(g: &GenericSpec) -> kotlin_taint::TaintSpec {
+    kotlin_taint::TaintSpec {
+        sources: g.sources.iter().map(to_kotlin_matcher).collect(),
+        sinks: g.sinks.iter().map(to_kotlin_matcher).collect(),
+        sanitizers: g.sanitizers.iter().map(to_kotlin_matcher).collect(),
+    }
+}
+
+fn to_kotlin_matcher(m: &GenericMatcher) -> kotlin_taint::NodeMatcher {
+    match m {
+        GenericMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => kotlin_taint::NodeMatcher::Attribute {
+            root: root.clone(),
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Call {
+            canonical,
+            description,
+        } => kotlin_taint::NodeMatcher::Call {
+            canonical: canonical.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ParamName { names, description } => kotlin_taint::NodeMatcher::ParamName {
+            names: names.clone(),
+            description: description.clone(),
+        },
+    }
+}
+
 /// A compiled Semgrep `mode: taint` rule.
 pub struct SemgrepTaintRule {
     pub id: String,
@@ -281,6 +352,32 @@ impl TaintFindingView {
         }
     }
     fn from_java(f: java_taint::TaintFinding) -> Self {
+        Self {
+            sink_start_byte: f.sink_start_byte,
+            sink_line: f.sink_line,
+            sink_column: f.sink_column,
+            sink_end_line: f.sink_end_line,
+            sink_end_column: f.sink_end_column,
+            source_description: f.source_description,
+            sink_description: f.sink_description,
+            source_line: f.source_line,
+            hops: f.hops,
+        }
+    }
+    fn from_c(f: c_taint::TaintFinding) -> Self {
+        Self {
+            sink_start_byte: f.sink_start_byte,
+            sink_line: f.sink_line,
+            sink_column: f.sink_column,
+            sink_end_line: f.sink_end_line,
+            sink_end_column: f.sink_end_column,
+            source_description: f.source_description,
+            sink_description: f.sink_description,
+            source_line: f.source_line,
+            hops: f.hops,
+        }
+    }
+    fn from_kotlin(f: kotlin_taint::TaintFinding) -> Self {
         Self {
             sink_start_byte: f.sink_start_byte,
             sink_line: f.sink_line,
@@ -362,6 +459,20 @@ impl Rule for SemgrepTaintRule {
                     .map(TaintFindingView::from_java)
                     .collect()
             }
+            Language::C => {
+                let spec = to_c_spec(&self.spec);
+                c_taint::analyze_tree(tree.root_node(), source, &spec, None)
+                    .into_iter()
+                    .map(TaintFindingView::from_c)
+                    .collect()
+            }
+            Language::Kotlin => {
+                let spec = to_kotlin_spec(&self.spec);
+                kotlin_taint::analyze_tree(tree.root_node(), source, &spec, None)
+                    .into_iter()
+                    .map(TaintFindingView::from_kotlin)
+                    .collect()
+            }
             _ => Vec::new(),
         };
         raw.into_iter()
@@ -438,7 +549,7 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
     };
 
     // Determine the target language. We support Python, JavaScript/TypeScript,
-    // and Go. The first recognised language wins.
+    // Go, Java, C, and Kotlin. The first recognised language wins.
     let lang = match yaml.get("languages").and_then(YamlValue::as_sequence) {
         Some(langs) => {
             let mut detected: Option<Language> = None;
@@ -460,6 +571,14 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
                         detected = Some(Language::Java);
                         break;
                     }
+                    "c" => {
+                        detected = Some(Language::C);
+                        break;
+                    }
+                    "kotlin" | "kt" => {
+                        detected = Some(Language::Kotlin);
+                        break;
+                    }
                     _ => {}
                 }
             }
@@ -467,7 +586,7 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
                 Some(l) => l,
                 None => {
                     return TaintRuleParse::Skip(format!(
-                        "taint rule `{}` targets unsupported languages; Python, JavaScript/TypeScript, Go, and Java are supported",
+                        "taint rule `{}` targets unsupported languages; Python, JavaScript/TypeScript, Go, Java, C, and Kotlin are supported",
                         id
                     ));
                 }
@@ -927,6 +1046,71 @@ pattern-sinks: [{pattern: eval($X)}]
     }
 
     #[test]
+    fn taint_rule_with_c_language_compiles() {
+        let yaml = r#"
+id: c-taint
+mode: taint
+languages: [c]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: getenv($X)}]
+pattern-sinks: [{pattern: system($X)}]
+"#;
+        let v: YamlValue = serde_yaml_ng::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => {
+                assert_eq!(r.lang, Language::C);
+                assert_eq!(r.spec.sources.len(), 1);
+                assert_eq!(r.spec.sinks.len(), 1);
+            }
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    #[test]
+    fn taint_rule_with_kotlin_language_compiles() {
+        let yaml = r#"
+id: kotlin-taint
+mode: taint
+languages: [kotlin]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: request.getParameter($X)}]
+pattern-sinks: [{pattern: Runtime.exec($X)}]
+"#;
+        let v: YamlValue = serde_yaml_ng::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => {
+                assert_eq!(r.lang, Language::Kotlin);
+                assert_eq!(r.spec.sources.len(), 1);
+                assert_eq!(r.spec.sinks.len(), 1);
+            }
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    #[test]
+    fn taint_rule_with_kt_alias_compiles_as_kotlin() {
+        let yaml = r#"
+id: kt-taint
+mode: taint
+languages: [kt]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: call.receiveText($X)}]
+pattern-sinks: [{pattern: Runtime.exec($X)}]
+"#;
+        let v: YamlValue = serde_yaml_ng::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => assert_eq!(r.lang, Language::Kotlin),
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    #[test]
     fn taint_rule_with_javascript_language_compiles() {
         let yaml = r#"
 id: js-taint
@@ -1108,6 +1292,172 @@ class Controller {
         );
         // Run the check and ensure no crash (result depends on engine sanitizer support).
         let tree = parse_file(src, Language::Java).expect("Java fixture should parse");
+        let _ = rule.check(src, &tree); // must not panic
+    }
+
+    #[test]
+    fn c_taint_rule_produces_finding_for_getenv_to_system() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: c-cmd-injection
+mode: taint
+languages: [c]
+severity: ERROR
+message: "Tainted env var reaches system()"
+metadata:
+  cwe: "CWE-78"
+pattern-sources:
+  - pattern: getenv($X)
+pattern-sinks:
+  - pattern: system($X)
+"#,
+        );
+
+        // getenv() result assigned to cmd, then passed to system().
+        let src = r#"
+#include <stdlib.h>
+void handler() {
+    char *cmd = getenv("CMD");
+    system(cmd);
+}
+"#;
+        let tree = parse_file(src, Language::C).expect("C fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            !findings.is_empty(),
+            "expected a finding for getenv -> system flow, got none"
+        );
+        assert!(
+            findings[0].description.contains("system")
+                || findings[0]
+                    .sink_description
+                    .as_deref()
+                    .is_some_and(|d| d.contains("system")),
+            "sink description should mention system: {:?}",
+            findings[0]
+        );
+    }
+
+    #[test]
+    fn c_taint_sanitizer_no_panic() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: c-cmd-sanitized
+mode: taint
+languages: [c]
+severity: ERROR
+message: "Tainted input reaches system()"
+pattern-sources:
+  - pattern: getenv($X)
+pattern-sinks:
+  - pattern: system($X)
+pattern-sanitizers:
+  - pattern: strlcpy($X)
+"#,
+        );
+
+        // Verify sanitizer compiles correctly and rule doesn't panic.
+        assert_eq!(
+            rule.spec.sanitizers.len(),
+            1,
+            "sanitizer spec should compile"
+        );
+        let src = r#"
+#include <stdlib.h>
+#include <string.h>
+void handler() {
+    char *input = getenv("CMD");
+    char safe[64];
+    strlcpy(safe, input, sizeof(safe));
+    system(safe);
+}
+"#;
+        let tree = parse_file(src, Language::C).expect("C fixture should parse");
+        let _ = rule.check(src, &tree); // must not panic
+    }
+
+    #[test]
+    fn kotlin_taint_rule_produces_finding_for_receive_to_exec() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: kotlin-cmd-injection
+mode: taint
+languages: [kotlin]
+severity: ERROR
+message: "Tainted request body reaches Runtime.exec"
+metadata:
+  cwe: "CWE-78"
+pattern-sources:
+  - pattern: call.receiveText($X)
+pattern-sinks:
+  - pattern: Runtime.exec($X)
+"#,
+        );
+
+        // call.receiveText() → cmd → Runtime.getRuntime().exec(cmd)
+        let src = r#"
+fun handler(call: ApplicationCall) {
+    val cmd = call.receiveText()
+    Runtime.getRuntime().exec(cmd)
+}
+"#;
+        let tree = parse_file(src, Language::Kotlin).expect("Kotlin fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            !findings.is_empty(),
+            "expected a finding for call.receiveText -> Runtime.exec flow, got none"
+        );
+        assert!(
+            findings[0].description.contains("exec")
+                || findings[0]
+                    .sink_description
+                    .as_deref()
+                    .is_some_and(|d| d.contains("exec")),
+            "sink description should mention exec: {:?}",
+            findings[0]
+        );
+    }
+
+    #[test]
+    fn kotlin_taint_sanitizer_no_panic() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: kotlin-cmd-sanitized
+mode: taint
+languages: [kotlin]
+severity: ERROR
+message: "Tainted request body reaches Runtime.exec"
+pattern-sources:
+  - pattern: call.receiveText($X)
+pattern-sinks:
+  - pattern: Runtime.exec($X)
+pattern-sanitizers:
+  - pattern: validate($X)
+"#,
+        );
+
+        // Verify sanitizer compiles correctly and rule doesn't panic.
+        assert_eq!(
+            rule.spec.sanitizers.len(),
+            1,
+            "sanitizer spec should compile"
+        );
+        let src = r#"
+fun handler(call: ApplicationCall) {
+    val body = call.receiveText()
+    val safe = validate(body)
+    Runtime.getRuntime().exec(safe)
+}
+"#;
+        let tree = parse_file(src, Language::Kotlin).expect("Kotlin fixture should parse");
         let _ = rule.check(src, &tree); // must not panic
     }
 

--- a/tests/semgrep_parity_c.rs
+++ b/tests/semgrep_parity_c.rs
@@ -1,0 +1,78 @@
+//! C Semgrep parity micro-pattern suite.
+//!
+//! Mirrors the structure of `tests/semgrep_parity_java.rs` but uses
+//! C-native sinks (`system()`, `printf()`) and `mode: taint` rule syntax.
+//! Each test runs foxguard against the same temp directory + YAML rule and
+//! asserts that foxguard produces findings in the expected locations.
+//! When `semgrep` is on PATH, tests additionally compare `(file, line)` pairs.
+//! Tests are skipped gracefully when `semgrep` is not on PATH so the suite
+//! remains green in restricted environments.
+
+mod common;
+
+use common::semgrep_parity_harness::{foxguard_findings, skip_if_semgrep_missing, write_file};
+use tempfile::TempDir;
+
+/// `mode: taint` parity test for C: `getenv()` → `system()`.
+///
+/// foxguard must detect the taint flow from `getenv()` (environment variable
+/// source) to `system()` (command-injection sink). Semgrep comparison is
+/// performed when available, comparing only `(file, line)` pairs.
+#[test]
+fn test_parity_taint_mode_c_getenv_to_system() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/taint.yaml",
+        r#"
+rules:
+  - id: c-taint-cmd-injection
+    mode: taint
+    languages: [c]
+    severity: ERROR
+    message: "Tainted env var flows to system()"
+    pattern-sources:
+      - pattern: getenv($X)
+    pattern-sinks:
+      - pattern: system($X)
+"#,
+    );
+    // The fixture: getenv() result assigned to cmd, then passed to system().
+    // The sink call is on line 5.
+    write_file(
+        repo.path(),
+        "handler.c",
+        "#include <stdlib.h>\nvoid handler() {\n    char *cmd = getenv(\"CMD\");\n    system(cmd);\n}\n",
+    );
+
+    // foxguard must emit at least one finding.
+    let foxguard = foxguard_findings(repo.path(), &rules, "handler.c");
+    assert!(
+        !foxguard.is_empty(),
+        "foxguard must detect the C taint flow (getenv → system); got no findings"
+    );
+
+    // foxguard should flag line 4 (the system() call).
+    assert!(
+        foxguard.iter().any(|f| f.line == 4),
+        "foxguard finding should be on line 4 (the sink); got: {:?}",
+        foxguard
+    );
+
+    // When semgrep is available, compare the set of (file, line) pairs.
+    if skip_if_semgrep_missing() {
+        return;
+    }
+    use common::semgrep_parity_harness::semgrep_findings;
+    let semgrep = semgrep_findings(repo.path(), &rules, "handler.c");
+    if !semgrep.is_empty() {
+        let foxguard_lines: std::collections::BTreeSet<_> =
+            foxguard.iter().map(|f| (&f.path, f.line)).collect();
+        let semgrep_lines: std::collections::BTreeSet<_> =
+            semgrep.iter().map(|f| (&f.path, f.line)).collect();
+        assert_eq!(
+            foxguard_lines, semgrep_lines,
+            "foxguard and semgrep disagree on the C taint finding locations"
+        );
+    }
+}

--- a/tests/semgrep_parity_kotlin.rs
+++ b/tests/semgrep_parity_kotlin.rs
@@ -1,0 +1,78 @@
+//! Kotlin Semgrep parity micro-pattern suite.
+//!
+//! Mirrors the structure of `tests/semgrep_parity_java.rs` but uses
+//! Kotlin-native sources (`call.receiveText()`) and sinks (`Runtime.exec()`).
+//! Each test runs foxguard against the same temp directory + YAML rule and
+//! asserts that foxguard produces findings in the expected locations.
+//! When `semgrep` is on PATH, tests additionally compare `(file, line)` pairs.
+//! Tests are skipped gracefully when `semgrep` is not on PATH so the suite
+//! remains green in restricted environments.
+
+mod common;
+
+use common::semgrep_parity_harness::{foxguard_findings, skip_if_semgrep_missing, write_file};
+use tempfile::TempDir;
+
+/// `mode: taint` parity test for Kotlin: `call.receiveText()` → `Runtime.exec()`.
+///
+/// foxguard must detect the taint flow from `call.receiveText()` (Ktor request
+/// body source) to `Runtime.exec()` (command-injection sink). Semgrep
+/// comparison is performed when available, comparing only `(file, line)` pairs.
+#[test]
+fn test_parity_taint_mode_kotlin_receive_to_exec() {
+    let repo = TempDir::new().expect("failed to create temp dir");
+    let rules = write_file(
+        repo.path(),
+        "rules/taint.yaml",
+        r#"
+rules:
+  - id: kotlin-taint-cmd-injection
+    mode: taint
+    languages: [kotlin]
+    severity: ERROR
+    message: "Tainted request body flows to Runtime.exec"
+    pattern-sources:
+      - pattern: call.receiveText($X)
+    pattern-sinks:
+      - pattern: Runtime.exec($X)
+"#,
+    );
+    // The fixture: call.receiveText() result flows into Runtime.getRuntime().exec().
+    // The sink call is on line 4.
+    write_file(
+        repo.path(),
+        "Handler.kt",
+        "fun handler(call: ApplicationCall) {\n    val cmd = call.receiveText()\n    Runtime.getRuntime().exec(cmd)\n}\n",
+    );
+
+    // foxguard must emit at least one finding.
+    let foxguard = foxguard_findings(repo.path(), &rules, "Handler.kt");
+    assert!(
+        !foxguard.is_empty(),
+        "foxguard must detect the Kotlin taint flow (call.receiveText → Runtime.exec); got no findings"
+    );
+
+    // foxguard should flag line 3 (the exec call).
+    assert!(
+        foxguard.iter().any(|f| f.line == 3),
+        "foxguard finding should be on line 3 (the sink); got: {:?}",
+        foxguard
+    );
+
+    // When semgrep is available, compare the set of (file, line) pairs.
+    if skip_if_semgrep_missing() {
+        return;
+    }
+    use common::semgrep_parity_harness::semgrep_findings;
+    let semgrep = semgrep_findings(repo.path(), &rules, "Handler.kt");
+    if !semgrep.is_empty() {
+        let foxguard_lines: std::collections::BTreeSet<_> =
+            foxguard.iter().map(|f| (&f.path, f.line)).collect();
+        let semgrep_lines: std::collections::BTreeSet<_> =
+            semgrep.iter().map(|f| (&f.path, f.line)).collect();
+        assert_eq!(
+            foxguard_lines, semgrep_lines,
+            "foxguard and semgrep disagree on the Kotlin taint finding locations"
+        );
+    }
+}


### PR DESCRIPTION
Extends the Semgrep `mode: taint` bridge to **C** and **Kotlin** — both engines (`c_taint`, `kotlin_taint`) already expose the shared `TaintSpec`/`NodeMatcher`/`analyze_tree` API, so this mirrors the Java wiring exactly.

## Changes
- `semgrep_taint.rs`: `Language::C` + `Language::Kotlin` dispatch (`to_c_spec`/`to_kotlin_spec`/`from_c`/`from_kotlin`); `"c"`, `"kotlin"`, `"kt"` accepted in `parse_taint_rule`.
- Tests: 7 unit (compiles, source→sink, sanitizer/no-panic per language; +kt alias) + 2 parity tests (`semgrep_parity_c.rs`, `semgrep_parity_kotlin.rs`).
- Source→sink pairs chosen from the engines' own recognized sources/sinks: C `getenv($X)`→`system($X)`; Kotlin `call.receiveText($X)`→`Runtime.exec($X)`.

## Verification (local)
- `cargo build --release` ✓ · dogfood `--severity high src/` & `secrets src/` clean ✓
- 9 new tests pass · `clippy --all-targets -D warnings` clean ✓ · no baseline.json churn.

Round 2 of the Semgrep-parity push. Taint bridge now: python/js/ts/go/java/**c**/**kotlin**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended taint mode language support to include C and Kotlin alongside Python, JavaScript/TypeScript, Go, and Java.

* **Documentation**
  * Updated compatibility information to reflect expanded language coverage and language-specific taint matching behavior.

* **Tests**
  * Added C and Kotlin taint mode parity tests with verification against Semgrep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->