### PR TITLE
fix(compat): address review findings (float suffix, exact eq, metavar digits)

### DIFF
--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -351,8 +351,13 @@ fn parse_comparison(comparison: &str) -> Result<(String, CmpOp, f64, bool), Stri
 /// from an integer-literal string (case-insensitive), so `10L` parses as `10`.
 fn strip_numeric_suffixes(s: &str) -> String {
     let upper = s.to_uppercase();
-    let stripped = upper.trim_end_matches(['L', 'U']);
-    stripped.to_string()
+    // Hex/binary literals end in digits that can look like suffixes (e.g. the
+    // trailing `F` in `0xFF`), so never strip from them.
+    if upper.starts_with("0X") || upper.starts_with("0B") {
+        return upper;
+    }
+    // Strip C-style integer/float suffixes: L/U (int) and F (float, e.g. `3.14f`).
+    upper.trim_end_matches(['L', 'U', 'F']).to_string()
 }
 
 /// Parse a numeric string (decimal int, hex `0x…`, binary `0b…`, or float)
@@ -554,8 +559,11 @@ impl MetavariableComparisonConstraint {
             CmpOp::Le => lhs <= rhs,
             CmpOp::Gt => lhs > rhs,
             CmpOp::Ge => lhs >= rhs,
-            CmpOp::Eq => (lhs - rhs).abs() < f64::EPSILON,
-            CmpOp::Ne => (lhs - rhs).abs() >= f64::EPSILON,
+            // Exact equality: both operands come from parsing the same kind of
+            // numeral, so matching Semgrep's Python exact-`==` semantics (not an
+            // epsilon band) is both simpler and more correct.
+            CmpOp::Eq => lhs == rhs,
+            CmpOp::Ne => lhs != rhs,
         }
     }
 }
@@ -2263,6 +2271,52 @@ rules:
         let mut bindings2 = HashMap::new();
         bindings2.insert("$X".to_string(), "2.0".to_string());
         assert!(!constraint.matches(&bindings2));
+    }
+
+    #[test]
+    fn test_numeric_suffix_strips_c_float_f_and_preserves_hex() {
+        // C float suffix `f`/`F` must be stripped so `2.5f` parses.
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("2.5f")), Some(2.5));
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("2.5F")), Some(2.5));
+        // Integer suffixes still stripped.
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("10UL")), Some(10.0));
+        // Hex/binary literals must NOT lose their trailing digits to suffix stripping.
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("0xFF")), Some(255.0));
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("0xff")), Some(255.0));
+        assert_eq!(parse_numeric(&strip_numeric_suffixes("0b101")), Some(5.0));
+    }
+
+    #[test]
+    fn test_constraint_eq_is_exact() {
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X == 5".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut hit = HashMap::new();
+        hit.insert("$X".to_string(), "5".to_string());
+        assert!(constraint.matches(&hit));
+        let mut miss = HashMap::new();
+        miss.insert("$X".to_string(), "6".to_string());
+        assert!(!constraint.matches(&miss));
+    }
+
+    #[test]
+    fn test_constraint_eq_c_float_suffix_binding() {
+        // Regression for the `f` suffix bug: a bound C float literal `1.5f`
+        // must compare equal to the literal `1.5` rather than being dropped.
+        let clause = SemgrepMetavariableComparisonClause {
+            metavariable: "$X".to_string(),
+            comparison: "$X == 1.5".to_string(),
+            base: None,
+            strip: None,
+        };
+        let constraint = MetavariableComparisonConstraint::from_yaml(&clause).unwrap();
+        let mut bindings = HashMap::new();
+        bindings.insert("$X".to_string(), "1.5f".to_string());
+        assert!(constraint.matches(&bindings));
     }
 
     #[test]

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -1109,7 +1109,12 @@ fn is_metavariable(s: &str) -> bool {
         _ => return false,
     }
     let rest: String = chars.collect();
-    !rest.is_empty() && rest.chars().all(|c| c.is_ascii_uppercase() || c == '_')
+    // Semgrep metavariables are `$` + `[A-Z_][A-Z0-9_]*` — allow trailing digits
+    // (e.g. `$ARG1`) while still rejecting lowercase (`$obj`).
+    !rest.is_empty()
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
 }
 
 fn describe(canonical: &str, role: MatcherRole) -> String {
@@ -1992,6 +1997,17 @@ pattern-sinks:
         // is not a metavariable; reject it so we don't accidentally match
         // oddly-named dotted callees.
         assert!(compile("$obj.method($X)", MatcherRole::Sink).is_none());
+    }
+
+    #[test]
+    fn metavar_with_trailing_digits_is_accepted() {
+        // Semgrep metavars are `[A-Z_][A-Z0-9_]*`, so `$ARG1` is valid — it must
+        // compile as a metavar-receiver sink (previously rejected on the digit).
+        assert!(is_metavariable("$ARG1"));
+        assert!(is_metavariable("$CONN_2"));
+        assert!(!is_metavariable("$obj"));
+        assert!(!is_metavariable("$"));
+        assert!(compile("$X1.executeQuery($P)", MatcherRole::Sink).is_some());
     }
 
     #[test]


### PR DESCRIPTION
Fixes from an adversarial review of this session's parity work (verdict: *fundamentally sound, no high-severity bugs*). Three real correctness gaps:

| Sev | Fix |
|-----|-----|
| **MED** | `metavariable-comparison` now strips the C float suffix `f`/`F` (`3.14f`) alongside `L`/`U`, **hex-guarded** so `0xFF` keeps its digits. Before: `$X < 1.5f` silently dropped the constraint (false positives); a bound `1.5f` failed to parse (false negative). |
| LOW | `==`/`!=` use exact f64 equality instead of an `f64::EPSILON` band — matches Semgrep's Python exact-equality. |
| LOW | taint `is_metavariable` accepts trailing digits (`$ARG1`) per Semgrep's `[A-Z_][A-Z0-9_]*` grammar; still rejects lowercase. |

## Verification (local)
- 4 regression tests (f-suffix+hex-guard, exact-eq, C-float-binding-eq, `$ARG1` accepted) · full suite 0 failures · clippy `-D warnings` clean · dogfood clean · no baseline churn.

Two other review findings (per-constraint warn-skip on unsupported `base:`, and the unused declarative `metavariable:` field) are documented graceful-degradation choices — left as-is intentionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric literal parsing to correctly handle hexadecimal and binary numbers
  * Fixed float suffix stripping for decimal literals
  * Corrected comparison operations to use exact equality instead of approximate matching

* **New Features**
  * Extended metavariable naming to support trailing digits (e.g., `$ARG1`, `$CONN_2`)

* **Tests**
  * Expanded test coverage for numeric suffix handling and comparison operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->