### PR TITLE
feat(compat): languages: [regex] support (+187 registry rules → 71.8%)

### DIFF
--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1305 (60.9%) |
-| Rules skipped | 839 (39.1%) |
+| Rules loaded OK | 1540 (71.8%) |
+| Rules skipped | 604 (28.2%) |
 
-**Headline load rate: 60.9%** (1305 / 2144 rules).
+**Headline load rate: 71.8%** (1540 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,33 +23,32 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `unsupported language: regex` | 200 | 23.8% | 9.3% |
-| `taint: patterns: inside source/sink` | 180 | 21.5% | 8.4% |
-| `unsupported language: yaml` | 100 | 11.9% | 4.7% |
-| `generic mode (languages: [generic])` | 78 | 9.3% | 3.6% |
-| `unsupported language: solidity` | 47 | 5.6% | 2.2% |
-| `unsupported language: dockerfile` | 39 | 4.6% | 1.8% |
-| `unsupported language: ocaml` | 34 | 4.1% | 1.6% |
-| `mode: taint (unsupported language: ruby)` | 33 | 3.9% | 1.5% |
-| `mode: taint (unsupported language: php)` | 21 | 2.5% | 1.0% |
-| `unsupported language: scala` | 18 | 2.1% | 0.8% |
-| `loader rejected (other)` | 17 | 2.0% | 0.8% |
-| `mode: taint (unsupported language: csharp)` | 11 | 1.3% | 0.5% |
-| `unsupported language: apex` | 9 | 1.1% | 0.4% |
-| `unsupported language: bash` | 9 | 1.1% | 0.4% |
-| `unsupported language: elixir` | 7 | 0.8% | 0.3% |
-| `unsupported language: json` | 7 | 0.8% | 0.3% |
-| `mode: taint (unsupported language: scala)` | 5 | 0.6% | 0.2% |
-| `unsupported language: clojure` | 5 | 0.6% | 0.2% |
-| `unsupported language: html` | 4 | 0.5% | 0.2% |
-| `mode: taint (unsupported language: apex)` | 3 | 0.4% | 0.1% |
-| `mode: taint (unsupported language: bash)` | 3 | 0.4% | 0.1% |
-| `mode: taint (unsupported language: solidity)` | 3 | 0.4% | 0.1% |
-| `unsupported language: hcl` | 2 | 0.2% | 0.1% |
-| `mode: taint (unsupported language: swift)` | 1 | 0.1% | 0.0% |
-| `mode: taint (unsupported shape)` | 1 | 0.1% | 0.0% |
-| `unsupported language: dart` | 1 | 0.1% | 0.0% |
-| `unsupported language: xml` | 1 | 0.1% | 0.0% |
+| `mode: taint (unsupported shape)` | 130 | 21.5% | 6.1% |
+| `unsupported language: yaml` | 100 | 16.6% | 4.7% |
+| `generic mode (languages: [generic])` | 78 | 12.9% | 3.6% |
+| `unsupported language: solidity` | 47 | 7.8% | 2.2% |
+| `unsupported language: dockerfile` | 39 | 6.5% | 1.8% |
+| `unsupported language: ocaml` | 34 | 5.6% | 1.6% |
+| `mode: taint (unsupported language: ruby)` | 33 | 5.5% | 1.5% |
+| `loader rejected (other)` | 30 | 5.0% | 1.4% |
+| `mode: taint (unsupported language: php)` | 21 | 3.5% | 1.0% |
+| `unsupported language: scala` | 18 | 3.0% | 0.8% |
+| `mode: taint (unsupported language: csharp)` | 11 | 1.8% | 0.5% |
+| `unsupported language: apex` | 9 | 1.5% | 0.4% |
+| `unsupported language: bash` | 9 | 1.5% | 0.4% |
+| `unsupported language: elixir` | 7 | 1.2% | 0.3% |
+| `unsupported language: json` | 7 | 1.2% | 0.3% |
+| `mode: taint (unsupported language: scala)` | 5 | 0.8% | 0.2% |
+| `unsupported language: clojure` | 5 | 0.8% | 0.2% |
+| `unsupported language: html` | 4 | 0.7% | 0.2% |
+| `mode: taint (unsupported language: apex)` | 3 | 0.5% | 0.1% |
+| `mode: taint (unsupported language: bash)` | 3 | 0.5% | 0.1% |
+| `mode: taint (unsupported language: solidity)` | 3 | 0.5% | 0.1% |
+| `taint: pattern-propagators` | 3 | 0.5% | 0.1% |
+| `unsupported language: hcl` | 2 | 0.3% | 0.1% |
+| `mode: taint (unsupported language: swift)` | 1 | 0.2% | 0.0% |
+| `unsupported language: dart` | 1 | 0.2% | 0.0% |
+| `unsupported language: xml` | 1 | 0.2% | 0.0% |
 
 ## Priority order — operator/feature backlog
 
@@ -57,11 +56,11 @@ Matcher capabilities (implementable in `semgrep_compat.rs` / `semgrep_taint.rs`)
 
 | Rank | Capability to add | Rules unlocked |
 |---:|---|---:|
-| 1 | `taint: patterns: inside source/sink` | 180 |
-| 2 | `loader rejected (other)` | 17 |
-| 3 | `mode: taint (unsupported shape)` | 1 |
+| 1 | `mode: taint (unsupported shape)` | 130 |
+| 2 | `loader rejected (other)` | 30 |
+| 3 | `taint: pattern-propagators` | 3 |
 
-Operator/feature gaps account for **198 rules** (9.2% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
+Operator/feature gaps account for **163 rules** (7.6% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
 
 ## Priority order — missing language grammars
 
@@ -69,32 +68,31 @@ Rules foxguard cannot run because it has no tree-sitter grammar for the target l
 
 | Rank | Language to add | Rules unlocked |
 |---:|---|---:|
-| 1 | `unsupported language: regex` | 200 |
-| 2 | `unsupported language: yaml` | 100 |
-| 3 | `generic mode (languages: [generic])` | 78 |
-| 4 | `unsupported language: solidity` | 47 |
-| 5 | `unsupported language: dockerfile` | 39 |
-| 6 | `unsupported language: ocaml` | 34 |
-| 7 | `mode: taint (unsupported language: ruby)` | 33 |
-| 8 | `mode: taint (unsupported language: php)` | 21 |
-| 9 | `unsupported language: scala` | 18 |
-| 10 | `mode: taint (unsupported language: csharp)` | 11 |
-| 11 | `unsupported language: apex` | 9 |
-| 12 | `unsupported language: bash` | 9 |
-| 13 | `unsupported language: elixir` | 7 |
-| 14 | `unsupported language: json` | 7 |
-| 15 | `mode: taint (unsupported language: scala)` | 5 |
-| 16 | `unsupported language: clojure` | 5 |
-| 17 | `unsupported language: html` | 4 |
-| 18 | `mode: taint (unsupported language: apex)` | 3 |
-| 19 | `mode: taint (unsupported language: bash)` | 3 |
-| 20 | `mode: taint (unsupported language: solidity)` | 3 |
-| 21 | `unsupported language: hcl` | 2 |
-| 22 | `mode: taint (unsupported language: swift)` | 1 |
-| 23 | `unsupported language: dart` | 1 |
-| 24 | `unsupported language: xml` | 1 |
+| 1 | `unsupported language: yaml` | 100 |
+| 2 | `generic mode (languages: [generic])` | 78 |
+| 3 | `unsupported language: solidity` | 47 |
+| 4 | `unsupported language: dockerfile` | 39 |
+| 5 | `unsupported language: ocaml` | 34 |
+| 6 | `mode: taint (unsupported language: ruby)` | 33 |
+| 7 | `mode: taint (unsupported language: php)` | 21 |
+| 8 | `unsupported language: scala` | 18 |
+| 9 | `mode: taint (unsupported language: csharp)` | 11 |
+| 10 | `unsupported language: apex` | 9 |
+| 11 | `unsupported language: bash` | 9 |
+| 12 | `unsupported language: elixir` | 7 |
+| 13 | `unsupported language: json` | 7 |
+| 14 | `mode: taint (unsupported language: scala)` | 5 |
+| 15 | `unsupported language: clojure` | 5 |
+| 16 | `unsupported language: html` | 4 |
+| 17 | `mode: taint (unsupported language: apex)` | 3 |
+| 18 | `mode: taint (unsupported language: bash)` | 3 |
+| 19 | `mode: taint (unsupported language: solidity)` | 3 |
+| 20 | `unsupported language: hcl` | 2 |
+| 21 | `mode: taint (unsupported language: swift)` | 1 |
+| 22 | `unsupported language: dart` | 1 |
+| 23 | `unsupported language: xml` | 1 |
 
-Missing-grammar gaps account for **641 rules** (29.9% of all rules).
+Missing-grammar gaps account for **441 rules** (20.6% of all rules).
 
 ## Per-language breakdown
 
@@ -102,10 +100,10 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 
 | Language | Total | Loaded | Skipped | Load rate |
 |---|---:|---:|---:|---:|
-| python | 423 | 346 | 77 | 81.8% |
+| python | 423 | 370 | 53 | 87.5% |
 | hcl | 359 | 357 | 2 | 99.4% |
-| javascript | 243 | 161 | 82 | 66.3% |
-| regex | 237 | 37 | 200 | 15.6% |
+| javascript | 243 | 185 | 58 | 76.1% |
+| regex | 237 | 224 | 13 | 94.5% |
 | java | 131 | 109 | 22 | 83.2% |
 | generic | 103 | 25 | 78 | 24.3% |
 | yaml | 100 | 0 | 100 | 0.0% |
@@ -142,16 +140,16 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **dockerfile**: `unsupported language: dockerfile` (39)
 - **elixir**: `unsupported language: elixir` (7)
 - **generic**: `generic mode (languages: [generic])` (78)
-- **go**: `taint: patterns: inside source/sink` (12), `mode: taint (unsupported shape)` (1)
+- **go**: `mode: taint (unsupported shape)` (13)
 - **hcl**: `unsupported language: hcl` (2)
 - **html**: `unsupported language: html` (4)
-- **java**: `taint: patterns: inside source/sink` (21), `loader rejected (other)` (1)
-- **javascript**: `taint: patterns: inside source/sink` (77), `loader rejected (other)` (5)
+- **java**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (3), `loader rejected (other)` (1)
+- **javascript**: `mode: taint (unsupported shape)` (53), `loader rejected (other)` (5)
 - **json**: `unsupported language: json` (7)
 - **ocaml**: `unsupported language: ocaml` (34)
 - **php**: `mode: taint (unsupported language: php)` (21), `loader rejected (other)` (1)
-- **python**: `taint: patterns: inside source/sink` (70), `loader rejected (other)` (7)
-- **regex**: `unsupported language: regex` (200)
+- **python**: `mode: taint (unsupported shape)` (46), `loader rejected (other)` (7)
+- **regex**: `loader rejected (other)` (13)
 - **ruby**: `mode: taint (unsupported language: ruby)` (33), `loader rejected (other)` (2)
 - **scala**: `unsupported language: scala` (18), `mode: taint (unsupported language: scala)` (5)
 - **solidity**: `unsupported language: solidity` (47), `mode: taint (unsupported language: solidity)` (3)

--- a/src/bin/gen_rules_ts.rs
+++ b/src/bin/gen_rules_ts.rs
@@ -51,6 +51,9 @@ fn language_slug(language: Language) -> &'static str {
         Language::HAProxyConf => "haproxyconf",
         Language::Dockerfile => "dockerfile",
         Language::Manifest => "manifest",
+        // Regex-mode rules fan out per language; this binary generates rules
+        // for concrete languages only.
+        Language::Regex => "regex",
     }
 }
 
@@ -73,6 +76,7 @@ fn language_display_name(language: Language) -> &'static str {
         Language::HAProxyConf => "HAProxy",
         Language::Dockerfile => "Dockerfile",
         Language::Manifest => "Manifest",
+        Language::Regex => "Regex",
     }
 }
 
