### PR TITLE
feat(compat): C# taint engine + bridge

### DIFF
--- a/src/bin/registry_coverage.rs
+++ b/src/bin/registry_coverage.rs
@@ -168,6 +168,9 @@ fn taint_language_supported(lang: &str) -> bool {
             | "ruby"
             | "rb"
             | "php"
+            | "csharp"
+            | "cs"
+            | "c#"
     )
 }
 

--- a/src/rules/csharp_taint.rs
+++ b/src/rules/csharp_taint.rs
@@ -1,0 +1,1162 @@
+//! Intraprocedural, flow-insensitive taint analysis for C#.
+//!
+//! Mirrors `java_taint.rs` in shape. C# is a statically-typed, OO language
+//! with similar method-invocation AST structure. The tree-sitter-c-sharp
+//! grammar uses different node kinds than Java; key ones used here:
+//!
+//! - `method_declaration` / `constructor_declaration` / `local_function_statement` —
+//!   scope boundaries for intraprocedural analysis.
+//! - `invocation_expression` — a method/function call; has `function` (callee)
+//!   and `argument_list` children.
+//! - `object_creation_expression` — `new SqlCommand(...)`, etc.; has `type`
+//!   and `argument_list` children.
+//! - `member_access_expression` — `Request.QueryString`, `Process.Start(...)`;
+//!   has `expression` (receiver) and `name` children.
+//! - `element_access_expression` — `Request.QueryString["key"]`; has
+//!   `expression` and `subscript_argument_list` children.
+//! - `assignment_expression` — `left = right`.
+//! - `variable_declarator` — `string x = expr`.
+//! - `binary_expression` — string concatenation `left + right`.
+//!
+//! # End-to-end correctness (bridge lesson from Ruby)
+//!
+//! The Semgrep bridge compiles a bare-identifier `pattern:` source to
+//! `GenericMatcher::ParamName`. For C#, the primary sources are DOTTED
+//! (`Request.QueryString`, `Request.Form`, `Console.ReadLine()`) so they
+//! arrive as `Attribute` or `Call` matchers through the bridge. The engine
+//! must match these in `match_source` against `member_access_expression` and
+//! `invocation_expression` nodes respectively, not just as identifier
+//! references. The bridge path therefore fires end-to-end on the real CLI.
+
+use crate::rules::common::{walk_tree, AliasTable};
+pub use crate::rules::taint_engine::{NodeMatcher, TaintFinding, TaintSpec};
+use std::collections::HashMap;
+use tree_sitter::Node;
+
+// ─── Internal taint state ─────────────────────────────────────────────────────
+
+#[derive(Clone, Debug)]
+struct TaintInfo {
+    description: String,
+    line: usize,
+    hops: u8,
+}
+
+#[derive(Default)]
+struct TaintState {
+    tainted: HashMap<String, TaintInfo>,
+}
+
+impl TaintState {
+    fn taint(&mut self, name: String, info: TaintInfo) {
+        self.tainted.insert(name, info);
+    }
+
+    fn clear(&mut self, name: &str) {
+        self.tainted.remove(name);
+    }
+
+    fn info(&self, name: &str) -> Option<&TaintInfo> {
+        self.tainted.get(name)
+    }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/// Run the C# taint engine over every method, constructor, and local function
+/// inside `root` and return one [`TaintFinding`] per source→sink flow.
+pub fn analyze_tree(
+    root: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    _aliases: Option<&AliasTable>,
+) -> Vec<TaintFinding> {
+    let mut findings = Vec::new();
+    walk_tree(root, source, &mut |node, src| {
+        if is_scope_node(node.kind()) {
+            analyze_scope(node, src, spec, &mut findings);
+        }
+    });
+    findings
+}
+
+// ─── Built-in specs ──────────────────────────────────────────────────────────
+
+/// All C# taint rule IDs paired with their specs.
+pub fn csharp_taint_rule_specs() -> Vec<(&'static str, TaintSpec)> {
+    vec![
+        ("csharp/taint-sql-injection", sql_injection_spec()),
+        ("csharp/taint-command-injection", command_injection_spec()),
+        ("csharp/taint-xss", xss_spec()),
+        ("csharp/taint-open-redirect", open_redirect_spec()),
+        ("csharp/taint-xxe", xxe_spec()),
+        ("csharp/taint-unsafe-load", unsafe_load_spec()),
+    ]
+}
+
+/// Shared sources for C# taint rules — ASP.NET / System.Web request inputs.
+pub fn csharp_taint_sources() -> Vec<NodeMatcher> {
+    vec![
+        // ─── ASP.NET classic (HttpRequest / HttpContext) ───────────────────
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "QueryString".into(),
+            description: "Request.QueryString".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Form".into(),
+            description: "Request.Form".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Params".into(),
+            description: "Request.Params".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Cookies".into(),
+            description: "Request.Cookies".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Headers".into(),
+            description: "Request.Headers".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "RawUrl".into(),
+            description: "Request.RawUrl".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Url".into(),
+            description: "Request.Url".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "Path".into(),
+            description: "Request.Path".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "UserAgent".into(),
+            description: "Request.UserAgent".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Request".into(),
+            field: "ServerVariables".into(),
+            description: "Request.ServerVariables".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "HttpContext".into(),
+            field: "Request".into(),
+            description: "HttpContext.Request".into(),
+        },
+        // ─── Console / stdin ──────────────────────────────────────────────
+        NodeMatcher::Call {
+            canonical: "Console.ReadLine".into(),
+            description: "Console.ReadLine()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Console.Read".into(),
+            description: "Console.Read()".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Console.ReadKey".into(),
+            description: "Console.ReadKey()".into(),
+        },
+        // ─── Environment / CLI args ───────────────────────────────────────
+        NodeMatcher::Call {
+            canonical: "Environment.GetEnvironmentVariable".into(),
+            description: "Environment.GetEnvironmentVariable()".into(),
+        },
+        NodeMatcher::Attribute {
+            root: "Environment".into(),
+            field: "GetCommandLineArgs".into(),
+            description: "Environment.GetCommandLineArgs()".into(),
+        },
+    ]
+}
+
+/// Shared sanitizers for C# taint rules.
+pub fn csharp_taint_sanitizers() -> Vec<NodeMatcher> {
+    vec![
+        // ─── HTML encoding ────────────────────────────────────────────────
+        NodeMatcher::Call {
+            canonical: "HttpUtility.HtmlEncode".into(),
+            description: "HttpUtility.HtmlEncode".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "HttpUtility.HtmlAttributeEncode".into(),
+            description: "HttpUtility.HtmlAttributeEncode".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "HttpUtility.UrlEncode".into(),
+            description: "HttpUtility.UrlEncode".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "HtmlEncoder.Default.Encode".into(),
+            description: "HtmlEncoder.Default.Encode".into(),
+        },
+        NodeMatcher::MethodName {
+            method: "HtmlEncode".into(),
+            description: "HtmlEncode".into(),
+        },
+        // ─── SQL parameterization ─────────────────────────────────────────
+        NodeMatcher::Call {
+            canonical: "SqlParameter".into(),
+            description: "SqlParameter (parameterized query)".into(),
+        },
+        // ─── Type conversion (taint-killing) ─────────────────────────────
+        NodeMatcher::Call {
+            canonical: "int.Parse".into(),
+            description: "int.Parse (numeric conversion)".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Convert.ToInt32".into(),
+            description: "Convert.ToInt32 (numeric conversion)".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Convert.ToInt64".into(),
+            description: "Convert.ToInt64 (numeric conversion)".into(),
+        },
+        // ─── Path sanitizers ─────────────────────────────────────────────
+        NodeMatcher::Call {
+            canonical: "Path.GetFileName".into(),
+            description: "Path.GetFileName (path sanitizer)".into(),
+        },
+        NodeMatcher::Call {
+            canonical: "Path.GetFullPath".into(),
+            description: "Path.GetFullPath (path canonicalization)".into(),
+        },
+    ]
+}
+
+fn sql_injection_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            // SqlCommand constructor with dynamic SQL
+            NodeMatcher::Call {
+                canonical: "SqlCommand".into(),
+                description: "SqlCommand() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "OleDbCommand".into(),
+                description: "OleDbCommand() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "MySqlCommand".into(),
+                description: "MySqlCommand() with tainted query (SQL injection)".into(),
+            },
+            // Execute methods
+            NodeMatcher::MethodName {
+                method: "ExecuteReader".into(),
+                description: "ExecuteReader() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "ExecuteNonQuery".into(),
+                description: "ExecuteNonQuery() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "ExecuteScalar".into(),
+                description: "ExecuteScalar() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "ExecuteXmlReader".into(),
+                description: "ExecuteXmlReader() with tainted query (SQL injection)".into(),
+            },
+            // Entity Framework / Dapper
+            NodeMatcher::MethodName {
+                method: "FromSqlRaw".into(),
+                description: "FromSqlRaw() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "ExecuteSqlRaw".into(),
+                description: "ExecuteSqlRaw() with tainted query (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Query".into(),
+                description: "Dapper.Query() with tainted SQL (SQL injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Execute".into(),
+                description: "Dapper.Execute() with tainted SQL (SQL injection)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+fn command_injection_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "Process.Start".into(),
+                description: "Process.Start() with tainted argument (command injection)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "ProcessStartInfo".into(),
+                description: "ProcessStartInfo() with tainted argument (command injection)".into(),
+            },
+            NodeMatcher::Attribute {
+                root: "ProcessStartInfo".into(),
+                field: "Arguments".into(),
+                description: "ProcessStartInfo.Arguments tainted (command injection)".into(),
+            },
+            NodeMatcher::Attribute {
+                root: "ProcessStartInfo".into(),
+                field: "FileName".into(),
+                description: "ProcessStartInfo.FileName tainted (command injection)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Start".into(),
+                description: "Process.Start() with tainted argument (command injection)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+fn xss_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "Response.Write".into(),
+                description: "Response.Write() with tainted content (XSS)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Write".into(),
+                description: "Response.Write() with tainted content (XSS)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+fn open_redirect_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "Response.Redirect".into(),
+                description: "Response.Redirect() with tainted URL (open redirect)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Redirect".into(),
+                description: "Response.Redirect() with tainted URL (open redirect)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+fn xxe_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "XmlReader.Create".into(),
+                description: "XmlReader.Create() with tainted input (XXE)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "LoadXml".into(),
+                description: "XmlDocument.LoadXml() with tainted input (XXE)".into(),
+            },
+            NodeMatcher::MethodName {
+                method: "Load".into(),
+                description: "XmlDocument.Load() with tainted input (XXE)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+fn unsafe_load_spec() -> TaintSpec {
+    TaintSpec {
+        sources: csharp_taint_sources(),
+        sinks: vec![
+            NodeMatcher::Call {
+                canonical: "Assembly.Load".into(),
+                description: "Assembly.Load() with tainted name (unsafe load)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "Assembly.LoadFrom".into(),
+                description: "Assembly.LoadFrom() with tainted path (unsafe load)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "Activator.CreateInstance".into(),
+                description: "Activator.CreateInstance() with tainted type (unsafe load)".into(),
+            },
+            NodeMatcher::Call {
+                canonical: "Type.GetType".into(),
+                description: "Type.GetType() with tainted type name (reflection injection)".into(),
+            },
+        ],
+        sanitizers: csharp_taint_sanitizers(),
+    }
+}
+
+// ─── Scope analysis ───────────────────────────────────────────────────────────
+
+fn analyze_scope(
+    scope_node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    out: &mut Vec<TaintFinding>,
+) {
+    let body = find_scope_body(scope_node).unwrap_or(scope_node);
+    let mut state = TaintState::default();
+
+    // Three passes cover `source -> local -> derived -> sink` chains without
+    // a fixed-point loop.
+    for _ in 0..3 {
+        propagate_assignments(body, source, spec, &mut state);
+    }
+    find_sinks(body, source, spec, &state, out);
+}
+
+fn propagate_assignments(scope: Node<'_>, source: &str, spec: &TaintSpec, state: &mut TaintState) {
+    walk_scope_nodes(scope, source, &mut |node, src| {
+        // `var x = expr;`  or  `Type x = expr;`
+        //
+        // AST structure (tree-sitter-c-sharp):
+        //   variable_declarator
+        //     name: identifier ("x")
+        //     <anon>: "="
+        //     <anon>: <value_expr>   ← NO `value` field name
+        //
+        // We detect the value as the last named child that is NOT the name identifier.
+        if node.kind() == "variable_declarator" {
+            let Some(name_node) = node.child_by_field_name("name") else {
+                return;
+            };
+            let name = node_text(name_node, src).to_string();
+            // Find the value: the last child that is not the `=` token and not the name.
+            if let Some(value) = variable_declarator_value(node) {
+                match expression_taint(value, src, spec, state) {
+                    Some(info) => state.taint(name, bump_hops(info)),
+                    None => state.clear(&name),
+                }
+            }
+        }
+
+        // `left = right`
+        if node.kind() == "assignment_expression" {
+            let Some(left) = node.child_by_field_name("left") else {
+                return;
+            };
+            let Some(right) = node.child_by_field_name("right") else {
+                return;
+            };
+            let name = assignment_target_name(left, src);
+            if let Some(name) = name {
+                match expression_taint(right, src, spec, state) {
+                    Some(info) => state.taint(name.to_string(), bump_hops(info)),
+                    None => state.clear(name),
+                }
+            }
+        }
+    });
+}
+
+fn find_sinks(
+    scope: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    state: &TaintState,
+    out: &mut Vec<TaintFinding>,
+) {
+    walk_scope_nodes(scope, source, &mut |node, src| {
+        let is_call = node.kind() == "invocation_expression";
+        let is_new = node.kind() == "object_creation_expression";
+        if !is_call && !is_new {
+            return;
+        }
+        let Some(sink_desc) = match_sink(node, src, spec) else {
+            return;
+        };
+        if let Some(info) = sink_argument_taint(node, src, spec, state) {
+            out.push(taint_finding_for_node(node, info, sink_desc));
+        }
+    });
+}
+
+// ─── Expression taint ────────────────────────────────────────────────────────
+
+fn expression_taint(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    state: &TaintState,
+) -> Option<TaintInfo> {
+    // Whole-expression text lookup in state first (catches `x` identifiers).
+    let text = node_text(node, source);
+    if let Some(info) = state.info(text) {
+        return Some(info.clone());
+    }
+
+    // Bare identifier.
+    if node.kind() == "identifier" {
+        return state.info(text).cloned();
+    }
+
+    // Sanitizer check before source check.
+    if is_sanitizer_call(node, source, spec) {
+        return None;
+    }
+
+    // Direct source match.
+    if let Some(desc) = classify_source_expr(node, source, spec) {
+        return Some(TaintInfo {
+            description: desc,
+            line: node.start_position().row + 1,
+            hops: 0,
+        });
+    }
+
+    // Propagation: member_access on a tainted receiver.
+    // e.g. `tainted.ToString()` or `tainted.field`
+    if node.kind() == "member_access_expression" {
+        if let Some(recv) = node.child_by_field_name("expression") {
+            if let Some(info) = expression_taint(recv, source, spec, state) {
+                return Some(bump_hops(info));
+            }
+        }
+    }
+
+    // Propagation: element_access on a tainted receiver.
+    // `Request.QueryString["key"]` or `tainted[x]`
+    // AST: element_access_expression { expression: <recv>, subscript: bracketed_argument_list }
+    if node.kind() == "element_access_expression" {
+        if let Some(expr) = node.child_by_field_name("expression") {
+            if let Some(info) = expression_taint(expr, source, spec, state) {
+                return Some(bump_hops(info));
+            }
+        }
+    }
+
+    // Propagation through arguments of a method call.
+    if node.kind() == "invocation_expression" {
+        if let Some(args) = call_arguments(node) {
+            if let Some(info) = argument_list_taint(args, source, spec, state) {
+                return Some(bump_hops(info));
+            }
+        }
+    }
+
+    // Propagation: binary_expression (string concat: `"SELECT * FROM " + id`).
+    if node.kind() == "binary_expression" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            // Skip the operator token ("+", etc.)
+            if !child.is_named() {
+                continue;
+            }
+            if let Some(info) = expression_taint(child, source, spec, state) {
+                return Some(info);
+            }
+        }
+    }
+
+    // Propagation: interpolated_string_expression `$"...{expr}..."`.
+    if node.kind() == "interpolated_string_expression" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "interpolation" {
+                let mut icursor = child.walk();
+                for inner in child.children(&mut icursor) {
+                    if let Some(info) = expression_taint(inner, source, spec, state) {
+                        return Some(info);
+                    }
+                }
+            }
+        }
+    }
+
+    // Generic recursive scan for other container node kinds.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(info) = expression_taint(child, source, spec, state) {
+            return Some(info);
+        }
+    }
+    None
+}
+
+/// Try to classify `node` as a known source expression.
+///
+/// Handles:
+/// - `member_access_expression`: `Request.QueryString`, `Request.Form`, etc.
+/// - `invocation_expression`: `Console.ReadLine()`, `Environment.GetEnvironmentVariable()`
+/// - `element_access_expression`: `Request.QueryString["x"]` (wraps the member access)
+/// - `ParamName` sources matched as bare identifiers (bridge path).
+fn classify_source_expr(node: Node<'_>, source: &str, spec: &TaintSpec) -> Option<String> {
+    for matcher in &spec.sources {
+        match matcher {
+            NodeMatcher::Attribute {
+                root,
+                field,
+                description,
+            } => {
+                // `Request.QueryString` → member_access_expression { expression=Request, name=QueryString }
+                if node.kind() == "member_access_expression" {
+                    let recv = node.child_by_field_name("expression");
+                    let name_node = node.child_by_field_name("name");
+                    if let (Some(recv), Some(name_node)) = (recv, name_node) {
+                        let recv_text = node_text(recv, source);
+                        let name_text = node_text(name_node, source);
+                        if recv_text == root.as_str() && name_text == field.as_str() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+                // `Request.QueryString["key"]` → element_access_expression { expression=member_access }
+                if node.kind() == "element_access_expression" {
+                    if let Some(expr) = node.child_by_field_name("expression") {
+                        if classify_source_expr(expr, source, spec).is_some() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+            }
+            NodeMatcher::Call {
+                canonical,
+                description,
+            } => {
+                // `Console.ReadLine()` → invocation_expression { function=member_access { … } }
+                if node.kind() == "invocation_expression" {
+                    if let Some(func) = node.child_by_field_name("function") {
+                        let resolved = resolve_callee(func, source);
+                        if resolved == canonical.as_str() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+                // Also match `new SomeType()` with a plain canonical type name.
+                if node.kind() == "object_creation_expression" {
+                    if let Some(type_node) = node.child_by_field_name("type") {
+                        if node_text(type_node, source) == canonical.as_str() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+            }
+            NodeMatcher::ParamName { names, description } => {
+                // Bare identifier compiled from a bridge `pattern: SomeName` source.
+                // In C# these fire on identifiers (local variables, parameters).
+                if node.kind() == "identifier" {
+                    let text = node_text(node, source);
+                    if names.iter().any(|n| n == text) {
+                        return Some(description.clone());
+                    }
+                }
+                // Also match member_access_expression whose leftmost receiver name
+                // appears in the list (e.g. `Request.QueryString` when `Request`
+                // is listed as a ParamName source).
+                if node.kind() == "member_access_expression"
+                    || node.kind() == "element_access_expression"
+                {
+                    if let Some(root_name) = leftmost_receiver_name(node, source) {
+                        if names.iter().any(|n| n == root_name) {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+            }
+            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+                // Sink-only matchers, never a source.
+            }
+        }
+    }
+    None
+}
+
+fn is_sanitizer_call(node: Node<'_>, source: &str, spec: &TaintSpec) -> bool {
+    spec.sanitizers
+        .iter()
+        .any(|matcher| matcher_matches_call(matcher, node, source))
+}
+
+fn match_sink(node: Node<'_>, source: &str, spec: &TaintSpec) -> Option<String> {
+    spec.sinks.iter().find_map(|matcher| {
+        if matcher_matches_call(matcher, node, source) {
+            Some(matcher.description().to_string())
+        } else {
+            None
+        }
+    })
+}
+
+/// Check whether `matcher` matches the given call / construction node.
+fn matcher_matches_call(matcher: &NodeMatcher, node: Node<'_>, source: &str) -> bool {
+    match matcher {
+        NodeMatcher::MethodName { method, .. } => {
+            // Match any invocation whose final method name equals `method`.
+            if node.kind() == "invocation_expression" {
+                if let Some(func) = node.child_by_field_name("function") {
+                    if let Some(method_name) = final_name_segment(func, source) {
+                        return method_name == method.as_str();
+                    }
+                }
+            }
+            false
+        }
+        NodeMatcher::Call { canonical, .. } => {
+            if node.kind() == "invocation_expression" {
+                if let Some(func) = node.child_by_field_name("function") {
+                    let resolved = resolve_callee(func, source);
+                    return resolved == canonical.as_str();
+                }
+            }
+            if node.kind() == "object_creation_expression" {
+                if let Some(type_node) = node.child_by_field_name("type") {
+                    return node_text(type_node, source) == canonical.as_str();
+                }
+            }
+            false
+        }
+        NodeMatcher::Attribute { root, field, .. } => {
+            // Match a member-assignment sink: e.g. `psi.Arguments = tainted`
+            // arrives as the LHS of an assignment_expression, not a call.
+            // For symmetry we also accept a `member_access_expression` node directly.
+            if node.kind() == "member_access_expression" {
+                let recv = node.child_by_field_name("expression");
+                let name_node = node.child_by_field_name("name");
+                if let (Some(recv), Some(name_node)) = (recv, name_node) {
+                    let recv_text = node_text(recv, source);
+                    let name_text = node_text(name_node, source);
+                    return recv_text == root.as_str() && name_text == field.as_str();
+                }
+            }
+            false
+        }
+        NodeMatcher::ParamName { .. } | NodeMatcher::MemberAssign { .. } => false,
+    }
+}
+
+fn sink_argument_taint(
+    node: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    state: &TaintState,
+) -> Option<TaintInfo> {
+    call_arguments(node).and_then(|args| argument_list_taint(args, source, spec, state))
+}
+
+// ─── C# AST helpers ──────────────────────────────────────────────────────────
+
+fn is_scope_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "method_declaration"
+            | "constructor_declaration"
+            | "local_function_statement"
+            | "lambda_expression"
+            | "anonymous_method_expression"
+    )
+}
+
+fn find_scope_body(node: Node<'_>) -> Option<Node<'_>> {
+    // C# methods have a `body` field (block) or an expression body after `=>`.
+    if let Some(body) = node.child_by_field_name("body") {
+        return Some(body);
+    }
+    let mut cursor = node.walk();
+    let result = node
+        .children(&mut cursor)
+        .find(|child| matches!(child.kind(), "block" | "arrow_expression_clause"));
+    result
+}
+
+fn walk_scope_nodes(scope: Node<'_>, source: &str, visitor: &mut impl FnMut(Node<'_>, &str)) {
+    let mut cursor = scope.walk();
+    for child in scope.children(&mut cursor) {
+        walk_scope_node(child, source, visitor);
+    }
+}
+
+fn walk_scope_node(node: Node<'_>, source: &str, visitor: &mut impl FnMut(Node<'_>, &str)) {
+    if is_scope_node(node.kind()) {
+        return;
+    }
+    visitor(node, source);
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        walk_scope_node(child, source, visitor);
+    }
+}
+
+/// Resolve a callee `function` node to a canonical dotted name.
+///
+/// Examples:
+/// - `Console.ReadLine`  → `"Console.ReadLine"`
+/// - `Process.Start`     → `"Process.Start"`
+/// - `myObj.DoSomething` → `"myObj.DoSomething"`
+fn resolve_callee<'a>(func_node: Node<'a>, source: &'a str) -> &'a str {
+    // For `member_access_expression`, the full text is the dotted chain.
+    // For a bare `identifier`, it's just the name.
+    node_text(func_node, source)
+}
+
+/// Return the final identifier segment of a callee node.
+/// `Console.ReadLine` → `"ReadLine"`.
+fn final_name_segment<'a>(func_node: Node<'a>, source: &'a str) -> Option<&'a str> {
+    if func_node.kind() == "member_access_expression" {
+        return func_node
+            .child_by_field_name("name")
+            .map(|n| node_text(n, source));
+    }
+    if func_node.kind() == "identifier" {
+        return Some(node_text(func_node, source));
+    }
+    None
+}
+
+/// Walk a receiver chain leftward and return the leftmost receiver name.
+fn leftmost_receiver_name<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    match node.kind() {
+        "identifier" => Some(node_text(node, source)),
+        "member_access_expression" => {
+            if let Some(recv) = node.child_by_field_name("expression") {
+                leftmost_receiver_name(recv, source)
+            } else {
+                None
+            }
+        }
+        "element_access_expression" => {
+            if let Some(recv) = node.child_by_field_name("expression") {
+                leftmost_receiver_name(recv, source)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract the value expression from a `variable_declarator` node.
+///
+/// In tree-sitter-c-sharp, `variable_declarator` has NO `value` field.
+/// The structure is: `name "=" <value_expr>` where all children are anonymous
+/// except the `name` field. The value is the last child that is not `=`.
+fn variable_declarator_value(node: Node<'_>) -> Option<Node<'_>> {
+    let count = node.child_count();
+    if count < 3 {
+        // Need at least: name, "=", value
+        return None;
+    }
+    // The value is the last child (index count-1).
+    let last = node.child(count - 1)?;
+    // Sanity: it should not be "=" or the name identifier's position.
+    if last.kind() == "=" {
+        return None;
+    }
+    Some(last)
+}
+
+fn call_arguments(node: Node<'_>) -> Option<Node<'_>> {
+    if node.kind() == "invocation_expression" || node.kind() == "object_creation_expression" {
+        return node.child_by_field_name("arguments");
+    }
+    None
+}
+
+/// Check taint in the argument_list of a call node.
+///
+/// The argument_list contains `argument` wrapper nodes. Each `argument` has one
+/// unnamed child that is the actual expression. We must unwrap the `argument`
+/// nodes to get to the real expression for taint checking.
+fn argument_list_taint(
+    arg_list: Node<'_>,
+    source: &str,
+    spec: &TaintSpec,
+    state: &TaintState,
+) -> Option<TaintInfo> {
+    let mut cursor = arg_list.walk();
+    for child in arg_list.children(&mut cursor) {
+        if child.kind() == "argument" {
+            // Unwrap the `argument` wrapper — check all its children.
+            let mut acursor = child.walk();
+            for expr in child.children(&mut acursor) {
+                if expr.is_named() {
+                    if let Some(info) = expression_taint(expr, source, spec, state) {
+                        return Some(info);
+                    }
+                }
+            }
+        } else if child.is_named() {
+            // Fallback for non-argument children.
+            if let Some(info) = expression_taint(child, source, spec, state) {
+                return Some(info);
+            }
+        }
+    }
+    None
+}
+
+fn assignment_target_name<'a>(node: Node<'a>, source: &'a str) -> Option<&'a str> {
+    match node.kind() {
+        "identifier" => Some(node_text(node, source)),
+        "member_access_expression" => Some(node_text(node, source)),
+        _ => None,
+    }
+}
+
+fn bump_hops(mut info: TaintInfo) -> TaintInfo {
+    info.hops = info.hops.saturating_add(1);
+    info
+}
+
+fn taint_finding_for_node(
+    node: Node<'_>,
+    source_info: TaintInfo,
+    sink_description: String,
+) -> TaintFinding {
+    let start = node.start_position();
+    let end = node.end_position();
+    TaintFinding {
+        sink_start_byte: node.start_byte(),
+        sink_end_byte: node.end_byte(),
+        sink_line: start.row + 1,
+        sink_column: start.column + 1,
+        sink_end_line: end.row + 1,
+        sink_end_column: end.column + 1,
+        source_description: source_info.description,
+        sink_description,
+        source_line: source_info.line,
+        rule_id_hint: None,
+        hops: source_info.hops.max(1),
+    }
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    &source[node.byte_range()]
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::parser::parse_file;
+    use crate::Language;
+
+    fn analyze(src: &str, spec: &TaintSpec) -> Vec<TaintFinding> {
+        let Some(tree) = parse_file(src, Language::CSharp) else {
+            panic!("C# fixture should parse");
+        };
+        analyze_tree(tree.root_node(), src, spec, None)
+    }
+
+    #[test]
+    #[ignore]
+    fn dump_ast_for_debug() {
+        let src = r#"
+class Controller {
+    public void Handle() {
+        string cmd = Request.QueryString["cmd"];
+        Process.Start(cmd);
+    }
+}
+"#;
+        let Some(tree) = parse_file(src, Language::CSharp) else {
+            panic!("should parse");
+        };
+        fn dump(node: tree_sitter::Node, source: &str, depth: usize) {
+            let indent = "  ".repeat(depth);
+            let text = &source[node.byte_range()];
+            let text_short: String = text.chars().take(50).collect();
+            // Print field names for children via cursor
+            let mut cursor = node.walk();
+            let has_fields = cursor.goto_first_child();
+            if has_fields {
+                loop {
+                    let field_name = cursor.field_name().unwrap_or("<anon>");
+                    eprintln!(
+                        "{}{}.{} = {:?}",
+                        indent,
+                        node.kind(),
+                        field_name,
+                        cursor.node().kind()
+                    );
+                    if !cursor.goto_next_sibling() {
+                        break;
+                    }
+                }
+            }
+            eprintln!("{}{} = {:?}", indent, node.kind(), text_short);
+            let mut c = node.walk();
+            for child in node.children(&mut c) {
+                dump(child, source, depth + 1);
+            }
+        }
+        dump(tree.root_node(), src, 0);
+        panic!("dump complete — check stderr");
+    }
+
+    // ── direct-unit tests (analyze_tree) ─────────────────────────────────
+
+    #[test]
+    fn command_injection_request_querystring_to_process_start() {
+        let src = r#"
+using System.Diagnostics;
+using System.Web;
+
+class Controller {
+    public void Handle() {
+        string cmd = Request.QueryString["cmd"];
+        Process.Start(cmd);
+    }
+}
+"#;
+        let findings = analyze(src, &command_injection_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect Request.QueryString -> Process.Start: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn sql_injection_request_form_to_execute_reader() {
+        let src = r#"
+using System.Data.SqlClient;
+using System.Web;
+
+class Dao {
+    public void Query() {
+        string id = Request.Form["id"];
+        string sql = "SELECT * FROM Users WHERE Id = " + id;
+        var cmd = new SqlCommand(sql);
+        cmd.ExecuteReader();
+    }
+}
+"#;
+        let findings = analyze(src, &sql_injection_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect Request.Form -> ExecuteReader: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn sanitizer_htmlencode_blocks_xss() {
+        let src = r#"
+using System.Web;
+
+class Controller {
+    public void Handle() {
+        string raw = Request.QueryString["q"];
+        string safe = HttpUtility.HtmlEncode(raw);
+        Response.Write(safe);
+    }
+}
+"#;
+        let findings = analyze(src, &xss_spec());
+        assert!(
+            findings.is_empty(),
+            "HtmlEncode must block XSS finding: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn xss_direct_response_write_no_sanitizer() {
+        let src = r#"
+using System.Web;
+
+class Controller {
+    public void Handle() {
+        string raw = Request.QueryString["q"];
+        Response.Write(raw);
+    }
+}
+"#;
+        let findings = analyze(src, &xss_spec());
+        assert!(!findings.is_empty(), "should detect XSS: {findings:?}");
+    }
+
+    #[test]
+    fn console_readline_to_process_start() {
+        let src = r#"
+using System;
+using System.Diagnostics;
+
+class App {
+    static void Main() {
+        string cmd = Console.ReadLine();
+        Process.Start(cmd);
+    }
+}
+"#;
+        let findings = analyze(src, &command_injection_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect Console.ReadLine -> Process.Start: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn clean_literal_no_finding() {
+        let src = r#"
+using System.Diagnostics;
+
+class App {
+    static void Main() {
+        string _ = Console.ReadLine();
+        Process.Start("notepad.exe");
+    }
+}
+"#;
+        let findings = analyze(src, &command_injection_spec());
+        assert!(
+            findings.is_empty(),
+            "literal argument must not trigger taint: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn int_parse_sanitizes_numeric_sql_injection() {
+        let src = r#"
+using System.Data.SqlClient;
+using System.Web;
+
+class Dao {
+    void Query() {
+        string rawId = Request.QueryString["id"];
+        int safeId = int.Parse(rawId);
+        string sql = "SELECT * FROM Users WHERE Id = " + safeId;
+        var cmd = new SqlCommand(sql);
+        cmd.ExecuteReader();
+    }
+}
+"#;
+        // int.Parse is a sanitizer that kills the taint.
+        let findings = analyze(src, &sql_injection_spec());
+        assert!(
+            findings.is_empty(),
+            "int.Parse should sanitize SQL injection: {findings:?}"
+        );
+    }
+
+    #[test]
+    fn open_redirect_via_request_params() {
+        let src = r#"
+using System.Web;
+
+class Controller {
+    void Redirect() {
+        string url = Request.Params["returnUrl"];
+        Response.Redirect(url);
+    }
+}
+"#;
+        let findings = analyze(src, &open_redirect_spec());
+        assert!(
+            !findings.is_empty(),
+            "should detect open redirect: {findings:?}"
+        );
+    }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -4,6 +4,7 @@ pub mod common;
 pub mod config;
 pub mod cross_file;
 pub mod csharp;
+pub mod csharp_taint;
 pub mod generic_mode;
 pub mod go;
 pub mod go_taint;

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -58,6 +58,7 @@
 
 use crate::rules::c_taint;
 use crate::rules::common::get_source_line;
+use crate::rules::csharp_taint;
 use crate::rules::go_taint;
 use crate::rules::java_taint;
 use crate::rules::javascript_taint;
@@ -476,6 +477,55 @@ fn to_php_spec(g: &GenericSpec) -> php_taint::TaintSpec {
     }
 }
 
+/// Convert the generic spec into a C# taint spec.
+fn to_csharp_spec(g: &GenericSpec) -> csharp_taint::TaintSpec {
+    csharp_taint::TaintSpec {
+        sources: g.sources.iter().map(to_csharp_matcher).collect(),
+        sinks: g.sinks.iter().map(to_csharp_matcher).collect(),
+        sanitizers: g.sanitizers.iter().map(to_csharp_matcher).collect(),
+    }
+}
+
+fn to_csharp_matcher(m: &GenericMatcher) -> csharp_taint::NodeMatcher {
+    match m {
+        GenericMatcher::Attribute {
+            root,
+            field,
+            description,
+        } => csharp_taint::NodeMatcher::Attribute {
+            root: root.clone(),
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Call {
+            canonical,
+            description,
+        } => csharp_taint::NodeMatcher::Call {
+            canonical: canonical.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ParamName { names, description } => csharp_taint::NodeMatcher::ParamName {
+            names: names.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::MethodName {
+            method,
+            description,
+        } => csharp_taint::NodeMatcher::MethodName {
+            method: method.clone(),
+            description: description.clone(),
+        },
+        // MemberAssign is JS-specific; included in the spec for completeness but
+        // the C# engine ignores it.
+        GenericMatcher::MemberAssign { field, description } => {
+            csharp_taint::NodeMatcher::MemberAssign {
+                field: field.clone(),
+                description: description.clone(),
+            }
+        }
+    }
+}
+
 fn to_php_matcher(m: &GenericMatcher) -> php_taint::NodeMatcher {
     match m {
         GenericMatcher::Attribute {
@@ -644,6 +694,19 @@ impl TaintFindingView {
             hops: f.hops,
         }
     }
+    fn from_csharp(f: csharp_taint::TaintFinding) -> Self {
+        Self {
+            sink_start_byte: f.sink_start_byte,
+            sink_line: f.sink_line,
+            sink_column: f.sink_column,
+            sink_end_line: f.sink_end_line,
+            sink_end_column: f.sink_end_column,
+            source_description: f.source_description,
+            sink_description: f.sink_description,
+            source_line: f.source_line,
+            hops: f.hops,
+        }
+    }
 }
 
 impl Rule for SemgrepTaintRule {
@@ -739,6 +802,13 @@ impl Rule for SemgrepTaintRule {
                 php_taint::analyze_tree(tree.root_node(), source, &spec, None)
                     .into_iter()
                     .map(TaintFindingView::from_php)
+                    .collect()
+            }
+            Language::CSharp => {
+                let spec = to_csharp_spec(&self.spec);
+                csharp_taint::analyze_tree(tree.root_node(), source, &spec, None)
+                    .into_iter()
+                    .map(TaintFindingView::from_csharp)
                     .collect()
             }
             _ => Vec::new(),
@@ -855,6 +925,10 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
                         detected = Some(Language::Php);
                         break;
                     }
+                    "csharp" | "cs" | "c#" => {
+                        detected = Some(Language::CSharp);
+                        break;
+                    }
                     _ => {}
                 }
             }
@@ -862,7 +936,7 @@ pub fn parse_taint_rule(yaml: &YamlValue) -> TaintRuleParse {
                 Some(l) => l,
                 None => {
                     return TaintRuleParse::Skip(format!(
-                        "taint rule `{}` targets unsupported languages; Python, JavaScript/TypeScript, Go, Java, C, Kotlin, Ruby, and PHP are supported",
+                        "taint rule `{}` targets unsupported languages; Python, JavaScript/TypeScript, Go, Java, C, Kotlin, Ruby, PHP, and C# are supported",
                         id
                     ));
                 }
@@ -3118,5 +3192,223 @@ pattern-sinks: [{pattern: system($X)}]
             TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
             TaintRuleParse::NotTaint => panic!("expected taint rule"),
         }
+    }
+
+    // ─── Bridge-level (end-to-end) tests for C# taint engine ─────────────────
+    //
+    // These compile a rule through `parse_taint_rule` (the SAME path the CLI
+    // uses) and run it against real C# source via the bridge. We test the
+    // primary dotted-source shapes that arrive as `Attribute` / `Call` matchers
+    // through the bridge (not `ParamName`, since C# sources are dotted).
+
+    /// `Request.QueryString["cmd"] → Process.Start(cmd)` fires end-to-end.
+    #[test]
+    fn csharp_bridge_dotted_source_to_process_start_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: csharp-cmd-injection
+mode: taint
+languages: [csharp]
+severity: ERROR
+message: "Tainted input reaches Process.Start"
+metadata:
+  cwe: "CWE-78"
+pattern-sources:
+  - pattern: Request.QueryString
+pattern-sinks:
+  - pattern: Process.Start($X)
+"#,
+        );
+
+        let src = r#"
+using System.Web;
+using System.Diagnostics;
+
+class Controller {
+    public void Handle() {
+        string cmd = Request.QueryString["cmd"];
+        Process.Start(cmd);
+    }
+}
+"#;
+        let tree = parse_file(src, Language::CSharp).expect("C# fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for Request.QueryString -> Process.Start, got {:?}",
+            findings
+        );
+        assert!(
+            findings[0].line > 0,
+            "finding should carry a valid line number"
+        );
+    }
+
+    /// Sanitized variant: `HttpUtility.HtmlEncode(raw)` blocks XSS.
+    #[test]
+    fn csharp_bridge_sanitized_variant_produces_no_finding() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: csharp-xss-sanitized
+mode: taint
+languages: [csharp]
+severity: ERROR
+message: "Tainted input reaches Response.Write"
+pattern-sources:
+  - pattern: Request.QueryString
+pattern-sanitizers:
+  - pattern: HttpUtility.HtmlEncode($X)
+pattern-sinks:
+  - pattern: Response.Write($X)
+"#,
+        );
+
+        let src = r#"
+using System.Web;
+
+class Controller {
+    public void Handle() {
+        string raw = Request.QueryString["q"];
+        string safe = HttpUtility.HtmlEncode(raw);
+        Response.Write(safe);
+    }
+}
+"#;
+        let tree = parse_file(src, Language::CSharp).expect("C# fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            findings.is_empty(),
+            "sanitized flow must produce no finding, got {:?}",
+            findings
+        );
+    }
+
+    /// Near-miss: tainted variable not passed to the sink → no finding.
+    #[test]
+    fn csharp_bridge_near_miss_produces_no_finding() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: csharp-cmd-nearmiss
+mode: taint
+languages: [csharp]
+severity: ERROR
+message: "Tainted input reaches Process.Start"
+pattern-sources:
+  - pattern: Request.QueryString
+pattern-sinks:
+  - pattern: Process.Start($X)
+"#,
+        );
+
+        // tainted is assigned but a literal "notepad.exe" is passed to the sink.
+        let src = r#"
+using System.Web;
+using System.Diagnostics;
+
+class Controller {
+    public void Handle() {
+        string _tainted = Request.QueryString["cmd"];
+        Process.Start("notepad.exe");
+    }
+}
+"#;
+        let tree = parse_file(src, Language::CSharp).expect("C# fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            findings.is_empty(),
+            "near-miss must produce no finding, got {:?}",
+            findings
+        );
+    }
+
+    /// `csharp` language alias parses correctly.
+    #[test]
+    fn taint_rule_with_csharp_language_compiles() {
+        let yaml = r#"
+id: cs-taint
+mode: taint
+languages: [csharp]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: Request.QueryString}]
+pattern-sinks: [{pattern: Process.Start($X)}]
+"#;
+        let v: YamlValue = serde_yaml_ng::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => {
+                assert_eq!(r.lang, Language::CSharp);
+                assert_eq!(r.spec.sources.len(), 1);
+                assert_eq!(r.spec.sinks.len(), 1);
+            }
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    /// `cs` alias compiles as C#.
+    #[test]
+    fn taint_rule_with_cs_alias_compiles_as_csharp() {
+        let yaml = r#"
+id: cs-taint
+mode: taint
+languages: [cs]
+severity: ERROR
+message: m
+pattern-sources: [{pattern: Request.QueryString}]
+pattern-sinks: [{pattern: Process.Start($X)}]
+"#;
+        let v: YamlValue = serde_yaml_ng::from_str(yaml).unwrap();
+        match parse_taint_rule(&v) {
+            TaintRuleParse::Compiled(r) => assert_eq!(r.lang, Language::CSharp),
+            TaintRuleParse::Skip(msg) => panic!("unexpected skip: {}", msg),
+            TaintRuleParse::NotTaint => panic!("expected taint rule"),
+        }
+    }
+
+    /// `Console.ReadLine()` → `Process.Start()` fires via Call source.
+    #[test]
+    fn csharp_bridge_console_readline_to_process_start() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: csharp-console-cmdi
+mode: taint
+languages: [csharp]
+severity: ERROR
+message: "Console.ReadLine input reaches Process.Start"
+pattern-sources:
+  - pattern: Console.ReadLine($X)
+pattern-sinks:
+  - pattern: Process.Start($X)
+"#,
+        );
+
+        let src = r#"
+using System;
+using System.Diagnostics;
+
+class App {
+    static void Main() {
+        string cmd = Console.ReadLine();
+        Process.Start(cmd);
+    }
+}
+"#;
+        let tree = parse_file(src, Language::CSharp).expect("C# fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for Console.ReadLine -> Process.Start, got {:?}",
+            findings
+        );
     }
 }


### PR DESCRIPTION
Adds a **C# taint engine** (`src/rules/csharp_taint.rs`, ~1150 lines on the shared `taint_engine` framework) + Semgrep bridge, so `mode: taint` `languages: [csharp]` rules work — 11 registry rules previously skipped as `mode: taint (unsupported language: csharp)`.

## Coverage
- **Sources:** `Request.QueryString`/`Form`/`Params`/`Cookies`/`Headers`, `Console.ReadLine`.
- **Sinks:** `Process.Start` (cmdi), `SqlCommand`/`ExecuteReader`/`ExecuteNonQuery` (SQLi), `Response.Write`/`Redirect` (XSS/open-redirect), `XmlDocument.LoadXml` (XXE).
- **Sanitizers:** `HttpUtility.HtmlEncode`, `int.Parse`/`Convert.ToInt32`, `Path.GetFileName`.

## Verification (independent, via the real binary)
- `Request.QueryString["cmd"] -> Process.Start(cmd)` (in a method) → **1 finding**.
- `int.Parse(Request.QueryString[..]) -> Process.Start("ls")` → **0 findings**.
- Plus bridge-level tests (through `parse_taint_rule`→`check()`) + 8 engine tests · full suite 0 failures · `clippy -D warnings` clean · `fmt --check` clean · both dogfood scans clean · **no baseline churn**.

Completes the taint bridge: python/js/ts/go/java/c/kotlin/ruby/php/**csharp** — every language with a tree-sitter grammar the engine framework supports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added C# language support for taint analysis mode, enabling security rule checks for C# code.
  * Implemented built-in taint sources and sinks for C# (e.g., Request.QueryString, Process.Start, SqlCommand).
  * Added security detections for SQL injection, command injection, XSS, open redirect, and XXE vulnerabilities in C#.
  * Included sanitizer support for HTML encoders and other C# security functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->