### PR TITLE
feat(grammars): apex/html/xml/dart/clojure search grammars (→ 93.4%)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,10 +907,13 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
+ "tree-sitter-clojure-orchard",
  "tree-sitter-containerfile",
+ "tree-sitter-dart",
  "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-hcl",
+ "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
@@ -921,9 +924,11 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-scala",
+ "tree-sitter-sfapex",
  "tree-sitter-solidity",
  "tree-sitter-swift",
  "tree-sitter-typescript",
+ "tree-sitter-xml",
  "tree-sitter-yaml",
  "unicode-segmentation",
  "unicode-width",
@@ -3357,10 +3362,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-clojure-orchard"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e2db28a1ab22649790656936325bdc69e992c38006258694ea39a7620e784d"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-containerfile"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1555ef425ecf06d7f65d58b3f9d3db3bb7fbd4ad135b4e7e40f194b0859ea16f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3391,6 +3416,16 @@ name = "tree-sitter-hcl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -3503,6 +3538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-sfapex"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac630633dad003566212db2adc29a2a75c3e581a7288713dde28f42a428b016"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-solidity"
 version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,6 +3572,16 @@ name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,11 @@ tree-sitter-ocaml = "0.25.0"
 tree-sitter-scala = "0.26.0"
 tree-sitter-elixir = "0.3.5"
 tree-sitter-json = "0.24.8"
+tree-sitter-html = "0.23"
+tree-sitter-xml = "0.7"
+tree-sitter-dart = "0.2"
+tree-sitter-clojure-orchard = "0.2.5"
+tree-sitter-sfapex = "3.0.0"
 
 [features]
 default = []

--- a/docs/parity/registry-coverage.md
+++ b/docs/parity/registry-coverage.md
@@ -12,10 +12,10 @@ Measures how well foxguard's existing Semgrep-compat YAML loader (`src/rules/sem
 | Rule files scanned | 2070 |
 | Files with YAML parse errors | 0 |
 | Total rules | 2144 |
-| Rules loaded OK | 1982 (92.4%) |
-| Rules skipped | 162 (7.6%) |
+| Rules loaded OK | 2002 (93.4%) |
+| Rules skipped | 142 (6.6%) |
 
-**Headline load rate: 92.4%** (1982 / 2144 rules).
+**Headline load rate: 93.4%** (2002 / 2144 rules).
 
 ## Skip-reason histogram
 
@@ -23,16 +23,11 @@ Sorted by frequency. The reason names the operator/key that blocks the rule toda
 
 | Skip reason | Rules | % of skipped | % of all rules |
 |---|---:|---:|---:|
-| `mode: taint (unsupported shape)` | 126 | 77.8% | 5.9% |
-| `unsupported language: apex` | 9 | 5.6% | 0.4% |
-| `generic mode (languages: [generic])` | 7 | 4.3% | 0.3% |
-| `taint: pattern-propagators` | 5 | 3.1% | 0.2% |
-| `unsupported language: clojure` | 5 | 3.1% | 0.2% |
-| `unsupported language: html` | 4 | 2.5% | 0.2% |
-| `mode: taint (unsupported language: apex)` | 3 | 1.9% | 0.1% |
-| `mode: taint (unsupported language: swift)` | 1 | 0.6% | 0.0% |
-| `unsupported language: dart` | 1 | 0.6% | 0.0% |
-| `unsupported language: xml` | 1 | 0.6% | 0.0% |
+| `mode: taint (unsupported shape)` | 126 | 88.7% | 5.9% |
+| `generic mode (languages: [generic])` | 7 | 4.9% | 0.3% |
+| `taint: pattern-propagators` | 5 | 3.5% | 0.2% |
+| `mode: taint (unsupported language: apex)` | 3 | 2.1% | 0.1% |
+| `mode: taint (unsupported language: swift)` | 1 | 0.7% | 0.0% |
 
 ## Priority order — operator/feature backlog
 
@@ -51,16 +46,11 @@ Rules foxguard cannot run because it has no tree-sitter grammar for the target l
 
 | Rank | Language to add | Rules unlocked |
 |---:|---|---:|
