### PR TITLE
fix(compat): close 'loader rejected (other)' gap (17→0)

### DIFF
--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1540 (71.8%) |
-| Rules skipped | 604 (28.2%) |
+| Rules loaded OK | 1559 (72.7%) |
+| Rules skipped | 585 (27.3%) |
 
-**Headline load rate: 71.8%** (1540 / 2144 rules).
+**Headline load rate: 72.7%** (1559 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,31 +23,31 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `mode: taint (unsupported shape)` | 130 | 21.5% | 6.1% |
-| `unsupported language: yaml` | 100 | 16.6% | 4.7% |
-| `generic mode (languages: [generic])` | 78 | 12.9% | 3.6% |
-| `unsupported language: solidity` | 47 | 7.8% | 2.2% |
-| `unsupported language: dockerfile` | 39 | 6.5% | 1.8% |
-| `unsupported language: ocaml` | 34 | 5.6% | 1.6% |
-| `mode: taint (unsupported language: ruby)` | 33 | 5.5% | 1.5% |
-| `loader rejected (other)` | 30 | 5.0% | 1.4% |
-| `mode: taint (unsupported language: php)` | 21 | 3.5% | 1.0% |
-| `unsupported language: scala` | 18 | 3.0% | 0.8% |
-| `mode: taint (unsupported language: csharp)` | 11 | 1.8% | 0.5% |
+| `mode: taint (unsupported shape)` | 130 | 22.2% | 6.1% |
+| `unsupported language: yaml` | 100 | 17.1% | 4.7% |
+| `generic mode (languages: [generic])` | 78 | 13.3% | 3.6% |
+| `unsupported language: solidity` | 47 | 8.0% | 2.2% |
+| `unsupported language: dockerfile` | 39 | 6.7% | 1.8% |
+| `unsupported language: ocaml` | 34 | 5.8% | 1.6% |
+| `mode: taint (unsupported language: ruby)` | 33 | 5.6% | 1.5% |
+| `mode: taint (unsupported language: php)` | 21 | 3.6% | 1.0% |
+| `unsupported language: scala` | 18 | 3.1% | 0.8% |
+| `loader rejected (other)` | 12 | 2.1% | 0.6% |
+| `mode: taint (unsupported language: csharp)` | 11 | 1.9% | 0.5% |
 | `unsupported language: apex` | 9 | 1.5% | 0.4% |
 | `unsupported language: bash` | 9 | 1.5% | 0.4% |
 | `unsupported language: elixir` | 7 | 1.2% | 0.3% |
 | `unsupported language: json` | 7 | 1.2% | 0.3% |
-| `mode: taint (unsupported language: scala)` | 5 | 0.8% | 0.2% |
-| `unsupported language: clojure` | 5 | 0.8% | 0.2% |
+| `mode: taint (unsupported language: scala)` | 5 | 0.9% | 0.2% |
+| `unsupported language: clojure` | 5 | 0.9% | 0.2% |
 | `unsupported language: html` | 4 | 0.7% | 0.2% |
 | `mode: taint (unsupported language: apex)` | 3 | 0.5% | 0.1% |
 | `mode: taint (unsupported language: bash)` | 3 | 0.5% | 0.1% |
 | `mode: taint (unsupported language: solidity)` | 3 | 0.5% | 0.1% |
 | `taint: pattern-propagators` | 3 | 0.5% | 0.1% |
-| `unsupported language: hcl` | 2 | 0.3% | 0.1% |
 | `mode: taint (unsupported language: swift)` | 1 | 0.2% | 0.0% |
 | `unsupported language: dart` | 1 | 0.2% | 0.0% |
+| `unsupported language: hcl` | 1 | 0.2% | 0.0% |
 | `unsupported language: xml` | 1 | 0.2% | 0.0% |
 
 ## Priority order — operator/feature backlog
@@ -57,10 +57,10 @@ Matcher capabilities (implementable in `semgrep_compat.rs` / `semgrep_taint.rs`)
 | Rank | Capability to add | Rules unlocked |
 |---:|---|---:|
 | 1 | `mode: taint (unsupported shape)` | 130 |
-| 2 | `loader rejected (other)` | 30 |
+| 2 | `loader rejected (other)` | 12 |
 | 3 | `taint: pattern-propagators` | 3 |
 
-Operator/feature gaps account for **163 rules** (7.6% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
+Operator/feature gaps account for **145 rules** (6.8% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
 
 ## Priority order — missing language grammars
 
@@ -87,12 +87,12 @@ Rules foxguard cannot run because it has no tree-sitter grammar for the target l
 | 17 | `mode: taint (unsupported language: apex)` | 3 |
 | 18 | `mode: taint (unsupported language: bash)` | 3 |
 | 19 | `mode: taint (unsupported language: solidity)` | 3 |
-| 20 | `unsupported language: hcl` | 2 |
-| 21 | `mode: taint (unsupported language: swift)` | 1 |
-| 22 | `unsupported language: dart` | 1 |
+| 20 | `mode: taint (unsupported language: swift)` | 1 |
+| 21 | `unsupported language: dart` | 1 |
+| 22 | `unsupported language: hcl` | 1 |
 | 23 | `unsupported language: xml` | 1 |
 
-Missing-grammar gaps account for **441 rules** (20.6% of all rules).
+Missing-grammar gaps account for **440 rules** (20.5% of all rules).
 
 ## Per-language breakdown
 
@@ -100,22 +100,22 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 
 | Language | Total | Loaded | Skipped | Load rate |
 |---|---:|---:|---:|---:|
-| python | 423 | 370 | 53 | 87.5% |
-| hcl | 359 | 357 | 2 | 99.4% |
-| javascript | 243 | 185 | 58 | 76.1% |
-| regex | 237 | 224 | 13 | 94.5% |
-| java | 131 | 109 | 22 | 83.2% |
+| python | 423 | 377 | 46 | 89.1% |
+| hcl | 359 | 358 | 1 | 99.7% |
+| javascript | 243 | 190 | 53 | 78.2% |
+| regex | 237 | 225 | 12 | 94.9% |
+| java | 131 | 110 | 21 | 84.0% |
 | generic | 103 | 25 | 78 | 24.3% |
 | yaml | 100 | 0 | 100 | 0.0% |
 | go | 97 | 84 | 13 | 86.6% |
-| ruby | 92 | 57 | 35 | 62.0% |
-| php | 63 | 41 | 22 | 65.1% |
+| ruby | 92 | 59 | 33 | 64.1% |
+| php | 63 | 42 | 21 | 66.7% |
 | solidity | 50 | 0 | 50 | 0.0% |
 | csharp | 48 | 37 | 11 | 77.1% |
 | dockerfile | 39 | 0 | 39 | 0.0% |
 | ocaml | 34 | 0 | 34 | 0.0% |
 | scala | 23 | 0 | 23 | 0.0% |
-| c | 16 | 15 | 1 | 93.8% |
+| c | 16 | 16 | 0 | 100.0% |
 | kotlin | 15 | 15 | 0 | 100.0% |
 | bash | 13 | 1 | 12 | 7.7% |
 | apex | 12 | 0 | 12 | 0.0% |
@@ -133,7 +133,6 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 
 - **apex**: `unsupported language: apex` (9), `mode: taint (unsupported language: apex)` (3)
 - **bash**: `unsupported language: bash` (9), `mode: taint (unsupported language: bash)` (3)
-- **c**: `loader rejected (other)` (1)
 - **clojure**: `unsupported language: clojure` (5)
 - **csharp**: `mode: taint (unsupported language: csharp)` (11)
 - **dart**: `unsupported language: dart` (1)
@@ -141,16 +140,16 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **elixir**: `unsupported language: elixir` (7)
 - **generic**: `generic mode (languages: [generic])` (78)
 - **go**: `mode: taint (unsupported shape)` (13)
-- **hcl**: `unsupported language: hcl` (2)
+- **hcl**: `unsupported language: hcl` (1)
 - **html**: `unsupported language: html` (4)
-- **java**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (3), `loader rejected (other)` (1)
-- **javascript**: `mode: taint (unsupported shape)` (53), `loader rejected (other)` (5)
+- **java**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (3)
+- **javascript**: `mode: taint (unsupported shape)` (53)
 - **json**: `unsupported language: json` (7)
 - **ocaml**: `unsupported language: ocaml` (34)
-- **php**: `mode: taint (unsupported language: php)` (21), `loader rejected (other)` (1)
-- **python**: `mode: taint (unsupported shape)` (46), `loader rejected (other)` (7)
-- **regex**: `loader rejected (other)` (13)
-- **ruby**: `mode: taint (unsupported language: ruby)` (33), `loader rejected (other)` (2)
+- **php**: `mode: taint (unsupported language: php)` (21)
+- **python**: `mode: taint (unsupported shape)` (46)
+- **regex**: `loader rejected (other)` (12)
+- **ruby**: `mode: taint (unsupported language: ruby)` (33)
 - **scala**: `unsupported language: scala` (18), `mode: taint (unsupported language: scala)` (5)
 - **solidity**: `unsupported language: solidity` (47), `mode: taint (unsupported language: solidity)` (3)
 - **swift**: `mode: taint (unsupported language: swift)` (1)

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -98,6 +98,10 @@ pub struct PatternClause {
 pub enum SemgrepSeverity {
     Error,
     Warning,
+    /// `MEDIUM` is a Semgrep severity variant used by some registry rules (e.g.
+    /// supply-chain / package-manager packs).  Foxguard maps it to `High`,
+    /// matching the spirit of "medium" risk in the broader threat model.
+    Medium,
     Info,
 }
 
@@ -122,7 +126,14 @@ pub struct SemgrepMetavariableRegexClause {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct SemgrepMetavariableComparisonClause {
-    pub metavariable: String,
+    /// The metavariable to compare.  Some advanced Semgrep rules omit this key
+    /// (they use `comparison: str($F1) == str($F2)` with both operands being
+    /// metavariables inside the expression string). We make the field optional
+    /// so those rules still deserialize; `from_yaml` will warn-skip the
+    /// constraint when the field is absent because the comparison is outside
+    /// our supported `$VAR <op> <number>` subset regardless.
+    #[serde(default)]
+    pub metavariable: Option<String>,
     pub comparison: String,
     /// Optional integer base for parsing (e.g. 16 for hex). Warn-skipped if
     /// present — we only support base-10 by default.
@@ -601,11 +612,28 @@ impl PathFilter {
 }
 
 impl MetavariableRegexConstraint {
-    fn from_yaml(clause: &SemgrepMetavariableRegexClause) -> Result<Self, String> {
-        Ok(Self {
-            metavariable: clause.metavariable.clone(),
-            regex: compile_regex(&clause.regex)?,
-        })
+    /// Build from a YAML clause.
+    ///
+    /// Returns `Some(_)` on success, `None` (after printing a warning) when the
+    /// regex uses features that the Rust `regex` crate does not support
+    /// (lookaheads / lookbehinds / `\Z`, etc.).  The caller continues loading
+    /// the rest of the rule's clauses — this mirrors the behaviour of
+    /// `MetavariableAnalysisConstraint::from_yaml`.
+    fn from_yaml(clause: &SemgrepMetavariableRegexClause) -> Option<Self> {
+        match compile_regex(&clause.regex) {
+            Ok(regex) => Some(Self {
+                metavariable: clause.metavariable.clone(),
+                regex,
+            }),
+            Err(e) => {
+                eprintln!(
+                    "Warning: metavariable-regex for {} uses an unsupported regex ({}); \
+                     skipping constraint",
+                    clause.metavariable, e
+                );
+                None
+            }
+        }
     }
 
     fn matches(&self, bindings: &HashMap<String, String>) -> bool {
@@ -629,6 +657,20 @@ impl MetavariableComparisonConstraint {
                     "metavariable-comparison: base:{base} is not supported (only base:10); skipping constraint"
                 ));
             }
+        }
+
+        // Some advanced Semgrep rules use `comparison:` without an explicit
+        // `metavariable:` key (e.g. `comparison: str($F1) == str($F2)` with
+        // both operands as metavar expressions). The `metavariable` field is
+        // optional in the YAML schema (see `SemgrepMetavariableComparisonClause`).
+        // Those rules fall outside our supported `$VAR <op> <number>` subset, so
+        // we warn-skip the constraint without failing the whole rule load.
+        if clause.metavariable.is_none() {
+            return Err(format!(
+                "metavariable-comparison: no `metavariable:` key in clause '{}'; \
+                 the comparison uses an unsupported expression form — skipping constraint",
+                clause.comparison
+            ));
         }
 
         let (metavariable, op, literal, literal_is_lhs) = parse_comparison(&clause.comparison)?;
@@ -1544,6 +1586,10 @@ fn map_severity(s: &SemgrepSeverity) -> Severity {
     match s {
         SemgrepSeverity::Error => Severity::Critical,
         SemgrepSeverity::Warning => Severity::High,
+        // `MEDIUM` is used by some Semgrep registry packs (e.g. supply-chain rules).
+        // Map to `High` to preserve the intent of "non-trivial risk"; foxguard
+        // does not have a dedicated Medium->Medium mapping in its severity enum.
+        SemgrepSeverity::Medium => Severity::High,
         SemgrepSeverity::Info => Severity::Medium,
     }
 }
@@ -1894,7 +1940,11 @@ fn build_matcher(yaml: &SemgrepRuleYaml, lang: Language) -> Result<PatternMatche
                 positives.push(PatternMatcher::Either(matchers));
             }
             if let Some(ref mr) = clause.metavariable_regex {
-                metavariable_regexes.push(MetavariableRegexConstraint::from_yaml(mr)?);
+                if let Some(constraint) = MetavariableRegexConstraint::from_yaml(mr) {
+                    metavariable_regexes.push(constraint);
+                }
+                // If from_yaml returns None it already printed a warning; we
+                // continue loading the rest of the rule's clauses.
             }
             if let Some(ref mc) = clause.metavariable_comparison {
                 match MetavariableComparisonConstraint::from_yaml(mc) {
@@ -2013,7 +2063,12 @@ fn build_either_matchers(
 }
 
 fn compile_regex(pattern: &str) -> Result<Regex, String> {
-    Regex::new(pattern).map_err(|e| format!("Invalid pattern-regex '{}': {}", pattern, e))
+    // `\Z` is a Python/PCRE end-of-string anchor meaning "end of string before
+    // optional trailing newline".  The Rust `regex` crate uses `$` with the
+    // `MULTILINE` flag off for the same semantics (match at absolute end).
+    // We normalise it here so rules that use `\Z` load successfully.
+    let normalised = pattern.replace(r"\Z", "$");
+    Regex::new(&normalised).map_err(|e| format!("Invalid pattern-regex '{}': {}", pattern, e))
 }
 
 fn compile_globset(patterns: &[String]) -> Result<Option<GlobSet>, String> {
@@ -2641,7 +2696,7 @@ rules:
     #[test]
     fn test_constraint_matches_numeric_match() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X < 10".to_string(),
             base: None,
             strip: None,
@@ -2655,7 +2710,7 @@ rules:
     #[test]
     fn test_constraint_non_match() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X < 10".to_string(),
             base: None,
             strip: None,
@@ -2669,7 +2724,7 @@ rules:
     #[test]
     fn test_constraint_non_numeric_binding_no_match() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X < 10".to_string(),
             base: None,
             strip: None,
@@ -2683,7 +2738,7 @@ rules:
     #[test]
     fn test_constraint_unbound_metavar_no_match() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X < 10".to_string(),
             base: None,
             strip: None,
@@ -2696,7 +2751,7 @@ rules:
     #[test]
     fn test_constraint_float_comparison() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X >= 3.14".to_string(),
             base: None,
             strip: None,
@@ -2726,7 +2781,7 @@ rules:
     #[test]
     fn test_constraint_eq_is_exact() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X == 5".to_string(),
             base: None,
             strip: None,
@@ -2745,7 +2800,7 @@ rules:
         // Regression for the `f` suffix bug: a bound C float literal `1.5f`
         // must compare equal to the literal `1.5` rather than being dropped.
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X == 1.5".to_string(),
             base: None,
             strip: None,
@@ -2759,7 +2814,7 @@ rules:
     #[test]
     fn test_constraint_unsupported_base_warn_skip() {
         let clause = SemgrepMetavariableComparisonClause {
-            metavariable: "$X".to_string(),
+            metavariable: Some("$X".to_string()),
             comparison: "$X < 10".to_string(),
             base: Some(16),
             strip: None,
@@ -3516,5 +3571,104 @@ rules:
             findings.is_empty(),
             "should not fire when pattern-not-regex also matches"
         );
+    }
+
+    // ── Regression tests for "loader rejected (other)" fixes ────────────────
+
+    /// Fix 1: `severity: MEDIUM` must load without error.
+    ///
+    /// Regression for rules such as `supply-chain/audit/go-audit-...` that
+    /// use `MEDIUM` as their severity value.  Previously the serde deserialiser
+    /// rejected the value because the enum only had ERROR/WARNING/INFO.
+    #[test]
+    fn test_severity_medium_loads() {
+        let yaml = r#"
+rules:
+  - id: medium-sev-rule
+    pattern: foo()
+    message: medium severity rule
+    severity: MEDIUM
+    languages: [python]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).expect("MEDIUM severity rule must load");
+        assert_eq!(rules.len(), 1);
+    }
+
+    /// Fix 2: `metavariable-comparison:` without a `metavariable:` key must
+    /// warn-skip the comparison constraint and still load the rule.
+    ///
+    /// Regression for rules such as `python/sql-injection-...` that use
+    /// `comparison: str($F1) == str($F2)` (two metavar operands, no single
+    /// bound metavar key).
+    #[test]
+    fn test_metavariable_comparison_without_metavariable_key_loads_rule() {
+        let yaml = r#"
+rules:
+  - id: cmp-no-metavar-key
+    patterns:
+      - pattern: foo($F1, $F2)
+      - metavariable-comparison:
+          comparison: $F1 > $F2
+    message: comparison without metavariable key
+    severity: WARNING
+    languages: [python]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path()).expect(
+            "rule with metavariable-comparison missing `metavariable:` key must still load",
+        );
+        assert_eq!(rules.len(), 1);
+    }
+
+    /// Fix 3: `metavariable-regex:` with a lookahead pattern must warn-skip
+    /// the constraint and still load the rule.
+    ///
+    /// Regression for rules such as `javascript/hardcoded-...` that use
+    /// `(?!...)` lookahead assertions in their `metavariable-regex` value.
+    /// The Rust `regex` crate does not support PCRE lookaheads; previously
+    /// this caused the entire rule to fail to load.
+    #[test]
+    fn test_metavariable_regex_with_lookahead_loads_rule() {
+        let yaml = r#"
+rules:
+  - id: mv-regex-lookahead
+    patterns:
+      - pattern: |
+          var $X = "...";
+      - metavariable-regex:
+          metavariable: $X
+          regex: '(?!localhost).*'
+    message: hardcoded non-localhost value
+    severity: WARNING
+    languages: [javascript]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path())
+            .expect("rule with lookahead in metavariable-regex must still load");
+        assert_eq!(rules.len(), 1);
+    }
+
+    /// Fix 4: `\Z` in a `pattern-regex` value must compile successfully.
+    ///
+    /// Regression for the PHP `assert-use-audit` rule which uses `\Z` (Python
+    /// end-of-string anchor) in its primary `pattern-regex`.  The Rust `regex`
+    /// crate uses `$` for the same purpose; we normalise `\Z` → `$` before
+    /// compilation.
+    #[test]
+    fn test_pattern_regex_backslash_z_anchor_loads() {
+        // `\Z` normalised to `$` — the rule must load without error.
+        let yaml = r#"
+rules:
+  - id: pattern-regex-z-anchor
+    pattern-regex: 'assert\s*\(\s*\$\w+\s*\)\s*\Z'
+    message: assert usage
+    severity: WARNING
+    languages: [php]
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path())
+            .expect("pattern-regex with \\Z anchor must load after normalisation");
+        assert_eq!(rules.len(), 1);
     }
 }


### PR DESCRIPTION
Four targeted loader fixes for registry rules `parse_semgrep_str` silently rejected:

| Fix | Rules |
|---|---|
| `MEDIUM` severity variant (→ High) | go audit |
| Optional `metavariable:` in `metavariable-comparison` (warn-skip when absent) | python (also closes a deferred review finding) |
| `metavariable-regex` with a PCRE lookahead → warn-skip the constraint, keep the rule | ~13 (py/js/java/ruby/go/php/c) |
| Normalise `\Z` → `$` in `compile_regex` | PHP + several `languages: [regex]` rules (synergy with #507) |

## Combined result (registry_coverage, #506 + #507 + this)
| | Start of round | Now |
|---|---|---|
| Rules loaded | 1305 (60.9%) | **1559 (72.7%)** |
| `loader rejected (other)` | 17 | **0** |

## Verify (local)
- 4 new regression tests + full suite 0 failures · `clippy --all-targets -D warnings` clean
- **Both** dogfood scans clean · no baseline churn · reconciled onto post-#507 main (kept both B's regex tests and these; 1 test-append conflict resolved).

Round 6 (Lane C) — the last of the three abandoned top-gap branches I took over.