### PR TITLE
feat(compat): generic-mode patterns/either/regex (+71 rules → 89.4%)

### DIFF
--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1845 (86.1%) |
-| Rules skipped | 299 (13.9%) |
+| Rules loaded OK | 1916 (89.4%) |
+| Rules skipped | 228 (10.6%) |
 
-**Headline load rate: 86.1%** (1845 / 2144 rules).
+**Headline load rate: 89.4%** (1916 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,20 +23,20 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `mode: taint (unsupported shape)` | 166 | 55.5% | 7.7% |
-| `generic mode (languages: [generic])` | 78 | 26.1% | 3.6% |
-| `loader rejected (other)` | 15 | 5.0% | 0.7% |
-| `unsupported language: apex` | 9 | 3.0% | 0.4% |
-| `mode: taint (unsupported language: scala)` | 5 | 1.7% | 0.2% |
-| `taint: pattern-propagators` | 5 | 1.7% | 0.2% |
-| `unsupported language: clojure` | 5 | 1.7% | 0.2% |
-| `unsupported language: html` | 4 | 1.3% | 0.2% |
-| `mode: taint (unsupported language: apex)` | 3 | 1.0% | 0.1% |
-| `mode: taint (unsupported language: bash)` | 3 | 1.0% | 0.1% |
-| `mode: taint (unsupported language: solidity)` | 3 | 1.0% | 0.1% |
-| `mode: taint (unsupported language: swift)` | 1 | 0.3% | 0.0% |
-| `unsupported language: dart` | 1 | 0.3% | 0.0% |
-| `unsupported language: xml` | 1 | 0.3% | 0.0% |
+| `mode: taint (unsupported shape)` | 166 | 72.8% | 7.7% |
+| `loader rejected (other)` | 15 | 6.6% | 0.7% |
+| `unsupported language: apex` | 9 | 3.9% | 0.4% |
+| `generic mode (languages: [generic])` | 7 | 3.1% | 0.3% |
+| `mode: taint (unsupported language: scala)` | 5 | 2.2% | 0.2% |
+| `taint: pattern-propagators` | 5 | 2.2% | 0.2% |
+| `unsupported language: clojure` | 5 | 2.2% | 0.2% |
+| `unsupported language: html` | 4 | 1.8% | 0.2% |
+| `mode: taint (unsupported language: apex)` | 3 | 1.3% | 0.1% |
+| `mode: taint (unsupported language: bash)` | 3 | 1.3% | 0.1% |
+| `mode: taint (unsupported language: solidity)` | 3 | 1.3% | 0.1% |
+| `mode: taint (unsupported language: swift)` | 1 | 0.4% | 0.0% |
+| `unsupported language: dart` | 1 | 0.4% | 0.0% |
+| `unsupported language: xml` | 1 | 0.4% | 0.0% |
 
 ## Priority order — operator/feature backlog
 
@@ -56,8 +56,8 @@ Rules foxguard cannot run because it has no tree-sitter grammar for the target l
 
 | Rank | Language to add | Rules unlocked |
 |---:|---|---:|
-| 1 | `generic mode (languages: [generic])` | 78 |
-| 2 | `unsupported language: apex` | 9 |
+| 1 | `unsupported language: apex` | 9 |
+| 2 | `generic mode (languages: [generic])` | 7 |
 | 3 | `mode: taint (unsupported language: scala)` | 5 |
 | 4 | `unsupported language: clojure` | 5 |
 | 5 | `unsupported language: html` | 4 |
@@ -68,7 +68,7 @@ Rules foxguard cannot run because it has no tree-sitter grammar for the target l
 | 10 | `unsupported language: dart` | 1 |
 | 11 | `unsupported language: xml` | 1 |
 
-Missing-grammar gaps account for **113 rules** (5.3% of all rules).
+Missing-grammar gaps account for **42 rules** (2.0% of all rules).
 
 ## Per-language breakdown
 
@@ -81,7 +81,7 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 | javascript | 243 | 199 | 44 | 81.9% |
 | regex | 237 | 225 | 12 | 94.9% |
 | java | 131 | 110 | 21 | 84.0% |
-| generic | 103 | 25 | 78 | 24.3% |
+| generic | 103 | 96 | 7 | 93.2% |
 | yaml | 100 | 99 | 1 | 99.0% |
 | go | 97 | 84 | 13 | 86.6% |
 | ruby | 92 | 69 | 23 | 75.0% |
@@ -113,7 +113,7 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **csharp**: `mode: taint (unsupported shape)` (10), `taint: pattern-propagators` (1)
 - **dart**: `unsupported language: dart` (1)
 - **dockerfile**: `loader rejected (other)` (1)
-- **generic**: `generic mode (languages: [generic])` (78)
+- **generic**: `generic mode (languages: [generic])` (7)
 - **go**: `mode: taint (unsupported shape)` (13)
 - **hcl**: `loader rejected (other)` (1)
 - **html**: `unsupported language: html` (4)

--- a/src/bin/registry_coverage.rs
+++ b/src/bin/registry_coverage.rs
@@ -364,9 +364,11 @@ fn classify_rule(rule: &Yaml) -> Outcome {
     }
 
     // Generic mode (languages: [generic]) — tokenized spacegrep matching;
-    // foxguard routes these to `generic_mode.rs`.
+    // foxguard routes these to `generic_mode.rs`. We now attempt to load
+    // them via the real loader; rules that produce no live matcher are
+    // reported as skipped with a generic-mode reason.
     if langs.iter().any(|l| l.eq_ignore_ascii_case("generic")) {
-        return Outcome::Skipped("generic mode (languages: [generic])".to_string());
+        return ground_truth(rule, "generic mode (languages: [generic])");
     }
 
     // `languages: [regex]` rules with no pattern-regex anywhere cannot be compiled
@@ -864,7 +866,9 @@ rules:
     }
 
     #[test]