@@ -95,6 +99,7 @@ fn language_array_name(language: Language) -> &'static str {
         Language::HAProxyConf => "haproxyconfRules",
         Language::Dockerfile => "dockerfileRules",
         Language::Manifest => "manifestRules",
+        Language::Regex => "regexRules",
     }
 }
 

--- a/src/bin/registry_coverage.rs
+++ b/src/bin/registry_coverage.rs
@@ -88,7 +88,8 @@ const SUPPORTED_PATTERN_OPERATORS: &[&str] = &[
 ];
 
 /// Languages the compat loader maps to a real foxguard parser
-/// (see `map_language`). Anything else is an unsupported-language skip.
+/// (see `map_language`), plus `regex` which is handled by the regex-mode
+/// engine (not a tree-sitter grammar). Anything else is an unsupported-language skip.
 fn language_supported(lang: &str) -> bool {
     matches!(
         lang.to_lowercase().as_str(),
@@ -115,6 +116,9 @@ fn language_supported(lang: &str) -> bool {
             | "kotlin"
             | "kt"
             | "c"
+            // `languages: [regex]` rules are handled by the regex-mode engine
+            // (pure pattern-regex against raw text, no tree-sitter parse needed).
+            | "regex"
     )
 }
 
@@ -327,15 +331,18 @@ fn classify_rule(rule: &Yaml) -> Outcome {
         }
     }
 
