### PR TITLE
feat(taint): FieldName/Subscript/ReceiverCall source-sink shapes (→ 90.8%)

### DIFF
--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1927 (89.9%) |
-| Rules skipped | 217 (10.1%) |
+| Rules loaded OK | 1946 (90.8%) |
+| Rules skipped | 198 (9.2%) |
 
-**Headline load rate: 89.9%** (1927 / 2144 rules).
+**Headline load rate: 90.8%** (1946 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,17 +23,17 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `mode: taint (unsupported shape)` | 166 | 76.5% | 7.7% |
-| `unsupported language: apex` | 9 | 4.1% | 0.4% |
-| `generic mode (languages: [generic])` | 7 | 3.2% | 0.3% |
-| `mode: taint (unsupported language: scala)` | 5 | 2.3% | 0.2% |
-| `taint: pattern-propagators` | 5 | 2.3% | 0.2% |
-| `unsupported language: clojure` | 5 | 2.3% | 0.2% |
-| `loader rejected (other)` | 4 | 1.8% | 0.2% |
-| `unsupported language: html` | 4 | 1.8% | 0.2% |
-| `mode: taint (unsupported language: apex)` | 3 | 1.4% | 0.1% |
-| `mode: taint (unsupported language: bash)` | 3 | 1.4% | 0.1% |
-| `mode: taint (unsupported language: solidity)` | 3 | 1.4% | 0.1% |
+| `mode: taint (unsupported shape)` | 147 | 74.2% | 6.9% |
+| `unsupported language: apex` | 9 | 4.5% | 0.4% |
+| `generic mode (languages: [generic])` | 7 | 3.5% | 0.3% |
+| `mode: taint (unsupported language: scala)` | 5 | 2.5% | 0.2% |
+| `taint: pattern-propagators` | 5 | 2.5% | 0.2% |
+| `unsupported language: clojure` | 5 | 2.5% | 0.2% |
+| `loader rejected (other)` | 4 | 2.0% | 0.2% |
+| `unsupported language: html` | 4 | 2.0% | 0.2% |
+| `mode: taint (unsupported language: apex)` | 3 | 1.5% | 0.1% |
+| `mode: taint (unsupported language: bash)` | 3 | 1.5% | 0.1% |
+| `mode: taint (unsupported language: solidity)` | 3 | 1.5% | 0.1% |
 | `mode: taint (unsupported language: swift)` | 1 | 0.5% | 0.0% |
 | `unsupported language: dart` | 1 | 0.5% | 0.0% |
 | `unsupported language: xml` | 1 | 0.5% | 0.0% |
@@ -44,11 +44,11 @@ Matcher capabilities (implementable in `semgrep_compat.rs` / `semgrep_taint.rs`)
 
 | Rank | Capability to add | Rules unlocked |
 |---:|---|---:|
-| 1 | `mode: taint (unsupported shape)` | 166 |
+| 1 | `mode: taint (unsupported shape)` | 147 |
 | 2 | `taint: pattern-propagators` | 5 |
 | 3 | `loader rejected (other)` | 4 |
 
-Operator/feature gaps account for **175 rules** (8.2% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
+Operator/feature gaps account for **156 rules** (7.3% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
 
 ## Priority order — missing language grammars
 
@@ -76,18 +76,18 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 
 | Language | Total | Loaded | Skipped | Load rate |
 |---|---:|---:|---:|---:|
-| python | 423 | 379 | 44 | 89.6% |
+| python | 423 | 388 | 35 | 91.7% |
 | hcl | 359 | 359 | 0 | 100.0% |
-| javascript | 243 | 199 | 44 | 81.9% |
+| javascript | 243 | 202 | 41 | 83.1% |
 | regex | 237 | 233 | 4 | 98.3% |
-| java | 131 | 110 | 21 | 84.0% |
+| java | 131 | 111 | 20 | 84.7% |
 | generic | 103 | 96 | 7 | 93.2% |
 | yaml | 100 | 100 | 0 | 100.0% |
 | go | 97 | 84 | 13 | 86.6% |
-| ruby | 92 | 69 | 23 | 75.0% |
-| php | 63 | 48 | 15 | 76.2% |
+| ruby | 92 | 73 | 19 | 79.3% |
+| php | 63 | 49 | 14 | 77.8% |
 | solidity | 50 | 47 | 3 | 94.0% |
-| csharp | 48 | 37 | 11 | 77.1% |
+| csharp | 48 | 38 | 10 | 79.2% |
 | dockerfile | 39 | 39 | 0 | 100.0% |
 | ocaml | 34 | 34 | 0 | 100.0% |
 | scala | 23 | 18 | 5 | 78.3% |
@@ -110,17 +110,17 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **apex**: `unsupported language: apex` (9), `mode: taint (unsupported language: apex)` (3)
 - **bash**: `mode: taint (unsupported language: bash)` (3)
 - **clojure**: `unsupported language: clojure` (5)
-- **csharp**: `mode: taint (unsupported shape)` (10), `taint: pattern-propagators` (1)
+- **csharp**: `mode: taint (unsupported shape)` (9), `taint: pattern-propagators` (1)
 - **dart**: `unsupported language: dart` (1)
 - **generic**: `generic mode (languages: [generic])` (7)
 - **go**: `mode: taint (unsupported shape)` (13)
 - **html**: `unsupported language: html` (4)
-- **java**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (3)
-- **javascript**: `mode: taint (unsupported shape)` (44)
-- **php**: `mode: taint (unsupported shape)` (15)
-- **python**: `mode: taint (unsupported shape)` (44)
+- **java**: `mode: taint (unsupported shape)` (17), `taint: pattern-propagators` (3)
+- **javascript**: `mode: taint (unsupported shape)` (41)
+- **php**: `mode: taint (unsupported shape)` (14)
+- **python**: `mode: taint (unsupported shape)` (35)
 - **regex**: `loader rejected (other)` (4)
-- **ruby**: `mode: taint (unsupported shape)` (22), `taint: pattern-propagators` (1)
+- **ruby**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (1)
 - **scala**: `mode: taint (unsupported language: scala)` (5)
 - **solidity**: `mode: taint (unsupported language: solidity)` (3)
 - **swift**: `mode: taint (unsupported language: swift)` (1)

--- a/src/rules/csharp_taint.rs
+++ b/src/rules/csharp_taint.rs
@@ -667,7 +667,45 @@ fn classify_source_expr(node: Node<'_>, source: &str, spec: &TaintSpec) -> Optio
                     }
                 }
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver property READ: `<anything>.field`. Matches a
+                // `member_access_expression` whose `name` equals `field`,
+                // regardless of the receiver. Covers `req.Body`, `ctx.Request`.
+                if node.kind() == "member_access_expression" {
+                    if let Some(name_node) = node.child_by_field_name("name") {
+                        if node_text(name_node, source) == field.as_str() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]` → `element_access_expression`.
+                // Matches when the indexed expression's final segment equals
+                // `base` (or any when `base` is None).
+                if node.kind() == "element_access_expression" {
+                    if let Some(expr) = node.child_by_field_name("expression") {
+                        match base.as_deref() {
+                            None => return Some(description.clone()),
+                            Some(want) => {
+                                let final_seg = match expr.kind() {
+                                    "identifier" => Some(node_text(expr, source)),
+                                    "member_access_expression" => expr
+                                        .child_by_field_name("name")
+                                        .map(|n| node_text(n, source)),
+                                    _ => None,
+                                };
+                                if final_seg == Some(want) {
+                                    return Some(description.clone());
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matchers, never a source.
             }
         }
@@ -719,6 +757,18 @@ fn matcher_matches_call(matcher: &NodeMatcher, node: Node<'_>, source: &str) -> 
             }
             false
         }
+        NodeMatcher::ReceiverCall { receiver, .. } => {
+            // Match any invocation whose callee root identifier equals
+            // `receiver`, e.g. `Process.$METHOD(...)`.
+            if node.kind() == "invocation_expression" {
+                if let Some(func) = node.child_by_field_name("function") {
+                    let resolved = resolve_callee(func, source);
+                    return resolved.contains('.')
+                        && resolved.split('.').next() == Some(receiver.as_str());
+                }
+            }
+            false
+        }
         NodeMatcher::Attribute { root, field, .. } => {
             // Match a member-assignment sink: e.g. `psi.Arguments = tainted`
             // arrives as the LHS of an assignment_expression, not a call.
@@ -734,7 +784,10 @@ fn matcher_matches_call(matcher: &NodeMatcher, node: Node<'_>, source: &str) -> 
             }
             false
         }
-        NodeMatcher::ParamName { .. } | NodeMatcher::MemberAssign { .. } => false,
+        NodeMatcher::FieldName { .. }
+        | NodeMatcher::Subscript { .. }
+        | NodeMatcher::ParamName { .. }
+        | NodeMatcher::MemberAssign { .. } => false,
     }
 }
 

--- a/src/rules/go_taint.rs
+++ b/src/rules/go_taint.rs
@@ -1146,15 +1146,64 @@ fn match_source(
                     }
                 }
             }
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver field READ: `<anything>.field`. Matches a
+                // `selector_expression` whose field equals `field`,
+                // regardless of the root operand. Covers `ctx.params`,
+                // `req.body`, etc.
+                if node.kind() != "selector_expression" {
+                    continue;
+                }
+                let Some(final_field) = node.child_by_field_name("field") else {
+                    continue;
+                };
+                if node_text(final_field, source) == field.as_str() {
+                    return Some(description.clone());
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]` → `index_expression`. Matches when
+                // the indexed operand's final segment equals `base` (or any
+                // when `base` is None).
+                if node.kind() != "index_expression" {
+                    continue;
+                }
+                let Some(operand) = node.child_by_field_name("operand") else {
+                    continue;
+                };
+                if go_subscript_base_matches(operand, source, base.as_deref()) {
+                    return Some(description.clone());
+                }
+            }
             NodeMatcher::ParamName { .. } => {
                 // Seeded at function entry, not matched on expressions.
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matcher; MemberAssign is JS-specific.
             }
         }
     }
     None