-| 1 | `unsupported language: apex` | 9 |
-| 2 | `generic mode (languages: [generic])` | 7 |
-| 3 | `unsupported language: clojure` | 5 |
-| 4 | `unsupported language: html` | 4 |
-| 5 | `mode: taint (unsupported language: apex)` | 3 |
-| 6 | `mode: taint (unsupported language: swift)` | 1 |
-| 7 | `unsupported language: dart` | 1 |
-| 8 | `unsupported language: xml` | 1 |
+| 1 | `generic mode (languages: [generic])` | 7 |
+| 2 | `mode: taint (unsupported language: apex)` | 3 |
+| 3 | `mode: taint (unsupported language: swift)` | 1 |
 
-Missing-grammar gaps account for **31 rules** (1.4% of all rules).
+Missing-grammar gaps account for **11 rules** (0.5% of all rules).
 
 ## Per-language breakdown
 
@@ -86,26 +76,23 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 | c | 16 | 16 | 0 | 100.0% |
 | kotlin | 15 | 15 | 0 | 100.0% |
 | bash | 13 | 13 | 0 | 100.0% |
-| apex | 12 | 0 | 12 | 0.0% |
+| apex | 12 | 9 | 3 | 75.0% |
 | rust | 10 | 10 | 0 | 100.0% |
 | elixir | 7 | 7 | 0 | 100.0% |
 | json | 7 | 7 | 0 | 100.0% |
 | swift | 6 | 5 | 1 | 83.3% |
-| clojure | 5 | 0 | 5 | 0.0% |
+| clojure | 5 | 5 | 0 | 100.0% |
 | terraform | 5 | 5 | 0 | 100.0% |
-| html | 4 | 0 | 4 | 0.0% |
-| dart | 1 | 0 | 1 | 0.0% |
-| xml | 1 | 0 | 1 | 0.0% |
+| html | 4 | 4 | 0 | 100.0% |
+| dart | 1 | 1 | 0 | 100.0% |
+| xml | 1 | 1 | 0 | 100.0% |
 
 ## Top skip reasons per language
 
-- **apex**: `unsupported language: apex` (9), `mode: taint (unsupported language: apex)` (3)
-- **clojure**: `unsupported language: clojure` (5)
+- **apex**: `mode: taint (unsupported language: apex)` (3)
 - **csharp**: `mode: taint (unsupported shape)` (9), `taint: pattern-propagators` (1)
-- **dart**: `unsupported language: dart` (1)
 - **generic**: `generic mode (languages: [generic])` (7)
 - **go**: `mode: taint (unsupported shape)` (13)
-- **html**: `unsupported language: html` (4)
 - **java**: `mode: taint (unsupported shape)` (17), `taint: pattern-propagators` (3)
 - **javascript**: `mode: taint (unsupported shape)` (35)
 - **php**: `mode: taint (unsupported shape)` (14)
@@ -113,7 +100,6 @@ Language is the rule's first declared language (js/ts/jsx/tsx collapsed to `java
 - **ruby**: `mode: taint (unsupported shape)` (15), `taint: pattern-propagators` (1)
 - **solidity**: `mode: taint (unsupported shape)` (1)
 - **swift**: `mode: taint (unsupported language: swift)` (1)
-- **xml**: `unsupported language: xml` (1)
 
 ---
 

--- a/src/bin/gen_rules_ts.rs
+++ b/src/bin/gen_rules_ts.rs
@@ -58,6 +58,11 @@ fn language_slug(language: Language) -> &'static str {
         Language::Scala => "scala",
         Language::Elixir => "elixir",
         Language::Json => "json",
+        Language::Apex => "apex",
+        Language::Clojure => "clojure",
+        Language::Html => "html",
+        Language::Xml => "xml",
+        Language::Dart => "dart",
         // Regex-mode rules fan out per language; this binary generates rules
         // for concrete languages only.
         Language::Regex => "regex",
@@ -90,6 +95,11 @@ fn language_display_name(language: Language) -> &'static str {
         Language::Scala => "Scala",
         Language::Elixir => "Elixir",
         Language::Json => "JSON",
+        Language::Apex => "Apex",
+        Language::Clojure => "Clojure",
+        Language::Html => "HTML",
+        Language::Xml => "XML",
+        Language::Dart => "Dart",
         Language::Regex => "Regex",
     }
 }
