### PR TITLE
ci: run C / Kotlin / inverse Semgrep parity suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
         run: cargo test --test semgrep_parity_go
       - name: Run Semgrep parity suite (Java)
         run: cargo test --test semgrep_parity_java
+      - name: Run Semgrep parity suite (C)
+        run: cargo test --test semgrep_parity_c
+      - name: Run Semgrep parity suite (Kotlin)
+        run: cargo test --test semgrep_parity_kotlin
+      - name: Run Semgrep parity suite (inverse / unsupported-skip)
+        run: cargo test --test semgrep_parity_inverse
 
   website:
     name: Website Build


### PR DESCRIPTION
The **Semgrep Parity** CI job only ran the python/js/go/java parity suites, so `tests/semgrep_parity_{c,kotlin,inverse}.rs` were never executed against the real `semgrep` CLI — they self-skip in the regular Test job (no semgrep there). This wires all three into the parity job so the C/Kotlin taint bridges (#495) and the unsupported-feature inverse checks are actually validated against semgrep in CI.

Pure CI config; test targets verified to resolve locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.**

This release contains internal CI/CD infrastructure updates to improve testing coverage and validation processes. No end-user features, bug fixes, or functionality changes are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->