-    // Generic mode (languages: [generic]) — no AST grammar, foxguard can't run it.
+    // Generic mode (languages: [generic]) — tokenized spacegrep matching;
+    // foxguard routes these to `generic_mode.rs`.
     if langs.iter().any(|l| l.eq_ignore_ascii_case("generic")) {
         return Outcome::Skipped("generic mode (languages: [generic])".to_string());
     }
-    if langs.iter().any(|l| l.eq_ignore_ascii_case("regex")) {
-        // pure regex-language rules: only work if a pattern-regex is present.
-        if !keys.iter().any(|k| k == "pattern-regex") {
-            return Outcome::Skipped("regex language (no pattern-regex)".to_string());
-        }
+
+    // `languages: [regex]` rules with no pattern-regex anywhere cannot be compiled
+    // by the regex-mode engine (it only supports pattern-regex, not AST patterns).
+    if langs.iter().any(|l| l.eq_ignore_ascii_case("regex"))
+        && !keys.iter().any(|k| k == "pattern-regex")
+    {
+        return Outcome::Skipped("regex language (no pattern-regex)".to_string());
     }
 
     // No supported language among the declared ones.
@@ -530,7 +537,8 @@ fn main() {
 fn is_language_gap(reason: &str) -> bool {
     reason.starts_with("unsupported language:")
         || reason.starts_with("generic mode")
-        || reason.starts_with("regex language")
+        // "regex language (no pattern-regex)" — the rule itself is malformed
+        // (only AST patterns in a regex-mode rule); classify as operator gap.
         || reason.starts_with("no/unknown languages")
         // `mode: taint (unsupported language: <lang>)` is gated on the taint
         // engine supporting that language's grammar — treat as a language axis.
@@ -910,5 +918,8 @@ rules:
         assert!(is_language_gap("generic mode (languages: [generic])"));
         assert!(!is_language_gap("metavariable-pattern"));
         assert!(!is_language_gap("focus-metavariable"));
+        // "regex language (no pattern-regex)" is an operator gap: the rule is
+        // malformed (no regex pattern), not a missing grammar.
+        assert!(!is_language_gap("regex language (no pattern-regex)"));
     }
 }

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -36,6 +36,9 @@ fn parse_source_for_path(
         | Language::HAProxyConf
         | Language::Dockerfile
         | Language::Manifest => tree_sitter_bash::LANGUAGE.into(),
+        // Regex-mode rules never use a tree-sitter parser — they match raw text
+        // only. Return `None` immediately so the scanner skips the tree build.
+        Language::Regex => return None,
     };
 
     parser.set_language(&ts_language).ok()?;

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -677,6 +677,9 @@ fn parse_inline_ignore(line: &str, language: Language) -> Option<(bool, InlineIg
             | Language::CSharp
             | Language::Swift
             | Language::Php
+            // Regex-mode rules inherit C-style block comment suppression so
+            // `/* foxguard: ignore */` works in files where that syntax is valid.
+            | Language::Regex
     ) {
         if let Some(result) = parse_block_comment_ignore(line) {
             return Some(result);
@@ -721,6 +724,9 @@ fn comment_markers(language: Language) -> &'static [&'static str] {
         | Language::HAProxyConf
         | Language::Dockerfile
         | Language::Manifest => &["#"],
+        // Regex-mode rules run against raw text with no guaranteed comment syntax.
+        // Use `#` as a safe fallback (it works for most config/script files).
+        Language::Regex => &["#"],
     }
 }
 
@@ -1398,6 +1404,9 @@ fn treats_tree_errors_as_parse_failures(language: Language, _path: &Path) -> boo
             | Language::HAProxyConf
             | Language::Dockerfile
             | Language::Manifest
+            // Regex-mode rules match raw text and never use the syntax tree;
+            // don't gate them behind tree-sitter parse success.
+            | Language::Regex
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,14 @@ pub enum Language {
     HAProxyConf,
     Dockerfile,
     Manifest,
+    /// Pseudo-language for Semgrep `languages: [regex]` rules.
+    ///
+    /// A `Regex`-language rule carries only `pattern-regex` / `pattern-not-regex`
+    /// matchers and is run against the raw text of **every** scanned file (no
+    /// tree-sitter parse required).  The scanner fans out one rule instance per
+    /// detectable language (mirroring the `generic` mode fan-out) so that the
+    /// existing `rule.language() == file_language` dispatch continues to work.
+    Regex,
 }
 
 impl std::fmt::Display for Language {
@@ -82,6 +90,7 @@ impl std::fmt::Display for Language {
             Language::HAProxyConf => write!(f, "haproxyconf"),
             Language::Dockerfile => write!(f, "dockerfile"),
             Language::Manifest => write!(f, "manifest"),
+            Language::Regex => write!(f, "regex"),
         }
     }
 }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -1566,13 +1566,258 @@ fn map_language(lang_str: &str) -> Option<Language> {
     }
 }
 