@@ -120,6 +130,11 @@ fn language_array_name(language: Language) -> &'static str {
         Language::Scala => "scalaRules",
         Language::Elixir => "elixirRules",
         Language::Json => "jsonRules",
+        Language::Apex => "apexRules",
+        Language::Clojure => "clojureRules",
+        Language::Html => "htmlRules",
+        Language::Xml => "xmlRules",
+        Language::Dart => "dartRules",
         Language::Regex => "regexRules",
     }
 }

--- a/src/bin/registry_coverage.rs
+++ b/src/bin/registry_coverage.rs
@@ -145,6 +145,20 @@ fn language_supported(lang: &str) -> bool {
             | "exs"
             // JSON grammar (tree-sitter-json).
             | "json"
+            // Apex grammar (tree-sitter-sfapex).
+            | "apex"
+            // Clojure grammar (tree-sitter-clojure-orchard).
+            | "clojure"
+            | "clj"
+            | "cljs"
+            | "cljc"
+            // HTML grammar (tree-sitter-html).
+            | "html"
+            | "htm"
+            // XML grammar (tree-sitter-xml).
+            | "xml"
+            // Dart grammar (tree-sitter-dart).
+            | "dart"
     )
 }
 
@@ -915,21 +929,38 @@ rules:
 
     #[test]
     fn unsupported_language_is_skipped() {
-        // Apex has no supported grammar — it must be skipped.
+        // COBOL has no supported grammar — it must be skipped.
+        let r = rule(
+            r#"
+rules:
+  - id: cobol-rule
+    pattern: foo
+    message: m
+    severity: INFO
+    languages: [cobol]
+"#,
+        );
+        match classify_rule(&r) {
+            Outcome::Skipped(reason) => assert_eq!(reason, "unsupported language: cobol"),
+            other => panic!("expected skip, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apex_language_loads() {
+        // Apex now has a real grammar (tree-sitter-sfapex), so search-mode
+        // Apex rules must load.
         let r = rule(
             r#"
 rules:
   - id: apex-rule
-    pattern: foo
+    pattern-regex: 'System\.debug'
     message: m
     severity: INFO
     languages: [apex]
 "#,
         );
-        match classify_rule(&r) {
-            Outcome::Skipped(reason) => assert_eq!(reason, "unsupported language: apex"),
-            other => panic!("expected skip, got {other:?}"),
-        }
+        assert!(matches!(classify_rule(&r), Outcome::Loaded));
     }
 
     #[test]

--- a/src/engine/parser.rs
+++ b/src/engine/parser.rs
@@ -42,6 +42,11 @@ fn parse_source_for_path(
         Language::Scala => tree_sitter_scala::LANGUAGE.into(),
         Language::Elixir => tree_sitter_elixir::LANGUAGE.into(),
         Language::Json => tree_sitter_json::LANGUAGE.into(),
+        Language::Apex => tree_sitter_sfapex::apex::LANGUAGE.into(),
+        Language::Clojure => tree_sitter_clojure_orchard::LANGUAGE.into(),
+        Language::Html => tree_sitter_html::LANGUAGE.into(),
+        Language::Xml => tree_sitter_xml::LANGUAGE_XML.into(),
+        Language::Dart => tree_sitter_dart::LANGUAGE.into(),
         // Regex-mode rules never use a tree-sitter parser — they match raw text
         // only. Return `None` immediately so the scanner skips the tree build.
         Language::Regex => return None,
@@ -143,6 +148,52 @@ contract Token {
         let source = "#!/bin/bash\necho \"Hello, world\"\nif [ -z \"$1\" ]; then\n  exit 1\nfi\n";
         let tree = parse_path(source, Language::Bash, Path::new("script.sh"))
             .expect("Bash parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_apex_without_errors() {
+        let source =
+            "public class Hello {\n  public void greet() {\n    String x = 'hi';\n  }\n}\n";
+        let tree = parse_path(source, Language::Apex, Path::new("Hello.cls"))
+            .expect("Apex parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_clojure_without_errors() {
+        let source = "(defn greet [name]\n  (println \"hello\" name))\n";
+        let tree = parse_path(source, Language::Clojure, Path::new("core.clj"))
+            .expect("Clojure parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_html_without_errors() {
+        let source = "<html>\n  <body>\n    <a href=\"/x\">link</a>\n  </body>\n</html>\n";
+        let tree = parse_path(source, Language::Html, Path::new("index.html"))
+            .expect("HTML parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_xml_without_errors() {
+        let source = "<?xml version=\"1.0\"?>\n<root>\n  <child id=\"1\">text</child>\n</root>\n";
+        let tree = parse_path(source, Language::Xml, Path::new("data.xml"))
+            .expect("XML parser should produce a tree");
+
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parses_dart_without_errors() {
+        let source = "void main() {\n  print('hello');\n}\n";
+        let tree = parse_path(source, Language::Dart, Path::new("main.dart"))
+            .expect("Dart parser should produce a tree");
 
         assert!(!tree.root_node().has_error());
     }

--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -358,6 +358,11 @@ pub fn detect_language(path: &Path) -> Option<Language> {
         "scala" | "sc" => Some(Language::Scala),
         "ex" | "exs" => Some(Language::Elixir),
         "json" => Some(Language::Json),
+        "cls" | "trigger" => Some(Language::Apex),
+        "clj" | "cljs" | "cljc" | "edn" => Some(Language::Clojure),
+        "html" | "htm" => Some(Language::Html),
+        "xml" => Some(Language::Xml),
+        "dart" => Some(Language::Dart),
         _ => None,
     }
 }
@@ -738,6 +743,9 @@ fn comment_markers(language: Language) -> &'static [&'static str] {
         Language::Scala => &["//"],
         Language::Elixir => &["#"],
         Language::Json => &[],
+        Language::Apex | Language::Dart => &["//", "/*"],
+        Language::Clojure => &[";"],
+        Language::Html | Language::Xml => &["<!--"],
         // Regex-mode rules run against raw text with no guaranteed comment syntax.
         // Use `#` as a safe fallback (it works for most config/script files).
         Language::Regex => &["#"],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,11 @@ pub enum Language {
     Scala,
     Elixir,
     Json,
+    Apex,
+    Clojure,
+    Html,
+    Xml,
+    Dart,
     /// Pseudo-language for Semgrep `languages: [regex]` rules.
     ///
     /// A `Regex`-language rule carries only `pattern-regex` / `pattern-not-regex`
@@ -104,6 +109,11 @@ impl std::fmt::Display for Language {
             Language::Scala => write!(f, "scala"),
             Language::Elixir => write!(f, "elixir"),
             Language::Json => write!(f, "json"),
+            Language::Apex => write!(f, "apex"),
+            Language::Clojure => write!(f, "clojure"),
+            Language::Html => write!(f, "html"),
+            Language::Xml => write!(f, "xml"),
+            Language::Dart => write!(f, "dart"),
             Language::Regex => write!(f, "regex"),
         }
     }

--- a/src/rules/generic_mode.rs
+++ b/src/rules/generic_mode.rs
@@ -68,6 +68,11 @@ const ALL_LANGUAGES: &[Language] = &[
     Language::Scala,
     Language::Elixir,
     Language::Json,
+    Language::Apex,
+    Language::Clojure,
+    Language::Html,
+    Language::Xml,
+    Language::Dart,
 ];
 
 // ─── Tokenizer ──────────────────────────────────────────────────────────────

--- a/src/rules/semgrep_compat.rs
+++ b/src/rules/semgrep_compat.rs
@@ -1194,7 +1194,13 @@ fn first_meaningful_node<'a>(
     let kind = node.kind();
 
     // These are top-level wrappers that tree-sitter adds
-    if kind == "module" || kind == "program" || kind == "source_file" || kind == "script" {
+    if kind == "module"
+        || kind == "program"
+        || kind == "source_file"
+        || kind == "script"
+        // tree-sitter-clojure-orchard names its top-level wrapper `source`.
+        || kind == "source"
+    {
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             // Skip the synthetic Go prelude that `prepare_pattern_for_grammar`
@@ -1740,6 +1746,11 @@ fn map_language(lang_str: &str) -> Option<Language> {
         "scala" | "sc" => Some(Language::Scala),
         "elixir" | "ex" | "exs" => Some(Language::Elixir),
         "json" => Some(Language::Json),
+        "apex" => Some(Language::Apex),
+        "clojure" | "clj" | "cljs" | "cljc" => Some(Language::Clojure),
+        "html" | "htm" => Some(Language::Html),
+        "xml" => Some(Language::Xml),
+        "dart" => Some(Language::Dart),
         _ => None,
     }
 }
@@ -1794,6 +1805,11 @@ const REGEX_MODE_ALL_LANGUAGES: &[Language] = &[
     Language::Scala,
     Language::Elixir,
     Language::Json,
+    Language::Apex,
+    Language::Clojure,
+    Language::Html,
+    Language::Xml,
+    Language::Dart,
 ];
 
 /// A compiled Semgrep `languages: [regex]` rule.
@@ -4214,6 +4230,160 @@ rules:
         let rules =
             parse_semgrep_file(f.path()).expect("ocaml language rule must load without error");
         assert!(!rules.is_empty(), "expected rules for ocaml language");
+    }
+
+    /// A `languages: [apex]` `pattern:` rule loads and matches inside Apex source.
+    #[test]
+    fn test_apex_pattern_loads_and_matches() {
+        use crate::engine::parser::parse_path;
+        use std::path::Path;
+
+        let yaml = r#"
+rules:
+  - id: apex-debug-call
+    pattern: System.debug(...)
+    message: Avoid System.debug
+    severity: WARNING
+    languages: [apex]
+"#;
+        let rules = parse_semgrep_str(yaml, "apex.yml")
+            .expect("apex language rule must load without error");
+        assert_eq!(rules.len(), 1, "expected one rule for apex language");
+
+        let source = "public class A {\n  void f() {\n    System.debug('x');\n  }\n}\n";
+        let tree = parse_path(source, Language::Apex, Path::new("A.cls")).expect("Apex must parse");
+        assert!(
+            !tree.root_node().has_error(),
+            "Apex parse must be error-free"
+        );
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            !findings.is_empty(),
+            "pattern System.debug(...) must match in Apex"
+        );
+    }
+
+    /// A `languages: [clojure]` `pattern:` rule loads and matches inside Clojure source.
+    #[test]
+    fn test_clojure_pattern_loads_and_matches() {
+        use crate::engine::parser::parse_path;
+        use std::path::Path;
+
+        let yaml = r#"
+rules:
+  - id: clojure-eval-call
+    pattern: (eval $X)
+    message: Avoid eval
+    severity: WARNING
+    languages: [clojure]
+"#;
+        let rules = parse_semgrep_str(yaml, "clojure.yml")
+            .expect("clojure language rule must load without error");
+        assert_eq!(rules.len(), 1, "expected one rule for clojure language");
+
+        let source = "(defn f [x]\n  (eval x))\n";
+        let tree = parse_path(source, Language::Clojure, Path::new("core.clj"))
+            .expect("Clojure must parse");
+        assert!(
+            !tree.root_node().has_error(),
+            "Clojure parse must be error-free"
+        );
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            !findings.is_empty(),
+            "pattern (eval ...) must match in Clojure"
+        );
+    }
+
+    /// A `languages: [html]` `pattern-regex` rule loads and matches inside HTML source.
+    #[test]
+    fn test_html_pattern_loads_and_matches() {
+        use crate::engine::parser::parse_path;
+        use std::path::Path;
+
+        let yaml = r#"
+rules:
+  - id: html-inline-onclick
+    pattern-regex: 'onclick='
+    message: Avoid inline event handlers
+    severity: WARNING
+    languages: [html]
+"#;
+        let rules = parse_semgrep_str(yaml, "html.yml").expect("html language rule must load");
+        assert_eq!(rules.len(), 1, "expected one rule for html language");
+
+        let source =
+            "<html>\n  <body>\n    <button onclick=\"go()\">x</button>\n  </body>\n</html>\n";
+        let tree =
+            parse_path(source, Language::Html, Path::new("index.html")).expect("HTML must parse");
+        assert!(
+            !tree.root_node().has_error(),
+            "HTML parse must be error-free"
+        );
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            !findings.is_empty(),
+            "pattern-regex onclick= must match in HTML"
+        );
+    }
+
+    /// A `languages: [xml]` `pattern-regex` rule loads and matches inside XML source.
+    #[test]
+    fn test_xml_pattern_loads_and_matches() {
+        use crate::engine::parser::parse_path;
+        use std::path::Path;
+
+        let yaml = r#"
+rules:
+  - id: xml-doctype
+    pattern-regex: '<!DOCTYPE'
+    message: Avoid DOCTYPE declarations
+    severity: WARNING
+    languages: [xml]
+"#;
+        let rules = parse_semgrep_str(yaml, "xml.yml").expect("xml language rule must load");
+        assert_eq!(rules.len(), 1, "expected one rule for xml language");
+
+        let source =
+            "<?xml version=\"1.0\"?>\n<!DOCTYPE root>\n<root>\n  <child>text</child>\n</root>\n";
+        let tree =
+            parse_path(source, Language::Xml, Path::new("data.xml")).expect("XML must parse");
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            !findings.is_empty(),
+            "pattern-regex <!DOCTYPE must match in XML"
+        );
+    }
+
+    /// A `languages: [dart]` search rule loads and matches inside Dart source.
+    #[test]
+    fn test_dart_pattern_loads_and_matches() {
+        use crate::engine::parser::parse_path;
+        use std::path::Path;
+
+        let yaml = r#"
+rules:
+  - id: dart-print-call
+    pattern-regex: 'print\('
+    message: Avoid print
+    severity: WARNING
+    languages: [dart]
+"#;
+        let rules = parse_semgrep_str(yaml, "dart.yml").expect("dart language rule must load");
+        assert_eq!(rules.len(), 1, "expected one rule for dart language");
+
+        let source = "void main() {\n  print('hello');\n}\n";
+        let tree =
+            parse_path(source, Language::Dart, Path::new("main.dart")).expect("Dart must parse");
+        assert!(
+            !tree.root_node().has_error(),
+            "Dart parse must be error-free"
+        );
+        let findings = rules[0].check(source, &tree);
+        assert!(
+            !findings.is_empty(),
+            "pattern-regex print\\( must match in Dart"
+        );
     }
 
     /// A `languages: [scala]` rule loads successfully.


### PR DESCRIPTION
## New tree-sitter grammars: apex, html, xml, dart, clojure → load rate 92.4% → 93.4%

Adds five search-mode grammars via the established 6-anchor pattern (Language enum + Display, parser arm, semgrep_compat map_language, scanner detect_language, registry_coverage, Cargo.toml, generic_mode/gen_rules_ts exhaustive matches). All on tree-sitter 0.25 — no downgrades or shims.

| Lang | Crate | Note |
|---|---|---|
| html | `tree-sitter-html@0.23` | LANGUAGE const |
| xml | `tree-sitter-xml@0.7` | LANGUAGE_XML const |
| dart | `tree-sitter-dart@0.2` | LANGUAGE const |
| clojure | `tree-sitter-clojure-orchard@0.2.5` | tree-sitter-language 0.1 |
| **apex** | `tree-sitter-sfapex@3.0.0` | the legacy `tree-sitter-apex@1.0.0` was **rejected** (links tree-sitter ~0.20, ABI-incompatible); sfapex uses the modern `apex::LANGUAGE` const |

### Results (independently re-measured)
| | before | after |
|---|---|---|
| Load rate | 92.4% (1982) | **93.4% (2002)** |

**+20 rules.** The search-mode `unsupported language` buckets for all five → **0**. Only `mode: taint (unsupported language: apex)` ×3 remains (no apex taint engine — out of scope).

### Verification (re-run on the branch)
- `registry_coverage` → 93.4% ✓
- both dogfood scans exit 0 · `cargo test` 842+ lib, 0 failed · clippy `-D warnings` clean · `fmt --check` clean · baseline untouched ✓
- Per-grammar tests: each parses a real fixture error-free + a `pattern:`/`pattern-regex:` search rule LOADS and matches via `parse_semgrep_str`.
- One small engine touch: taught the AST pattern unwrapper about clojure-orchard's `source` top node so Clojure `pattern:` rules descend correctly (distinctive node name, full suite green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Apex, Clojure, HTML, XML, and Dart language analysis.
  * Enhanced language detection to recognize additional file types.

* **Improvements**
  * Increased rule registry coverage to 93.4% (from 92.4%), with 2,002 rules successfully loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->