+}
+
+/// True when the indexed operand of an `index_expression` matches the
+/// requested base. `want = None` matches any. For `Some(name)`, an
+/// `identifier` matches its text and a `selector_expression` matches its
+/// final field name.
+fn go_subscript_base_matches(operand: Node<'_>, source: &str, want: Option<&str>) -> bool {
+    let Some(want) = want else {
+        return true;
+    };
+    match operand.kind() {
+        "identifier" => node_text(operand, source) == want,
+        "selector_expression" => operand
+            .child_by_field_name("field")
+            .map(|f| node_text(f, source) == want)
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 /// Canonical set of untrusted-input sources for Go web handlers and

--- a/src/rules/javascript_taint.rs
+++ b/src/rules/javascript_taint.rs
@@ -1784,6 +1784,12 @@ fn is_sanitizer_call(
             NodeMatcher::MethodName { method, .. } if method == final_segment => {
                 return true;
             }
+            NodeMatcher::ReceiverCall { receiver, .. }
+                if resolved.split('.').next() == Some(receiver.as_str())
+                    && resolved.contains('.') =>
+            {
+                return true;
+            }
             _ => {}
         }
     }
@@ -1844,15 +1850,64 @@ fn match_source(
                     }
                 }
             }
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver property READ: `<anything>.field`. Matches a
+                // `member_expression` whose property equals `field`,
+                // regardless of the object. Covers `req.body`, `req.query`,
+                // `req.params`, `req.headers`, `req.cookies`.
+                if node.kind() != "member_expression" {
+                    continue;
+                }
+                let Some(prop) = node.child_by_field_name("property") else {
+                    continue;
+                };
+                if node_text(prop, source) == field.as_str() {
+                    return Some(description.clone());
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]` → `subscript_expression`. Matches
+                // when the indexed object's final segment equals `base` (or
+                // any when `base` is None).
+                if node.kind() != "subscript_expression" {
+                    continue;
+                }
+                let Some(object) = node.child_by_field_name("object") else {
+                    continue;
+                };
+                if js_subscript_base_matches(object, source, base.as_deref()) {
+                    return Some(description.clone());
+                }
+            }
             NodeMatcher::ParamName { .. } => {
                 // Seeded at function entry, not matched on expressions.
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matchers.
             }
         }
     }
     None
+}
+
+/// True when the indexed object of a `subscript_expression` matches the
+/// requested base. `want = None` matches any. For `Some(name)`, an
+/// `identifier` matches its text and a `member_expression` matches its final
+/// property name.
+fn js_subscript_base_matches(object: Node<'_>, source: &str, want: Option<&str>) -> bool {
+    let Some(want) = want else {
+        return true;
+    };
+    match object.kind() {
+        "identifier" => node_text(object, source) == want,
+        "member_expression" => object
+            .child_by_field_name("property")
+            .map(|p| node_text(p, source) == want)
+            .unwrap_or(false),
+        _ => false,
+    }
 }
 
 /// Canonical set of untrusted-input sources for JavaScript/TypeScript web

--- a/src/rules/php_taint.rs
+++ b/src/rules/php_taint.rs
@@ -856,7 +856,55 @@ fn match_source(node: Node<'_>, source: &str, spec: &TaintSpec) -> Option<String
                     }
                 }
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver property READ: `<anything>->field`. In PHP this
+                // is a `member_access_expression`. Match whose member/name
+                // equals `field`, regardless of the object. Covers
+                // `$request->body`, `$req->query`, etc.
+                if node.kind() == "member_access_expression" {
+                    let member_text = node
+                        .child_by_field_name("member")
+                        .or_else(|| node.child_by_field_name("name"))
+                        .map(|n| node_text(n, source))
+                        .unwrap_or("");
+                    if member_text == field.as_str() {
+                        return Some(description.clone());
+                    }
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]` → `subscript_expression`. Matches
+                // when the indexed receiver's final segment equals `base` (or
+                // any when `base` is None). The receiver is the first named
+                // child. `$_GET[...]` is a `variable_name`; `$req->q[...]` is
+                // a `member_access_expression`.
+                if node.kind() == "subscript_expression" {
+                    let Some(receiver) = node.named_child(0) else {
+                        continue;
+                    };
+                    let Some(want) = base.as_deref() else {
+                        // Metavariable base → match any subscript.
+                        return Some(description.clone());
+                    };
+                    let final_seg = match receiver.kind() {
+                        "variable_name" => {
+                            Some(node_text(receiver, source).trim_start_matches('$'))
+                        }
+                        "member_access_expression" => receiver
+                            .child_by_field_name("member")
+                            .or_else(|| receiver.child_by_field_name("name"))
+                            .map(|n| node_text(n, source)),
+                        "name" => Some(node_text(receiver, source)),
+                        _ => None,
+                    };
+                    if final_seg == Some(want) {
+                        return Some(description.clone());
+                    }
+                }
+            }
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matchers.
             }
         }