-/// True when a rule's `languages` selects generic (spacegrep) matching:
-/// `generic` or its `regex` alias. Generic rules are AST-less and handled by
-/// [`crate::rules::generic_mode`].
+/// True when a rule's `languages` selects generic (spacegrep) matching.
+/// Generic rules are AST-less and handled by [`crate::rules::generic_mode`].
+///
+/// Note: `languages: [regex]` is *not* generic mode — it is a distinct Semgrep
+/// mode that runs pure `pattern-regex` against raw file bytes.  Those rules are
+/// routed to [`build_regex_mode_rules`] instead.
 fn is_generic_language_rule(languages: &[String]) -> bool {
-    languages
+    languages.iter().any(|l| l.to_lowercase() == "generic")
+}
+
+/// True when a rule targets Semgrep's pure-regex mode (`languages: [regex]`).
+///
+/// Regex-mode rules only support `pattern-regex` and `pattern-not-regex`; they
+/// do not use a tree-sitter AST and are run against raw text on every file that
+/// passes the rule's `paths:` filter.
+fn is_regex_language_rule(languages: &[String]) -> bool {
+    languages.iter().any(|l| l.to_lowercase() == "regex")
+}
+
+// ─── Regex-mode Rule ─────────────────────────────────────────────────────────
+
+/// Every language the scanner can hand to a rule. A regex-mode rule is
+/// language-agnostic and runs against every file's raw text, so we register one
+/// rule instance per detectable language (fan-out mirrors the generic-mode
+/// approach). The compiled matcher is shared via `Arc`, so the fan-out is cheap.
+const REGEX_MODE_ALL_LANGUAGES: &[Language] = &[
+    Language::JavaScript,
+    Language::Python,
+    Language::Go,
+    Language::Ruby,
+    Language::Java,
+    Language::Php,
+    Language::Rust,
+    Language::CSharp,
+    Language::Swift,
+    Language::Kotlin,
+    Language::C,
+    Language::Hcl,
+    Language::NginxConf,
+    Language::ApacheConf,
+    Language::HAProxyConf,
+    Language::Dockerfile,
+    Language::Manifest,
+];
+
+/// A compiled Semgrep `languages: [regex]` rule.
+///
+/// Regex-mode rules carry only `pattern-regex` / `pattern-not-regex` matchers
+/// and are run against the raw text of every scanned file (no tree-sitter parse
+/// required).  One rule instance is created per detectable language so the
+/// existing `rule.language() == file_language` dispatch continues to work.
+struct RegexModeRule {
+    id: String,
+    message: String,
+    severity: Severity,
+    cwe: Option<String>,
+    /// Language this instance is registered under.
+    lang: Language,
+    /// The positive regex(es) — all must match at least once (AND semantics when
+    /// multiple are present, matching Semgrep's `patterns:` AND-block behaviour).
+    positives: std::sync::Arc<Vec<Regex>>,
+    /// Negative regexes — if any match the entire file, the finding is suppressed.
+    negatives: std::sync::Arc<Vec<Regex>>,
+    path_filter: Option<std::sync::Arc<PathFilter>>,
+}
+
+impl Rule for RegexModeRule {
+    fn id(&self) -> &str {
+        &self.id
+    }
+    fn severity(&self) -> Severity {
+        self.severity
+    }
+    fn cwe(&self) -> Option<&str> {
+        self.cwe.as_deref()
+    }
+    fn description(&self) -> &str {
+        &self.message
+    }
+    fn language(&self) -> Language {
+        self.lang
+    }
+    fn applies_to_path(&self, path: &Path) -> bool {
+        self.path_filter
+            .as_ref()
+            .is_none_or(|filter| filter.matches(path))
+    }
+
+    fn check(&self, source: &str, _tree: &tree_sitter::Tree) -> Vec<Finding> {
+        // Run the positive regexes in intersection: each positive must produce
+        // at least one match.  If any positive misses, the rule doesn't fire.
+        let candidates: Option<Vec<MatchRange>> =
+            self.positives
+                .iter()
+                .fold(None, |acc: Option<Vec<MatchRange>>, re| {
+                    let hits: Vec<MatchRange> = match_regex_pattern(re, source);
+                    Some(match acc {
+                        None => hits,
+                        Some(prev) => {
+                            // Intersect: keep matches from `prev` that overlap with
+                            // at least one match from `hits` (AND semantics across
+                            // patterns: clauses, mirroring the AST Combined path).
+                            prev.into_iter()
+                                .filter(|p| {
+                                    hits.iter().any(|h| {
+                                        p.start_byte < h.end_byte && h.start_byte < p.end_byte
+                                    })
+                                })
+                                .collect()
+                        }
+                    })
+                });
+
+        let mut results = candidates.unwrap_or_default();
+        if results.is_empty() {
+            return Vec::new();
+        }
+
+        // Apply negative filters: drop any positive match that overlaps with a
+        // negative regex match anywhere in the file.
+        for neg in self.negatives.iter() {
+            let neg_hits: Vec<MatchRange> = match_regex_pattern(neg, source);
+            if !neg_hits.is_empty() {
+                results.retain(|r| {
+                    !neg_hits
+                        .iter()
+                        .any(|n| r.start_byte < n.end_byte && n.start_byte < r.end_byte)
+                });
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|m| Finding {
+                rule_id: self.id.clone(),
+                severity: self.severity,
+                cwe: self.cwe.clone(),
+                description: self.message.clone(),
+                file: String::new(),
+                line: m.line,
+                column: m.column,
+                end_line: m.end_line,
+                end_column: m.end_column,
+                snippet: m.snippet,
+                source_line: None,
+                source_description: None,
+                sink_line: None,
+                sink_description: None,
+                fix_suggestion: None,
+                sink_start_byte: None,
+                sink_end_byte: None,
+                confidence: 0.7,
+                taint_hops: None,
+                tags: vec![],
+                crypto_algorithm: None,
+                cnsa2_deadline: None,
+                dep_name: None,
+                dep_version: None,
+                dep_ecosystem: None,
+                dep_purl: None,
+                dep_vulnerability_id: None,
+                dep_fixed_version: None,
+                dep_source: None,
+                dep_vulnerability_severity: None,
+                dep_path: vec![],
+            })
+            .collect()
+    }
+}
+
+/// Compile a `languages: [regex]` rule into one [`RegexModeRule`] per
+/// detectable language. Warns and returns an empty vec for rules that carry
+/// only AST patterns (no `pattern-regex` anywhere).
+fn build_regex_mode_rules(
+    yaml: &SemgrepRuleYaml,
+    severity: Severity,
+    cwe: &Option<String>,
+    path_filter: &Option<PathFilter>,
+) -> Result<Vec<Box<dyn Rule>>, String> {
+    // Collect all pattern-regex clauses from top-level AND from patterns: blocks.
+    let mut positives: Vec<Regex> = Vec::new();
+    let mut negatives: Vec<Regex> = Vec::new();
+
+    // Top-level pattern-regex / pattern-not-regex.
+    if let Some(ref re) = yaml.pattern_regex {
+        positives.push(compile_regex(re)?);
+    }
+    if let Some(ref re) = yaml.pattern_not_regex {
+        negatives.push(compile_regex(re)?);
+    }
+
+    // patterns: [...] blocks — collect pattern-regex / pattern-not-regex subclauses.
+    if let Some(ref clauses) = yaml.patterns {
+        for clause in clauses {
+            if let Some(ref re) = clause.pattern_regex {
+                positives.push(compile_regex(re)?);
+            }
+            if let Some(ref re) = clause.pattern_not_regex {
+                negatives.push(compile_regex(re)?);
+            }
+            // Nested pattern-either entries may also carry pattern-regex.
+            if let Some(ref entries) = clause.pattern_either {
+                for entry in entries {
+                    if let Some(ref re) = entry.pattern_regex {
+                        positives.push(compile_regex(re)?);
+                    }
+                }
+            }
+        }
+    }
+
+    // Top-level pattern-either regex entries.
+    if let Some(ref entries) = yaml.pattern_either {
+        for entry in entries {
+            if let Some(ref re) = entry.pattern_regex {
+                positives.push(compile_regex(re)?);
+            }
+        }
+    }
+
+    if positives.is_empty() {
+        // Rule has no regex patterns at all (only AST patterns that regex mode
+        // cannot execute). Warn-skip rather than build a no-op matcher.
+        eprintln!(
+            "Warning: languages: [regex] rule '{}' has no pattern-regex; \
+             regex mode cannot run AST patterns — skipping",
+            yaml.id
+        );
+        return Ok(Vec::new());
+    }
+
+    let positives = std::sync::Arc::new(positives);
+    let negatives = std::sync::Arc::new(negatives);
+    let path_filter = path_filter.clone().map(std::sync::Arc::new);
+
+    let rules = REGEX_MODE_ALL_LANGUAGES
         .iter()
-        .any(|l| matches!(l.to_lowercase().as_str(), "generic" | "regex"))
+        .map(|&lang| {
+            Box::new(RegexModeRule {
+                id: format!("semgrep/{}", yaml.id),
+                message: yaml.message.clone(),
+                severity,
+                cwe: cwe.clone(),
+                lang,
+                positives: std::sync::Arc::clone(&positives),
+                negatives: std::sync::Arc::clone(&negatives),
+                path_filter: path_filter.clone(),
+            }) as Box<dyn Rule>
+        })
+        .collect();
+
+    Ok(rules)
 }
 
 /// Compile a generic-mode rule via [`crate::rules::generic_mode`]. Thin
@@ -1899,11 +2144,23 @@ pub fn parse_semgrep_str(content: &str, source_label: &str) -> Result<Vec<Box<dy
         let severity = map_severity(&yaml_rule.severity);
         let path_filter = PathFilter::from_yaml(yaml_rule.paths.as_ref())?;
 
-        // `languages: [generic]` (and the `regex` alias) are AST-less spacegrep
-        // rules — route them to the generic-mode matcher instead of the
-        // tree-sitter pattern bridge. See `generic_mode.rs`.
+        // `languages: [generic]` — AST-less spacegrep rules routed to the
+        // generic-mode (tokenized) matcher.  See `generic_mode.rs`.
         if is_generic_language_rule(&yaml_rule.languages) {
             rules.extend(build_generic_mode_rules(
+                &yaml_rule,
+                severity,
+                &cwe,
+                &path_filter,
+            )?);
+            continue;
+        }
+
+        // `languages: [regex]` — pure regex rules that run `pattern-regex` /
+        // `pattern-not-regex` against raw file text, with no tree-sitter parse.
+        // They are language-agnostic and fan out across all detectable languages.
+        if is_regex_language_rule(&yaml_rule.languages) {
+            rules.extend(build_regex_mode_rules(
                 &yaml_rule,
                 severity,
                 &cwe,
@@ -3108,5 +3365,156 @@ rules:
         );
         // `b` is the 6th character on line 2 in "sink(b)"
         assert_eq!(findings[0].column, 6, "$X (`b`) should be at column 6");
+    }
+
+    // ── languages: [regex] ────────────────────────────────────────────────────
+
+    /// (a) A `languages: [regex]` rule with `pattern-regex` loads (produces rule
+    /// instances) and FIRES on a file whose text matches.
+    #[test]
+    fn regex_lang_rule_loads_and_fires_on_matching_text() {
+        let yaml = r#"
+rules:
+  - id: test/detect-token
+    pattern-regex: "MYTOKEN[0-9]{4}"
+    languages: [regex]
+    message: Token detected
+    severity: ERROR
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        // Fan-out produces one instance per detectable language.
+        assert!(
+            !rules.is_empty(),
+            "regex-mode rule should produce at least one rule instance"
+        );
+
+        // All instances should have the correct id, severity, and language.
+        for rule in &rules {
+            assert_eq!(rule.id(), "semgrep/test/detect-token");
+            assert_eq!(rule.severity(), Severity::Critical);
+        }
+
+        // Pick any instance and run it against matching text.
+        let source = "access_token = \"MYTOKEN1234\"\n";
+        let tree = parse_file(source, Language::Python).unwrap();
+        let findings = rules[0].check(source, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected exactly one finding for matching text"
+        );
+        assert_eq!(findings[0].line, 1);
+    }
+
+    /// (b) The same rule does NOT fire on non-matching text.
+    #[test]
+    fn regex_lang_rule_does_not_fire_on_non_matching_text() {
+        let yaml = r#"
+rules:
+  - id: test/detect-token
+    pattern-regex: "MYTOKEN[0-9]{4}"
+    languages: [regex]
+    message: Token detected
+    severity: ERROR
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+
+        let source = "access_token = \"NOT_A_TOKEN\"\n";
+        let tree = parse_file(source, Language::Python).unwrap();
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            findings.is_empty(),
+            "regex-mode rule must not fire on non-matching text"
+        );
+    }
+
+    /// (c) `paths.include` / `paths.exclude` respected by the regex-mode rule.
+    #[test]
+    fn regex_lang_rule_respects_paths_filter() {
+        let yaml = r#"
+rules:
+  - id: test/jsp-scriptlet
+    pattern-regex: "<%[^@]"
+    languages: [regex]
+    message: JSP scriptlet detected
+    severity: WARNING
+    paths:
+      include:
+        - "*.jsp"
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        assert!(!rules.is_empty(), "should produce at least one rule");
+
+        // Should apply to .jsp files.
+        assert!(
+            rules[0].applies_to_path(std::path::Path::new("view.jsp")),
+            "rule should apply to .jsp files"
+        );
+        // Should NOT apply to .py files.
+        assert!(
+            !rules[0].applies_to_path(std::path::Path::new("main.py")),
+            "rule must not apply to .py files when paths.include = [*.jsp]"
+        );
+    }
+
+    /// (d) A `languages: [regex]` rule with only an AST `pattern:` (no
+    /// `pattern-regex`) should warn-skip (produce zero rule instances).
+    #[test]
+    fn regex_lang_rule_with_only_ast_pattern_warns_and_skips() {
+        let yaml = r#"
+rules:
+  - id: test/ast-only-in-regex-mode
+    pattern: eval(...)
+    languages: [regex]
+    message: This should be skipped
+    severity: ERROR
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        assert!(
+            rules.is_empty(),
+            "regex-mode rule with only an AST pattern must produce zero rule instances"
+        );
+    }
+
+    /// Regex-mode rule with `patterns:` block (pattern-regex + pattern-not-regex)
+    /// loads and correctly applies negation.
+    #[test]
+    fn regex_lang_rule_patterns_block_with_negation() {
+        let yaml = r#"
+rules:
+  - id: test/detect-artifactory-token
+    patterns:
+      - pattern-regex: "\\bAKC[a-zA-Z0-9]{10,}"
+      - pattern-not-regex: "sha(128|256|512)"
+    languages: [regex]
+    message: Artifactory token detected
+    severity: ERROR
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).unwrap();
+        assert!(!rules.is_empty(), "should produce rule instances");
+
+        let tree = parse_file("x = 1\n", Language::Python).unwrap();
+
+        // Matching text without the excluded pattern — should fire.
+        let matching = "token = \"AKCp1234567890abcdef\"\n";
+        let findings = rules[0].check(matching, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "should fire on text matching pattern-regex"
+        );
+
+        // Text matching the negative pattern — should NOT fire.
+        let negated = "hash = \"sha256_AKCp1234567890abcdef\"\n";
+        let findings = rules[0].check(negated, &tree);
+        assert!(
+            findings.is_empty(),
+            "should not fire when pattern-not-regex also matches"
+        );
     }
 }