-    fn generic_mode_is_skipped() {
+    fn generic_mode_simple_pattern_now_loads() {
+        // A simple `pattern: foo` generic rule now goes through the real loader
+        // and produces a live rule — classify_rule should return Loaded.
         let r = rule(
             r#"
 rules:
@@ -875,10 +879,32 @@ rules:
     languages: [generic]
 "#,
         );
-        match classify_rule(&r) {
-            Outcome::Skipped(reason) => assert!(reason.starts_with("generic mode")),
-            other => panic!("expected skip, got {other:?}"),
-        }
+        // The loader produces live rules → Loaded (no longer hard-skipped).
+        assert!(
+            matches!(classify_rule(&r), Outcome::Loaded),
+            "simple generic pattern: rule should now load"
+        );
+    }
+
+    #[test]
+    fn generic_mode_patterns_block_now_loads() {
+        // A `patterns:` AND-block generic rule should now load.
+        let r = rule(
+            r#"
+rules:
+  - id: gen-patterns
+    patterns:
+      - pattern: ssl_protocols ...
+      - pattern-not: ssl_protocols TLSv1_3
+    message: m
+    severity: WARNING
+    languages: [generic]
+"#,
+        );
+        assert!(
+            matches!(classify_rule(&r), Outcome::Loaded),
+            "generic patterns: rule should now load"
+        );
     }
 
     #[test]

--- a/src/rules/generic_mode.rs
+++ b/src/rules/generic_mode.rs
@@ -16,16 +16,19 @@
 //!
 //! ## Scope
 //!
-//! Supported: `pattern`, `pattern-either`, `pattern-not`, `pattern-regex`
-//! (passthrough), `...` ellipsis, `$METAVAR` binding with equality
-//! enforcement, and `paths.include` / `paths.exclude` scoping (handled by the
-//! shared [`PathFilter`] on the compat side).
+//! Supported: `pattern`, `pattern-either`, `patterns:` (AND-block with
+//! `pattern:`, `pattern-not:`, `pattern-regex:`, `pattern-not-regex:`, and
+//! nested `pattern-either:`), `pattern-regex:` / `pattern-not-regex:`
+//! (passthrough against raw text), `...` ellipsis, `$METAVAR` binding with
+//! equality enforcement, and `paths.include` / `paths.exclude` scoping
+//! (handled by the shared [`PathFilter`] on the compat side).
 //!
 //! Deliberately **not** implemented here: `metavariable-comparison` and
 //! `metavariable-pattern` (owned by other modules), `pattern-inside` /
-//! `pattern-not-inside` for generic mode, and the deep-vs-shallow ellipsis
-//! brace-aware matching semgrep applies to brace-delimited languages. Generic
-//! mode here treats the file as a flat token stream.
+//! `pattern-not-inside` for generic mode (warn-skipped gracefully), and the
+//! deep-vs-shallow ellipsis brace-aware matching semgrep applies to
+//! brace-delimited languages. Generic mode here treats the file as a flat
+//! token stream.
 
 use crate::rules::common::get_source_line;
 use crate::rules::semgrep_compat::PathFilter;
@@ -266,6 +269,15 @@ enum GenericMatcher {
         positive: Box<GenericMatcher>,
         negatives: Vec<GenericMatcher>,
     },
+    /// `patterns:` AND-block: all positives must produce at least one match;
+    /// matches from later positives are intersected (must overlap) with the
+    /// accumulated set; negatives exclude any overlapping matches.
+    ///
+    /// This mirrors the AST-engine `Combined` path but over generic tokens.
+    Combined {
+        positives: Vec<GenericMatcher>,
+        negatives: Vec<GenericMatcher>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -298,13 +310,71 @@ impl GenericMatcher {
             } => {
                 let mut matches = positive.find_all(source, tokens);
                 if !negatives.is_empty() {
-                    let neg: Vec<GenericMatch> = negatives
-                        .iter()
-                        .flat_map(|n| n.find_all(source, tokens))
-                        .collect();
-                    matches.retain(|m| !neg.iter().any(|n| overlaps(m, n)));
+                    apply_negatives(&mut matches, negatives, source, tokens);
                 }
                 matches
+            }
+            GenericMatcher::Combined {
+                positives,
+                negatives,
+            } => {
+                // AND semantics: start with all matches from the first positive,
+                // then intersect with each subsequent positive (keep only those
+                // that overlap at least one match from the next positive).
+                // Finally, apply negatives.
+                let mut candidates: Option<Vec<GenericMatch>> = None;
+                for pos in positives {
+                    let hits = pos.find_all(source, tokens);
+                    candidates = Some(match candidates {
+                        None => hits,
+                        Some(prev) => {
+                            // Intersect: keep prev matches that overlap ≥1 hit.
+                            prev.into_iter()
+                                .filter(|p| hits.iter().any(|h| overlaps(p, h)))
+                                .collect()
+                        }
+                    });
+                }
+                let mut results = candidates.unwrap_or_default();
+                if !negatives.is_empty() {
+                    apply_negatives(&mut results, negatives, source, tokens);
+                }
+                results
+            }
+        }
+    }
+}
+
+/// Apply negative matchers to a list of candidate matches.
+///
+/// Negative semantics:
+/// - `Pattern` negatives: span-overlap — a positive match is dropped if any
+///   negative *token-pattern* match overlaps its byte range.
+/// - `Regex` negatives: file-level — if the regex matches **anywhere** in the
+///   file, **all** positive matches are dropped. This mirrors Semgrep's
+///   `pattern-not-regex` semantics in generic/regex mode where the regex is
+///   evaluated against the whole file, not individual match spans.
+fn apply_negatives(
+    positives: &mut Vec<GenericMatch>,
+    negatives: &[GenericMatcher],
+    source: &str,
+    tokens: &[Token<'_>],
+) {
+    for neg in negatives {
+        if positives.is_empty() {
+            break;
+        }
+        match neg {
+            // Regex negative: file-level — if it matches anywhere, clear all.
+            GenericMatcher::Regex(re) => {
+                if re.is_match(source) {
+                    positives.clear();
+                }
+            }
+            // Pattern/Either/Filtered/Combined negatives: span-overlap.
+            _ => {
+                let neg_matches = neg.find_all(source, tokens);
+                positives.retain(|m| !neg_matches.iter().any(|n| overlaps(m, n)));
             }
         }
     }
@@ -501,43 +571,172 @@ fn byte_offset_to_position(source: &str, byte_offset: usize) -> (usize, usize) {
 
 // ─── Construction (called from the compat bridge) ──────────────────────────────
 
-/// Build the generic matcher tree from the flat fields of a generic rule.
-///
-/// `pattern`, `pattern-regex`, `pattern-either`, and `pattern-not` are the
-/// generic-mode subset we support; `patterns:` AND-blocks fall back to the
-/// first positive (semgrep generic packs in our scope do not use AND-blocks).
-fn build_matcher(
-    pattern: Option<&str>,
-    pattern_regex: Option<&str>,
-    pattern_either: &[String],
-    pattern_not: Option<&str>,
-) -> Result<GenericMatcher, String> {
-    let positive = if let Some(p) = pattern {
-        GenericMatcher::Pattern(compile_pattern(p))
-    } else if let Some(re) = pattern_regex {
-        GenericMatcher::Regex(compile_regex(re)?)
-    } else if !pattern_either.is_empty() {
-        let inner = pattern_either
-            .iter()
-            .map(|p| GenericMatcher::Pattern(compile_pattern(p)))
-            .collect();
-        GenericMatcher::Either(inner)
-    } else {
-        return Err("generic rule has no pattern / pattern-regex / pattern-either".to_string());
-    };
+// ─── Clause types for `patterns:` AND-blocks ────────────────────────────────
 
-    if let Some(pn) = pattern_not {
-        Ok(GenericMatcher::Filtered {
-            positive: Box::new(positive),
-            negatives: vec![GenericMatcher::Pattern(compile_pattern(pn))],
-        })
+/// A single entry inside a `patterns:` (AND) block for generic mode.
+///
+/// Supports `pattern:`, `pattern-not:`, `pattern-regex:`, `pattern-not-regex:`,
+/// and `pattern-either:` (OR of patterns). Unsupported sub-clauses such as
+/// `pattern-inside:` / `pattern-not-inside:` and constraint clauses are
+/// warn-skipped at the caller side; they do not abort sibling clauses.
+#[derive(Debug, Clone, Default)]
+pub struct GenericPatternsClause {
+    /// A positive spacegrep pattern that must match.
+    pub pattern: Option<String>,
+    /// A positive raw-text regex that must match.
+    pub pattern_regex: Option<String>,
+    /// OR-list of patterns to treat as a single positive sub-matcher.
+    pub pattern_either: Vec<GenericEitherEntry>,
+    /// A negative spacegrep pattern that must NOT overlap any positive match.
+    pub pattern_not: Option<String>,
+    /// A negative raw-text regex that must NOT match anywhere.
+    pub pattern_not_regex: Option<String>,
+}
+
+/// One arm inside a `pattern-either:` list.
+#[derive(Debug, Clone, Default)]
+pub struct GenericEitherEntry {
+    pub pattern: Option<String>,
+    pub pattern_regex: Option<String>,
+}
+
+// ─── Matcher builders ─────────────────────────────────────────────────────────
+
+/// Build a single `GenericMatcher` from a `pattern-either:` OR-list.
+fn build_either_matcher(entries: &[GenericEitherEntry]) -> Result<GenericMatcher, String> {
+    let mut inner = Vec::new();
+    for entry in entries {
+        if let Some(ref p) = entry.pattern {
+            inner.push(GenericMatcher::Pattern(compile_pattern(p)));
+        } else if let Some(ref re) = entry.pattern_regex {
+            inner.push(GenericMatcher::Regex(compile_regex(re)?));
+        }
+    }
+    if inner.is_empty() {
+        return Err(
+            "pattern-either: block has no supported pattern or pattern-regex entries".to_string(),
+        );
+    }
+    if inner.len() == 1 {
+        Ok(inner.into_iter().next().expect("checked len==1"))
     } else {
-        Ok(positive)
+        Ok(GenericMatcher::Either(inner))
     }
 }
 
+/// Build the generic matcher tree from the full rule spec.
+///
+/// Dispatch order:
+/// 1. `patterns:` AND-block if present → `Combined` matcher.
+/// 2. Top-level `pattern-either:` → `Either` matcher (with optional `pattern-not`).
+/// 3. Top-level `pattern:` → `Pattern` (with optional `pattern-not`).
+/// 4. Top-level `pattern-regex:` → `Regex` (with optional `pattern-not-regex`).
+/// 5. Else → error (no expressible matcher).
+fn build_matcher(spec: &GenericRuleSpec<'_>) -> Result<GenericMatcher, String> {
+    // ── 1. `patterns:` AND-block ──────────────────────────────────────────────
+    if !spec.patterns_clauses.is_empty() {
+        let mut positives: Vec<GenericMatcher> = Vec::new();
+        let mut negatives: Vec<GenericMatcher> = Vec::new();
+
+        for clause in &spec.patterns_clauses {
+            // Positive matchers (at most one per clause in practice).
+            if let Some(ref p) = clause.pattern {
+                positives.push(GenericMatcher::Pattern(compile_pattern(p)));
+            }
+            if let Some(ref re) = clause.pattern_regex {
+                match compile_regex(re) {
+                    Ok(r) => positives.push(GenericMatcher::Regex(r)),
+                    Err(e) => eprintln!("Warning: generic patterns clause has invalid pattern-regex: {e}; skipping clause"),
+                }
+            }
+            if !clause.pattern_either.is_empty() {
+                match build_either_matcher(&clause.pattern_either) {
+                    Ok(m) => positives.push(m),
+                    Err(e) => eprintln!("Warning: generic patterns clause has invalid pattern-either: {e}; skipping clause"),
+                }
+            }
+            // Negative matchers.
+            if let Some(ref pn) = clause.pattern_not {
+                negatives.push(GenericMatcher::Pattern(compile_pattern(pn)));
+            }
+            if let Some(ref re) = clause.pattern_not_regex {
+                match compile_regex(re) {
+                    Ok(r) => negatives.push(GenericMatcher::Regex(r)),
+                    Err(e) => eprintln!("Warning: generic patterns clause has invalid pattern-not-regex: {e}; skipping clause"),
+                }
+            }
+        }
+
+        if positives.is_empty() {
+            return Err(
+                "generic patterns: block has no supported positive matchers (pattern, pattern-regex, or pattern-either)"
+                    .to_string(),
+            );
+        }
+
+        // Simplify: a single positive with negatives → Filtered; multiple → Combined.
+        if positives.len() == 1 && negatives.is_empty() {
+            return Ok(positives.into_iter().next().expect("checked len==1"));
+        }
+        if positives.len() == 1 {
+            return Ok(GenericMatcher::Filtered {
+                positive: Box::new(positives.into_iter().next().expect("checked len==1")),
+                negatives,
+            });
+        }
+        return Ok(GenericMatcher::Combined {
+            positives,
+            negatives,
+        });
+    }
+
+    // ── 2–5. Top-level single-operator forms ──────────────────────────────────
+
+    // Helper: wrap in Filtered when there are negatives.
+    let wrap_with_negatives = |positive: GenericMatcher,
+                               pattern_not: Option<&str>,
+                               pattern_not_regex: Option<&str>|
+     -> Result<GenericMatcher, String> {
+        let mut negatives: Vec<GenericMatcher> = Vec::new();
+        if let Some(pn) = pattern_not {
+            negatives.push(GenericMatcher::Pattern(compile_pattern(pn)));
+        }
+        if let Some(re) = pattern_not_regex {
+            negatives.push(GenericMatcher::Regex(compile_regex(re)?));
+        }
+        if negatives.is_empty() {
+            Ok(positive)
+        } else {
+            Ok(GenericMatcher::Filtered {
+                positive: Box::new(positive),
+                negatives,
+            })
+        }
+    };
+
+    if !spec.pattern_either.is_empty() {
+        let positive = build_either_matcher(&spec.pattern_either)?;
+        return wrap_with_negatives(positive, spec.pattern_not, spec.pattern_not_regex);
+    }
+
+    if let Some(p) = spec.pattern {
+        let positive = GenericMatcher::Pattern(compile_pattern(p));
+        return wrap_with_negatives(positive, spec.pattern_not, spec.pattern_not_regex);
+    }
+
+    if let Some(re) = spec.pattern_regex {
+        let positive = GenericMatcher::Regex(compile_regex(re)?);
+        return wrap_with_negatives(positive, spec.pattern_not, spec.pattern_not_regex);
+    }
+
+    Err("generic rule has no expressible matcher (no pattern / pattern-regex / pattern-either / patterns)".to_string())
+}
+
 fn compile_regex(pattern: &str) -> Result<Regex, String> {
-    Regex::new(pattern).map_err(|e| format!("Invalid pattern-regex '{pattern}': {e}"))
+    // `\Z` is a Python/PCRE end-of-string anchor; normalise to `$` for the
+    // Rust `regex` crate (same semantics with MULTILINE off).
+    let normalised = pattern.replace(r"\Z", "$");
+    Regex::new(&normalised).map_err(|e| format!("Invalid pattern-regex '{pattern}': {e}"))
 }
 
 /// Parameters extracted from the compat YAML layer, kept as a small POD so the
@@ -547,10 +746,19 @@ pub struct GenericRuleSpec<'a> {
     pub message: &'a str,
     pub severity: Severity,
     pub cwe: Option<String>,
+    /// Top-level `pattern:`.
     pub pattern: Option<&'a str>,
+    /// Top-level `pattern-regex:`.
     pub pattern_regex: Option<&'a str>,
-    pub pattern_either: Vec<String>,
+    /// Top-level `pattern-either:` entries (may contain `pattern:` and/or
+    /// `pattern-regex:` arms).
+    pub pattern_either: Vec<GenericEitherEntry>,
+    /// Top-level `pattern-not:`.
     pub pattern_not: Option<&'a str>,
+    /// Top-level `pattern-not-regex:`.
+    pub pattern_not_regex: Option<&'a str>,
+    /// `patterns:` AND-block clauses.
+    pub patterns_clauses: Vec<GenericPatternsClause>,
     pub path_filter: Option<PathFilter>,
 }
 
@@ -558,12 +766,7 @@ pub struct GenericRuleSpec<'a> {
 /// detectable language. The compiled matcher and path filter are shared via
 /// `Arc` so the fan-out is cheap.
 pub fn build_generic_rules(spec: GenericRuleSpec<'_>) -> Result<Vec<Box<dyn Rule>>, String> {
-    let matcher = Arc::new(build_matcher(
-        spec.pattern,
-        spec.pattern_regex,
-        &spec.pattern_either,
-        spec.pattern_not,
-    )?);
+    let matcher = Arc::new(build_matcher(&spec)?);
     let path_filter = spec.path_filter.map(Arc::new);
 
     let rules = ALL_LANGUAGES
@@ -723,10 +926,353 @@ mod tests {
             pattern_regex: None,
             pattern_either: Vec::new(),
             pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: Vec::new(),
             path_filter: None,
         };
         let rules = build_generic_rules(spec).unwrap();
         assert_eq!(rules.len(), ALL_LANGUAGES.len());
         assert_eq!(rules[0].id(), "semgrep/generic-test");
+    }
+
+    // ─── New tests for patterns: AND-block, pattern-either, pattern-regex ────
+
+    /// Create a minimal dummy tree for rules that don't use the AST.
+    /// Generic-mode rules ignore the tree entirely; we parse Rust source
+    /// (which is always available as a test dependency) to get a valid tree
+    /// to satisfy the Rule::check() signature.
+    fn dummy_tree() -> tree_sitter::Tree {
+        use crate::engine::parser::parse_file;
+        parse_file("fn main() {}", Language::Rust).expect("Rust parser must succeed")
+    }
+
+    /// `patterns:` AND-block: pattern + pattern-not loads and fires only when
+    /// the positive matches but the negative does not overlap.
+    #[test]
+    fn generic_patterns_and_block_with_pattern_not() {
+        let spec = GenericRuleSpec {
+            id: "and-block-test",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: vec![GenericPatternsClause {
+                pattern: Some("ssl_protocols ...".to_string()),
+                pattern_not: Some("ssl_protocols TLSv1_3".to_string()),
+                ..Default::default()
+            }],
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+        assert_eq!(rules.len(), ALL_LANGUAGES.len());
+
+        let tree = dummy_tree();
+
+        let findings = rules[0].check("ssl_protocols TLSv1;\n", &tree);
+        assert!(
+            !findings.is_empty(),
+            "expected a finding for ssl_protocols TLSv1"
+        );
+
+        let findings = rules[0].check("ssl_protocols TLSv1_3;\n", &tree);
+        assert!(
+            findings.is_empty(),
+            "expected no finding when pattern-not matches (ssl_protocols TLSv1_3)"
+        );
+    }
+
+    /// `patterns:` block with a `pattern-either:` clause: fires when any of the
+    /// OR-branches matches.
+    #[test]
+    fn generic_patterns_with_pattern_either_clause() {
+        let spec = GenericRuleSpec {
+            id: "either-in-patterns",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: vec![GenericPatternsClause {
+                pattern_either: vec![
+                    GenericEitherEntry {
+                        pattern: Some("rewrite ... redirect".to_string()),
+                        pattern_regex: None,
+                    },
+                    GenericEitherEntry {
+                        pattern: Some("rewrite ... permanent".to_string()),
+                        pattern_regex: None,
+                    },
+                ],
+                ..Default::default()
+            }],
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+        assert_eq!(rules.len(), ALL_LANGUAGES.len());
+
+        let tree = dummy_tree();
+
+        let source_redirect = "rewrite ^/old$ /new redirect;\n";
+        let source_permanent = "rewrite ^/old$ /new permanent;\n";
+        let source_none = "location / { proxy_pass http://up; }\n";
+
+        assert!(
+            !rules[0].check(source_redirect, &tree).is_empty(),
+            "expected a finding for 'rewrite ... redirect'"
+        );
+        assert!(
+            !rules[0].check(source_permanent, &tree).is_empty(),
+            "expected a finding for 'rewrite ... permanent'"
+        );
+        assert!(
+            rules[0].check(source_none, &tree).is_empty(),
+            "expected no finding when neither branch matches"
+        );
+    }
+
+    /// Top-level `pattern-either:` generic rule: loads and fires on either branch
+    /// (both spacegrep `pattern:` and `pattern-regex:` arms are supported).
+    #[test]
+    fn generic_top_level_pattern_either() {
+        let spec = GenericRuleSpec {
+            id: "top-either",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: vec![
+                GenericEitherEntry {
+                    pattern: Some("ssl_protocols TLSv1".to_string()),
+                    pattern_regex: None,
+                },
+                GenericEitherEntry {
+                    pattern: Some("ssl_protocols TLSv1_1".to_string()),
+                    pattern_regex: None,
+                },
+            ],
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: Vec::new(),
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+
+        let tree = dummy_tree();
+
+        assert!(!rules[0].check("ssl_protocols TLSv1;\n", &tree).is_empty());
+        assert!(!rules[0].check("ssl_protocols TLSv1_1;\n", &tree).is_empty());
+        assert!(rules[0].check("ssl_protocols TLSv1_3;\n", &tree).is_empty());
+    }
+
+    /// Top-level `pattern-either:` with `pattern-regex:` arms (not just `pattern:`)
+    /// loads correctly — this covers rules like mcp-tool-poisoning.
+    #[test]
+    fn generic_top_level_pattern_either_regex_arms() {
+        let spec = GenericRuleSpec {
+            id: "top-either-regex",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: vec![
+                GenericEitherEntry {
+                    pattern: None,
+                    pattern_regex: Some("ANTHROPIC_BASE_URL\\s*=".to_string()),
+                },
+                GenericEitherEntry {
+                    pattern: None,
+                    pattern_regex: Some("OPENAI_BASE_URL\\s*=".to_string()),
+                },
+            ],
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: Vec::new(),
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+
+        let tree = dummy_tree();
+
+        assert!(!rules[0]
+            .check("ANTHROPIC_BASE_URL = https://evil.com\n", &tree)
+            .is_empty());
+        assert!(!rules[0]
+            .check("OPENAI_BASE_URL = https://evil.com\n", &tree)
+            .is_empty());
+        assert!(rules[0]
+            .check("SOME_OTHER_URL = https://safe.com\n", &tree)
+            .is_empty());
+    }
+
+    /// `pattern-regex:` in `patterns:` clause loads and fires on a raw-text match.
+    #[test]
+    fn generic_patterns_with_pattern_regex_clause() {
+        let spec = GenericRuleSpec {
+            id: "regex-in-patterns",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: vec![GenericPatternsClause {
+                // Match baseURL = "..." where the URL does NOT start with 'h'
+                // (i.e., not http/https). Use explicit hex escape for the quote.
+                pattern_regex: Some("baseURL\\s*=\\s*\"[^h]".to_string()),
+                ..Default::default()
+            }],
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+
+        let tree = dummy_tree();
+
+        let match_src = "baseURL = \"/relative/path\"\n";
+        let no_match_src = "baseURL = \"https://example.com\"\n";
+
+        assert!(
+            !rules[0].check(match_src, &tree).is_empty(),
+            "expected a finding for non-http baseURL"
+        );
+        assert!(
+            rules[0].check(no_match_src, &tree).is_empty(),
+            "expected no finding for https baseURL"
+        );
+    }
+
+    /// `patterns:` block with `pattern-not-regex:` clause.
+    #[test]
+    fn generic_patterns_with_pattern_not_regex() {
+        let spec = GenericRuleSpec {
+            id: "not-regex-test",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: vec![GenericPatternsClause {
+                pattern: Some("baseURL = ...".to_string()),
+                pattern_not_regex: Some("(?i)https://".to_string()),
+                ..Default::default()
+            }],
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+
+        let tree = dummy_tree();
+
+        // No https → fires.
+        let match_src = "baseURL = \"/relative\"\n";
+        // Has https → suppressed.
+        let no_match_src = "baseURL = \"https://example.com\"\n";
+
+        assert!(
+            !rules[0].check(match_src, &tree).is_empty(),
+            "expected finding when no https"
+        );
+        assert!(
+            rules[0].check(no_match_src, &tree).is_empty(),
+            "expected no finding when https present"
+        );
+    }
+
+    /// `pattern-regex:` at top level (outside patterns block) loads and fires.
+    #[test]
+    fn generic_top_level_pattern_regex() {
+        let spec = GenericRuleSpec {
+            id: "top-regex",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: Some("ANTHROPIC_BASE_URL\\s*="),
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: Vec::new(),
+            path_filter: None,
+        };
+        let rules = build_generic_rules(spec).unwrap();
+
+        let tree = dummy_tree();
+
+        assert!(!rules[0]
+            .check("ANTHROPIC_BASE_URL = https://evil.com\n", &tree)
+            .is_empty());
+        assert!(rules[0]
+            .check("ANTHROPIC_BASE_URL_EXTRA = something\n", &tree)
+            .is_empty());
+    }
+
+    /// A `patterns:` block with no expressible positive matcher must return an
+    /// error rather than producing a no-op rule.
+    #[test]
+    fn generic_patterns_empty_positives_returns_error() {
+        let spec = GenericRuleSpec {
+            id: "empty-positives",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: None,
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            // A clause with only a pattern-not and no positive — should fail.
+            patterns_clauses: vec![GenericPatternsClause {
+                pattern_not: Some("foo".to_string()),
+                ..Default::default()
+            }],
+            path_filter: None,
+        };
+        assert!(build_generic_rules(spec).is_err());
+    }
+
+    /// `paths:` filter is respected: `applies_to_path` returns false for paths
+    /// outside the include glob.
+    #[test]
+    fn generic_paths_filter_respected() {
+        use crate::rules::semgrep_compat::{PathFilter, SemgrepPaths};
+        use std::path::PathBuf;
+
+        let path_filter = PathFilter::from_yaml(Some(&SemgrepPaths {
+            include: vec!["*.conf".to_string()],
+            exclude: vec![],
+        }))
+        .unwrap()
+        .unwrap();
+
+        let spec = GenericRuleSpec {
+            id: "path-filter-test",
+            message: "msg",
+            severity: Severity::High,
+            cwe: None,
+            pattern: Some("ssl_protocols TLSv1"),
+            pattern_regex: None,
+            pattern_either: Vec::new(),
+            pattern_not: None,
+            pattern_not_regex: None,
+            patterns_clauses: Vec::new(),
+            path_filter: Some(path_filter),
+        };
+        let rules = build_generic_rules(spec).unwrap();
+        let rule = &rules[0];
+
+        assert!(rule.applies_to_path(&PathBuf::from("nginx/site.conf")));
+        assert!(!rule.applies_to_path(&PathBuf::from("nginx/site.py")));
     }
 }

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -1884,19 +1884,97 @@ fn build_regex_mode_rules(
 /// Compile a generic-mode rule via [`crate::rules::generic_mode`]. Thin
 /// adapter: pulls the supported generic-mode fields off the YAML and delegates
 /// all matching logic to that module.
+///
+/// Mapping from YAML → [`GenericRuleSpec`]:
+/// - Top-level `pattern` / `pattern-regex` / `pattern-either` / `pattern-not` /
+///   `pattern-not-regex` are forwarded as-is.
+/// - `patterns:` AND-blocks are mapped clause-by-clause into
+///   [`GenericPatternsClause`] structs; unsupported sub-clauses (e.g.
+///   `pattern-inside`, `metavariable-*`) are warn-skipped without aborting
+///   the rest of the rule.
 fn build_generic_mode_rules(
     yaml: &SemgrepRuleYaml,
     severity: Severity,
     cwe: &Option<String>,
     path_filter: &Option<PathFilter>,
 ) -> Result<Vec<Box<dyn Rule>>, String> {
-    use crate::rules::generic_mode::{build_generic_rules, GenericRuleSpec};
+    use crate::rules::generic_mode::{
+        build_generic_rules, GenericEitherEntry, GenericPatternsClause, GenericRuleSpec,
+    };
 
-    let pattern_either: Vec<String> = yaml
+    // Top-level pattern-either: both `pattern:` and `pattern-regex:` arms are
+    // forwarded so rules like `mcp-tool-poisoning` (all-regex arms) also load.
+    let pattern_either: Vec<GenericEitherEntry> = yaml
         .pattern_either
         .iter()
         .flatten()
-        .filter_map(|entry| entry.pattern.clone())
+        .map(|entry| GenericEitherEntry {
+            pattern: entry.pattern.clone(),
+            pattern_regex: entry.pattern_regex.clone(),
+        })
+        .collect();
+
+    // Map `patterns:` clauses.
+    let patterns_clauses: Vec<GenericPatternsClause> = yaml
+        .patterns
+        .iter()
+        .flatten()
+        .filter_map(|clause| {
+            // Warn-skip entirely constraint-only or unsupported clauses that
+            // have neither a positive match nor a negative filter we can use.
+            // Supported: pattern, pattern-regex, pattern-either, pattern-not,
+            // pattern-not-regex. Unsupported: pattern-inside, pattern-not-inside,
+            // metavariable-*.
+            if clause.pattern_inside.is_some() {
+                eprintln!(
+                    "Warning: generic mode does not support pattern-inside in rule '{}'; \
+                     skipping clause",
+                    yaml.id
+                );
+                return None;
+            }
+            if clause.pattern_not_inside.is_some() {
+                eprintln!(
+                    "Warning: generic mode does not support pattern-not-inside in rule '{}'; \
+                     skipping clause",
+                    yaml.id
+                );
+                return None;
+            }
+
+            // Build the either-entries for a nested pattern-either: clause.
+            let pattern_either_entries: Vec<GenericEitherEntry> = clause
+                .pattern_either
+                .iter()
+                .flatten()
+                .map(|e| GenericEitherEntry {
+                    pattern: e.pattern.clone(),
+                    pattern_regex: e.pattern_regex.clone(),
+                })
+                .collect();
+
+            // Silently skip pure constraint clauses (metavariable-regex, etc.)
+            // that carry no match expression — they have no effect in generic
+            // mode but also do not block loading.
+            let has_positive = clause.pattern.is_some()
+                || clause.pattern_regex.is_some()
+                || !pattern_either_entries.is_empty();
+            let has_negative = clause.pattern_not.is_some() || clause.pattern_not_regex.is_some();
+
+            if !has_positive && !has_negative {
+                // Pure constraint clause (metavariable-regex / metavariable-comparison /
+                // metavariable-analysis / focus-metavariable / etc.) — silently skip.
+                return None;
+            }
+
+            Some(GenericPatternsClause {
+                pattern: clause.pattern.clone(),
+                pattern_regex: clause.pattern_regex.clone(),
+                pattern_either: pattern_either_entries,
+                pattern_not: clause.pattern_not.clone(),
+                pattern_not_regex: clause.pattern_not_regex.clone(),
+            })
+        })
         .collect();
 
     build_generic_rules(GenericRuleSpec {
@@ -1908,6 +1986,8 @@ fn build_generic_mode_rules(
         pattern_regex: yaml.pattern_regex.as_deref(),
         pattern_either,
         pattern_not: yaml.pattern_not.as_deref(),
+        pattern_not_regex: yaml.pattern_not_regex.as_deref(),
+        patterns_clauses,
         path_filter: path_filter.clone(),
     })
 }


### PR DESCRIPTION
Extends the **generic (spacegrep) mode** loader so `languages: [generic]` rules using `patterns:` / `pattern-either:` / `pattern-regex:` load and match — previously only a single `pattern:` worked, so 78 of 98 registry generic rules skipped.

## What now loads
- `patterns:` AND-blocks (`pattern:` + `pattern-not:` / `pattern-not-regex:`) combined over the generic token matcher
- `pattern-either:` (recursively flattened; `pattern:` and `pattern-regex:` arms)
- `pattern-regex:` / `pattern-not-regex:` as raw-text regex; `paths.include`/`exclude` honored
- Coverage classifier now `ground_truth`s generic rules (they're implemented, not hard-skipped)

## Measured unlock
| | Loaded | Rate |
|---|---|---|
| Before | 1845 | 86.1% |
| **After** | **1916** | **89.4%** |

Generic rules: **25/103 → 96/103 loaded**. The 7 stragglers use deeply-nested `patterns:` inside `pattern-either:` arms with `metavariable-pattern:`.

## Verify (local + independent)
- 11 new tests · full suite 0 failures · `clippy -D warnings` clean · `fmt --check` clean · **both** dogfood scans clean · no baseline churn.
- **Independently CLI-verified:** generic `patterns:` with `pattern-either`+`pattern-regex` fires (bad=1/good=0) and `pattern-regex`+`pattern-not-regex` suppression works (eval=1/safeEval=0) on a scanned `.js` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced generic-mode rules with support for AND-block pattern matching, regex patterns, and improved negation handling to enable more sophisticated rule definitions.

* **Bug Fixes**
  * Improved rule registry coverage metrics from 86.1% to 89.4% by refining generic-mode rule evaluation and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->