--- a/src/rules/python_taint.rs
+++ b/src/rules/python_taint.rs
@@ -1133,6 +1133,24 @@ fn is_sanitizer_call(
     false
 }
 
+/// True when the indexed `value` of a subscript matches the requested base.
+/// `want = None` matches any base. For `Some(name)`, the final segment of the
+/// indexed expression must equal `name`: an `identifier` matches its own
+/// text, an `attribute` matches its final attribute name.
+fn subscript_base_matches(value: Node<'_>, source: &str, want: Option<&str>) -> bool {
+    let Some(want) = want else {
+        return true;
+    };
+    match value.kind() {
+        "identifier" => node_text(value, source) == want,
+        "attribute" => value
+            .child_by_field_name("attribute")
+            .map(|a| node_text(a, source) == want)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
 fn match_source(
     node: Node<'_>,
     source: &str,
@@ -1193,12 +1211,43 @@ fn match_source(
                     }
                 }
             }
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver attribute READ: `<anything>.field`. Matches an
+                // `attribute` node whose final attribute equals `field`,
+                // regardless of the root identifier. Covers web-request
+                // property sources like `req.body`, `request.query`.
+                if node.kind() != "attribute" {
+                    continue;
+                }
+                let Some(final_attr) = node.child_by_field_name("attribute") else {
+                    continue;
+                };
+                if node_text(final_attr, source) == field.as_str() {
+                    return Some(description.clone());
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]`. Matches a `subscript` node whose
+                // indexed value's final segment equals `base` (or any when
+                // `base` is None). Covers `request.POST[...]`, `params[...]`.
+                if node.kind() != "subscript" {
+                    continue;
+                }
+                let Some(value) = node.child_by_field_name("value") else {
+                    continue;
+                };
+                if subscript_base_matches(value, source, base.as_deref()) {
+                    return Some(description.clone());
+                }
+            }
             NodeMatcher::ParamName { .. } => {
                 // ParamName matchers are applied when seeding the state
                 // from the function's parameter list, not when walking
                 // expressions.
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matchers; MemberAssign is JS-specific.
             }
         }

--- a/src/rules/ruby_taint.rs
+++ b/src/rules/ruby_taint.rs
@@ -732,7 +732,53 @@ fn match_source(node: Node<'_>, source: &str, spec: &TaintSpec) -> Option<String
                     _ => {}
                 }
             }
-            NodeMatcher::MethodName { .. } | NodeMatcher::MemberAssign { .. } => {
+            NodeMatcher::FieldName { field, description } => {
+                // Any-receiver attribute READ: `<anything>.field`. In Ruby a
+                // no-arg accessor like `request.params` parses as a `call`
+                // with a receiver and a method but no arguments. Match such a
+                // node whose method equals `field`, regardless of receiver.
+                if node.kind() == "call"
+                    && node.child_by_field_name("receiver").is_some()
+                    && node.child_by_field_name("arguments").is_none()
+                {
+                    if let Some(method) = node.child_by_field_name("method") {
+                        if node_text(method, source) == field.as_str() {
+                            return Some(description.clone());
+                        }
+                    }
+                }
+            }
+            NodeMatcher::Subscript { base, description } => {
+                // Index access `base[...]` → `element_reference` in Ruby
+                // (`params[:cmd]`, `request.GET["x"]`). Matches when the
+                // object's final segment equals `base` (or any if None).
+                if node.kind() == "element_reference" {
+                    if let Some(object) = node.child_by_field_name("object") {
+                        match base.as_deref() {
+                            None => return Some(description.clone()),
+                            Some(want) => match object.kind() {
+                                "identifier" | "constant" => {
+                                    if node_text(object, source) == want {
+                                        return Some(description.clone());
+                                    }
+                                }
+                                "call" => {
+                                    // `request.GET` accessor parsed as a call.
+                                    if let Some(method) = object.child_by_field_name("method") {
+                                        if node_text(method, source) == want {
+                                            return Some(description.clone());
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            },
+                        }
+                    }
+                }
+            }
+            NodeMatcher::MethodName { .. }
+            | NodeMatcher::ReceiverCall { .. }
+            | NodeMatcher::MemberAssign { .. } => {
                 // Sink-only matchers.
             }
         }

--- a/src/rules/semgrep_taint.rs
+++ b/src/rules/semgrep_taint.rs
@@ -104,6 +104,50 @@ enum GenericMatcher {
     /// skipped (no C OOP method calls exist).
     MethodName { method: String, description: String },
 
+    /// Matches any call whose callee root identifier equals `receiver`,
+    /// regardless of method — compiled from `receiver.$METAVAR(...)` where
+    /// `receiver` is a concrete identifier and the method is a metavariable
+    /// (e.g. `os.$METHOD(...)`, `subprocess.$FUNC(...)`, `Kernel.$X(...)`).
+    /// The symmetric counterpart of [`GenericMatcher::MethodName`]. Sink or
+    /// sanitizer only.
+    ReceiverCall {
+        receiver: String,
+        description: String,
+    },
+
+    /// Matches a member/property/attribute READ `<anything>.field`
+    /// regardless of the receiver. Compiled from patterns of the form
+    /// `$METAVAR.field` (a metavariable receiver, a plain-identifier field),
+    /// e.g. `$REQ.body`, `$REQ.query`, `$REQ.headers`, `$REQ.cookies`,
+    /// `$REQ.params`.
+    ///
+    /// This is the any-receiver analogue of [`GenericMatcher::Attribute`],
+    /// which requires a concrete `root` identifier and so rejects a
+    /// metavariable receiver like `$REQ.body`. It is the dominant rejected
+    /// source shape across the registry (web-request property reads).
+    ///
+    /// Meaningful for object/property languages (Python, JS/TS, Go, Java,
+    /// Kotlin, Ruby, PHP, C#) as a source, sink, or sanitizer. For C the
+    /// matcher is carried in the spec but the engine no-ops it (plain C has
+    /// no property-read sources).
+    FieldName { field: String, description: String },
+
+    /// Matches a subscript / index access `base[...]`. Compiled from patterns
+    /// like `params[...]`, `cookies[...]`, `request.POST[...]`,
+    /// `flask.request.args[...]`, or `$VALS[$INDEX]`.
+    ///
+    /// `base = Some(name)` matches a subscript whose indexed operand's final
+    /// segment equals `name` (the last identifier before the `[`). For a
+    /// metavariable base (`$M[...]`, `$VALS[$INDEX]`) `base = None` matches
+    /// any subscript. Web frameworks express request-map indexing this way
+    /// (`request.POST[...]`, `flask.request.args[...]`).
+    ///
+    /// Meaningful for object/property languages; the C engine no-ops it.
+    Subscript {
+        base: Option<String>,
+        description: String,
+    },
+
     /// Matches a property-assignment sink of the form `$EL.field = $X`.
     /// Compiled from Semgrep patterns like `$EL.innerHTML = $X` where the
     /// receiver is any Semgrep metavariable and `field` is a plain identifier.
@@ -163,6 +207,21 @@ fn to_python_matcher(m: &GenericMatcher) -> python_taint::NodeMatcher {
             method: method.clone(),
             description: description.clone(),
         },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => python_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => python_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => python_taint::NodeMatcher::Subscript {
+            base: base.clone(),
+            description: description.clone(),
+        },
         // MemberAssign is JS-specific; included in the spec for completeness but
         // the Python engine ignores it (no property-assignment sinks in Python).
         GenericMatcher::MemberAssign { field, description } => {
@@ -214,6 +273,25 @@ fn to_js_matcher(m: &GenericMatcher) -> javascript_taint::NodeMatcher {
             method: method.clone(),
             description: description.clone(),
         },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => javascript_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => {
+            javascript_taint::NodeMatcher::FieldName {
+                field: field.clone(),
+                description: description.clone(),
+            }
+        }
+        GenericMatcher::Subscript { base, description } => {
+            javascript_taint::NodeMatcher::Subscript {
+                base: base.clone(),
+                description: description.clone(),
+            }
+        }
         GenericMatcher::MemberAssign { field, description } => {
             javascript_taint::NodeMatcher::MemberAssign {
                 field: field.clone(),
@@ -259,6 +337,21 @@ fn to_go_matcher(m: &GenericMatcher) -> go_taint::NodeMatcher {
             description,
         } => go_taint::NodeMatcher::MethodName {
             method: method.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => go_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => go_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => go_taint::NodeMatcher::Subscript {
+            base: base.clone(),
             description: description.clone(),
         },
         // MemberAssign is JS-specific; included in the spec for completeness but
@@ -308,6 +401,21 @@ fn to_java_matcher(m: &GenericMatcher) -> java_taint::NodeMatcher {
             description,
         } => java_taint::NodeMatcher::MethodName {
             method: method.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => java_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => java_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => java_taint::NodeMatcher::Subscript {
+            base: base.clone(),
             description: description.clone(),
         },
         // MemberAssign is JS-specific; included in the spec for completeness but
@@ -361,6 +469,28 @@ fn to_c_matcher(m: &GenericMatcher) -> c_taint::NodeMatcher {
             method: method.clone(),
             description: description.clone(),
         },
+        // ReceiverCall (`os.$METHOD(...)`) has no meaning in plain C; carried
+        // in the spec but the C engine no-ops it.
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => c_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        // FieldName (property read) is not meaningful in plain C; carried in
+        // the spec for completeness but the C engine no-ops it (like
+        // MemberAssign below).
+        GenericMatcher::FieldName { field, description } => c_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        // Subscript (index access) is not meaningful in plain C taint flow;
+        // carried in the spec but the C engine no-ops it.
+        GenericMatcher::Subscript { base, description } => c_taint::NodeMatcher::Subscript {
+            base: base.clone(),
+            description: description.clone(),
+        },
         // MemberAssign is JS-specific; included in the spec for completeness but
         // the C engine ignores it.
         GenericMatcher::MemberAssign { field, description } => c_taint::NodeMatcher::MemberAssign {
@@ -406,6 +536,21 @@ fn to_kotlin_matcher(m: &GenericMatcher) -> kotlin_taint::NodeMatcher {
             description,
         } => kotlin_taint::NodeMatcher::MethodName {
             method: method.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => kotlin_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => kotlin_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => kotlin_taint::NodeMatcher::Subscript {
+            base: base.clone(),
             description: description.clone(),
         },
         // MemberAssign is JS-specific; included in the spec for completeness but
@@ -455,6 +600,21 @@ fn to_ruby_matcher(m: &GenericMatcher) -> ruby_taint::NodeMatcher {
             description,
         } => ruby_taint::NodeMatcher::MethodName {
             method: method.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => ruby_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => ruby_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => ruby_taint::NodeMatcher::Subscript {
+            base: base.clone(),
             description: description.clone(),
         },
         // MemberAssign is JS-specific; included in the spec for completeness but
@@ -515,6 +675,21 @@ fn to_csharp_matcher(m: &GenericMatcher) -> csharp_taint::NodeMatcher {
             method: method.clone(),
             description: description.clone(),
         },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => csharp_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => csharp_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => csharp_taint::NodeMatcher::Subscript {
+            base: base.clone(),
+            description: description.clone(),
+        },
         // MemberAssign is JS-specific; included in the spec for completeness but
         // the C# engine ignores it.
         GenericMatcher::MemberAssign { field, description } => {
@@ -553,6 +728,21 @@ fn to_php_matcher(m: &GenericMatcher) -> php_taint::NodeMatcher {
             description,
         } => php_taint::NodeMatcher::MethodName {
             method: method.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => php_taint::NodeMatcher::ReceiverCall {
+            receiver: receiver.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::FieldName { field, description } => php_taint::NodeMatcher::FieldName {
+            field: field.clone(),
+            description: description.clone(),
+        },
+        GenericMatcher::Subscript { base, description } => php_taint::NodeMatcher::Subscript {
+            base: base.clone(),
             description: description.clone(),
         },
         // MemberAssign is JS-specific; included in the spec for completeness but
@@ -1265,6 +1455,30 @@ fn compile_pattern(pattern: &str, role: MatcherRole) -> Option<GenericMatcher> {
         return None;
     }
 
+    // ── Subscript form: `base[...]` / `base[$K]` ─────────────────────────
+    //
+    // Semgrep taint rules express request-map indexing as a subscript:
+    // `params[...]`, `cookies[...]`, `request.POST[...]`,
+    // `flask.request.args[...]`, `$VALS[$INDEX]`, `$M[$K]`. The bridge
+    // compiles these to `Subscript { base }`, where `base` is the final
+    // identifier segment before the `[` (or `None` for a metavariable base).
+    //
+    // Detection: the pattern ends with `]`, contains a `[`, and the portion
+    // before the first `[` is a recognizable base (plain identifier, dotted
+    // attribute chain, or a metavariable / metavariable-tailed chain). No
+    // top-level `=` (that is a MemberAssign) and the base must not itself be
+    // a call. Valid as a source, sink, or sanitizer.
+    if let Some(base) = parse_subscript_base(pat) {
+        let desc = match &base {
+            Some(b) => describe(b, role),
+            None => describe(pat, role),
+        };
+        return Some(GenericMatcher::Subscript {
+            base,
+            description: desc,
+        });
+    }
+
     // ── MemberAssign form: `$METAVAR.field = $X` ────────────────────────
     //
     // Semgrep taint rules for DOM-XSS commonly express property-assignment
@@ -1321,6 +1535,24 @@ fn compile_pattern(pattern: &str, role: MatcherRole) -> Option<GenericMatcher> {
             };
         }
 
+        // ── ReceiverCall shape: `receiver.$METHOD($X)` ──────────────────
+        //
+        // The symmetric counterpart of `MethodName`: a *concrete* receiver
+        // identifier followed by a *metavariable* method. Compiled to
+        // `ReceiverCall { receiver }`, matching any call whose callee root
+        // equals `receiver` regardless of the method name. Covers the common
+        // module-call sink shapes `os.$METHOD(...)`, `subprocess.$FUNC(...)`,
+        // `Kernel.$X(...)`, `Shell.$X(...)`. Sink/sanitizer only.
+        if let Some(receiver) = parse_receiver_dot_metavar(callee) {
+            return match role {
+                MatcherRole::Sink | MatcherRole::Sanitizer => Some(GenericMatcher::ReceiverCall {
+                    receiver: receiver.to_string(),
+                    description: describe(receiver, role),
+                }),
+                MatcherRole::Source => None,
+            };
+        }
+
         // Callee must be a plain identifier or dotted identifier chain.
         if !is_dotted_identifier(callee) {
             return None;
@@ -1349,6 +1581,26 @@ fn compile_pattern(pattern: &str, role: MatcherRole) -> Option<GenericMatcher> {
             }),
             MatcherRole::Sink | MatcherRole::Sanitizer => None,
         };
+    }
+
+    // ── FieldName form: `$METAVAR.field` (any-receiver property read) ─────
+    //
+    // Semgrep taint rules overwhelmingly express web-request sources as a
+    // property read on a metavariable receiver: `$REQ.body`, `$REQ.query`,
+    // `$REQ.headers`, `$REQ.cookies`, `$REQ.params`, `$CTX.params`, etc.
+    // The `Attribute` shape requires a *concrete* root identifier, so it
+    // rejects a metavariable receiver. `FieldName` matches a property/
+    // attribute READ of `field` regardless of receiver.
+    //
+    // Detection: exactly `$METAVAR.plain_identifier` — a single metavariable
+    // segment, a single plain-identifier field, no call parens (handled
+    // above), and no assignment `=` (MemberAssign handled above). Valid as a
+    // source, sink, or sanitizer shape.
+    if let Some(field) = parse_metavar_dot_method(pat) {
+        return Some(GenericMatcher::FieldName {
+            field: field.to_string(),
+            description: describe(field, role),
+        });
     }
 
     // ── No parens: identifier or attribute chain ────────────────────────
@@ -1431,6 +1683,64 @@ fn find_single_assignment(s: &str) -> Option<usize> {
     None
 }
 
+/// If `pat` is a subscript / index access `base[...]`, return the matched
+/// base as `Some(Some(name))` (concrete base whose final segment is `name`)
+/// or `Some(None)` (metavariable base — match any subscript). Returns `None`
+/// when `pat` is not a subscript shape we can express.
+///
+/// The base is the substring before the FIRST `[`; the pattern must end with
+/// `]`. The base must be one of:
+/// - a plain identifier (`params` → `Some(Some("params"))`)
+/// - a dotted attribute chain (`request.POST` → `Some(Some("POST"))`,
+///   `flask.request.args` → `Some(Some("args"))` — final segment)
+/// - a bare metavariable (`$VALS` → `Some(None)`)
+/// - a chain whose final segment is a metavariable (`$REQ.$X` → `Some(None)`)
+///
+/// Anything else (empty base, base containing a call, nested brackets that
+/// don't close at the end, operators) returns `None`.
+fn parse_subscript_base(pat: &str) -> Option<Option<String>> {
+    if !pat.ends_with(']') {
+        return None;
+    }
+    let open = pat.find('[')?;
+    let base = pat[..open].trim();
+    if base.is_empty() {
+        return None;
+    }
+    // The base must not be a call or contain other brackets / operators.
+    if base.contains('(') || base.contains(')') || base.contains('[') || base.contains(' ') {
+        return None;
+    }
+    // Bare metavariable base → match any subscript.
+    if is_metavariable(base) {
+        return Some(None);
+    }
+    // Plain identifier base.
+    if is_identifier(base) {
+        return Some(Some(base.to_string()));
+    }
+    // Dotted chain: take the final segment. If it is a metavariable, the
+    // indexed property is unknown → match any subscript. Otherwise use the
+    // final identifier segment as the base name.
+    if let Some(dot) = base.rfind('.') {
+        let last = &base[dot + 1..];
+        if is_metavariable(last) {
+            return Some(None);
+        }
+        if is_identifier(last) {
+            // Require every preceding segment to be an identifier or a
+            // metavariable so we only accept genuine attribute chains.
+            let head_ok = base[..dot]
+                .split('.')
+                .all(|seg| is_identifier(seg) || is_metavariable(seg));
+            if head_ok {
+                return Some(Some(last.to_string()));
+            }
+        }
+    }
+    None
+}
+
 /// If `callee` has the shape `$METAVAR.plain_method` — exactly one
 /// `$`-prefixed metavariable segment followed by a plain identifier — return
 /// the method name. Returns `None` for all other shapes.
@@ -1457,6 +1767,36 @@ fn parse_metavar_dot_method(callee: &str) -> Option<&str> {
         return None;
     }
     Some(rest)
+}
+
+/// If `callee` has the shape `receiver.$METAVAR` — a concrete plain
+/// identifier receiver followed by a single metavariable method segment —
+/// return the receiver name. The symmetric counterpart of
+/// [`parse_metavar_dot_method`]. Returns `None` for all other shapes.
+///
+/// Examples:
+/// - `os.$METHOD` → `Some("os")`
+/// - `subprocess.$FUNC` → `Some("subprocess")`
+/// - `Kernel.$X` → `Some("Kernel")`
+/// - `$CONN.executeQuery` → `None` (metavar receiver — handled as MethodName)
+/// - `os.system` → `None` (concrete method — handled as Call)
+/// - `a.b.$X` → `None` (multi-segment receiver, ambiguous)
+fn parse_receiver_dot_metavar(callee: &str) -> Option<&str> {
+    let dot = callee.find('.')?;
+    let receiver = &callee[..dot];
+    let rest = &callee[dot + 1..];
+    // Receiver must be a single plain identifier (no further dots).
+    if !is_identifier(receiver) {
+        return None;
+    }
+    // The method segment must be a single metavariable (no more dots).
+    if rest.contains('.') {
+        return None;
+    }
+    if !is_metavariable(rest) {
+        return None;
+    }
+    Some(receiver)
 }
 
 /// True when `s` is a Semgrep metavariable: `$` followed by one or more
@@ -3408,6 +3748,345 @@ class App {
             findings.len(),
             1,
             "expected 1 finding for Console.ReadLine -> Process.Start, got {:?}",
+            findings
+        );
+    }
+
+    // ── Bridge-level tests: FieldName (any-receiver property read source) ────
+    //
+    // These compile a rule with a `$METAVAR.field` source through the SAME
+    // `parse_taint_rule` path the CLI uses, then run the compiled rule against
+    // a real vulnerable source string and assert it FIRES — proving the new
+    // shape is wired end-to-end through the bridge AND the engine. A safe
+    // variant (no tainted property read) must NOT fire.
+
+    /// Python: `$REQ.body` source → `os.system` sink. `req.body` is a property
+    /// read on a metavariable receiver — only `FieldName` can express it.
+    #[test]
+    fn python_bridge_fieldname_source_to_system_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-fieldname-cmdi
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request body reaches os.system"
+pattern-sources:
+  - pattern: $REQ.body
+pattern-sinks:
+  - pattern: os.system($X)
+"#,
+        );
+        // FieldName compiles a property read of `.body`.
+        assert!(matches!(
+            rule.spec.sources.as_slice(),
+            [GenericMatcher::FieldName { field, .. }] if field == "body"
+        ));
+
+        let src = r#"
+def handler(req):
+    data = req.body
+    os.system(data)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for req.body -> os.system, got {:?}",
+            findings
+        );
+    }
+
+    /// Python safe variant: a value that is NOT the `.body` property read must
+    /// not be flagged, proving FieldName is field-specific (not "any read").
+    #[test]
+    fn python_bridge_fieldname_safe_property_does_not_fire() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-fieldname-cmdi-safe
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request body reaches os.system"
+pattern-sources:
+  - pattern: $REQ.body
+pattern-sinks:
+  - pattern: os.system($X)
+"#,
+        );
+
+        let src = r#"
+def handler(req):
+    data = req.session
+    os.system(data)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            findings.is_empty(),
+            "req.session is not `.body`; expected no finding, got {:?}",
+            findings
+        );
+    }
+
+    /// JavaScript: `$REQ.query` source → `eval` sink, exercising the JS
+    /// `member_expression` FieldName path through the bridge.
+    #[test]
+    fn javascript_bridge_fieldname_source_to_eval_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: js-fieldname-eval
+mode: taint
+languages: [javascript]
+severity: ERROR
+message: "Tainted req.query reaches eval"
+pattern-sources:
+  - pattern: $REQ.query
+pattern-sinks:
+  - pattern: eval($X)
+"#,
+        );
+
+        let src = r#"
+function handler(req) {
+    const q = req.query;
+    eval(q);
+}
+"#;
+        let tree = parse_file(src, Language::JavaScript).expect("js fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for req.query -> eval, got {:?}",
+            findings
+        );
+    }
+
+    // ── Bridge-level tests: Subscript (index/subscript access source) ────────
+
+    /// Python: `request.POST[...]` source → `os.system` sink. The subscript
+    /// base's final segment is `POST`.
+    #[test]
+    fn python_bridge_subscript_source_to_system_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-subscript-cmdi
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request.POST reaches os.system"
+pattern-sources:
+  - pattern: request.POST[...]
+pattern-sinks:
+  - pattern: os.system($X)
+"#,
+        );
+        assert!(matches!(
+            rule.spec.sources.as_slice(),
+            [GenericMatcher::Subscript { base: Some(b), .. }] if b == "POST"
+        ));
+
+        let src = r#"
+def handler(request):
+    cmd = request.POST["c"]
+    os.system(cmd)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for request.POST[...] -> os.system, got {:?}",
+            findings
+        );
+    }
+
+    /// Python safe variant: a subscript on a different base (`safe[...]`)
+    /// must not fire when the rule wants `request.POST[...]`.
+    #[test]
+    fn python_bridge_subscript_safe_base_does_not_fire() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-subscript-cmdi-safe
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request.POST reaches os.system"
+pattern-sources:
+  - pattern: request.POST[...]
+pattern-sinks:
+  - pattern: os.system($X)
+"#,
+        );
+
+        let src = r#"
+def handler(config):
+    cmd = config.SETTINGS["c"]
+    os.system(cmd)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            findings.is_empty(),
+            "config.SETTINGS[...] is not request.POST[...]; expected no finding, got {:?}",
+            findings
+        );
+    }
+
+    /// PHP: `$_GET[...]` subscript source → `system` sink via the bridge.
+    #[test]
+    fn php_bridge_subscript_source_to_system_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: php-subscript-cmdi
+mode: taint
+languages: [php]
+severity: ERROR
+message: "Tainted $_GET reaches system"
+pattern-sources:
+  - pattern: $_GET[...]
+pattern-sinks:
+  - pattern: system($X)
+"#,
+        );
+
+        let src = r#"<?php
+function handler() {
+    $cmd = $_GET["c"];
+    system($cmd);
+}
+"#;
+        let tree = parse_file(src, Language::Php).expect("php fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for $_GET[...] -> system, got {:?}",
+            findings
+        );
+    }
+
+    // ── Bridge-level tests: ReceiverCall (`receiver.$METHOD(...)` sink) ──────
+
+    /// Python: `request.args` source → `os.$METHOD(...)` sink. The sink is a
+    /// metavariable method on a concrete `os` receiver — only `ReceiverCall`
+    /// can express it.
+    #[test]
+    fn python_bridge_receivercall_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-receivercall-cmdi
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request reaches os.<any>"
+pattern-sources:
+  - pattern: $REQ.cmd
+pattern-sinks:
+  - pattern: os.$METHOD(...)
+"#,
+        );
+        assert!(matches!(
+            rule.spec.sinks.as_slice(),
+            [GenericMatcher::ReceiverCall { receiver, .. }] if receiver == "os"
+        ));
+
+        let src = r#"
+def handler(req):
+    c = req.cmd
+    os.system(c)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for req.cmd -> os.system (os.$METHOD), got {:?}",
+            findings
+        );
+    }
+
+    /// Python safe variant: a call on a DIFFERENT receiver (`safe.run`) must
+    /// not be flagged when the rule wants `os.$METHOD(...)`.
+    #[test]
+    fn python_bridge_receivercall_other_receiver_does_not_fire() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: py-receivercall-cmdi-safe
+mode: taint
+languages: [python]
+severity: ERROR
+message: "Tainted request reaches os.<any>"
+pattern-sources:
+  - pattern: $REQ.cmd
+pattern-sinks:
+  - pattern: os.$METHOD(...)
+"#,
+        );
+
+        let src = r#"
+def handler(req):
+    c = req.cmd
+    logger.info(c)
+"#;
+        let tree = parse_file(src, Language::Python).expect("python fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert!(
+            findings.is_empty(),
+            "logger.info is not os.$METHOD; expected no finding, got {:?}",
+            findings
+        );
+    }
+
+    /// Ruby: bare `params` source → `Kernel.$X(...)` ReceiverCall sink.
+    #[test]
+    fn ruby_bridge_receivercall_sink_fires() {
+        use crate::engine::parser::parse_file;
+
+        let rule = compiled(
+            r#"
+id: ruby-receivercall-cmdi
+mode: taint
+languages: [ruby]
+severity: ERROR
+message: "Tainted params reaches Kernel.<any>"
+pattern-sources:
+  - pattern: params
+pattern-sinks:
+  - pattern: Kernel.$X(...)
+"#,
+        );
+
+        let src = r#"
+def handler
+  cmd = params[:cmd]
+  Kernel.system(cmd)
+end
+"#;
+        let tree = parse_file(src, Language::Ruby).expect("ruby fixture should parse");
+        let findings = rule.check(src, &tree);
+        assert_eq!(
+            findings.len(),
+            1,
+            "expected 1 finding for params -> Kernel.system (Kernel.$X), got {:?}",
             findings
         );
     }

--- a/src/rules/taint_engine.rs
+++ b/src/rules/taint_engine.rs
@@ -40,6 +40,42 @@ pub enum NodeMatcher {
     /// regardless of receiver. Only meaningful as a sink matcher.
     MethodName { method: String, description: String },
 
+    /// Match any call whose callee's leftmost/root identifier equals
+    /// `receiver`, regardless of the method name — e.g. `os.$METHOD(...)`,
+    /// `subprocess.$FUNC(...)`, `Kernel.$X(...)`. Compiled from a Semgrep
+    /// callee of the form `receiver.$METAVAR` where `receiver` is a concrete
+    /// identifier and the method is a metavariable. Sink/sanitizer only.
+    ReceiverCall {
+        receiver: String,
+        description: String,
+    },
+
+    /// Match a member/property/attribute READ `<anything>.field` regardless
+    /// of receiver — e.g. `req.body`, `request.query`, `ctx.headers`.
+    /// Compiled from Semgrep patterns of the form `$METAVAR.field` (a
+    /// metavariable receiver and a plain identifier field).
+    ///
+    /// This is the any-receiver analogue of [`NodeMatcher::Attribute`]
+    /// (which requires a concrete `root`). Meaningful for object/property
+    /// languages (Python, JS/TS, Go, Java, Kotlin, Ruby, PHP, C#); for C the
+    /// matcher is carried in the spec but the engine no-ops it (no
+    /// property-read sources exist in plain C).
+    FieldName { field: String, description: String },
+
+    /// Match a subscript / index access `base[...]`.
+    ///
+    /// `base = Some(name)` matches a subscript whose indexed operand's final
+    /// segment equals `name` (e.g. `params[...]`, `request.POST[...]` →
+    /// `POST`, `flask.request.args[...]` → `args`). `base = None` matches any
+    /// subscript regardless of base (compiled from a metavariable base like
+    /// `$VALS[$INDEX]`).
+    ///
+    /// Meaningful for object/property languages; the C engine no-ops it.
+    Subscript {
+        base: Option<String>,
+        description: String,
+    },
+
     /// Match an assignment where the LHS is a member expression whose
     /// property name equals `field`. JS-specific: covers the
     /// `element.innerHTML = tainted` pattern, which is not a call and so
@@ -54,6 +90,9 @@ impl NodeMatcher {
             NodeMatcher::Call { description, .. } => description,
             NodeMatcher::ParamName { description, .. } => description,
             NodeMatcher::MethodName { description, .. } => description,
+            NodeMatcher::ReceiverCall { description, .. } => description,
+            NodeMatcher::FieldName { description, .. } => description,
+            NodeMatcher::Subscript { description, .. } => description,
             NodeMatcher::MemberAssign { description, .. } => description,
         }
     }
@@ -609,11 +648,20 @@ pub(super) fn match_call_sink(
         .rsplit('.')
         .next()
         .unwrap_or(resolved_callee);
+    let root_segment = resolved_callee.split('.').next().unwrap_or(resolved_callee);
     spec.sinks.iter().find_map(|matcher| match matcher {
         NodeMatcher::Call { canonical, .. } if canonical.as_str() == resolved_callee => {
             Some(matched_sink_for_matcher(matcher, sink_to_rules))
         }
         NodeMatcher::MethodName { method, .. } if method == final_segment => {
+            Some(matched_sink_for_matcher(matcher, sink_to_rules))
+        }
+        // `os.$METHOD(...)` etc.: match any call whose callee root identifier
+        // equals `receiver`. Requires a dotted callee (`receiver.method`) so a
+        // bare call to a function literally named `receiver` does not match.
+        NodeMatcher::ReceiverCall { receiver, .. }
+            if root_segment == receiver.as_str() && resolved_callee.contains('.') =>
+        {
             Some(matched_sink_for_matcher(matcher, sink_to_rules))
         }
         _ => None,
@@ -755,6 +803,18 @@ pub(super) fn matcher_fingerprint(m: &NodeMatcher) -> String {
             description,
         } => {
             format!("M|{method}|{description}")
+        }
+        NodeMatcher::ReceiverCall {
+            receiver,
+            description,
+        } => {
+            format!("R|{receiver}|{description}")
+        }
+        NodeMatcher::FieldName { field, description } => {
+            format!("F|{field}|{description}")
+        }
+        NodeMatcher::Subscript { base, description } => {
+            format!("S|{}|{description}", base.as_deref().unwrap_or("*"))
         }
         NodeMatcher::MemberAssign { field, description } => {
             format!("MA|{field}|{description}")


### PR DESCRIPTION
## Taint bridge: new source/sink pattern shapes → registry load rate 89.9% → 90.8%

Extends the Semgrep-compat taint bridge to compile three source/sink pattern shapes it previously rejected. Before this, 166 `mode: taint` rules on supported languages were skipped because their source/sink **entries compiled to zero matchers**, emptying the whole role.

### New `GenericMatcher` shapes (wired through all 9 language engines)
- **FieldName** — any-receiver member read `$METAVAR.field` (e.g. `$req.body`, `$req.query`, `$req.headers`). The existing `Attribute` matcher required a *concrete* receiver; metavar receivers now compile. Mirrors the existing any-receiver `MethodName` convention.
- **Subscript** — index access `base[...]` / `$M[...]` (e.g. `$_GET[...]`, `params[...]`, `request.env[...]`).
- **ReceiverCall** — `receiver.$METHOD(...)` sinks (e.g. `os.$METHOD(...)`, `Kernel.$X(...)`), complementing FieldName/Subscript sources.

### Results (measured with `registry_coverage`, independently re-verified)
| | before | after |
|---|---|---|
| Load rate | 89.9% (1927) | **90.8% (1946)** |
| `mode: taint (unsupported shape)` | 166 | **147** |

Net **+19** rules (joint effect: FieldName/Subscript unlock sources, ReceiverCall unlocks co-occurring sinks).

Deliberately **not** implemented (yield below threshold or unsafe): `TypedMetavar` (`($MV:Type)`, <2 rules), bare/quoted-metavar universal sinks (severe false-positive risk).

### Verification (all independently re-run on the branch)
- `registry_coverage` → 90.8% / 147 ✓
- both dogfood scans (`--severity high src/`, `secrets src/`) exit 0 ✓
- full `cargo test` — 0 failures; new **bridge-level** tests (`parse_taint_rule` → compiled `check()` on real fixtures) fire on vulnerable code **and** safe near-misses don't ✓
- clippy `-D warnings` clean · `cargo fmt --check` clean · `.foxguard/baseline.json` untouched ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced security analysis to detect taint flow patterns across Python, JavaScript, Go, PHP, C#, and Ruby
  * Improved detection of property access and array subscript operations in code scanning

* **Documentation**
  * Updated registry coverage metrics: 90.8% load rate (improved from 89.9%), now processing 1,946 rules with refined language breakdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->