### PR TITLE
feat(compat): fancy-regex fallback for lookahead/backref (→ 91.0%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,7 +215,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -223,6 +232,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -762,8 +777,19 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -853,6 +879,7 @@ dependencies = [
  "clap",
  "colored",
  "crossterm",
+ "fancy-regex 0.16.2",
  "globset",
  "hex",
  "hmac",
@@ -2974,7 +3001,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitflags 2.11.0",
- "fancy-regex",
+ "fancy-regex 0.11.0",
  "filedescriptor",
  "finl_unicode",
  "fixedbitset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ walkdir = "2"
 rayon = "1"
 ignore = "0.4"
 regex = "1"
+fancy-regex = "0.16"
 serde_yaml_ng = "0.10"
 sha2 = "0.10"
 uuid = { version = "1", features = ["v5"] }

--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1946 (90.8%) |
-| Rules skipped | 198 (9.2%) |
+| Rules loaded OK | 1950 (91.0%) |
+| Rules skipped | 194 (9.0%) |
 
-**Headline load rate: 90.8%** (1946 / 2144 rules).
+**Headline load rate: 91.0%** (1950 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,14 +23,13 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `mode: taint (unsupported shape)` | 147 | 74.2% | 6.9% |
-| `unsupported language: apex` | 9 | 4.5% | 0.4% |
-| `generic mode (languages: [generic])` | 7 | 3.5% | 0.3% |
-| `mode: taint (unsupported language: scala)` | 5 | 2.5% | 0.2% |
-| `taint: pattern-propagators` | 5 | 2.5% | 0.2% |
-| `unsupported language: clojure` | 5 | 2.5% | 0.2% |
-| `loader rejected (other)` | 4 | 2.0% | 0.2% |
-| `unsupported language: html` | 4 | 2.0% | 0.2% |
+| `mode: taint (unsupported shape)` | 147 | 75.8% | 6.9% |
+| `unsupported language: apex` | 9 | 4.6% | 0.4% |
+| `generic mode (languages: [generic])` | 7 | 3.6% | 0.3% |
+| `mode: taint (unsupported language: scala)` | 5 | 2.6% | 0.2% |
+| `taint: pattern-propagators` | 5 | 2.6% | 0.2% |
+| `unsupported language: clojure` | 5 | 2.6% | 0.2% |
+| `unsupported language: html` | 4 | 2.1% | 0.2% |
 | `mode: taint (unsupported language: apex)` | 3 | 1.5% | 0.1% |
 | `mode: taint (unsupported language: bash)` | 3 | 1.5% | 0.1% |
 | `mode: taint (unsupported language: solidity)` | 3 | 1.5% | 0.1% |
@@ -46,9 +45,8 @@ Matcher capabilities (implementable in `semgrep_compat.rs` / `semgrep_taint.rs`)
 |---:|---|---:|
 | 1 | `mode: taint (unsupported shape)` | 147 |
 | 2 | `taint: pattern-propagators` | 5 |
-| 3 | `loader rejected (other)` | 4 |
 
-Operator/feature gaps account for **156 rules** (7.3% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
+Operator/feature gaps account for **152 rules** (7.1% of all rules). Closing the top of this list is the highest-leverage parity work that does not require a new parser.
 
 ## Priority order — missing language grammars
 
@@ -79,7 +77,7 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 | python | 423 | 388 | 35 | 91.7% |
 | hcl | 359 | 359 | 0 | 100.0% |
 | javascript | 243 | 202 | 41 | 83.1% |
-| regex | 237 | 233 | 4 | 98.3% |
+| regex | 237 | 237 | 0 | 100.0% |
 | java | 131 | 111 | 20 | 84.7% |
 | generic | 103 | 96 | 7 | 93.2% |
 | yaml | 100 | 100 | 0 | 100.0% |
@@ -119,7 +117,6 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **javascript**: `mode: taint (unsupported shape)` (41)
 - **php**: `mode: taint (unsupported shape)` (14)
 - **python**: `mode: taint (unsupported shape)` (35)
-- **regex**: `loader rejected (other)` (4)
 - **ruby**: `mode: taint (unsupported shape)` (18), `taint: pattern-propagators` (1)
 - **scala**: `mode: taint (unsupported language: scala)` (5)
 - **solidity**: `mode: taint (unsupported language: solidity)` (3)

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -15,6 +15,56 @@ const RESERVED_RULE_ID_NAMESPACES: &[&str] = &[
     "config", "manifest",
 ];
 
+/// A compiled regex that prefers the fast `regex` crate but transparently falls
+/// back to `fancy-regex` (a backtracking engine) for patterns the `regex` crate
+/// cannot compile — most importantly PCRE features such as lookahead
+/// `(?=...)` / `(?!...)`, lookbehind `(?<=...)` / `(?<!...)`, and named
+/// backreferences, which many Semgrep registry rules rely on.
+///
+/// The `regex` crate remains the primary path: `fancy-regex` is only used when
+/// the `regex` crate rejects the pattern, so the common case keeps the linear,
+/// allocation-free matching of the fast engine.
+#[derive(Debug, Clone)]
+pub enum CompiledRegex {
+    /// Compiled with the fast, linear-time `regex` crate (the common case).
+    Fast(Regex),
+    /// Compiled with the backtracking `fancy-regex` engine (lookaround /
+    /// backreferences). `fancy_regex::Regex::is_match` returns a `Result`; any
+    /// error (e.g. backtrack-limit exceeded) is treated as "no match" rather
+    /// than panicking.
+    Fancy(fancy_regex::Regex),
+}
+
+impl CompiledRegex {
+    /// Returns `true` if the pattern matches anywhere in `text`.
+    ///
+    /// For the fancy-regex backend, a matcher error (such as exceeding the
+    /// backtrack limit) is treated as no-match.
+    pub fn is_match(&self, text: &str) -> bool {
+        match self {
+            CompiledRegex::Fast(re) => re.is_match(text),
+            CompiledRegex::Fancy(re) => re.is_match(text).unwrap_or(false),
+        }
+    }
+
+    /// Returns the non-overlapping byte ranges `(start, end)` of every match in
+    /// `text`, left-to-right — the same iteration order as
+    /// [`regex::Regex::find_iter`].
+    ///
+    /// For the fancy-regex backend, iteration stops at the first matcher error
+    /// (errors are treated as "no further matches" rather than panicking).
+    pub fn find_matches(&self, text: &str) -> Vec<(usize, usize)> {
+        match self {
+            CompiledRegex::Fast(re) => re.find_iter(text).map(|m| (m.start(), m.end())).collect(),
+            CompiledRegex::Fancy(re) => re
+                .find_iter(text)
+                .map_while(Result::ok)
+                .map(|m| (m.start(), m.end()))
+                .collect(),
+        }
+    }
+}
+
 // ─── YAML Schema ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -304,7 +354,7 @@ pub enum PatternMatcher {
     /// Single pattern
     Single(CompiledAstPattern),
     /// Regex match against source text
-    Regex(Regex),
+    Regex(CompiledRegex),
     /// Match any of these patterns (OR)
     Either(Vec<PatternMatcher>),
     /// Combine multiple clauses (AND): positives must all match, negatives must not
@@ -327,7 +377,7 @@ pub enum PatternMatcher {
 #[derive(Debug, Clone)]
 pub enum NegativeMatcher {
     Pattern(CompiledAstPattern),
-    Regex(Regex),
+    Regex(CompiledRegex),
 }
 
 #[derive(Clone)]
@@ -356,7 +406,7 @@ pub struct PathFilter {
 #[derive(Debug, Clone)]
 pub struct MetavariableRegexConstraint {
     metavariable: String,
-    regex: Regex,
+    regex: CompiledRegex,
 }
 
 /// Comparison operator for `metavariable-comparison`.
@@ -1114,20 +1164,21 @@ fn match_single_pattern(
     results
 }
 
-fn match_regex_pattern(regex: &Regex, source: &str) -> MatchResult {
+fn match_regex_pattern(regex: &CompiledRegex, source: &str) -> MatchResult {
     regex
-        .find_iter(source)
-        .map(|matched| {
-            let (line, column) = byte_offset_to_position(source, matched.start());
-            let (end_line, end_column) = byte_offset_to_position(source, matched.end());
+        .find_matches(source)
+        .into_iter()
+        .map(|(start, end)| {
+            let (line, column) = byte_offset_to_position(source, start);
+            let (end_line, end_column) = byte_offset_to_position(source, end);
             MatchRange {
-                start_byte: matched.start(),
-                end_byte: matched.end(),
+                start_byte: start,
+                end_byte: end,
                 line,
                 column,
                 end_line,
                 end_column,
-                snippet: get_source_line(source, matched.start()),
+                snippet: get_source_line(source, start),
                 bindings: HashMap::new(),
                 binding_ranges: HashMap::new(),
             }
@@ -1760,9 +1811,9 @@ struct RegexModeRule {
     lang: Language,
     /// The positive regex(es) — all must match at least once (AND semantics when
     /// multiple are present, matching Semgrep's `patterns:` AND-block behaviour).
-    positives: std::sync::Arc<Vec<Regex>>,
+    positives: std::sync::Arc<Vec<CompiledRegex>>,
     /// Negative regexes — if any match the entire file, the finding is suppressed.
-    negatives: std::sync::Arc<Vec<Regex>>,
+    negatives: std::sync::Arc<Vec<CompiledRegex>>,
     path_filter: Option<std::sync::Arc<PathFilter>>,
 }
 
@@ -1880,8 +1931,8 @@ fn build_regex_mode_rules(
     path_filter: &Option<PathFilter>,
 ) -> Result<Vec<Box<dyn Rule>>, String> {
     // Collect all pattern-regex clauses from top-level AND from patterns: blocks.
-    let mut positives: Vec<Regex> = Vec::new();
-    let mut negatives: Vec<Regex> = Vec::new();
+    let mut positives: Vec<CompiledRegex> = Vec::new();
+    let mut negatives: Vec<CompiledRegex> = Vec::new();
 
     // Helper: push a compiled regex or warn-skip if unsupported features are used.
     // Consistent with MetavariableRegexConstraint::from_yaml graceful degradation.
@@ -2303,7 +2354,7 @@ fn build_either_matchers(
     Ok(matchers)
 }
 
-fn compile_regex(pattern: &str) -> Result<Regex, String> {
+fn compile_regex(pattern: &str) -> Result<CompiledRegex, String> {
     // `\Z` is a Python/PCRE end-of-string anchor meaning "end of string before
     // optional trailing newline".  The Rust `regex` crate uses `$` with the
     // `MULTILINE` flag off for the same semantics (match at absolute end).
@@ -2321,7 +2372,23 @@ fn compile_regex(pattern: &str) -> Result<Regex, String> {
     // followed by a valid quantifier body.
     let normalised = escape_bare_braces(&normalised);
 
-    Regex::new(&normalised).map_err(|e| format!("Invalid pattern-regex '{}': {}", pattern, e))
+    // Fast path: the linear-time `regex` crate handles the overwhelming
+    // majority of patterns.  Keep it as the primary engine.
+    match Regex::new(&normalised) {
+        Ok(re) => Ok(CompiledRegex::Fast(re)),
+        // Fallback path: the `regex` crate rejected the pattern.  This is the
+        // case for PCRE features it deliberately does not support —
+        // lookahead `(?=...)`/`(?!...)`, lookbehind `(?<=...)`/`(?<!...)`, and
+        // named/numeric backreferences.  The backtracking `fancy-regex`
+        // engine supports these, so we retry there before giving up.
+        Err(fast_err) => match fancy_regex::Regex::new(&normalised) {
+            Ok(re) => Ok(CompiledRegex::Fancy(re)),
+            Err(fancy_err) => Err(format!(
+                "Invalid pattern-regex '{}': {} (fancy-regex fallback also failed: {})",
+                pattern, fast_err, fancy_err
+            )),
+        },
+    }
 }
 
 /// Escape bare `{` characters that Rust's `regex` crate would reject as
@@ -4502,5 +4569,107 @@ rules:
         let input = r"[{}\s]*";
         let result = escape_bare_braces(input);
         Regex::new(&result).expect("normalised regex must compile");
+    }
+
+    /// `compile_regex` must keep using the fast `regex` crate for ordinary
+    /// patterns that contain no PCRE-only features — the fancy-regex fallback
+    /// is reserved for patterns the fast engine rejects.
+    #[test]
+    fn test_compile_regex_fast_path_for_plain_pattern() {
+        let compiled = compile_regex(r"password\s*=").expect("plain pattern must compile");
+        assert!(
+            matches!(compiled, CompiledRegex::Fast(_)),
+            "a pattern with no lookaround/backref must compile on the fast `regex` crate"
+        );
+        assert!(
+            compiled.is_match("password = 'hunter2'"),
+            "fast-path regex must match the obvious case"
+        );
+        assert!(
+            !compiled.is_match("token = 'hunter2'"),
+            "fast-path regex must not match unrelated text"
+        );
+        // The fast engine reports byte ranges just like the fancy one.
+        assert_eq!(
+            compiled.find_matches("x; password=1"),
+            vec![(3, 12)],
+            "fast-path find_matches must return the matched byte range"
+        );
+    }
+
+    /// `compile_regex` must transparently fall back to the backtracking
+    /// `fancy-regex` engine when the fast `regex` crate rejects a PCRE
+    /// lookahead, and the resulting matcher must honour the lookahead.
+    #[test]
+    fn test_compile_regex_fancy_path_for_lookahead() {
+        // Anchored negative lookahead: at the start of the string, match
+        // `password =` only when it is NOT prefixed by `test_`. Anchoring with
+        // `^` ties the negative lookahead to the whole-line result so the
+        // exclusion is observable. The fast `regex` crate rejects `(?!...)`.
+        let pattern = r"^(?!test_)password\s*=";
+        assert!(
+            Regex::new(pattern).is_err(),
+            "sanity: the fast `regex` crate must reject this lookahead pattern"
+        );
+
+        let compiled = compile_regex(pattern).expect("lookahead pattern must compile via fallback");
+        assert!(
+            matches!(compiled, CompiledRegex::Fancy(_)),
+            "a lookahead pattern must compile on the fancy-regex fallback engine"
+        );
+
+        // Real password assignment → the negative lookahead allows the match.
+        assert!(
+            compiled.is_match("password = 'secret'"),
+            "fancy-path regex must match a non-test password assignment"
+        );
+        // `test_password =` → the `^` anchor pins the match attempt to position
+        // 0, where the negative lookahead `(?!test_)` fails, so there is no
+        // match anywhere.
+        assert!(
+            !compiled.is_match("test_password = 'secret'"),
+            "fancy-path regex must reject a `test_`-prefixed password assignment"
+        );
+    }
+
+    /// End-to-end: a `languages: [regex]` rule whose `pattern-regex` uses a PCRE
+    /// lookahead now LOADS (previously warn-skipped as `loader rejected
+    /// (other)`) and fires on the right source while sparing the excluded one.
+    #[test]
+    fn regex_lang_rule_with_lookahead_loads_and_matches() {
+        let yaml = r#"
+rules:
+  - id: test/lookahead-password
+    pattern-regex: '^(?!test_)password\s*='
+    languages: [regex]
+    message: Hardcoded password assignment
+    severity: ERROR
+"#;
+        let f = make_yaml(yaml);
+        let rules = parse_semgrep_file(f.path())
+            .expect("lookahead pattern-regex rule must load via the fancy-regex fallback");
+        assert!(
+            !rules.is_empty(),
+            "lookahead regex-mode rule must produce at least one rule instance"
+        );
+
+        // Source the rule SHOULD flag (real password assignment).
+        let hit_src = "password = 'hunter2'\n";
+        let tree = parse_file(hit_src, Language::Python).unwrap();
+        let findings = rules[0].check(hit_src, &tree);
+        assert!(
+            !findings.is_empty(),
+            "rule must fire on a non-test password assignment"
+        );
+
+        // Source the rule should NOT flag (the `test_` prefix is excluded by the
+        // negative lookahead).
+        let miss_src = "test_password = 'hunter2'\n";
+        let tree = parse_file(miss_src, Language::Python).unwrap();
+        let findings = rules[0].check(miss_src, &tree);
+        assert!(
+            findings.is_empty(),
+            "rule must NOT fire when the negative lookahead excludes the match"
+        );
     }
 }


### PR DESCRIPTION
## fancy-regex fallback for PCRE lookahead/backref patterns → load rate 90.8% → 91.0%

The `regex` crate can't compile PCRE lookahead `(?=)/(?!)/(?<=)/(?<!)` or named backrefs, so 4 `languages: [regex]` rules were rejected (`loader rejected (other)`). This adds `fancy-regex` as a **fallback only** — the fast `regex` crate stays the primary path; `compile_regex` falls back to `fancy-regex` only when `regex` rejects a pattern, via a `CompiledRegex { Fast | Fancy }` wrapper.

### Results (independently re-measured with `registry_coverage`)
| | before | after |
|---|---|---|
| Load rate | 90.8% (1946) | **91.0% (1950)** |
| `loader rejected (other)` | 4 | **0** |

The +4 are exactly the 4 regex-mode lookahead rules. The fallback also now *preserves* lookahead constraints inside `metavariable-regex`/`pattern-regex` (previously dropped) instead of broadening — no separate count claimed.

### Verification (re-run on the branch)
- `registry_coverage` → 91.0% / loader-rejected 0 ✓
- both dogfood scans exit 0 ✓ · `cargo test` 785 pass ✓ · clippy `-D warnings` clean ✓ · `fmt --check` clean ✓ · baseline untouched ✓
- New tests: `test_compile_regex_fast_path_for_plain_pattern` (stays on `regex` crate), `test_compile_regex_fancy_path_for_lookahead` (falls back), `regex_lang_rule_with_lookahead_loads_and_matches` (end-to-end load + fire/reject).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced regex pattern matching to support advanced patterns including lookahead assertions and backreferences through automatic fallback to a more comprehensive regex engine when the standard engine cannot handle them.

* **Documentation**
  * Updated registry coverage statistics showing improved overall load rate to 91.0% with 1,950 of 2,144 rules loaded and expanded regex language support coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->