### PR DESCRIPTION
The single biggest parity gap — **195 rules** skipping as `unsupported language: regex`. These are pure-regex rules (only `pattern-regex`, no AST).

## Approach
`Language::Regex` → a `RegexModeRule` that runs `pattern-regex`/`pattern-not-regex` (top-level, inside `patterns:` blocks, and `pattern-either:` entries) against the **raw text of every scanned file** — no tree-sitter grammar. Mirrors `generic_mode.rs`'s per-language fan-out so the existing scanner dispatch handles them; `paths.include`/`exclude` honored. A `regex` rule with only AST patterns warn-skips.

## Measured unlock (registry_coverage, combined with #506)
| | Baseline | After #506+this |
|---|---|---|
| Rules loaded | 1305 (60.9%) | **1540 (71.8%)** |
| `unsupported language: regex` | 200 | **0** |
| regex-lang rules loaded | 37/237 | **224/237 (94.5%)** |

**+187 rules** from this PR. The 13 still-failing use regex syntax the Rust `regex` crate rejects (e.g. `\Z` anchor) → correctly fall to `loader rejected (other)`.

## Verify (local)
- 5 new tests (loads+fires / no-match / paths filter / AST-only warn-skip / patterns-block negation) · full suite 0 failures · `clippy --all-targets -D warnings` clean
- **Both** dogfood scans clean · no baseline churn · reconciled onto post-#506 main (registry_coverage.rs 3-way, 0 conflicts).

Round 6 (Lane B). Sibling Lane C (loader-rejected) in flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for regex-mode rules, enabling pattern-based matching across supported languages.

* **Documentation**
  * Updated registry coverage metrics: headline load rate improved to 71.8% (from 60.9%), with 1,540 rules successfully loaded. Enhanced language support with significant improvements in regex and other language rule coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->